### PR TITLE
[FIX] test_website: remove undeterministicTour key

### DIFF
--- a/addons/website/static/tests/tours/snippet_popup_open_on_top.js
+++ b/addons/website/static/tests/tours/snippet_popup_open_on_top.js
@@ -10,7 +10,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_popup_open_on_top",
     {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         edition: true,
     },
     () => [


### PR DESCRIPTION
Fix undeterministic tours by making some triggers more precise in a few steps.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
