### PR TITLE
[FIX] mail: no 'is typing' when editing a message

### DIFF
--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -52,6 +52,9 @@ patch(Composer.prototype, {
         this.detectTyping(ev);
     },
     detectTyping() {
+        if (this.props.composer.message) {
+            return;
+        }
         const value = this.props.composer.composerText;
         if (this.thread?.model === "discuss.channel" && value.startsWith("/")) {
             const [firstWord] = value.substring(1).split(/\s/);

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -10,7 +10,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { animationFrame, describe, test } from "@odoo/hoot";
 import { advanceTime, mockDate } from "@odoo/hoot-mock";
 import {
     asyncStep,
@@ -788,6 +788,7 @@ test("[text composer] show typing in member list", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMember", { count: 2 });
+    // simulate other user typing
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
@@ -795,14 +796,34 @@ test("[text composer] show typing in member list", async () => {
         })
     );
     await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']");
-    withUser(serverState.userId, () =>
+    await insertText(".o-mail-Composer-input", "HelloWorld!");
+    await contains(
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`
+    );
+    await click(".o-mail-Composer button:enabled[aria-label='Send']");
+    await contains(
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`,
+        { count: 0 }
+    );
+    await advanceTime(Store.OTHER_LONG_TYPING);
+    await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']", { count: 0 });
+    // check editing doesn't trigger is typing
+    await contains(".o-mail-Message-content:has(:text('HelloWorld!'))");
+    await click(".o-mail-Message [title='Edit']");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "GoodByeWorld!");
+    await animationFrame();
+    await advanceTime(SHORT_TYPING / 2);
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
         })
     );
+    await animationFrame();
+    await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']");
     await contains(
-        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`,
+        { count: 0 }
     );
 });
 
@@ -823,6 +844,7 @@ test("show typing in member list", async () => {
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMember", { count: 2 });
+    // simulate other user typing
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
@@ -830,14 +852,47 @@ test("show typing in member list", async () => {
         })
     );
     await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']");
-    withUser(serverState.userId, () =>
+    const threadComposerEditor = {
+        document,
+        editable: document.querySelector(
+            ".o-mail-Composer.o-discussApp .o-mail-Composer-html.odoo-editor-editable"
+        ),
+    };
+    await htmlInsertText(threadComposerEditor, "HelloWorld!");
+    await contains(
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`
+    );
+    await click(".o-mail-Composer button:enabled[aria-label='Send']");
+    await contains(
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`,
+        { count: 0 }
+    );
+    await advanceTime(Store.OTHER_LONG_TYPING);
+    await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']", { count: 0 });
+    // check editing doesn't trigger is typing
+    await contains(".o-mail-Message-content:has(:text('HelloWorld!'))");
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-html.odoo-editor-editable");
+    const messageComposerEditor = {
+        document,
+        editable: document.querySelector(
+            ".o-mail-Message .o-mail-Composer-html.odoo-editor-editable"
+        ),
+    };
+    await htmlInsertText(messageComposerEditor, "GoodByeWorld!");
+    await animationFrame();
+    await advanceTime(SHORT_TYPING / 2);
+    await withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,
             is_typing: true,
         })
     );
+    await animationFrame();
+    await contains(".o-discuss-ChannelMemberList [title='Other 10 is typing...']");
     await contains(
-        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`
+        `.o-discuss-ChannelMemberList [title='${serverState.partnerName} is typing...']`,
+        { count: 0 }
     );
 });
 


### PR DESCRIPTION
Before this commit, when editing a message, this was triggering the "is typing" on this member. This "is typing" was only stopped after the long timeout of 1 min.

Typing indicator is meant to expect other others to receive a new message, so this is misleading to show the "is typing" when editing the message. Usually editing message is to fix small typo in a very short time, so it's quite expected for other people to see the new changes without requiring UI indicator other than the "(edited)" label on message textual content.

This commit fixes the issue by not notifying is typing on composer of message edition.

Task-6045905