### PR TITLE
[FIX] hr: allow writing on partners and users linked to employees

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -59,6 +59,30 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <!-- Bypass base.res_partner_rule_write_self -->
+    <record id="res_partner_rule_write_self" model="ir.rule">
+        <field name="name">HR: Allow HR officers to edit partners linked to employees</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="domain_force">[('employee_ids', '!=', False)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Bypass base.res_users_rule_write_self -->
+    <record id="res_users_rule_write_self" model="ir.rule">
+        <field name="name">HR: Allow HR officers to edit users linked to employees</field>
+        <field name="model_id" ref="base.model_res_users"/>
+        <field name="domain_force">[('employee_ids', '!=', False)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
     <record id="ir_rule_res_partner_bank_internal_users" model="ir.rule">
         <field name="name">HR: Prevent non HR officers from accessing employee bank accounts</field>
         <field name="model_id" ref="base.model_res_partner_bank"/>

--- a/addons/hr/tests/test_payroll_fields_access.py
+++ b/addons/hr/tests/test_payroll_fields_access.py
@@ -28,9 +28,9 @@ class TestPayrollFieldsAccess(TransactionCase):
         fields_readonly = []
         for f_name, field in employee_fields.items():
             v_field = version_fields[f_name]
-            if not (field.groups and field.groups != v_field):
+            if field.groups != v_field.groups:
                 fields_without_group.append(f_name)
-            elif not (field.related and field.related == f'version_id.{f_name}'):
+            elif field.related != f'version_id.{f_name}':
                 fields_without_related.append(f_name)
             elif field.readonly != v_field.readonly:
                 fields_readonly.append(f_name)

--- a/addons/hr/tests/test_payroll_fields_access.py
+++ b/addons/hr/tests/test_payroll_fields_access.py
@@ -2,7 +2,10 @@
 
 from lxml import etree
 
+from odoo.exceptions import AccessError
 from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 @tagged('post_install', '-at_install')
@@ -99,3 +102,29 @@ class TestPayrollFieldsAccess(TransactionCase):
 
     def test_payroll_fields_are_hidden_to_non_payroll_users_in_version_form_view(self):
         self._test_payroll_fields_are_hidden_to_non_payroll_users('hr.version', 'hr.hr_contract_template_form_view', 'information')
+
+    def test_officer_access_address(self):
+        res_users_hr_officer = mail_new_test_user(
+            self.env,
+            email='hro@example.com',
+            login='hro',
+            groups='base.group_user,hr.group_hr_user',
+            name='HR Officer',
+        )
+
+        employee = self.env['hr.employee'].create({
+            'name': 'Richard',
+            'sex': 'male',
+            'country_id': self.env.ref('base.be').id,
+            'user_id': self.env['res.users'].create({
+                'name': 'Richard',
+                'email': 'rmo23@example.com',
+                'image_1920': False,
+                'login': 'demo_1',
+                'password': 'demo_123',
+            }).id,
+        })
+
+        employee.with_user(res_users_hr_officer).user_id.partner_id.country_id = self.env.ref('base.fr')
+        with self.assertRaisesRegex(AccessError, 'access the field "country_id" on User'):
+            employee.with_user(res_users_hr_officer).user_id.country_id = self.env.ref('base.us')


### PR DESCRIPTION
Steps to reproduce:
* create a belgian company
* as admin, set right on user -> no contact, accounting bookeeper, employee manage all
* remove the country on Laurie Poiret Employee form (personnal info) and on her contact
* create a SEPA payment (accounting -> vendor -> payment ) and confirm it
* as demo, create a batch payemnt with SEPA as payment method and select the Laurie poiret payment
* a banner appears The country or city of these partners is not set, which could cause the file to be refused by the bank.
* as demo, go into the partner to set the country
* set it and save it -> access error on res.user -> see traceback in the console

opw-5966767
