### PR TITLE
[FIX] pos_self_order: correct compute of combo with multiple qty in self

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -304,9 +304,10 @@ class PosOrder(models.Model):
             max_free = combo.qty_free
 
             for line in child_lines:
+                qty_per_line = line.qty / line.combo_parent_id.qty if line.combo_parent_id.qty else line.qty
                 qty_free = max(0, max_free - free_count)
-                free_qty = min(line.qty, qty_free)
-                extra_qty = line.qty - free_qty
+                free_qty = min(qty_per_line, qty_free)
+                extra_qty = qty_per_line - free_qty
 
                 if free_qty > 0:
                     child_line_free.append(line)
@@ -323,7 +324,7 @@ class PosOrder(models.Model):
             combo = combo_item.combo_id
             unit_devision_factor = original_total or 1
             price_unit = currency.round(combo.base_price * parent_lst_price / unit_devision_factor)
-            remaining_total -= price_unit * child.qty
+            remaining_total -= price_unit * (child.qty / child.combo_parent_id.qty if child.combo_parent_id.qty else child.qty)
 
             if index == len(child_line_free) - 1:
                 price_unit += remaining_total

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -4,6 +4,7 @@ import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
+import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -90,5 +91,51 @@ registry.category("web_tour.tours").add("test_product_dont_display_all_variants"
         ProductPage.clickComboProduct("Coke never only"),
         Utils.clickBtn("Red"),
         Utils.clickBtn("Add to cart"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_self_order_combo_multiple_qty", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickCategory("Uncategorised"),
+        ProductPage.clickProduct("Combo Drinks"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Water",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Checkout"),
+        {
+            trigger: ".btn .oi-plus",
+            run: "click",
+        },
+        Utils.clickBtn("Order"),
+        Numpad.click("2"),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Close"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickCategory("Uncategorised"),
+        ProductPage.clickProduct("Price for drinks"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Water 2",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Checkout"),
+        {
+            trigger: ".btn .oi-plus",
+            run: "click",
+        },
+        {
+            trigger: ".btn .oi-plus",
+            run: "click",
+        },
+        Utils.clickBtn("Order"),
+        Numpad.click("3"),
+        Utils.clickBtn("Order"),
     ],
 });

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -184,3 +184,83 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "test_product_dont_display_all_variants")
+
+    def test_self_order_combo_multiple_qty(self):
+        """
+        Tests that when having a combo with multiple qty, the price in the backend
+        is correctly computed based on the combo product's price.
+        """
+        water, orange_juice, water2, orange_juice2 = self.env['product.product'].create([
+            {
+                'name': 'Water',
+                'available_in_pos': True,
+                'list_price': 0.0,
+                'taxes_id': [],
+            },
+            {
+                'name': 'Orange Juice',
+                'available_in_pos': True,
+                'list_price': 0.0,
+            },
+            {
+                'name': 'Water 2',
+                'available_in_pos': True,
+                'list_price': 2.0,
+                'taxes_id': [],
+            },
+            {
+                'name': 'Orange Juice 2',
+                'available_in_pos': True,
+                'list_price': 2.0,
+            }
+
+        ])
+        drinks_combo, drinks_combo_with_price = self.env['product.combo'].create([
+            {
+                'name': 'Drinks',
+                'combo_item_ids': [
+                    Command.create({'product_id': water.id, 'extra_price': 0}),
+                    Command.create({'product_id': orange_juice.id, 'extra_price': 0}),
+                ],
+            },
+            {
+                'name': 'Drinks2',
+                'combo_item_ids': [
+                    Command.create({'product_id': water2.id, 'extra_price': 0}),
+                    Command.create({'product_id': orange_juice2.id, 'extra_price': 0}),
+                ],
+            }
+        ])
+        self.env['product.product'].create([
+            {
+                'name': 'Combo Drinks',
+                'type': 'combo',
+                'available_in_pos': True,
+                'list_price': 12.0,
+                'combo_ids': [
+                    Command.set([drinks_combo.id]),
+                ],
+            },
+            {
+                'name': 'Price for drinks',
+                'type': 'combo',
+                'available_in_pos': True,
+                'list_price': 12.0,
+                'combo_ids': [
+                    Command.set([drinks_combo_with_price.id]),
+                ],
+            }
+        ])
+
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_self_order_combo_multiple_qty")
+        orders = self.env['pos.order'].search([], order='id desc', limit=2)
+        self.assertEqual(orders[1].amount_total, 24)
+        self.assertEqual(orders[0].amount_total, 36)


### PR DESCRIPTION
**Steps to reproduce:**
- Create 2 products, set their price to 0
- Create a combo product, set it's price to 10
- The combo choices should be the 2 products created before
- Go to the self order, order the combo and change the qty to 3
- The price is 30, correct in the frontend
- Go to the order in the backend, the price is 0

**Why the fix:**

In the backend, during the price recomputation, we did not account for the fact that we could have a parent line with multiple quantity during the split between the free and the extra lines.
This means that we counted too many lines, and had to put some in the extra lines. We then override the price_unit with the total_price in this code
https://github.com/odoo/odoo/blob/f73c32960721b046076b91e4bc017ddb924e0837/addons/pos_self_order/models/pos_order.py#L341-L342 
But the total price has been computed to zero, so the previously computed price_unit is overriden and set to zero.

We now divide the line's qty by the parent line's qty to get the qty per parent line, allowing us to have a qty of more than 1 for the parent line.

The same is done for the computation of the remaining amount to pay, as **child.qty** is the number of time the item is selected in the combo * the number of combo ordered, meaning it was messing up the computation.

opw-6032408