### PR TITLE
[PERF] purchase_mrp: cache cost share scan during bom explode

### DIFF
--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
@@ -8,6 +7,11 @@ from odoo.tools import float_is_zero, float_round
 
 class MrpBom(models.Model):
     _inherit = 'mrp.bom'
+
+    def explode(self, product, quantity, picking_type=False, never_attribute_values=False):
+        cache = self.env.context.get('purchase_mrp_cost_share_cache')
+        bom = self.with_context(purchase_mrp_cost_share_cache={}) if cache is None else self
+        return super(MrpBom, bom).explode(product, quantity, picking_type=picking_type, never_attribute_values=never_attribute_values)
 
     @api.constrains('product_id', 'product_tmpl_id', 'bom_line_ids', 'byproduct_ids', 'operation_ids')
     def _check_bom_lines(self):
@@ -42,10 +46,22 @@ class MrpBomLine(models.Model):
     def _get_cost_share(self):
         self.ensure_one()
         product = self.env.context.get('bom_variant_id', self.env['product.product'])
-        variant_bom_lines = self.bom_id.bom_line_ids.filtered(lambda bl: not bl._skip_bom_line(product) and not bl.product_uom_id.is_zero(bl.product_qty))
-        if not float_is_zero(self.cost_share, precision_digits=2) or not len(variant_bom_lines) or not all(float_is_zero(bom_line.cost_share, precision_digits=2) for bom_line in variant_bom_lines):
+        cache = self.env.context.get('purchase_mrp_cost_share_cache')
+        if cache is None:
+            cache = {}
+        variant_key = (self.bom_id.id, product.id)
+        if variant_key not in cache:
+            variant_bom_lines = self.bom_id.bom_line_ids.filtered(
+                lambda bl: not bl._skip_bom_line(product) and not bl.product_uom_id.is_zero(bl.product_qty)
+            )
+            cache[variant_key] = (
+                len(variant_bom_lines),
+                any(not float_is_zero(bom_line.cost_share, precision_digits=2) for bom_line in variant_bom_lines),
+            )
+        variant_bom_line_count, has_non_zero_cost_share = cache[variant_key]
+        if not float_is_zero(self.cost_share, precision_digits=2) or not variant_bom_line_count or has_non_zero_cost_share:
             return self.cost_share / 100
-        return 1 / len(variant_bom_lines)
+        return 1 / variant_bom_line_count
 
     def _prepare_bom_done_values(self, quantity, product, original_quantity, boms_done):
         result = super()._prepare_bom_done_values(quantity, product, original_quantity, boms_done)

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -1,4 +1,5 @@
 from unittest import skip
+from unittest.mock import patch
 
 from odoo.exceptions import UserError
 from odoo.fields import Command, Date, Datetime
@@ -748,3 +749,42 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
             {'product_id': c5.id, 'value': 500.0},
             {'product_id': c6.id, 'value': 0.0},
         ])
+
+    def test_kit_cost_share_is_cached_per_variant(self):
+        """Ensure variant line filtering is computed once per explode call."""
+        product_template = self.env['product.template'].create({
+            'name': "Large Kit",
+            'type': 'consu',
+        })
+        components = self.env['product.product'].create([{
+            'name': f'Comp {index}',
+            'is_storable': True,
+        } for index in range(40)])
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': component.id,
+                    'product_qty': 1,
+                })
+                for component in components
+            ],
+        })
+
+        call_count = 0
+        model = self.env.registry['mrp.bom.line']
+        original_skip_bom_line = model._skip_bom_line
+
+        def counted_skip_bom_line(line, product, never_attribute_values=False):
+            nonlocal call_count
+            call_count += 1
+            return original_skip_bom_line(line, product, never_attribute_values)
+
+        with patch.object(model, '_skip_bom_line', counted_skip_bom_line):
+            bom.explode(product_template.product_variant_id, 1.0)
+
+        # Expect 2N calls: base explosion and one cached shared-cost scan.
+        self.assertEqual(call_count, len(components) * 2)


### PR DESCRIPTION
Before this commit, confirming a Sale Order that creates a Manufacturing Order for a product with a large BoM could take several minutes when `purchase_mrp` was installed.

The slowdown comes from `mrp.bom.line._get_cost_share()`, which is called for every line during a BoM explosion. When no explicit `cost_share` is set, the method recomputes the list of eligible BoM lines and checks whether any of them has a manual cost share.

That computation depends only on the BoM and the product variant, but it is recomputed for every exploded line during `mrp.bom.explode()`. This causes a full BoM scan to be repeated for every single line.

This commit introduces a contextual cache `purchase_mrp_cost_share_cache` to store these results. We calculate the metadata once and reuse it for all lines of the same (BoM, variant) within the same explosion.

### Benchmark:
- BoM lines: 992

| Before  | After  |
|---------|--------|
| 229.246s | 9.068s |

opw-6017626

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
