### PR TITLE
[FIX] repair: avoid double stock valuation

### DIFF
--- a/addons/repair/models/__init__.py
+++ b/addons/repair/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move_line
 from . import repair
 from . import stock_move
 from . import stock_move_line

--- a/addons/repair/models/account_move_line.py
+++ b/addons/repair/models/account_move_line.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _eligible_for_stock_account(self):
+        moves = self._get_stock_moves()
+        already_accounted = any(m.repair_id and m.account_move_id for m in moves.filtered(lambda m: m.repair_line_type == 'add'))
+        return super()._eligible_for_stock_account() and not already_accounted

--- a/addons/repair/models/account_move_line.py
+++ b/addons/repair/models/account_move_line.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _eligible_for_stock_account(self):
+        moves = self._get_stock_moves()
+        already_accounted = any(m.repair_id and m.account_move_id for m in moves)
+        return super()._eligible_for_stock_account() and not already_accounted

--- a/addons/repair/tests/test_anglo_saxon_valuation.py
+++ b/addons/repair/tests/test_anglo_saxon_valuation.py
@@ -5,6 +5,7 @@ from unittest import skip
 
 from odoo.tests import Form, tagged
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 from odoo.exceptions import UserError
 
 
@@ -82,4 +83,54 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             {'debit': 1, 'credit': 0, 'account_id': self.company_data['default_account_receivable'].id},
             {'debit': 0, 'credit': 10, 'account_id': self.company_data['default_account_stock_out'].id},
             {'debit': 10, 'credit': 0, 'account_id': self.company_data['default_account_expense'].id},
+        ])
+
+
+@tagged('post_install', '-at_install')
+class TestAngloSaxonValuationNoSkip(TestStockValuationCommon):
+
+    def test_ro_invoice_double_valuation(self):
+        """This test make sure that the valuation entry for a repair is created only once.
+           It could happen if the repair order was already creating the valuation, then the sale order would also create it
+           when invoiced"""
+
+        self.product_fifo_auto.taxes_id = False
+        self.env['stock.quant']._update_available_quantity(self.product_fifo_auto, self.warehouse.lot_stock_id, 5)
+
+        self.account_inventory = self.env['account.account'].create({
+            'name': 'Inventory Account',
+            'code': '100101',
+            'account_type': 'asset_current',
+        })
+        inventory_locations = self.warehouse.repair_type_id.default_location_dest_id
+        inventory_locations.valuation_account_id = self.account_inventory.id
+
+        ro = self.env['repair.order'].create({
+            'product_id': self.product.id,
+            'partner_id': self.owner.id,
+            'move_ids': [(0, 0, {
+                'repair_line_type': 'add',
+                'product_id': self.product_fifo_auto.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        ro.action_validate()
+        ro.action_repair_start()
+        ro.action_repair_end()
+
+        ro.sudo().action_create_sale_order()
+        so = ro.sale_order_id
+        so.sudo().action_confirm()
+        self.assertEqual(so.order_line.qty_to_invoice, 1)
+
+        invoice = so._create_invoices()
+        invoice.action_post()
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'debit': 0.0, 'credit': 20.0, 'account_id': self.account_income.id},
+            {'debit': 20.0, 'credit': 0.0, 'account_id': self.account_receivable.id},
+        ])
+        self.assertRecordValues(ro.move_ids.account_move_id.line_ids, [
+            {'debit': 0.0, 'credit': 10.0, 'account_id': self.account_stock_valuation.id},
+            {'debit': 10.0, 'credit': 0.0, 'account_id': self.account_inventory.id},
         ])

--- a/addons/repair/tests/test_anglo_saxon_valuation.py
+++ b/addons/repair/tests/test_anglo_saxon_valuation.py
@@ -83,3 +83,77 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             {'debit': 0, 'credit': 10, 'account_id': self.company_data['default_account_stock_out'].id},
             {'debit': 10, 'credit': 0, 'account_id': self.company_data['default_account_expense'].id},
         ])
+
+
+@tagged('post_install', '-at_install')
+class TestAngloSaxonValuationNoSkip(ValuationReconciliationTestCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env.user.company_id.anglo_saxon_accounting = True
+
+        cls.fifo_product = cls.env['product.product'].create({
+            'name': 'product',
+            'is_storable': True,
+            'categ_id': cls.stock_account_product_categ.id,
+        })
+
+        cls.basic_accountman = cls.env['res.users'].create({
+            'name': 'Basic Accountman',
+            'login': 'basic_accountman',
+            'password': 'basic_accountman',
+            'group_ids': [(6, 0, cls.env.ref('account.group_account_invoice').ids)],
+        })
+
+    def test_ro_invoice_double_valuation(self):
+        """This test make sure that the valuation entry for a repair is created only once.
+           It could happen if the repair order was already creating the valuation, then the sale order would also create it
+           when invoiced"""
+
+        self.fifo_product.standard_price = 100
+        self.fifo_product.taxes_id = False
+
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        self.env['stock.quant']._update_available_quantity(self.fifo_product, warehouse.lot_stock_id, 5)
+
+        self.account_inventory = self.env['account.account'].create({
+            'name': 'Inventory Account',
+            'code': '100101',
+            'account_type': 'asset_current',
+        })
+        inventory_locations = self.env['stock.location'].search([('usage', '=', 'internal'), ('company_id', '=', self.company.id)])
+        inventory_locations.valuation_account_id = self.account_inventory.id
+
+        ro = self.env['repair.order'].create({
+            'product_id': self.product_a.id,
+            'partner_id': self.partner_a.id,
+            'move_ids': [(0, 0, {
+                'repair_line_type': 'add',
+                'product_id': self.fifo_product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        ro.action_validate()
+        ro.action_repair_start()
+        ro.action_repair_end()
+
+        ro.sudo().action_create_sale_order()
+        so = ro.sale_order_id
+        so.sudo().action_confirm()
+        self.assertEqual(so.order_line.qty_to_invoice, 1)
+
+        invoice = so._create_invoices()
+        self.env.invalidate_all()
+        self.env.flush_all()
+        invoice.with_user(self.basic_accountman).action_post()
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'debit': 0.0, 'credit': 1.0, 'account_id': self.company_data['default_account_revenue'].id},
+            {'debit': 1.0, 'credit': 0.0, 'account_id': self.company_data['default_account_receivable'].id},
+        ])
+        self.assertRecordValues(ro.move_ids.account_move_id.line_ids, [
+            {'debit': 0.0, 'credit': 100.0, 'account_id': self.account_inventory.id},
+            {'debit': 100.0, 'credit': 0.0, 'account_id': self.company_data['default_account_stock_valuation'].id},
+        ])


### PR DESCRIPTION
When finishing a repair order a stock valuation entry is created for the
product used. If you then make a quotation and invoice it another
stock valuation entry would be created for the same product.

Steps to reproduce:
-------------------
* Create a category using FIFO and real time valuation
* Create a product using this category and set it's cost to 5€
* Set some on hand quantity for the product
* Create a repair order and add the product with the "Add" option
* Finish the repair order
> Observation: At this point you should have a valuation entry in the
  accouting app
* From the repair order create a quotation and invoice it
> Obesrvation: If you check the accounting entries again you will see
  a second valuation entry

Why the fix:
------------
When checking if the line is eligible for valuation we make sure that if
it is linked to a repair order, this repair order should not have any
accounting entries linked to it.

opw-5429996