### PR TITLE
[IMP] pos_self_order: allow future orders in self

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -89,17 +89,11 @@ class PosController(PortalAccount):
             ]
             pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 
-        if not pos_config or not pos_config.active or pos_config.has_active_session and not pos_session:
+        if not pos_config or not pos_config.active or pos_config.current_session_id and not pos_session:
             return request.redirect('/odoo/action-point_of_sale.action_client_pos_menu')
 
-        if not pos_config.has_active_session:
-            # Acquire an row-level lock on the pos_config record to prevent race conditions
-            # This prevents multiple concurrent processes from creating duplicate POS sessions
-            request.env.cr.execute(
-                "SELECT id FROM pos_config WHERE id = %s FOR UPDATE NOWAIT",
-                (pos_config.id,)
-            )
-            pos_config.open_ui()
+        if not pos_config.current_session_id:
+            pos_config.open_session_if_not_opened()  # Create a session after doing the necessary checks.
             pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 
         # The POS only works in one company, so we enforce the one of the session in the context

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -89,10 +89,10 @@ class PosController(PortalAccount):
             ]
             pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 
-        if not pos_config or not pos_config.active or pos_config.has_active_session and not pos_session:
+        if not pos_config or not pos_config.active or pos_config.current_session_id and not pos_session:
             return request.redirect('/odoo/action-point_of_sale.action_client_pos_menu')
 
-        if not pos_config.has_active_session:
+        if not pos_config.current_session_id:
             # Acquire an row-level lock on the pos_config record to prevent race conditions
             # This prevents multiple concurrent processes from creating duplicate POS sessions
             request.env.cr.execute(

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -358,9 +358,9 @@ class PosConfig(models.Model):
             rescue_sessions = opened_sessions.filtered('rescue')
             session = pos_config.session_ids.filtered(lambda s: s.state != 'closed' and not s.rescue)
             # sessions ordered by id desc
-            pos_config.has_active_session = opened_sessions and True or False
-            pos_config.current_session_id = session and session[0].id or False
-            pos_config.current_session_state = session and session[0].state or False
+            pos_config.has_active_session = bool(opened_sessions.filtered(lambda s: s.state != 'opening_control')) or False
+            pos_config.current_session_id = (session and session[0].id) or False
+            pos_config.current_session_state = (session and session[0].state) or False
             pos_config.number_of_rescue_session = len(rescue_sessions)
 
     def _search_current_session(self, operator, value):
@@ -873,6 +873,13 @@ class PosConfig(models.Model):
         self._check_currencies()
         self._check_profit_loss_cash_journal()
         self._check_payment_method_ids()
+
+    def open_session_if_not_opened(self):
+        if not self.current_session_id:
+            # Acquire an row-level lock on the pos_config record to prevent race conditions
+            # This prevents multiple concurrent processes from creating duplicate POS sessions
+            self.lock_for_update()
+            self.open_ui()
 
     def open_ui(self):
         """Open the pos interface with config_id as an extra argument.

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -379,9 +379,9 @@ class PosConfig(models.Model):
             rescue_sessions = opened_sessions.filtered('rescue')
             session = pos_config.session_ids.filtered(lambda s: s.state != 'closed' and not s.rescue)
             # sessions ordered by id desc
-            pos_config.has_active_session = opened_sessions and True or False
-            pos_config.current_session_id = session and session[0].id or False
-            pos_config.current_session_state = session and session[0].state or False
+            pos_config.has_active_session = bool(opened_sessions.filtered(lambda s: s.state != 'opening_control')) or False
+            pos_config.current_session_id = (session and session[0].id) or False
+            pos_config.current_session_state = (session and session[0].state) or False
             pos_config.number_of_rescue_session = len(rescue_sessions)
 
     def _compute_statistics_for_session(self):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -51,7 +51,7 @@ class PosOrder(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        return [('state', '=', 'draft'), ('config_id', '=', config.id)]
+        return [('config_id', '=', config.id), '|', ('state', '=', 'draft'), '&', ('state', 'in', ['paid', 'done']), ('preset_time', '>', fields.Datetime.now())]
 
     @api.model
     def _process_order(self, order, existing_order):

--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -96,7 +96,7 @@ class PosPreset(models.Model):
         usage = defaultdict(int)
         orders = self.env['pos.order'].search([
             ('preset_id', '=', self.id),
-            ('session_id.state', '=', 'opened'),
+            ('session_id.state', '!=', 'closed'),
             ('preset_time', '!=', False),
             ('state', 'in', ['draft', 'paid']),
             ('create_date', '>=', fields.Datetime.now() - timedelta(days=1)),

--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -75,7 +75,7 @@ class PosPreset(models.Model):
         usage = defaultdict(int)
         orders = self.env['pos.order'].search([
             ('preset_id', '=', self.id),
-            ('session_id.state', '=', 'opened'),
+            ('session_id.state', '!=', 'closed'),
             ('preset_time', '!=', False),
             ('state', 'in', ['draft', 'paid']),
             ('create_date', '>=', fields.Datetime.now() - timedelta(days=1))

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -362,6 +362,19 @@ class PosSession(models.Model):
             not (o.preset_time and o.preset_time.date() > today)
         )
 
+    def get_order_count_by_preset(self):
+        orders = self.order_ids.filtered(lambda o: o.state != 'cancel' and o.preset_id and o.preset_time and o.preset_time > fields.Datetime.now())
+        orders_by_preset = {}
+        for order in orders:
+            if order.preset_id.id not in orders_by_preset:
+                orders_by_preset[order.preset_id.id] = {
+                    'id': order.preset_id.id,
+                    'name': order.preset_id.name,
+                    'count': 0,
+                }
+            orders_by_preset[order.preset_id.id]['count'] += 1
+        return list(orders_by_preset.values())
+
     def action_pos_session_closing_control(self, balancing_account=False, amount_to_balance=0, bank_payment_method_diffs=None):
         bank_payment_method_diffs = bank_payment_method_diffs or {}
         for session in self:

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
@@ -1,12 +1,13 @@
 import { useService } from "@web/core/utils/hooks";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { MoneyDetailsPopup } from "@point_of_sale/app/components/popups/money_details_popup/money_details_popup";
-import { Component, proxy } from "@odoo/owl";
+import { Component, proxy, onMounted } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { parseFloat } from "@web/views/fields/parsers";
 import { Dialog } from "@web/core/dialog/dialog";
 import { RPCError } from "@web/core/network/rpc";
 import { CashInput } from "@point_of_sale/app/components/inputs/input/cash_input/cash_input";
+import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 
 class CustomDialog extends Dialog {
     onEscape() {}
@@ -29,12 +30,24 @@ export class OpeningControlPopup extends Component {
                 this.pos.session.cash_register_balance_start || 0,
                 false
             ),
+            ordersByPreset: [],
         });
         this.ui = useService("ui");
+        this.getOrderCountByPreset = useTrackedAsync(
+            async () =>
+                (this.state.ordersByPreset = await this.pos.data.call(
+                    "pos.session",
+                    "get_order_count_by_preset",
+                    [this.pos.session.id]
+                ))
+        );
+
+        onMounted(() => {
+            this.getOrderCountByPreset.call();
+        });
     }
     get orderCount() {
-        return this.pos.models["pos.order"].filter((o) => o.lines.length > 0 && o.state === "draft")
-            .length;
+        return this.state.ordersByPreset.reduce((total, preset) => total + preset.count, 0);
     }
     async confirm() {
         try {

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
@@ -9,6 +9,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { RPCError } from "@web/core/network/rpc";
 import { CashInput } from "@point_of_sale/app/components/inputs/input/cash_input/cash_input";
 
+const { DateTime } = luxon;
 class CustomDialog extends Dialog {
     onEscape() {}
 }
@@ -34,8 +35,35 @@ export class OpeningControlPopup extends Component {
         this.ui = useService("ui");
     }
     get orderCount() {
-        return this.pos.models["pos.order"].filter((o) => o.lines.length > 0 && o.state === "draft")
-            .length;
+        return this.pos.models["pos.order"].filter(
+            (o) =>
+                o.lines.length > 0 &&
+                (o.state === "draft" ||
+                    (["paid", "done"].includes(o.state) && o.preset_time > DateTime.now()))
+        ).length;
+    }
+    get ordersByPreset() {
+        const presetCount = this.pos.models["pos.order"]
+            .filter(
+                (o) =>
+                    o.lines.length > 0 &&
+                    (o.state === "draft" ||
+                        (["paid", "done"].includes(o.state) && o.preset_time > DateTime.now()))
+            )
+            .map((o) => o.preset_id)
+            .filter(Boolean)
+            .reduce((acc, preset_id) => {
+                if (!acc[preset_id.id]) {
+                    acc[preset_id.id] = {
+                        id: preset_id.id,
+                        name: preset_id.name,
+                        orderCount: 0,
+                    };
+                }
+                acc[preset_id.id].orderCount += 1;
+                return acc;
+            }, {});
+        return Object.values(presetCount);
     }
     async confirm() {
         try {

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
@@ -9,8 +9,13 @@
             </t>
             <div class="mb-3" t-if="this.orderCount > 0">
                 <label class="form-label">Orders status</label>
-                <div class="alert alert-info" role="alert">
-                    You still have <span t-out="this.orderCount" /> open orders for the next few days.
+                <div class="alert alert-info d-flex" role="alert">
+                    <span>You have <span t-out="this.orderCount" /> order(s) for the next few days:</span>
+                    <ul class="mb-0 px-2">
+                        <li t-if="this.getOrderCountByPreset.status == 'success'" t-foreach="this.state.ordersByPreset" t-as="preset" t-key="preset_index">
+                            - <span t-out="preset.count" /> <t t-out="preset.name" />
+                        </li>
+                    </ul>
                 </div>
             </div>
             <div class="opening-cash-section mb-3" t-if="this.cashMethodCount">

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
@@ -9,8 +9,13 @@
             </t>
             <div class="mb-3" t-if="this.orderCount > 0">
                 <label class="form-label">Orders status</label>
-                <div class="alert alert-info" role="alert">
-                    You still have <span t-out="this.orderCount" /> open orders for the next few days.
+                <div class="alert alert-info d-flex" role="alert">
+                    <span>You still have <span t-out="this.orderCount" /> open order(s) for the next few days:</span>
+                    <ul class="mb-0 px-2">
+                        <li t-foreach="this.ordersByPreset" t-as="preset" t-key="preset_index">
+                            - <span t-out="preset.orderCount" /> <t t-out="preset.name" />
+                        </li>
+                    </ul>
                 </div>
             </div>
             <div class="opening-cash-section mb-3" t-if="this.cashMethodCount">

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -11,7 +11,7 @@ import {
     generateQRCodeDataUrl,
     getColorScheme,
 } from "@point_of_sale/utils";
-import { ConnectionLostError } from "@web/core/network/rpc";
+import { ConnectionLostError, RPCError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { OpeningControlPopup } from "@point_of_sale/app/components/popups/opening_control_popup/opening_control_popup";
 import { OrderDetailsDialog } from "@point_of_sale/app/screens/ticket_screen/order_details_dialog/order_details_dialog";
@@ -2103,11 +2103,25 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (this.session.state === "opening_control") {
-            const data = await this.data.call("pos.session", "delete_opening_control_session", [
-                this.session.id,
-            ]);
-
-            if (data.status === "success") {
+            try {
+                await this.data.call("pos.session", "delete_opening_control_session", [
+                    this.session.id,
+                ]);
+            } catch (error) {
+                if (error instanceof RPCError) {
+                    // If the error is an RPC error, it should be "You can only cancel a session that is in opening control state and has no orders."
+                    // In this case, we still go to the backend without deleting the session.
+                    logPosMessage(
+                        "Store",
+                        "closePos",
+                        "Failed to delete opening control session, redirecting to backend",
+                        CONSOLE_COLOR,
+                        [error]
+                    );
+                } else {
+                    throw error;
+                }
+            } finally {
                 this.redirectToBackend();
             }
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -9,7 +9,7 @@ import {
     orderUsageUTCtoLocalUtil,
     getTimeUtil,
 } from "@point_of_sale/utils";
-import { ConnectionLostError } from "@web/core/network/rpc";
+import { ConnectionLostError, RPCError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { OpeningControlPopup } from "@point_of_sale/app/components/popups/opening_control_popup/opening_control_popup";
 import { SelectLotPopup } from "@point_of_sale/app/components/popups/select_lot_popup/select_lot_popup";
@@ -2006,11 +2006,25 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (this.session.state === "opening_control") {
-            const data = await this.data.call("pos.session", "delete_opening_control_session", [
-                this.session.id,
-            ]);
-
-            if (data.status === "success") {
+            try {
+                await this.data.call("pos.session", "delete_opening_control_session", [
+                    this.session.id,
+                ]);
+            } catch (error) {
+                if (error instanceof RPCError) {
+                    // If the error is an RPC error, it should be "You can only cancel a session that is in opening control state and has no orders."
+                    // In this case, we still go to the backend without deleting the session.
+                    logPosMessage(
+                        "Store",
+                        "closePos",
+                        "Failed to delete opening control session, redirecting to backend",
+                        CONSOLE_COLOR,
+                        [error]
+                    );
+                } else {
+                    throw error;
+                }
+            } finally {
                 this.redirectToBackend();
             }
         }

--- a/addons/point_of_sale/static/tests/unit/data/pos_session.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_session.data.js
@@ -159,6 +159,10 @@ export class PosSession extends models.ServerModel {
         return [];
     }
 
+    get_order_count_by_preset() {
+        return [];
+    }
+
     _records = [
         {
             id: 1,

--- a/addons/pos_mercado_pago/controllers/main.py
+++ b/addons/pos_mercado_pago/controllers/main.py
@@ -59,7 +59,7 @@ class PosMercadoPagoWebhook(http.Controller):
         session_id, payment_method_id, _ = match.groups()
 
         pos_session_sudo = request.env['pos.session'].sudo().browse(int(session_id))
-        if not pos_session_sudo or pos_session_sudo.state != 'opened':
+        if not pos_session_sudo or pos_session_sudo.state == 'closed':
             _logger.error("Invalid session id: %s", session_id)
             # This error is not related with Mercado Pago, simply acknowledge Mercado Pago message
             return http.Response('OK', status=200)

--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -25,7 +25,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
     @staticmethod
     def _ensure_session_open(pos_order_sudo):
-        if pos_order_sudo.session_id.state != 'opened':
+        if pos_order_sudo.session_id.state == 'closed':
             raise AccessError(_("The POS session is not opened."))
 
     def _get_partner_sudo(self, user_sudo):

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -58,7 +58,7 @@ class RestaurantFloor(models.Model):
     def write(self, vals):
         for floor in self:
             for config in floor.pos_config_ids:
-                if config.has_active_session and (vals.get('pos_config_ids') or vals.get('active')):
+                if config.current_session_id and (vals.get('pos_config_ids') or vals.get('active')):
                     raise UserError(
                         self.env._(
                             "Please close and validate the following open PoS Session before modifying this floor.\n"

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -294,20 +294,20 @@ class PosSelfOrderController(http.Controller):
             return {'address': None}
         return AutoCompleteController()._perform_complete_place_search(address, api_key=google_places_api_key, google_place_id=google_place_id)
 
-    def _verify_pos_config(self, access_token, check_active_session=True):
+    def _verify_pos_config(self, access_token):
         """
         Finds the pos.config with the given access_token and returns a record with reduced privileges.
         The record is has no sudo access and is in the context of the record's company and current pos.session's user.
         """
         pos_config_sudo = request.env['pos.config'].sudo().search([('access_token', '=', access_token)], limit=1)
-        if self._verify_config_constraint(pos_config_sudo, check_active_session):
+        if self._verify_config_constraint(pos_config_sudo):
             raise Unauthorized("Invalid access token")
         company = pos_config_sudo.company_id
         user = pos_config_sudo.self_ordering_default_user_id
         return pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
-    def _verify_config_constraint(self, pos_config_sudo, check_active_session=True):
-        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk') or (check_active_session and not pos_config_sudo.has_active_session)
+    def _verify_config_constraint(self, pos_config_sudo):
+        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk')
 
     def _verify_authorization(self, access_token, table_identifier, order):
         """
@@ -328,5 +328,5 @@ class PosSelfOrderController(http.Controller):
 
     @http.route(['/pos-self/ping'], type='jsonrpc', auth='public')
     def pos_ping(self, access_token):
-        self._verify_pos_config(access_token, check_active_session=False)
+        self._verify_pos_config(access_token)
         return {'response': 'pong'}

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -42,6 +42,7 @@ class PosSelfOrderController(http.Controller):
             'pos.order.line': self.env['pos.order.line']._load_pos_self_data_read(order.lines, config),
             'pos.payment': self.env['pos.payment']._load_pos_self_data_read(order.payment_ids, config),
             'product.attribute.custom.value': self.env['product.attribute.custom.value']._load_pos_self_data_read(order.lines.custom_attribute_value_ids, config),
+            'pos.session': self.env['pos.session']._load_pos_self_data_read(order.session_id, config),
         }
 
     def _verify_line_price(self, lines, pos_config, preset_id):
@@ -185,20 +186,20 @@ class PosSelfOrderController(http.Controller):
         amount_total = sum(lines.mapped('price_subtotal_incl'))
         return amount_total, amount_untaxed
 
-    def _verify_pos_config(self, access_token, check_active_session=True):
+    def _verify_pos_config(self, access_token):
         """
         Finds the pos.config with the given access_token and returns a record with reduced privileges.
         The record is has no sudo access and is in the context of the record's company and current pos.session's user.
         """
         pos_config_sudo = request.env['pos.config'].sudo().search([('access_token', '=', access_token)], limit=1)
-        if self._verify_config_constraint(pos_config_sudo, check_active_session):
+        if self._verify_config_constraint(pos_config_sudo):
             raise Unauthorized("Invalid access token")
         company = pos_config_sudo.company_id
         user = pos_config_sudo.self_ordering_default_user_id
         return pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
-    def _verify_config_constraint(self, pos_config_sudo, check_active_session=True):
-        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk') or (check_active_session and not pos_config_sudo.has_active_session)
+    def _verify_config_constraint(self, pos_config_sudo):
+        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk')
 
     def _verify_authorization(self, access_token, table_identifier, order):
         """
@@ -219,5 +220,5 @@ class PosSelfOrderController(http.Controller):
 
     @http.route(['/pos-self/ping'], type='jsonrpc', auth='public')
     def pos_ping(self, access_token):
-        self._verify_pos_config(access_token, check_active_session=False)
+        self._verify_pos_config(access_token)
         return {'response': 'pong'}

--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -70,7 +70,7 @@ class PosSelfKiosk(http.Controller):
         if not pos_config:
             raise werkzeug.exceptions.NotFound()
 
-        if pos_config and pos_config.has_active_session and pos_config.self_ordering_mode == 'mobile':
+        if pos_config and pos_config.self_ordering_mode == 'mobile':
             table_sudo = table_identifier and (
                 request.env["restaurant.table"]
                 .sudo()

--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -68,7 +68,7 @@ class PosSelfKiosk(http.Controller):
         if not pos_config:
             raise werkzeug.exceptions.NotFound()
 
-        if pos_config and pos_config.has_active_session and pos_config.self_ordering_mode == 'mobile':
+        if pos_config and pos_config.self_ordering_mode == 'mobile':
             if config_access_token:
                 config_access_token = pos_config.access_token
             table_sudo = table_identifier and (

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -108,7 +108,7 @@ class PosConfig(models.Model):
             'self_ordering_image_brand', 'self_ordering_image_brand_name', 'currency_id', 'has_paper',
             'floor_ids', 'fiscal_position_ids', 'receipt_header', 'receipt_footer', 'current_session_id',
             'pricelist_id', 'available_pricelist_ids', 'default_fiscal_position_id', 'use_pricelist', 'module_pos_restaurant',
-            'rounding_method', 'cash_rounding', 'only_round_cash_method', 'has_active_session',
+            'rounding_method', 'cash_rounding', 'only_round_cash_method',
             'available_preset_ids', 'default_preset_id', 'use_presets', 'iface_tax_included',
             'status', 'self_ordering_image_background_ids', 'preparation_printer_ids',
             'receipt_printer_ids', 'use_order_printer', 'other_devices', 'pos_snooze_ids', 'self_ordering_primary_color',
@@ -364,7 +364,7 @@ class PosConfig(models.Model):
 
     def _compute_status(self):
         for record in self:
-            record.status = 'active' if record.has_active_session else 'inactive'
+            record.status = 'active' if record.current_session_id else 'inactive'
 
     def action_open_wizard(self):
         self.ensure_one()

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -109,10 +109,10 @@ class PosConfig(models.Model):
             'floor_ids', 'fiscal_position_ids', 'is_order_printer', 'iface_print_via_proxy', 'receipt_header',
             'receipt_footer', 'proxy_ip', 'current_session_id', 'pricelist_id', 'available_pricelist_ids',
             'default_fiscal_position_id', 'use_pricelist', 'module_pos_restaurant', 'is_header_or_footer',
-            'rounding_method', 'cash_rounding', 'only_round_cash_method', 'has_active_session',
-            'available_preset_ids', 'default_preset_id', 'use_presets', 'iface_tax_included',
-            'status', 'self_ordering_image_background_ids', 'preparation_printer_ids', 'default_receipt_printer_id',
-            'receipt_printer_ids', 'use_order_printer', 'other_devices', 'pos_snooze_ids', 'self_ordering_primary_color',
+            'rounding_method', 'cash_rounding', 'only_round_cash_method', 'available_preset_ids', 'default_preset_id',
+            'use_presets', 'iface_tax_included', 'status', 'self_ordering_image_background_ids',
+            'preparation_printer_ids', 'default_receipt_printer_id', 'receipt_printer_ids', 'use_order_printer',
+            'other_devices', 'pos_snooze_ids', 'self_ordering_primary_color',
         ]
 
     def _update_access_token(self):
@@ -363,7 +363,7 @@ class PosConfig(models.Model):
 
     def _compute_status(self):
         for record in self:
-            record.status = 'active' if record.has_active_session else 'inactive'
+            record.status = 'active' if record.current_session_id else 'inactive'
 
     def action_open_wizard(self):
         self.ensure_one()

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -3,7 +3,7 @@
 import logging
 
 from odoo import Command, models, fields, api, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError, LockError
 
 _logger = logging.getLogger(__name__)
 
@@ -173,6 +173,17 @@ class PosOrder(models.Model):
 
         if not preset_id and pos_config.use_presets:
             raise UserError(_("Invalid preset"))
+
+        if not order['session_id'] or order['session_id'] != pos_config.current_session_id.id:
+            try:
+                pos_config.open_session_if_not_opened()  # Create a session after doing the necessary checks.
+            except ValidationError as e:
+                _logger.warning("pos_self_order: Error while opening a session for future orders: %s", e.args[0])
+                raise UserError(_("Impossible to create a new order."))
+            except LockError:
+                _logger.warning("pos_self_order: Lock not available while opening a session for future orders.")
+                raise UserError(_("Error while creating the order. Please try again."))
+            order['session_id'] = pos_config.current_session_id.id
 
         existing_order = pos_config.env['pos.order']._get_open_order(order)
         if not existing_order.exists():

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -3,7 +3,7 @@
 import logging
 
 from odoo import Command, models, fields, api, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -148,6 +148,15 @@ class PosOrder(models.Model):
 
         if not preset_id and pos_config.use_presets:
             raise UserError(_("Invalid preset"))
+
+        if not order['session_id'] or order['session_id'] != pos_config.current_session_id.id:
+            if not pos_config.current_session_id:
+                try:
+                    pos_config.open_ui()  # Create a session after doing the necessary checks.
+                except ValidationError as e:
+                    _logger.warning("pos_self_order: Error while opening a session for future orders: %s", e.args[0])
+                    raise UserError(_("Impossible to create a new order."))
+            order['session_id'] = pos_config.current_session_id.id
 
         pos_reference, tracking_number = pos_config._get_next_order_refs()
         prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -6,7 +6,7 @@ from odoo import models, api
 
 class PosSession(models.Model):
     _inherit = 'pos.session'
-    
+
     @api.model
     def _load_pos_data_models(self, config_id):
         data = super()._load_pos_data_models(config_id)
@@ -19,7 +19,7 @@ class PosSession(models.Model):
 
     @api.model
     def _load_pos_self_data_domain(self, data, config):
-        return [('config_id', '=', config.id), ('state', '=', 'opened')]
+        return [('config_id', '=', config.id), ('state', 'not in', ['closed', 'closing_control'])]
 
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -6,7 +6,7 @@ from odoo import models, api
 
 class PosSession(models.Model):
     _inherit = 'pos.session'
-    
+
     @api.model
     def _load_pos_data_models(self, config_id):
         data = super()._load_pos_data_models(config_id)
@@ -15,7 +15,7 @@ class PosSession(models.Model):
 
     @api.model
     def _load_pos_self_data_domain(self, data, config):
-        return [('config_id', '=', config.id), ('state', '=', 'opened')]
+        return [('config_id', '=', config.id), ('state', 'not in', ['closed', 'closing_control'])]
 
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -123,7 +123,7 @@ class ProductProduct(models.Model):
     def _send_availability_status(self):
         config_self = self.env['pos.config'].sudo().search([('self_ordering_mode', '!=', 'nothing')])
         for config in config_self:
-            if config.current_session_id and config.access_token:
+            if config.access_token:
                 records = self.env["product.template"].load_product_from_pos(config.id, [('id', '=', self.product_tmpl_id.id)])
                 payload = {}
                 self_models = self.env["pos.config"]._load_self_data_models()

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -99,7 +99,7 @@ class ProductProduct(models.Model):
     def _send_availability_status(self):
         config_self = self.env['pos.config'].sudo().search([('self_ordering_mode', '!=', 'nothing')])
         for config in config_self:
-            if config.current_session_id and config.access_token:
+            if config.access_token:
                 records = self.env["product.template"].load_product_from_pos(config.id, [('id', '=', self.product_tmpl_id.id)])
                 payload = {}
                 self_models = self.env["pos.config"]._load_self_data_models()

--- a/addons/pos_self_order/static/src/app/components/info_popup/info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/info_popup/info_popup.js
@@ -1,0 +1,10 @@
+import { Component } from "@odoo/owl";
+
+export class InfoPopup extends Component {
+    static template = "pos_self_order.InfoPopup";
+    static props = {
+        text: String,
+        close: Function,
+        buttons: Array,
+    };
+}

--- a/addons/pos_self_order/static/src/app/components/info_popup/info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/info_popup/info_popup.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_self_order.InfoPopup">
+        <div class="self_order_text_popup o_dialog" t-att-id="this.id">
+            <div role="dialog" class="modal d-block" tabindex="-1">
+                <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                        <div class="position-absolute top-0 start-50 translate-middle px-4 py-3 rounded-4 text-bg-300 border border-white border-5">
+                            <i class="fa fa-info fa-2x" aria-hidden="true"/>
+                        </div>
+                        <div class="modal-body pt-5 overflow-visible text-center">
+                            <span class="fs-2" t-out="this.props.text"/>
+                        </div>
+                        <div t-if="this.props.buttons" class="d-flex flex-wrap justify-content-center gap-2 px-3 pb-3 border-transparent">
+                            <button 
+                                t-foreach="this.props.buttons"
+                                t-as="button"
+                                t-key="button_index"
+                                t-attf-class="btn btn-secondary kiosk-p-btn-lg popup_button"
+                                t-on-click="button.onClick"
+                                type="button">
+                                <t t-out="button.text"/>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -30,7 +30,10 @@ export class EatingLocationPage extends Component {
     // In the self, we don't want to display presets that have service_at table. Except if the clients are in
     // restaurant (they scanned QR Code and have a table_identifier in the URL) or if the self is in KioskMode.
     get presets() {
-        const all = this.selfOrder.models["pos.preset"].getAll();
+        let all = this.selfOrder.models["pos.preset"].getAll();
+        if (!this.selfOrder.isSessionOpened && this.selfOrder.ordering) {
+            all = all.filter((item) => item.use_timing);
+        }
         return this.router.getTableIdentifier() != null || this.selfOrder.kioskMode
             ? all
             : all.filter((item) => item.service_at !== "table");

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -27,7 +27,10 @@ export class EatingLocationPage extends Component {
     // In the self, we don't want to display presets that have service_at table. Except if the clients are in
     // restaurant (they scanned QR Code and have a table_identifier in the URL) or if the self is in KioskMode.
     get presets() {
-        const all = this.selfOrder.models["pos.preset"].getAll();
+        let all = this.selfOrder.models["pos.preset"].getAll();
+        if (!this.selfOrder.isSessionOpened && this.selfOrder.ordering) {
+            all = all.filter((item) => item.use_timing);
+        }
         return this.router.getTableIdentifier() != null || this.selfOrder.kioskMode
             ? all
             : all.filter((item) => item.service_at !== "table");

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -8,7 +8,7 @@
                        <t t-if="this.selfOrder.config.module_pos_restaurant">Where do you want to eat?</t>
                        <t t-else="">Select your preferred option</t>
                    </h1>
-                   <div class="grid py-3 py-lg-4 gap-3 gap-sm-4" t-att-class="{'d-flex justify-content-center': this.presets.length === 1}">
+                   <div class="grid py-3 py-lg-4 gap-3 gap-sm-4">
                        <article
                             t-foreach="this.presets"
                             t-as="preset" t-key="preset.id"
@@ -17,8 +17,9 @@
                             class="preset_btn fs-2 fw-medium g-col-12 g-col-sm-6 d-flex flex-row-inverse flex-sm-column align-items-center border border-light shadow-sm overflow-hidden bg-white rounded cursor-pointer rounded-4 position-relative"
                             t-att-class="{
                                 'justify-content-center': !preset.has_image,
-                                'g-col-md-6': this.presets.length &lt; 3,
+                                'g-col-md-6': this.presets.length === 2,
                                 'g-col-md-4': this.presets.length &gt; 2,
+                                'g-start-sm-4': this.presets.length === 1,
                             }">
                             <t t-if="preset.has_image">
                                 <div class="img_container flex-shrink-0 w-25 w-sm-100 position-relative">

--- a/addons/pos_self_order/static/src/app/self_order_index.xml
+++ b/addons/pos_self_order/static/src/app/self_order_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.selfOrderIndex">
-        <div t-if="!this.selfOrder.session" class="o-self-closed w-100 m-0 text-center bg-black text-white py-2">
+        <div t-if="!this.selfOrder.ordering and !this.selfOrder.session" class="o-self-closed w-100 m-0 text-center bg-black text-white py-2">
             We're currently closed.
         </div>
         <div t-if="this.selfOrder.rpcLoading">

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -22,6 +22,7 @@ import { getOrderLineValues } from "./card_utils";
 import { initLNA } from "@point_of_sale/app/utils/init_lna";
 import { GeneratePrinterData } from "@point_of_sale/app/utils/printer/generate_printer_data";
 import { SnoozedProductTracker } from "@point_of_sale/app/models/utils/snooze_tracker";
+import { InfoPopup } from "@pos_self_order/app/components/info_popup/info_popup";
 import { session } from "@web/session";
 
 const { DateTime } = luxon;
@@ -125,7 +126,6 @@ export class SelfOrder extends Reactive {
         if (this.config.self_ordering_mode === "kiosk") {
             this.data.connectWebSocket("STATUS", ({ status }) => {
                 if (status === "closed") {
-                    this.pos_session = [];
                     this.ordering = false;
                 } else {
                     // reload to get potential new settings
@@ -241,6 +241,10 @@ export class SelfOrder extends Reactive {
         return this.config.use_presets && presets.length > 0
             ? this.currentOrder?.preset_id?.service_at
             : this.config.self_ordering_service_mode;
+    }
+
+    get isSessionOpened() {
+        return this.session?.state === "opened";
     }
 
     getAvailableCategories() {
@@ -697,16 +701,27 @@ export class SelfOrder extends Reactive {
     async initMobileData() {
         if (this.config.self_ordering_mode !== "qr_code") {
             if (
-                this.session &&
                 this.access_token &&
-                this.config.self_ordering_mode !== "consultation"
+                this.config.self_ordering_mode !== "consultation" &&
+                (this.session || this.models["pos.preset"].filter((p) => p.use_timing).length > 0)
             ) {
                 await this.getUserDataFromServer();
                 this.ordering = true;
-            }
-
-            if (!this.ordering) {
-                return;
+                if (!this.isSessionOpened) {
+                    this.dialog.add(InfoPopup, {
+                        text: _t(
+                            "The shop is currently closed but you can still place an order for later."
+                        ),
+                        buttons: [
+                            {
+                                text: _t("Close"),
+                                onClick: () => {
+                                    this.dialog.closeAll();
+                                },
+                            },
+                        ],
+                    });
+                }
             }
         }
     }

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -22,6 +22,7 @@ import { getOrderLineValues } from "./card_utils";
 import { initLNA } from "@point_of_sale/app/utils/init_lna";
 import { GeneratePrinterData } from "@point_of_sale/app/utils/printer/generate_printer_data";
 import { SnoozedProductTracker } from "@point_of_sale/app/models/utils/snooze_tracker";
+import { InfoPopup } from "@pos_self_order/app/components/info_popup/info_popup";
 
 const { DateTime } = luxon;
 
@@ -57,7 +58,6 @@ export class SelfOrder extends Reactive {
 
         // data
         this.models = this.data.models;
-        this.session = this.models["pos.session"].getFirst();
         this.config = this.models["pos.config"].getFirst();
         this.company = this.config.company_id;
         this.currency = this.config.currency_id;
@@ -114,7 +114,6 @@ export class SelfOrder extends Reactive {
         if (this.config.self_ordering_mode === "kiosk") {
             this.data.connectWebSocket("STATUS", ({ status }) => {
                 if (status === "closed") {
-                    this.pos_session = [];
                     this.ordering = false;
                 } else {
                     // reload to get potential new settings
@@ -195,6 +194,14 @@ export class SelfOrder extends Reactive {
         return this.config.use_presets && presets.length > 0
             ? this.currentOrder?.preset_id?.service_at
             : this.config.self_ordering_service_mode;
+    }
+
+    get session() {
+        return this.models["pos.session"].getFirst();
+    }
+
+    get isSessionOpened() {
+        return this.session?.state === "opened";
     }
 
     getAvailableCategories() {
@@ -547,16 +554,27 @@ export class SelfOrder extends Reactive {
     async initMobileData() {
         if (this.config.self_ordering_mode !== "qr_code") {
             if (
-                this.session &&
                 this.access_token &&
-                this.config.self_ordering_mode !== "consultation"
+                this.config.self_ordering_mode !== "consultation" &&
+                (this.session || this.models["pos.preset"].filter((p) => p.use_timing).length > 0)
             ) {
                 await this.getUserDataFromServer();
                 this.ordering = true;
-            }
-
-            if (!this.ordering) {
-                return;
+                if (!this.isSessionOpened) {
+                    this.dialog.add(InfoPopup, {
+                        text: _t(
+                            "The shop is currently closed but you can still place an order for later."
+                        ),
+                        buttons: [
+                            {
+                                text: _t("Close"),
+                                onClick: () => {
+                                    this.dialog.closeAll();
+                                },
+                            },
+                        ],
+                    });
+                }
             }
         }
     }

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -71,6 +71,7 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         })
 
         self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
 
         self.start_tour(self_route, "self_multi_attribute_selector")
@@ -150,6 +151,7 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         self.pos_config.limit_categories = True
         self.pos_config.iface_available_categ_ids = [(4, pos_categ_misc.id)]
         self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route(floor.table_ids[0].id)
 
         self.start_tour(self_route, "self_order_product_info")


### PR DESCRIPTION
This commit adds the possibility for users to create new orders for config without an opened session. Users will be allowed to create orders in the self-ordering interface for mobile configurations with preset using time slots. It will automatically create a new session for the config in opening control.

task-id: 6034751
Enterprise PR: https://github.com/odoo/enterprise/pull/110976

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
