### PR TITLE
[FIX] delivery: hide cash on delivery for unsupported carriers

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -41,6 +41,7 @@ class DeliveryCarrier(models.Model):
         default="fixed",
         required=True,
     )
+    supports_cash_on_delivery = fields.Boolean(compute="_compute_supports_cash_on_delivery")
     allow_cash_on_delivery = fields.Boolean(
         string="Cash on Delivery",
         help="Allow customers to choose Cash on Delivery as their payment method.",
@@ -215,6 +216,11 @@ class DeliveryCarrier(models.Model):
             carrier.can_generate_return = False
 
     @api.depends("delivery_type")
+    def _compute_supports_cash_on_delivery(self):
+        for carrier in self:
+            carrier.supports_cash_on_delivery = carrier.delivery_type in {"base_on_rule", "fixed"}
+
+    @api.depends("delivery_type")
     def _compute_supports_shipping_insurance(self):
         for carrier in self:
             carrier.supports_shipping_insurance = False
@@ -354,6 +360,11 @@ class DeliveryCarrier(models.Model):
         )
         if not self.country_ids:
             self.zip_prefix_ids = [Command.clear()]
+
+    def write(self, vals):
+        if "delivery_type" in vals:
+            vals["allow_cash_on_delivery"] = False
+        return super().write(vals)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)

--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -249,3 +249,12 @@ class TestDeliveryAvailability(DeliveryCommon):
         self.assertEqual(
             delivery_wizard["context"]["default_carrier_id"], self.non_restricted_carrier.id
         )
+
+    def test_reset_allow_cash_on_delivery_on_carrier_type_change(self):
+        delivery_method = self._prepare_carrier(
+            self._prepare_carrier_product(),
+            delivery_type="fixed",
+            allow_cash_on_delivery=True,
+        )
+        delivery_method.delivery_type = 'base_on_rule'
+        self.assertFalse(delivery_method.allow_cash_on_delivery)

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -96,7 +96,7 @@
                                 <field name="delivery_type" />
                                 <button string="Install more Providers" name="install_more_provider" type="object" class="oe_link oe_edit_only"/>
                             </div>
-                            <field name="allow_cash_on_delivery"/>
+                            <field name="allow_cash_on_delivery" invisible="not supports_cash_on_delivery"/>
                             <field name="integration_level" widget="radio" invisible="delivery_type == 'fixed' or delivery_type == 'base_on_rule'"/>
                             <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
                         </group>


### PR DESCRIPTION
In [^1] the Cash on Delivery functionality was generalized to be within the delivery module rather than reimplemented in UPS and Shiprocket.

However, it has an issue in that it is shown for all carriers that may not have any support for it in the API or implementation. This leads to cases where a customer can pick Cash On Delivery on a payment option
without the carrier being told they are required to collect, leading to cases of potentially free deliveries.

This is fixed through the introduction of the `suppors_cash_on_delivery` computed field that can gate the visibility of the `allow_cash_on_delivery` checkbox.

Base carriers (fixed/rule-based) default to True; third-party providers override the compute method to opt in.

task-none
[^1]: https://github.com/odoo/odoo/pull/191542

See also:

- https://github.com/odoo/enterprise/pull/111010