### PR TITLE
[IMP] point_of_sale: show max quantity on combo choice selection

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
@@ -8,7 +8,10 @@
                     <t t-if="combo.qty_free > 0">
                         <h5 class="text-muted ms-2 mb-0">
                             <t t-out="this.getSelectedComboItemsText(combo)"/>
-                            <span class="fst-italic"> included</span>
+                            <span class="fst-italic"> included </span>
+                            <t t-if="combo.qty_free != combo.qty_max" >
+                                <span class="text-danger fst-italic"> (up to <t t-out="combo.qty_max"/>) </span>
+                            </t>
                         </h5>
                     </t>
                     <t t-else="">

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -42,7 +42,12 @@
                     <div class="d-flex o_self_fade" t-if="!this.isAttributeSelection() and !this.state.showResume">
                         <div class="d-flex flex-column w-100">
                             <div t-if="this.selectedChoice.qty_free &gt; 0 and this.selectedChoice.qty_free  &lt; this.selectedChoice.qty_max" class="d-flex justify-content-center mb-3 mb-lg-4">
-                                <h2 class="m-0">Choose your <t t-out="this.selectedChoice.name"/> — <span class="text-muted"><t t-out="this.selectedChoice.qty_free"/> included</span></h2>
+                                <h2 class="m-0">
+                                    Choose your <t t-out="this.selectedChoice.name"/> 
+                                    — 
+                                    <span class="text-muted"><t t-out="this.selectedChoice.qty_free"/> included</span>
+                                    <span class="text-danger fst-italic"> (up to <t t-out="this.selectedChoice.qty_max"/>)</span>
+                                </h2>
                             </div>
                             <div class="o_self_combo_products row  justify-content-center" t-att-class="{ 'small-item-nb': this.comboItems.length &lt; 3}">
                                 <div class="d-flex col-12 col-md-4 col-lg-3 col-kiosk-p-3" t-att-class="{'col-kiosk-p-4 ': this.comboItems.length &lt; 4}" t-foreach="this.comboItems" t-as="comboItem" t-key="comboItem.id" t-if="comboItem.product_id">


### PR DESCRIPTION
Before we only showed the included quantity in the selection screen of a combo. The maximum quantity is not shown anywhere and it can be a bit of an unexpected behaviour when you can select an arbitrary number of choices before the UI blocks further selections.

The commit will add the max_qty of the selection on both the pos_self and the standard point of sale combo selection pages


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
