### PR TITLE
[IMP] website: enable to translate static page url

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -582,7 +582,6 @@
         </record>
         <record id="menu_home" model="website.menu">
             <field name="name">Home</field>
-            <field name="url">/</field>
             <field name="page_id" ref="website.homepage_page"/>
             <field name="parent_id" ref="website.main_menu"/>
             <field name="sequence" type="int">10</field>

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -559,7 +559,7 @@ class IrModuleModule(models.Model):
                SET name = %(o_menu_name)s
               FROM website_menu o_menu
              INNER JOIN website_menu s_menu
-                ON o_menu.name->>'en_US' = s_menu.name->>'en_US' AND o_menu.url = s_menu.url
+                ON o_menu.name->>'en_US' = s_menu.name->>'en_US'
              INNER JOIN website_menu root_menu
                 ON s_menu.parent_id = root_menu.id AND root_menu.parent_id IS NULL
              WHERE o_menu.website_id IS NULL AND o_menu.parent_id = %(default_menu_id)s
@@ -571,6 +571,42 @@ class IrModuleModule(models.Model):
         ))
 
         return res
+        # default_menus = self.env['website.menu'].search([
+        #     ('website_id', '=', False),
+        #     ('parent_id', '=', default_menu.id)
+        # ])
+
+        # site_menus = self.env['website.menu'].search([
+        #     ('website_id', '!=', False),
+        #     ('parent_id', '!=', False),
+        #     ('parent_id.parent_id', '=', None)
+        # ])
+        # for o_menu in default_menus:
+        #     for menu in site_menus:
+        #         if menu.url == o_menu.url and o_menu.with_context(lang='en_US').name == menu.with_context(lang='en_US').name:
+
+        #             lang_value_list = [
+        #                 SQL("%(lang)s, %(value)s", lang=lang, value=o_menu.with_context(lang=lang).name)
+        #                 for lang in langs if lang != 'en_US'
+        #             ]
+
+        #             update_jsonb_list = [
+        #                 SQL('jsonb_build_object(%s)', SQL(', ').join(items))
+        #                 for items in split_every(50, lang_value_list)
+        #             ]
+        #             update_jsonb = SQL(' || ').join(update_jsonb_list)
+
+        #             o_menu_name = SQL('menu.name || %s' if overwrite else '%s || menu.name', update_jsonb)
+
+        #             self.env.cr.execute(SQL(
+        #                 """
+        #                 UPDATE website_menu menu
+        #                 SET name = %(o_menu_name)s
+        #                 WHERE id = %(menu_id)s
+        #                 """,
+        #                 o_menu_name=o_menu_name,
+        #                 menu_id=menu.id
+        #             ))
 
     # ----------------------------------------------------------------
     # New page templates

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -31,6 +31,7 @@ class IrModuleModule(models.Model):
     _theme_translated_fields = {
         'theme.ir.ui.view': [('theme.ir.ui.view,arch', 'ir.ui.view,arch_db')],
         'theme.website.menu': [('theme.website.menu,name', 'website.menu,name')],
+        'theme.website.page': [('theme.website.page,url', 'website.page,url')],
     }
 
     image_ids = fields.One2many('ir.attachment', 'res_id',

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -137,7 +137,7 @@ class ThemeWebsiteMenu(models.Model):
     _description = 'Website Theme Menu'
 
     name = fields.Char(required=True, translate=True)
-    url = fields.Char(default='')
+    url = fields.Char(default='#')
     page_id = fields.Many2one('theme.website.page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')
     sequence = fields.Integer()
@@ -180,7 +180,7 @@ class ThemeWebsitePage(models.Model):
         'website.page_options.mixin',
     ]
 
-    url = fields.Char()
+    url = fields.Char(translate=True)
     view_id = fields.Many2one('theme.ir.ui.view', required=True, index=True, ondelete="cascade")
     website_indexed = fields.Boolean('Page Indexed', default=True)
     is_published = fields.Boolean()

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1242,7 +1242,6 @@ class Website(models.CachedModel):
             if not menu:
                 default_menu_values = {
                     'name': name,
-                    'url': page_url,
                     'parent_id': website.menu_id.id,
                     'page_id': page.id,
                     'website_id': website.id,

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -6,7 +6,7 @@ import werkzeug.urls
 from werkzeug.urls import url_parse
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools.translate import html_translate
@@ -39,7 +39,8 @@ class WebsiteMenu(models.Model):
                 menu.mega_menu_classes = False
 
     name = fields.Char('Menu', required=True, translate=True)
-    url = fields.Char("Url", compute="_compute_url", store=True, required=True, readonly=False, default="#", copy=True)
+    url = fields.Char("Url", compute="_compute_url", inverse="_inverse_url", search="_search_url")
+    url_defined_by_user = fields.Char('Url defined by user')
     page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade', index='btree_not_null')
     controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')
@@ -68,13 +69,111 @@ class WebsiteMenu(models.Model):
                 menu_name += f' [{menu.website_id.name}]'
             menu.display_name = menu_name
 
-    @api.depends("page_id", "is_mega_menu", "child_id")
+    @api.depends("page_id", "page_id.url", "is_mega_menu", "child_id", "url_defined_by_user")
     def _compute_url(self):
         for menu in self:
             if menu.is_mega_menu or menu.child_id:
                 menu.url = "#"
             else:
-                menu.url = (menu.page_id.url if menu.page_id else menu.url) or "#"
+                menu.url = (menu.page_id.sudo().url if menu.page_id else menu.url_defined_by_user) or "#"
+
+    def _inverse_url(self):
+        for menu in self:
+            # search for a page that has the url and adapt url_defined_by_user
+            # and page_id correctly.
+            # Check if the url matches a website.page (to set the m2o relation),
+            # except if the menu url contains '#', we then unset the page_id
+            if '#' in menu.url:
+                # Multiple case possible
+                # 1. `#` => menu container (dropdown, ..)
+                # 2. `#top` or `#bottom` => special anchors valid for any page
+                # 3. `#anchor` => anchor on current page
+                # 4. `/url#something` => valid internal URL
+                # 5. https://google.com#smth => valid external URL
+                if menu.page_id:
+                    menu.page_id = None
+                if request and menu.url.startswith('#') and len(menu.url) > 1 and \
+                        menu.url not in ['#top', '#bottom']:
+                    # Working on case 2.: prefix anchor with referer URL
+                    referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
+                    menu.url = referer_url + menu.url
+                menu.url_defined_by_user = menu.url
+            else:
+                domain = menu.website_id.website_domain() & (
+                    Domain("url", "=", menu["url"])
+                    | Domain("url", "=", "/" + menu["url"])
+                )
+                page = self.env["website.page"].search(domain, limit=1)
+                if page:
+                    menu.page_id = page.id
+                    menu.url_defined_by_user = ''
+                else:
+                    if menu.page_id:
+                        try:
+                            # a page shouldn't have the same url as a controller
+                            self.env['ir.http']._match(menu.url)
+                            menu.page_id = None
+                            menu.url_defined_by_user = menu.url
+                        except werkzeug.exceptions.NotFound:
+                            menu.page_id.write({'url': menu.url})
+                            menu.url_defined_by_user = ''
+                    else:
+                        menu.url_defined_by_user = menu.url
+
+    def _search_url(self, operator, value):
+        domain_menu_defined_by_url = Domain.AND([
+            [('mega_menu_content', '=', False)],
+            [('child_id', '=', False)],
+        ])
+        domain_menu_not_defined_by_url = Domain.OR([
+            [('mega_menu_content', '!=', False)],
+            [('child_id', '!=', False)],
+        ])
+        if (value == '#' or '#' in value):
+            if operator == '=' or (operator == 'in' and len(value) == 1):
+                # A menu url will be '#' if: it has mega menu content, it has
+                # child menu or if it is not linked to any page and there is no
+                # url defined by the user (in this case,the default url is '#').
+                # The last possibility is if '#' was defined explicitly by the
+                # user s the menu url.
+                return Domain.OR([
+                    domain_menu_not_defined_by_url,
+                    Domain('page_id', '=', False) & Domain('url_defined_by_user', '=', False),
+                    Domain('page_id', '=', False) & Domain('url_defined_by_user', '=', '#')
+                ])
+            if operator == '!=' or (operator == 'not in' and len(value) == 1):
+                # A menu url will be different of '#' if: it does not have a
+                # mega menu content or a child menu and it is either linked to a
+                # page or has a url defined by the user.
+                return Domain.AND([
+                    domain_menu_defined_by_url,
+                    Domain('page_id', '!=', False) | Domain('url_defined_by_user', '!=', False),
+                    Domain('page_id', '!=', False) | Domain('url_defined_by_user', '!=', '#'),
+                ])
+            return NotImplemented
+        if operator in ['=', 'in', '=like', 'like', 'ilike', '=ilike']:
+            return Domain.AND([
+                domain_menu_defined_by_url,
+                Domain.OR([
+                    Domain('page_id', '!=', False) & Domain('page_id.url', operator, value),
+                    Domain('page_id', '=', False) & Domain('url_defined_by_user', operator, value),
+                ])
+            ])
+        if operator in ['!=', 'not in', 'not =like', 'not like', 'not ilike', 'not =ilike']:
+            return Domain.OR([
+                domain_menu_not_defined_by_url,
+                Domain.OR([
+                    Domain('page_id', '!=', False) & Domain('page_id.url', operator, value),
+                    Domain('page_id', '=', False) & Domain('url_defined_by_user', operator, value),
+                ])
+            ])
+        return NotImplemented
+
+    @api.constrains('url')
+    def _check_url_is_set(self):
+        for menu in self:
+            if not menu.url:
+                raise ValidationError(_("Menu %(menu)s needs a url", menu=menu))
 
     @api.constrains("parent_id", "child_id", "is_mega_menu", "mega_menu_content")
     def _validate_parent_menu(self):
@@ -152,8 +251,6 @@ class WebsiteMenu(models.Model):
         return menus
 
     def write(self, vals):
-        if any(self._ids):
-            self.env.registry.clear_cache('templates')
         res = super().write(vals)
         if 'group_ids' in vals and not self.env.context.get("adding_designer_group_to_menu"):
             self.filtered("group_ids").with_context(
@@ -307,41 +404,6 @@ class WebsiteMenu(models.Model):
                 replace_id(mid, new_menu.id)
         for menu in data['data']:
             menu_id = self.browse(menu['id'])
-            # Check if the url match a website.page (to set the m2o relation),
-            # except if the menu url contains '#', we then unset the page_id
-            if '#' in menu['url']:
-                # Multiple case possible
-                # 1. `#` => menu container (dropdown, ..)
-                # 2. `#top` or `#bottom` => special anchors valid for any page
-                # 3. `#anchor` => anchor on current page
-                # 4. `/url#something` => valid internal URL
-                # 5. https://google.com#smth => valid external URL
-                if menu_id.page_id:
-                    menu_id.page_id = None
-                if request and menu['url'].startswith('#') and len(menu['url']) > 1 and \
-                        menu['url'] not in ['#top', '#bottom']:
-                    # Working on case 2.: prefix anchor with referer URL
-                    referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
-                    menu['url'] = referer_url + menu['url']
-            else:
-                domain = self.env["website"].browse(website_id).website_domain() & (
-                    Domain("url", "=", menu["url"])
-                    | Domain("url", "=", "/" + menu["url"])
-                )
-                page = self.env["website.page"].search(domain, limit=1)
-                if page:
-                    menu['page_id'] = page.id
-                    menu['url'] = page.url
-                    if isinstance(menu.get('parent_id'), str):
-                        # Avoid failure if parent_id is sent as a string from a customization.
-                        menu['parent_id'] = int(menu['parent_id'])
-                elif menu_id.page_id:
-                    try:
-                        # a page shouldn't have the same url as a controller
-                        self.env['ir.http']._match(menu['url'])
-                        menu_id.page_id = None
-                    except werkzeug.exceptions.NotFound:
-                        menu_id.page_id.write({'url': menu['url']})
             menu_id.write(menu)
 
         return True

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import time
+import werkzeug.exceptions
 from collections import Counter
 
 from odoo import api, fields, models, tools
@@ -14,6 +15,8 @@ from odoo.tools import SQL, escape_psql
 
 from odoo.addons.base.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
 from odoo.addons.website.tools import text_from_html
+from odoo.tools.translate import adapt_translated_field_value
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +45,7 @@ class WebsitePage(models.Model):
         compute='_compute_name', inverse='_inverse_name', store=True,
         translate=True,
     )
-    url = fields.Char('Page URL', required=True)
+    url = fields.Char('Page URL', required=True, translate=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, index=True, ondelete="cascade")
 
     view_write_uid = fields.Many2one('res.users', "Last Content Update by",
@@ -86,8 +89,9 @@ class WebsitePage(models.Model):
 
     def _compute_is_homepage(self):
         website = self.env['website'].get_current_website()
+        website_default_lang = website.default_lang_id.code
         for page in self:
-            page.is_homepage = page.url == (website.homepage_url or page.website_id == website and '/')
+            page.is_homepage = page.with_context(lang=website_default_lang).url == (website.homepage_url or page.website_id == website and '/')
 
     def _compute_visible(self):
         for page in self:
@@ -168,7 +172,7 @@ class WebsitePage(models.Model):
             menu = self.env['website.menu'].search([('page_id', '=', page_id)], limit=1)
             if menu:
                 # If the page being cloned has a menu, clone it too
-                menu.copy({'url': new_page.url, 'name': new_page.name, 'page_id': new_page.id})
+                menu.copy({'name': new_page.name, 'page_id': new_page.id})
 
         return new_page.url
 
@@ -188,15 +192,53 @@ class WebsitePage(models.Model):
             self.env.registry.clear_cache('templates')
         return super().unlink()
 
+    def _handle_url_update(self, page, website_id, url, lang):
+        """ Handles a url update. More specifically, it makes sure that the url
+        is unique, handles redirection update and updates website homepage url
+        if needed.
+        :param page: The page whose url is updated.
+        :param website_id: The id of the website linked to the page.
+        :param url: The new slugified url.
+        :param lang: The lang for which the url has to be updated.
+        """
+        page = page.with_context(lang=lang)
+        if page.url != url:
+            # Make sure that the slugified url is unique.
+            url = self.env['website'].with_context(website_id=website_id, lang=lang).get_unique_path(url)
+            self.env.registry.clear_cache('templates')
+            # Handle the synchronization of website's homepage URL if the lang
+            # is the default website language.
+            website = self.env['website'].get_current_website().with_context(lang=lang)
+            website_default_lang = website.default_lang_id.code
+            if lang == website_default_lang:
+                page_url_normalized = {'homepage_url': page.url}
+                website._handle_homepage_url(page_url_normalized)
+                if website.homepage_url == page_url_normalized['homepage_url']:
+                    website.homepage_url = url
+        return url
+
+    def _update_field_translations(self, field_name, translations, digest=None, source_lang=''):
+        self.ensure_one()
+        if field_name == 'url':
+            for lang, url in translations.items():
+                website_id = self.website_id.id if self.website_id else False
+                # Slugify the translated url
+                url = '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
+                translations[lang] = self._handle_url_update(self, website_id, url, lang)
+        return super()._update_field_translations(field_name, translations, digest, source_lang)
+
     def write(self, vals):
         if name_in_vals := ('name' in vals):
             old_en_names = self.with_context(lang='en_US').mapped('name')
 
         if url_in_vals := ('url' in vals):
             vals_url = vals.pop('url')
-            url = vals_url or ''
-            url = '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
-            vals_url = url
+            vals_url = adapt_translated_field_value(
+                self.env, vals_url,
+                lambda lang, url: (
+                    '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
+                )
+            )
 
         if 'visibility' in vals:
             if vals['visibility'] != 'restricted_group':
@@ -208,17 +250,10 @@ class WebsitePage(models.Model):
 
         if url_in_vals:
             for page in self:
-                if vals_url == page.url:
-                    continue
-                # If URL has been edited, slug it
-                url = self.env['website'].with_context(website_id=page.website_id.id).get_unique_path(vals_url)
-                page.menu_ids.write({'url': url})
-                # Sync website's homepage URL
-                website = self.env['website'].get_current_website()
-                page_url_normalized = {'homepage_url': page.url}
-                website._handle_homepage_url(page_url_normalized)
-                if website.homepage_url == page_url_normalized['homepage_url']:
-                    website.homepage_url = url
+                url = adapt_translated_field_value(
+                    self.env, vals_url,
+                    lambda lang, url: self._handle_url_update(page, page.website_id.id, url, lang)
+                )
                 super(WebsitePage, page).write({'url': url})
 
         if name_in_vals:
@@ -494,20 +529,50 @@ class WebsitePage(models.Model):
 
     @tools.conditional(
         'xml' not in tools.config['dev_mode'],
-        tools.ormcache('(request.httprequest.path, self.env.context.get("website_id"))', cache='templates.cached_values'),
+        tools.ormcache('(request.httprequest.path, self.env.context.get("website_id"), request.env.lang)', cache='templates.cached_values'),
     )
     @api.model
     def _get_page_info(self, request) -> dict | None:
         req_page = request.httprequest.path
 
+        def _search_page(comparator='='):
+            page_domain = Domain('url', comparator, req_page) & request.website.website_domain()
+            search_page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+            if search_page:
+                return search_page
+            else:
+                # Search if the page domain can be found thanks to a translation
+                # of language installed on the website.
+                self.env.cr.execute("""
+                    SELECT id
+                    FROM website_page p
+                    WHERE (
+                        p.website_id = %(website_id)s OR p.website_id IS NULL
+                    )
+                    AND EXISTS (
+                        SELECT 1
+                        FROM jsonb_each_text(p.url) AS t(lang, value)
+                        WHERE (
+                            (%(case_sensitive)s AND value = %(req)s)
+                            OR
+                            (NOT %(case_sensitive)s AND lower(value) = lower(%(req)s))
+                        )
+                    )
+                    ORDER BY p.website_id;;
+                """, params={'req': req_page, 'website_id': request.website.id, 'case_sensitive': comparator == '='})
+                res = self.env.cr.fetchall()
+                search_page = len(res) and self.browse(res[0])
+                if search_page:
+                    redirect = request.redirect_query(search_page.sudo().with_context(lang=request.env.lang).url, request.httprequest.args)
+                    redirect.set_cookie('frontend_lang', request.env.lang)
+                    werkzeug.exceptions.abort(redirect)
+
         # specific page first
-        page_domain = Domain('url', '=', req_page) & request.website.website_domain()
-        page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+        page = _search_page()
 
         # case insensitive search
         if not page:
-            page_domain = Domain('url', '=ilike', req_page) & request.website.website_domain()
-            page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+            page = _search_page('=ilike')
 
         if page:
             return {

--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -219,6 +219,13 @@ class WebsitePageProperties(models.TransientModel):
         store=False,
         required=True,
     )
+    url_in_website_default_lang = fields.Char(compute='_compute_url_in_website_default_lang')
+
+    @api.depends('url')
+    def _compute_url_in_website_default_lang(self):
+        for record in self:
+            website_default_lang = record.website_id.default_lang_id.code
+            record.url_in_website_default_lang = record.with_context(lang=website_default_lang).url
 
     @api.depends('url', 'website_id.homepage_url')
     def _compute_is_homepage(self):
@@ -256,7 +263,8 @@ class WebsitePageProperties(models.TransientModel):
                 vals['parent_id'] = False
         records = super().create(vals_list)
         for record in records:
-            record.old_url = record.url
+            website_default_lang = record.website_id.default_lang_id.code
+            record.old_url = record.with_context(lang=website_default_lang).url
         return records
 
     def write(self, vals):
@@ -267,21 +275,21 @@ class WebsitePageProperties(models.TransientModel):
 
         # Once website.page has been written, the url might have been modified.
         # We can now create the redirects.
-        if 'url' in vals:
-            for record in self:
-                old_url = record.old_url
-                new_url = record.url
-                if old_url != new_url:
-                    if record.redirect_old_url:
-                        self.env['website.rewrite'].create(
-                            {
-                                'name': record.with_context(lang='en_US').name,
-                                'redirect_type': record.redirect_type,
-                                'url_from': old_url,
-                                'url_to': new_url,
-                                'website_id': record.website_id.id,
-                            }
-                        )
-                    record.old_url = new_url
+        for record in self:
+            old_url = record.old_url
+            website_default_lang = record.website_id.default_lang_id.code
+            new_url = record.with_context(lang=website_default_lang).url
+            if old_url != new_url:
+                if record.redirect_old_url:
+                    self.env['website.rewrite'].create(
+                        {
+                            'name': record.with_context(lang='en_US').name,
+                            'redirect_type': record.redirect_type,
+                            'url_from': old_url,
+                            'url_to': new_url,
+                            'website_id': record.website_id.id,
+                        }
+                    )
+                record.old_url = new_url
 
         return write_result

--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -116,6 +116,9 @@ class WebsitePagePropertiesBase(models.TransientModel):
     def _inverse_is_homepage(self):
         self.ensure_one()
         url = self.url
+        self._update_homepage(url)
+
+    def _update_homepage(self, url):
         if self.is_homepage:
             if url and url != '/':
                 self.website_id.homepage_url = url
@@ -224,9 +227,16 @@ class WebsitePageProperties(models.TransientModel):
         accessed route's url.
         """
         for record in self:
-            url = record.url
+            website_default_lang = record.website_id.default_lang_id.code
+            url = record.with_context(lang=website_default_lang).url
             current_homepage_url = record.website_id.homepage_url or '/'
             record.is_homepage = url == current_homepage_url
+
+    def _inverse_is_homepage(self):
+        self.ensure_one()
+        website_default_lang = self.website_id.default_lang_id.code
+        url = self.with_context(lang=website_default_lang).url
+        self._update_homepage(url)
 
     @api.depends('parent_id')
     def _compute_has_parent_page(self):

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -7,13 +7,14 @@ import { _t } from "@web/core/l10n/translation";
 import { debounce } from "@web/core/utils/timing";
 import { Component } from "@odoo/owl";
 import { charField, CharField } from "@web/views/fields/char/char_field";
+import { TranslationButton } from "@web/views/fields/translation_button";
 
 /**
  * Displays website page dependencies and URL redirect options when the page URL
  * is updated.
  */
 class PageUrlField extends UrlField {
-    static components = { PageDependencies };
+    static components = { PageDependencies, TranslationButton };
     static template = "website.PageUrlField";
     static defaultProps = {
         ...UrlField.defaultProps,
@@ -67,6 +68,9 @@ class PageUrlField extends UrlField {
         // and thus doesn't accept an empty string.
         this.props.record.data[this.props.name] = `/${value.trim()}`;
         return value;
+    }
+    get isTranslatable() {
+        return this.props.record.fields[this.props.name].translate;
     }
 }
 

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -9,6 +9,16 @@
             t-out="this.serverUrl.length > slicingLength ? this.serverUrl.slice(0, (slicingLength / 2) - 1) + '..' + this.serverUrl.slice((-slicingLength / 2) + 1) : this.serverUrl"
         />
     </xpath>
+    <xpath expr="//input" position="after">
+        <t t-if="isTranslatable">
+            <div class="o_field_input_buttons">
+                <TranslationButton
+                    fieldName="props.name"
+                    record="props.record"
+                />
+            </div>
+        </t>
+    </xpath>
 </t>
 
 <t t-name="website.FieldImageRadio">

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -796,3 +796,43 @@ export function changeImageShape(shape = "html_builder/geometric/geo_shuriken") 
         },
     ];
 }
+
+export function addLanguage(lang, lang_code) {
+    return [
+        ...goToTheme(),
+        {
+            content: "click on Add a language",
+            trigger: "button[data-action-id='addLanguage']",
+            run: "click",
+        },
+        {
+            content: "confirm leave editor",
+            trigger: ".modal-dialog button.btn-primary",
+            run: "click",
+        },
+        {
+            content: `type ${lang}`,
+            trigger: 'div[name="lang_ids"] .o_input_dropdown input',
+            run: `edit ${lang}`,
+        },
+        {
+            content: `select ${lang}`,
+            trigger: `.dropdown-item:contains(${lang})`,
+            run: "click",
+        },
+        {
+            trigger: `.modal-dialog div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(${lang})`,
+        },
+        {
+            content: `load ${lang}`,
+            trigger: ".modal-footer .btn-primary",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: `Check that the language of the page is ${lang}`,
+            trigger: `:iframe html[lang*="${lang_code}"]`,
+            timeout: 60000,
+        },
+    ];
+}

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -2,52 +2,18 @@ import {
     clickOnEditAndWaitEditModeInTranslatedPage,
     clickOnSave,
     insertSnippet,
-    goToTheme,
     registerWebsitePreviewTour,
+    addLanguage,
 } from "@website/js/tours/tour_utils";
 import { editorsWeakMap, setSelection } from "@html_editor/../tests/tours/helpers/editor";
 
 function installParseltongueAndOpenLangDropdown() {
     return [
-        ...goToTheme(),
-        {
-            content: "click on Add a language",
-            trigger: "button[data-action-id='addLanguage']",
-            run: "click",
-        },
-        {
-            content: "confirm leave editor",
-            trigger: ".modal-dialog button.btn-primary",
-            run: "click",
-        },
-        {
-            content: "type Parseltongue",
-            trigger: 'div[name="lang_ids"] .o_input_dropdown input',
-            run: "edit Parseltongue",
-        },
-        {
-            content: "select Parseltongue",
-            trigger: ".dropdown-item:contains(Parseltongue)",
-            run: "click",
-        },
-        {
-            trigger:
-                '.modal-dialog div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
-        },
-        {
-            content: "load Parseltongue",
-            trigger: ".modal-footer .btn-primary",
-            run: "click",
-        },
+        ...addLanguage("Parseltongue", "pa-GB"),
         {
             content: "click language dropdown (2)",
             trigger: ":iframe .js_language_selector .dropdown-toggle",
-            timeout: 60000,
             run: "click",
-        },
-        {
-            content: "Check that the language of the page is Parseltongue",
-            trigger: ':iframe html[lang*="pa-GB"]',
         },
     ];
 }

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -1,0 +1,85 @@
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+const translateUrl = function (newUrl) {
+    return [
+        {
+            content: "Click on the 'Site' button",
+            trigger: "button:contains('Site')",
+            run: "click",
+        },
+        {
+            content: "Click on the 'Properties' button",
+            trigger: "a:contains('Properties')",
+            run: "click",
+        },
+        {
+            content: "Click on the input url",
+            trigger: "[name=url] input.o_input",
+            run: "click",
+        },
+        {
+            content: "Click on the translate button",
+            trigger: "button.o_field_translate:contains('EN')",
+            run: "click",
+        },
+        {
+            content: "Change the french translation of the contactus page url",
+            trigger: `div.row:contains('French') input[type='text']`,
+            run: `edit ${newUrl}`,
+        },
+        {
+            content: "Click on 'Save' in the translate modal",
+            trigger: ".modal-content:contains('Translate: url') footer button:contains('Save')",
+            run: "click",
+        },
+        {
+            content: "Click on the 'Save' of the Page Properties",
+            trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
+            run: "click",
+        },
+        {
+            content: "Wait for the load operation to finish",
+            trigger: "body.o_web_client:not(.modal-open)",
+        },
+        {
+            trigger: ":iframe .s_website_form",
+        },
+    ];
+};
+
+registerWebsitePreviewTour("translate_url_exists_in_other_language", {}, () => [
+    ...translateUrl("/page-en"),
+]);
+
+registerWebsitePreviewTour("translate_url_exists_in_same_language", {}, () => [
+    ...translateUrl("/page-fr"),
+]);
+
+registerWebsitePreviewTour("update_homepage_url", {}, () => [...translateUrl("/contactus-fr")]);
+
+registerWebsitePreviewTour("set_homepage_property_of_a_page", {}, () => [
+    {
+        content: "Click on the 'Site' button",
+        trigger: "button:contains('Site')",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Properties' button",
+        trigger: "a:contains('Properties')",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Is Homepage' button",
+        trigger: "#is_homepage_0",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Save' of the Page Properties",
+        trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
+        run: "click",
+    },
+    {
+        content: "Wait for the load operation to finish",
+        trigger: "body.o_web_client:not(.modal-open)",
+    },
+]);

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -1,22 +1,30 @@
-import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { addLanguage, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+const enterPageProperties = [
+    {
+        content: "Click on the 'Site' button",
+        trigger: "button:contains('Site')",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Properties' button",
+        trigger: "a:contains('Properties')",
+        run: "click",
+    },
+];
+
+const enterPagePropertiesAndClickOnInputUrl = [
+    ...enterPageProperties,
+    {
+        content: "Click on the input url",
+        trigger: "[name=url] input.o_input",
+        run: "click",
+    },
+];
 
 const translateUrl = function (newUrl) {
     return [
-        {
-            content: "Click on the 'Site' button",
-            trigger: "button:contains('Site')",
-            run: "click",
-        },
-        {
-            content: "Click on the 'Properties' button",
-            trigger: "a:contains('Properties')",
-            run: "click",
-        },
-        {
-            content: "Click on the input url",
-            trigger: "[name=url] input.o_input",
-            run: "click",
-        },
+        ...enterPagePropertiesAndClickOnInputUrl,
         {
             content: "Click on the translate button",
             trigger: "button.o_field_translate:contains('EN')",
@@ -58,16 +66,7 @@ registerWebsitePreviewTour("translate_url_exists_in_same_language", {}, () => [
 registerWebsitePreviewTour("update_homepage_url", {}, () => [...translateUrl("/contactus-fr")]);
 
 registerWebsitePreviewTour("set_homepage_property_of_a_page", {}, () => [
-    {
-        content: "Click on the 'Site' button",
-        trigger: "button:contains('Site')",
-        run: "click",
-    },
-    {
-        content: "Click on the 'Properties' button",
-        trigger: "a:contains('Properties')",
-        run: "click",
-    },
+    ...enterPageProperties,
     {
         content: "Click on the 'Is Homepage' button",
         trigger: "#is_homepage_0",
@@ -81,5 +80,14 @@ registerWebsitePreviewTour("set_homepage_property_of_a_page", {}, () => [
     {
         content: "Wait for the load operation to finish",
         trigger: "body.o_web_client:not(.modal-open)",
+    },
+]);
+
+registerWebsitePreviewTour("add_language_and_translate_url", { edition: true }, () => [
+    ...addLanguage("Parseltongue", "pa-GB"),
+    ...enterPagePropertiesAndClickOnInputUrl,
+    {
+        content: "Check that the translate button is visible",
+        trigger: "button.o_field_translate:contains('EN')",
     },
 ]);

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -22,6 +22,21 @@ const enterPagePropertiesAndClickOnInputUrl = [
     },
 ];
 
+const saveChanges = [
+    {
+        content: "Click on the 'Save' of the Page Properties",
+        trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
+        run: "click",
+    },
+    {
+        content: "Wait for the load operation to finish",
+        trigger: "body.o_web_client:not(.modal-open)",
+    },
+    {
+        trigger: ":iframe .s_website_form",
+    },
+];
+
 const translateUrl = function (newUrl) {
     return [
         ...enterPagePropertiesAndClickOnInputUrl,
@@ -40,30 +55,23 @@ const translateUrl = function (newUrl) {
             trigger: ".modal-content:contains('Translate: url') footer button:contains('Save')",
             run: "click",
         },
-        {
-            content: "Click on the 'Save' of the Page Properties",
-            trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
-            run: "click",
-        },
-        {
-            content: "Wait for the load operation to finish",
-            trigger: "body.o_web_client:not(.modal-open)",
-        },
-        {
-            trigger: ":iframe .s_website_form",
-        },
     ];
 };
 
 registerWebsitePreviewTour("translate_url_exists_in_other_language", {}, () => [
     ...translateUrl("/page-en"),
+    ...saveChanges,
 ]);
 
 registerWebsitePreviewTour("translate_url_exists_in_same_language", {}, () => [
     ...translateUrl("/page-fr"),
+    ...saveChanges,
 ]);
 
-registerWebsitePreviewTour("update_homepage_url", {}, () => [...translateUrl("/contactus-fr")]);
+registerWebsitePreviewTour("update_homepage_url", {}, () => [
+    ...translateUrl("/contactus-fr"),
+    ...saveChanges,
+]);
 
 registerWebsitePreviewTour("set_homepage_property_of_a_page", {}, () => [
     ...enterPageProperties,
@@ -90,4 +98,14 @@ registerWebsitePreviewTour("add_language_and_translate_url", { edition: true }, 
         content: "Check that the translate button is visible",
         trigger: "button.o_field_translate:contains('EN')",
     },
+]);
+
+registerWebsitePreviewTour("translate_url_and_redirect", {}, () => [
+    ...translateUrl("/contactus-fr"),
+    {
+        content: "Click on 'Redirect Old URL'",
+        trigger: ".modal-content:contains('Page Properties') #redirect_old_url_0",
+        run: "click",
+    },
+    ...saveChanges,
 ]);

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -170,3 +170,99 @@ class TestControllerRedirect(TestLangUrlCommon):
         # website.page
         assertUrlRedirect('/fr/page_1/', '/fr/page_1', "Check for website.page with language in URL.")
         assertUrlRedirect('/fr/page_1/?a=b', '/fr/page_1?a=b', "Check for website.page with language in URL + URL params.")
+
+
+@tagged('-at_install', 'post_install')
+class TestTranslateUrl(TestLangUrl):
+    def setUp(self):
+        super().setUp()
+        self.base = self.base_url()
+        view_test_translate_url = self.env['ir.ui.view'].create({
+            'name': 'NewPage',
+            'type': 'qweb',
+            'arch': '<div>NewPage</div>',
+            'key': 'test.view_test_translate_url',
+        })
+        self.name_page_en = '/page-en'
+        self.page = self.env['website.page'].create({
+            'view_id': view_test_translate_url.id,
+            'url': self.name_page_en,
+            'is_published': True,
+            'website_id': self.website.id,
+        })
+        self.name_page_fr = '/page-fr'
+        self.page.with_context(lang='fr_FR').url = self.name_page_fr
+
+    def test_access_translated_url(self):
+        # Trying to access the french url of a page (without the lang in the
+        # url) if the website language is in english should redirect to the
+        # english url of this page.
+        r = self.url_open(self.name_page_fr)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + self.name_page_en)
+
+        # Trying to access the french url of a page (with the lang in the url)
+        # should change the website language to french and access the french url
+        # of the page.
+        r = self.url_open('/fr' + self.name_page_fr)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + self.name_page_fr)
+
+        # Trying to access the english url of a page (without the lang in the
+        # url) if the website language is in french should redirect to the
+        # french url of this page.
+        r = self.url_open(self.name_page_en)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + self.name_page_fr)
+
+    def test_access_translated_homepage(self):
+        # From the homepage, changing the language of the website should
+        # redirect to the french url of the specific homepage (as it is the
+        # first menu).
+        name_homepage_url_fr = '/accueil'
+        homepage_domain = [('url', '=', '/')] + self.website.website_domain()
+        homepage_specific = self.env['website.page'].search(homepage_domain, order='website_id asc', limit=1)
+        homepage_specific.with_context(lang='fr_FR').url = name_homepage_url_fr
+        r = self.url_open('/fr', timeout=800)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + name_homepage_url_fr)
+
+    def test_translate_url_exists_in_other_language(self):
+        # It should be possible to translate the url of a page with a url that
+        # exists in another language.
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'translate_url_exists_in_other_language', login='admin')
+        r = self.url_open('/fr/page-en')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr/page-en')
+
+    def test_translate_url_exists_in_current_language(self):
+        # It should not be possible to have two url that are the same in the
+        # same language
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'translate_url_exists_in_same_language', login='admin')
+        r = self.url_open('/fr/page-fr-1')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr/page-fr-1')
+
+    def test_update_url_impact_homepage_url(self):
+        # If a page url is the website homepage url, updating this url through
+        # the "translate" modal should also update the homepage url if the
+        # translation is done in the website default language.
+        self.website.homepage_url = '/contactus'
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'update_homepage_url', login='admin')
+        self.assertEqual(self.website.homepage_url, '/contactus-fr')
+
+    def test_new_homepage_impact_homepage_url_translations(self):
+        # Using a page as the default website page should update the website
+        # homepage url.
+        page = self.env['website.page'].search([('url', '=', '/contactus')])
+        page_name_fr = '/contactus-fr'
+        page.with_context(lang='fr_FR').url = page_name_fr
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
+        self.assertEqual(self.website.homepage_url, page_name_fr)
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
+        self.assertEqual(self.website.homepage_url, False)

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -267,6 +267,11 @@ class TestTranslateUrl(TestLangUrl):
         self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
         self.assertEqual(self.website.homepage_url, False)
 
+    def test_translate_url_in_website_default_lang_and_redirect(self):
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'translate_url_and_redirect', login='admin')
+        self.assertTrue(self.env['website.rewrite'].search([('url_from', '=', '/contactus'), ('url_to', '=', '/contactus-fr')]))
+
 
 @tagged('-at_install', 'post_install')
 class TestAddLanguageAndTranslateUrl(HttpCase):

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -266,3 +266,15 @@ class TestTranslateUrl(TestLangUrl):
         self.assertEqual(self.website.homepage_url, page_name_fr)
         self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
         self.assertEqual(self.website.homepage_url, False)
+
+
+@tagged('-at_install', 'post_install')
+class TestAddLanguageAndTranslateUrl(HttpCase):
+    def test_add_language_and_translate_url(self):
+        self.env['res.lang'].create({
+            'name': 'Parseltongue',
+            'code': 'pa_GB',
+            'iso_code': 'pa_GB',
+            'url_code': 'pa_GB',
+        })
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'add_language_and_translate_url', login='admin')

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -311,6 +311,61 @@ class TestMenu(common.TransactionCase):
         with self.assertRaises(UserError):
             self.main_menu.parent_id = self.another_menu.id
 
+    def test_menu_search(self):
+        Menu = self.env['website.menu']
+        page_url = '/page_specific'
+        page = self.env['website.page'].create({
+            'url': page_url,
+            'website_id': self.ref('website.default_website'),
+            # ir.ui.view properties
+            'name': 'Base',
+            'type': 'qweb',
+            'arch': '<div>Specific View</div>',
+            'key': 'test.specific_view',
+        })
+        existing_menus = Menu.search([])
+        root_menu = menu_root = Menu.create({
+            'name': 'Root',
+        })
+        mega_menu = Menu.create({
+            'name': 'Mega menu',
+            'mega_menu_content': '<body><div/></body>',
+        })
+        child_menu_without_url = Menu.create({
+            'name': 'Child menu',
+            'parent_id': menu_root.id,
+        })
+        child_menu_url = 'https://child_menu_with_url'
+        child_menu_with_url = Menu.create({
+            'name': 'Child menu',
+            'parent_id': menu_root.id,
+            'url': child_menu_url
+        })
+        page_specific_menu = Menu.create({
+            'name': 'Page Specific menu',
+            'page_id': page.id
+        })
+        url_defined_by_user = 'https://external_url_menu'
+        external_url_menu = Menu.create({
+            'name': 'External url menu',
+            'url': url_defined_by_user
+        })
+        hashtag_url = "#"
+        hashtag_url_menu = Menu.create({
+            'name': 'Hashtag url menu',
+            'url': hashtag_url
+        })
+        res = Menu.search([('url', '=', '#')])
+        self.assertEqual(res - existing_menus, root_menu + mega_menu + child_menu_without_url + hashtag_url_menu)
+        res = Menu.search([('url', '!=', '#')])
+        self.assertEqual(res - existing_menus, child_menu_with_url + page_specific_menu + external_url_menu)
+        res = Menu.search([('url', '=', child_menu_url)])
+        self.assertEqual(res - existing_menus, child_menu_with_url)
+        res = Menu.search([('url', '=', url_defined_by_user)])
+        self.assertEqual(res - existing_menus, external_url_menu)
+        res = Menu.search([('url', '!=', url_defined_by_user)])
+        self.assertEqual(res - existing_menus, page_specific_menu + child_menu_with_url + child_menu_without_url + mega_menu + root_menu + hashtag_url_menu)
+
 
 class TestMenuHttp(common.HttpCase):
     def setUp(self):

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -70,7 +70,7 @@
             <label for="url" string="Page URL"/>
             <div class="o_col">
                 <field name="url" widget="page_url"/>
-                <div class="my-4" invisible="url == old_url">
+                <div class="my-4" invisible="url_in_website_default_lang == old_url">
                     <div class="o_row">
                         <field name="redirect_old_url" widget="boolean_toggle" options="{'autosave': False}"/>
                         <label for="redirect_old_url" string="Redirect Old URL"/>

--- a/addons/website/wizard/base_language_install.py
+++ b/addons/website/wizard/base_language_install.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, Command
+from werkzeug import urls
 
 
 class BaseLanguageInstall(models.TransientModel):
@@ -25,5 +26,9 @@ class BaseLanguageInstall(models.TransientModel):
         params = self.env.context.get('params', {})
         if 'url_return' in params:
             url = params['url_return'].replace('[lang]', self.first_lang_id.code)
-            return self.env['website'].get_client_action(url)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'reload',
+                'params': {'action_id': 'website_preview?' + urls.url_encode({"path": url})},
+            }
         return action


### PR DESCRIPTION
[IMP] website: enable to translate static page url

The goal of this commit is to add the possibility to translate page url.
Here is an example to illustrate the case: A website page has the url
`/page-en`. If the user adds "French (BE)" as a language on its website,
he can now translate the `page-en` website url into `page-fr`. If the
language of the website and its default language is English, the url of
the page will be `/page-en` but if the language of the website is
French, the url of the page will be `/fr_BE/page-fr`. If the language of
the website is in English and the user is searching for `/page-fr`, the
system detects that the requested page exists but redirects the user to
the English version of the page as the language of the website is in
English. However, if the user is searching for `/fr_BE/page-fr`, it will
be redirected to the French version of the page and the language of the
website will switch to French whatever the original language of the
website was.

When a user translates a url, it is slugified and made unique.
Concerning the website homepage url, if it is a page url, it has to be
the one of the default website language. When a user modifies a page
url, the website homepage url is updated if the modification of the url
is done in the website default language and if the original url was the
default website url.

This commit also modifies the url field of the `website.menu` model: the
`required` and `default` properties are removed; if a menu is linked to
a page, no `url` is needed at record creation. However, the `compute`
method of the field fallbacks on `#` and a `constrains` has been added
on the `url` to ensure it is always set. The field is also not stored:
as the `url` might be the one of the website page that could be
translated, it should be recomputed each time we access it. Because a
menu url could be the one of an external url, another field
`manual_url` is introduced to store it.

task-3355343

-------------------------------------------------------------------------------------------------------------------------------------

[FIX] website: reload web client when installing new language

Steps to reproduce:
- On a website with only 'English' installed, enter in edit mode and add
a new language.
- Go to 'Site' > 'This page' > 'Properties'.
- Hover the 'Page URL' field

-> It is not possible to translate the url.

The problem is that, when a new language is installed, the iframe is
reloaded but not the web client. Due to it, `TranslationButton` has a
wrong version of `localization`.

task-3355343


-------------------------------------------------------------------------------------------------------------------------------------

[IMP] website: correctly display the redirect button at url change

Now that the url can be translated, we only want the redirect button to
appear if the url has been changed in the website default language.

task-3355343

-------------------------------------------------------------------------------------------------------------------------------------

[IMP] website: update cache to avoid extra SQL queries

Since [1], the `all_menus` variable contains website specific menus and
generic menus (not linked to a website). However, the `_update_cache()`
of `child_id` was only applied on website specific menus. The problem is
that due to the previous commits, the `url` field of `website.menu` is
not a stored field anymore and depends on `child_id`. Because
`_compute_visible()` in `website_sale` requires the menu's url, an extra
SQL query was triggered to determine the `child_id` of the generic
menus.

To solve the problem, this commit performs the `_update_cache()` of
`child_id` on all the generic and specific menus at `_compute_menu()` of
a specific website.

[1]: https://github.com/odoo/odoo/commit/aa5bbab0183b1d61d64bd2292cacbff82befeaf1

task-3355343

-------------------------------------------------------------------------------------------------------------------------------------

[IMP] website: only rewrite page url for internal links

Steps to reproduce:
- Create a new page and add it to the website menu.
- Edit the menu item and change its URL to an external one (e.g.
https://www.odoo.com/).
- Save.

-> Clicking on the menu item does not open the external url.

Because the menu is linked to a page, changing the menu url rewrites the
page url. This is not the expected behavior if the new url is external.
Note that this problem became visible thanks to the previous commits
that made menu url not stored. Indeed, before those commits, changing
the menu url still rewrote the page url but as the url was a stored
field of the menu record, clicking on the menu led to the external url.

task-3355343


