### PR TITLE
[PERF] website_sale: fix N+1 queries on categories

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1570,8 +1570,9 @@
             <t t-set="children" t-value="request.env.user._is_internal() and children or children.filtered('has_published_products')"/>
 
             <ul t-if="children" class="nav flex-column nav-hierarchy mt-1 ps-3">
-                <t t-foreach="children" t-as="c">
-                    <t t-if="not search or c.id in search_categories_ids">
+                <!-- PERF: iterate on the original recordset to preserve _prefetch_ids -->
+                <t t-foreach="c.child_id" t-as="c">
+                    <t t-if="c.id in children.ids">
                         <t t-call="website_sale.categories_recursive" />
                     </t>
                 </t>
@@ -1681,8 +1682,11 @@
                     <t t-set="parentCategoryId" t-value="c.id"/>
                     <t t-if="isOffcanvas" t-set="parentCategoryId" t-valuef="offcanvas_{{c.id}}"/>
 
-                    <t t-foreach="children" t-as="c">
-                        <t t-call="website_sale.option_collapse_categories_recursive"/>
+                    <!-- PERF: iterate on the original recordset to preserve _prefetch_ids -->
+                    <t t-foreach="c.child_id" t-as="c">
+                        <t t-if="c.id in children.ids">
+                            <t t-call="website_sale.option_collapse_categories_recursive"/>
+                        </t>
                     </t>
                 </ul>
             </li>


### PR DESCRIPTION
Before this commit, the product categories templates recursively
rendered on new recordsets created using `filtered()`. This caused a
performance regression when there were nested categories, as
`_prefetch_ids` would be cleared, generating N+1 queries when fetching
each child category.

This commit changes the t-foreach to iterate over the original
recordset, in order to preserve _prefetch_ids and improve caching
performance.

Benchmarks opening /shop with sidebar categories
|Category count  |Time before|Queries before|Time after|Queries after|
|----------------|-----------|--------------|----------|-------------|
|2000, nested    |29.52s     |4843          |0.83s     |76           |
|2000, not nested|0.89s      |91            |0.80s     |75           |

opw-5969878