### PR TITLE
[FIX] l10n_dk_nemhandel: Add prefix to PartyIdentification text

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
@@ -160,15 +160,16 @@ class AccountEdiXmlOIOUBL21(models.AbstractModel):
                 },
             })
         if partner.nemhandel_identifier_type and partner.nemhandel_identifier_value:
-            prefix = 'DK' if partner.nemhandel_identifier_type == '0184' else ''
+            prefix = 'DK' if partner.nemhandel_identifier_type in {'0184', '0198'} else ''
             party_node['cbc:EndpointID'] = {
                 '_text': f'{prefix}{partner.nemhandel_identifier_value}',
                 'schemeID': SCHEME_ID_MAPPING[partner.nemhandel_identifier_type],
             }
         if partner.nemhandel_identifier_value or partner.ref:
+            prefix = 'DK' if partner.nemhandel_identifier_type in {'0184', '0198'} else ''
             party_node['cac:PartyIdentification'] = {
                 'cbc:ID': {
-                    '_text': partner.nemhandel_identifier_value or partner.ref,
+                    '_text': f'{prefix}{partner.nemhandel_identifier_value or partner.ref}',
                     'schemeID': SCHEME_ID_MAPPING[partner.nemhandel_identifier_type],
                 }
             }

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
@@ -23,7 +23,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
@@ -84,7 +84,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -25,7 +25,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -23,7 +23,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -23,7 +23,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
@@ -84,7 +84,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -22,7 +22,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -22,7 +22,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
@@ -83,7 +83,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+        <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>


### PR DESCRIPTION
In this commit af94099c4d74e9c48251a1c1656e3ad11b9f8a70, we made a fix
regarding OIOUBL21 XML files, but we forgot to add the 'DK' prefix
for CVR nemhandel identifier. The format should be 'DK' + nemhandel_identifier_value.

no-task
