### PR TITLE
[FIX] stock : allow bulk counted quantity edit

### DIFF
--- a/addons/stock/static/src/widgets/counted_quantity_widget.js
+++ b/addons/stock/static/src/widgets/counted_quantity_widget.js
@@ -31,20 +31,17 @@ export class CountedQuantityWidgetField extends FloatField {
     }
 
     onInput(ev) {
-        return this.props.record.update({ inventory_quantity_set: true });
+        //TODO remove in master
     }
 
     updateValue(ev){
         try {
-           const val = this.parse(ev.target.value);
-            this.props.record.update({ [this.props.name]: val });
+            const val = this.parse(ev.target.value);
+            this.props.record.update({ [this.props.name]: val, inventory_quantity_set: true });
         } catch {} // ignore since it will be handled later
     }
 
     onBlur(ev) {
-         if (!this.props.record.data.inventory_quantity_set) {
-           return;
-        }
         this.updateValue(ev);
     }
 


### PR DESCRIPTION
# How to reproduce
- Go to the Pysical Invetory list view
- Select more than one record
- In the Counted field, try to type a two digit number

# The problem
A popup asking for confirmation for editing a field is shown before the user has the time to type in the other digits. This makes it so it is not possible to input a number that has more than one digit.

# Cause
The Counted (invetory_quantity) field in the list view uses a special widget (CountedQuantityWidgetField). This widget has the responsability to set the inventory_quantity_set field to true when the the value of the inventory_quantity field is updated.

The inventory_quantity_set field is updated on input :
https://github.com/odoo/odoo/blob/f450bb6379b5c0354c048abcc688428d8bff1172/addons/stock/static/src/widgets/counted_quantity_widget.js#L33-L35

The inventory_quantity field is updated on blur :
https://github.com/odoo/odoo/blob/f450bb6379b5c0354c048abcc688428d8bff1172/addons/stock/static/src/widgets/counted_quantity_widget.js#L44-L49

This does not make a lot of sense, because we tell the backend that the quantity has been changed before sending the new quantity. This was not really an issue before but starting in 19.0, this commit (https://github.com/odoo/odoo/commit/9f0470b48e4e8c783513788e269ad16cbf84b7af) made the Physical Invetory list view multi-editable, highlighting the desynchronization

This fix aims to resynchronize the editing of both of theses values, allowing the bulk edit at the same time.

opw-5908205

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
