### PR TITLE
[FIX] mail: prevent malformed presence channel for anonymous visitors

### DIFF
--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -82,6 +82,9 @@ export class ResPartner extends Record {
     offline_since = fields.Datetime();
     presenceChannel = fields.Attr(null, {
         compute() {
+            if (!this.id) {
+                return null;
+            }
             const channel = `odoo-presence-res.partner_${this.id}`;
             if (this.im_status_access_token) {
                 return channel + `-${this.im_status_access_token}`;

--- a/doc/cla/corporate/polimex.md
+++ b/doc/cla/corporate/polimex.md
@@ -1,0 +1,15 @@
+Bulgaria, 2026-03-17
+
+Polimex Holding Ltd. agrees to the terms of the Odoo Corporate Contributor
+License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign
+this declaration.
+
+Signed,
+
+Lyubomir Georgiev lgeorgiev@securitybulgaria.com https://github.com/polimex-lgeorgiev
+
+List of contributors:
+
+Lyubomir Georgiev lgeorgiev@securitybulgaria.com https://github.com/polimex-lgeorgiev

--- a/doc/cla/corporate/polimex.md
+++ b/doc/cla/corporate/polimex.md
@@ -13,3 +13,4 @@ Lyubomir Georgiev lgeorgiev@securitybulgaria.com https://github.com/polimex-lgeo
 List of contributors:
 
 Lyubomir Georgiev lgeorgiev@securitybulgaria.com https://github.com/polimex-lgeorgiev
+Lyubomir Georgiev 41366661+polimex-lgeorgiev@users.noreply.github.com https://github.com/polimex-lgeorgiev


### PR DESCRIPTION
## Description

When an anonymous website visitor loads a page that includes the chatter component (e.g. a product page in eCommerce), the `res.partner` `presenceChannel` computed field constructs a bus channel string using `this.id`, which is `undefined` for anonymous visitors. This produces the channel name `odoo-presence-res.partner_undefined`, which does not match the expected regex pattern in `ir_websocket.py`, resulting in continuous WARNING logs:

```
WARNING db odoo.addons.mail.models.ir_websocket: Malformed presence channel: odoo-presence-res.partner_undefined
```

On a production instance with moderate website traffic, this generates **100+ warnings per day**, adding noise to the logs and making it harder to spot real issues.

## Root Cause

In `addons/mail/static/src/core/common/res_partner_model.js`, the `presenceChannel` computed field unconditionally builds the channel string:

```javascript
presenceChannel = fields.Attr(null, {
    compute() {
        const channel = `odoo-presence-res.partner_${this.id}`;
        // ...
    },
});
```

When `this.id` is `undefined` (anonymous visitor with no partner record), the channel becomes `odoo-presence-res.partner_undefined`.

Note: `monitorPresence` has a guard `this.id <= 0`, but `undefined <= 0` evaluates to `false` in JavaScript (NaN comparison), so it does not catch this case.

## Fix

Added a guard in the `presenceChannel` compute to return `null` when `this.id` is not set. This prevents the malformed channel from being subscribed to via the bus service. When `presenceChannel` is `null`, `_triggerPresenceSubscription` evaluates to falsy and no subscription is made.

## Steps to reproduce

1. Install the `website_sale` module (or any module that adds chatter to public pages)
2. Open a product page in an incognito/private browser window (anonymous visitor)
3. Check the server logs

**Expected:** No warnings related to presence channels
**Actual:** `WARNING ... Malformed presence channel: odoo-presence-res.partner_undefined` appears on every page load

## CLA

Corporate CLA for **Polimex Holding Ltd.** is included in this PR (`doc/cla/corporate/polimex.md`).

---

Contributed by [Polimex Holding Ltd.](https://polimex.co) — Official Odoo Partner based in Bulgaria, specializing in access control, security systems, and ERP integration. Bug discovered through automated production log monitoring across multiple Odoo 19 instances.