### PR TITLE
[FIX] website: prevent crash in `google_font_metadata`

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -1114,7 +1114,7 @@ class Website(Home):
                     'mimetype': 'application/json',
                     'raw': json_content,
                 })
-        return json.loads(metadata.raw)
+        return json.loads(metadata.raw.content)
 
     def _get_customize_data(self, keys, is_view_data):
         model = 'ir.ui.view' if is_view_data else 'ir.asset'

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
@@ -6,8 +6,8 @@
         <label class="col-12" t-attf-style="font-weight: {{previewWeight}};" t-out="previewLabel"/>
     </div>
     <div class="mb-3 row">
-        <div class="col-11 offset-1" t-attf-style="font-family: '{{this.previewFontName}}';">
-            <input t-if="this.previewFontName" class="w-100 border-0 bg-transparent" t-custom-model="this.state.previewText" t-attf-style="font-weight: {{previewWeight}};"/>
+        <div class="col-11 offset-1" t-attf-style="font-family: '{{previewFontName}}';">
+            <input t-if="previewFontName" class="w-100 border-0 bg-transparent" t-custom-model="this.state.previewText" t-attf-style="font-weight: {{previewWeight}};"/>
             <input t-else="" class="w-100 border-0 bg-transparent" readonly="1" t-attf-style="font-weight: {{previewWeight}};"/>
         </div>
     </div>

--- a/addons/website/static/tests/tours/font_family.js
+++ b/addons/website/static/tests/tours/font_family.js
@@ -78,5 +78,9 @@ registerWebsitePreviewTour(
             content: "Check that the preview of the selected font is displayed in the modal",
             trigger: ".modal:contains('Preview of Second test font')",
         },
+        {
+            content: "Check that the 3 previews are correctly set in the modal",
+            trigger: `.modal div[style="font-family: 'Second test font';"]:count(3)`,
+        },
     ]
 );

--- a/addons/website/static/tests/tours/font_family.js
+++ b/addons/website/static/tests/tours/font_family.js
@@ -59,5 +59,24 @@ registerWebsitePreviewTour(
             content: "Check that 'Arvo' font family is still applied and not reverted",
             trigger: "button:has(span[style*='font-family: Arvo;'])",
         },
+        {
+            content: "Click on the 'Add a custom font' button",
+            trigger: ".o_popover .o_we_add_font_btn",
+            run: "click",
+        },
+        {
+            content: "Fetch Google fonts",
+            trigger: ".modal #google_font",
+            run: "click",
+        },
+        {
+            content: "Select a Google font in the list",
+            trigger: ".modal .dropdown-item:contains('Second test font')",
+            run: "click",
+        },
+        {
+            content: "Check that the preview of the selected font is displayed in the modal",
+            trigger: ".modal:contains('Preview of Second test font')",
+        },
     ]
 );

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -723,6 +723,13 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env['website'].get_client_action_url('/', True), "snippet_visibility_option", login="admin")
 
     def test_website_font_family(self):
+        self.env['ir.attachment'].create({
+            'name': 'googleFontMetadata',
+            'type': 'binary',
+            'mimetype': 'application/json',
+            'raw': b'{"familyMetadataList":[{"family":"First test font"}, {"family":"Second test font"}]}',
+            'public': True,
+        })
         self.start_tour(self.env['website'].get_client_action_url('/', True), "website_font_family", login="admin")
 
     def test_website_seo_notification(self):


### PR DESCRIPTION
Since odoo/odoo@41fe2eb, the bytes from a `fields.Binary` are retrieved with `.content`. Due to an oversight, it was not added here.

__Steps to reproduce__
- In edit mode, go to the Theme tab
- Click on a "Font Family" option and select "Add a Custom Font"
- Click on the "Select a Google Font" dropdown ⮕ Traceback

task-6030788