### PR TITLE
[FIX] point_of_sale: use payment amounts for sale details total

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -126,6 +126,18 @@ class ReportSaleDetails(models.AbstractModel):
             for session in sessions:
                 configs.append(session.config_id)
 
+        cash_rounding_total = 0.0
+        for order in orders:
+            order_currency = order.session_id.currency_id
+            rounding_diff = order.amount_paid - order.amount_total
+            if user_currency != order_currency:
+                cash_rounding_total += order_currency._convert(
+                    rounding_diff, user_currency, order.company_id,
+                    order.date_order or fields.Date.today())
+            else:
+                cash_rounding_total += rounding_diff
+        cash_rounding_total = user_currency.round(cash_rounding_total)
+
         for payment in payments:
             payment['count'] = False
 
@@ -331,6 +343,7 @@ class ReportSaleDetails(models.AbstractModel):
             'discount_amount': discount_amount,
             'invoiceList': invoiceList,
             'invoiceTotal': invoiceTotal,
+            'cash_rounding_total': cash_rounding_total,
         }
 
     def _get_product_total_amount(self, line):

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -185,3 +185,56 @@ class TestReportSession(TestPoSCommon):
         self.config.current_session_id.action_pos_session_closing_control()
         report = self.env['report.point_of_sale.report_saledetails'].get_sale_details()
         self.assertEqual(report["taxes_info"]["base_amount"], 100, "Base amount should be equal to 100")
+
+    def test_report_sale_details_total_with_cash_rounding(self):
+        """Test that the sale details report shows the cash rounding amount."""
+        rounding_method = self.env['account.cash.rounding'].create({
+            'name': 'Rounding 0.05',
+            'rounding': 0.05,
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+        self.config.write({
+            'cash_rounding': True,
+            'rounding_method': rounding_method.id,
+            'only_round_cash_method': False,
+        })
+
+        tax = self.env['account.tax'].create({
+            'name': 'Tax 1',
+            'amount': 10,
+        })
+        # 10.42 + 10% tax = 11.462 → rounded to 11.45
+        product = self.create_product('Product Rounding', self.categ_basic, 10.42, tax.id)
+
+        self.config.open_ui()
+        session = self.config.current_session_id
+
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': session.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': product.id,
+                'price_unit': 10.42,
+                'qty': 1,
+                'tax_ids': [[6, False, [tax.id]]],
+                'price_subtotal': 10.42,
+                'price_subtotal_incl': 11.46,
+            })],
+            'pricelist_id': self.config.pricelist_id.id,
+            'amount_paid': 11.45,
+            'amount_total': 11.46,
+            'amount_tax': 1.04,
+            'amount_return': 0.0,
+            'last_order_preparation_change': '{}',
+            'to_invoice': False,
+        })
+        self.make_payment(order, self.cash_pm1, 11.45)
+        session.action_pos_session_closing_control()
+
+        report = self.env['report.point_of_sale.report_saledetails'].get_sale_details(session_ids=[session.id])
+        self.assertAlmostEqual(
+            report['cash_rounding_total'], 11.45 - 11.46, places=2,
+            msg="Cash rounding total should equal sum of (amount_paid - amount_total) across orders"
+        )

--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -402,7 +402,20 @@
                 <br/>
                 <div class="oe_structure"></div>
                     <div style="break-inside: avoid;">
-                        <strong>Total: 
+                        <t t-if="cash_rounding_total">
+                            <strong>Cash Rounding:
+                                <span t-if="currency['position']">
+                                    <span t-out='cash_rounding_total' t-options="{'widget': 'float', 'precision': currency['precision']}">0.00</span>
+                                    <span t-out='currency["symbol"]'>$</span>
+                                </span>
+                                <span t-else="">
+                                    <span t-out='currency["symbol"]'>$</span>
+                                    <span t-out='cash_rounding_total' t-options="{'widget': 'float', 'precision': currency['precision']}">0.00</span>
+                                </span>
+                            </strong>
+                            <br/>
+                        </t>
+                        <strong>Total:
                             <span t-if="currency['position']">
                                 <span t-out='currency["total_paid"]' t-options="{'widget': 'float', 'precision': currency['precision']}">99.99</span>
                                 <span t-out='currency["symbol"]'>$</span>


### PR DESCRIPTION
The sale details report total_paid was computed from sum(order.amount_total), which does not include the cash rounding adjustment. This caused a discrepancy between the displayed total and the sum of individual payment lines when cash rounding is enabled.

Use the sum of actual payment amounts instead, which naturally includes cash rounding since payments are recorded with their rounded values.

opw-5253018