### PR TITLE
[FIX] microsoft_calendar: prevent destructive recurrence recreation when base event is exception

### DIFF
--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -102,7 +102,14 @@ class RecurrenceRule(models.Model):
         super()._write_from_microsoft(microsoft_event, vals)
         new_event_values = self.env["calendar.event"]._microsoft_to_odoo_values(microsoft_event)
         # Edge case:  if the base event was deleted manually in 'self_only' update, skip applying recurrence.
-        if self._has_base_event_time_fields_changed(new_event_values) and (new_event_values['start'] >= self.base_event_id.start):
+        # Also skip when the base event is an exception (follow_recurrence=False), because its
+        # modified time will differ from the seriesMaster pattern without the master having changed,
+        # and entering the destructive path would clear all Microsoft IDs
+        if (
+            self._has_base_event_time_fields_changed(new_event_values) and
+            (new_event_values['start'] >= self.base_event_id.start) and
+            self.base_event_id.follow_recurrence
+        ):
             # we need to recreate the recurrence, time_fields were modified.
             base_event_id = self.base_event_id
             # We archive the old events to recompute the recurrence. These events are already deleted on Microsoft side.

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -1414,6 +1414,83 @@ class TestUpdateEvents(TestCommon):
         self.organizer_user.with_user(self.organizer_user).restart_microsoft_synchronization()
         self.assertTrue(all(ev.need_sync_m for ev in self.recurrent_events))
 
+    @freeze_time('2021-09-22')
+    @patch.object(MicrosoftCalendarService, 'get_events')
+    def test_resync_recurrence_with_exception_base_event_preserves_microsoft_ids(self, mock_get_events):
+        """
+        When an attendee syncs a recurrence where the base event is an exception
+        (modified by the organizer), re-syncing the unchanged seriesMaster should NOT
+        trigger the destructive recreation path that clears all Microsoft IDs.
+
+        Scenario:
+        1. Attendee syncs a recurrence (seriesMaster + occurrences) — all events get Microsoft IDs
+        2. Organizer modifies the first occurrence's end time — it becomes an exception
+        3. Attendee syncs again (e.g. after accepting invitation) — the seriesMaster is unchanged
+           but the base event's time no longer matches the pattern → must NOT destroy other events
+        """
+        # ----------- Setup test data and check assumptions -----------
+
+        recurrence = self.recurrence
+        all_events = recurrence.calendar_event_ids.sorted(key=lambda r: r.start)
+        initial_event_count = len(all_events)
+        for event in all_events:
+            self.assertTrue(event.microsoft_id, "All events should have a microsoft_id before the test")
+            self.assertTrue(event.ms_universal_event_id, "All events should have a ms_universal_event_id before the test")
+
+        base_event = recurrence.base_event_id
+
+        # ----------- Sync exception -----------
+
+        # Make the first occurrence an exception with modified end time
+        new_end_time = (self.end_date - timedelta(minutes=30))
+        events = list(self.recurrent_event_from_outlook_organizer)
+        events[1] = dict(
+            events[1],
+            end={
+                'dateTime': new_end_time.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
+                'timeZone': 'UTC',
+            },
+            type="exception",
+            lastModifiedDateTime=_modified_date_in_the_future(base_event),
+        )
+        events[0] = dict(
+            events[0],
+            lastModifiedDateTime=_modified_date_in_the_future(base_event),
+        )
+
+        mock_get_events.return_value = (MicrosoftEvent(events), None)
+        self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
+
+        base_event.invalidate_recordset()
+        self.assertFalse(base_event.follow_recurrence, "Base event should be an exception (follow_recurrence=False)")
+        self.assertEqual(base_event.stop, new_end_time, "Base event end time should be updated")
+
+        # ----------- Re-sync unchanged seriesMaster -----------
+
+        # Same payload again. The base event is now an exception whose time doesn't
+        # match the pattern — this must NOT trigger the destructive recreation path.
+        self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
+
+        recurrence.invalidate_recordset()
+        all_events_after = recurrence.calendar_event_ids.sorted(key=lambda r: r.start)
+
+        self.assertEqual(
+            len(all_events_after), initial_event_count,
+            "Event count should be preserved — no events should be deleted and recreated",
+        )
+
+        for event in all_events_after:
+            self.assertTrue(
+                event.microsoft_id,
+                f"Event {event.id} (start={event.start}) should still have a microsoft_id",
+            )
+            self.assertTrue(
+                event.ms_universal_event_id,
+                f"Event {event.id} (start={event.start}) should still have a ms_universal_event_id",
+            )
+
+        self.assertFalse(base_event.follow_recurrence, "Base event should remain an exception")
+
     @patch.object(MicrosoftSync, '_write_from_microsoft')
     @patch.object(MicrosoftCalendarService, 'get_events')
     def test_update_old_event_synced_with_outlook(self, mock_get_events, mock_write_from_microsoft):


### PR DESCRIPTION
When an attendee syncs a recurring event where the first occurrence (base event) was modified by the organizer, `_write_from_microsoft` falsely triggers the destructive recreation path. This happens because `_has_base_event_time_fields_changed` compares the exception's modified time against the seriesMaster's pattern time, detecting a "change" even though the master hasn't changed.

This causes:
- All non-base events lose their microsoft_id and ms_universal_event_id
- The base event gets recreated without Microsoft IDs
- A duplicate event is pushed to Outlook on the next odoo2microsoft sync
- Spurious "join the meeting now" notifications are sent to attendees

Add a `follow_recurrence` guard so that when the base event is an exception (follow_recurrence=False), the non-destructive else branch is taken instead, preserving all Microsoft IDs.