### PR TITLE
[FIX] hr_holidays_attendance: create overtime on allocation approval

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -56,6 +56,15 @@ class HolidaysAllocation(models.Model):
                 allocation.overtime_id.sudo().duration = -1 * duration
         return res
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_overtime_id(self):
+        self.overtime_id.sudo().unlink()
+
+    def action_set_to_confirm(self):
+        res = super().action_set_to_confirm()
+        self._validate_overtime_and_create_adjustment()
+        return res
+
     def action_refuse(self):
         res = super().action_refuse()
         self.overtime_id.sudo().unlink()

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -34,18 +34,7 @@ class HolidaysAllocation(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        for allocation in res:
-            if allocation.overtime_deductible:
-                duration = allocation.number_of_hours_display
-                if duration > allocation.employee_id.total_overtime:
-                    raise ValidationError(_('The employee does not have enough overtime hours to request this leave.'))
-                if not allocation.overtime_id:
-                    allocation.sudo().overtime_id = self.env['hr.attendance.overtime'].sudo().create({
-                        'employee_id': allocation.employee_id.id,
-                        'date': allocation.date_from,
-                        'adjustment': True,
-                        'duration': -1 * duration,
-                    })
+        res._create_overtimes()
         return res
 
     def write(self, vals):
@@ -64,10 +53,32 @@ class HolidaysAllocation(models.Model):
                 allocation.overtime_id.sudo().duration = -1 * duration
         return res
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_overtime_id(self):
+        self.overtime_id.sudo().unlink()
+
+    def action_set_to_confirm(self):
+        res = super().action_set_to_confirm()
+        self._create_overtimes()
+        return res
+
     def action_refuse(self):
         res = super().action_refuse()
         self.overtime_id.sudo().unlink()
         return res
+
+    def _create_overtimes(self):
+        for allocation in self.sudo().filtered('overtime_deductible'):
+            duration = allocation.number_of_hours_display
+            if duration > allocation.employee_id.total_overtime:
+                raise ValidationError(_('The employee does not have enough overtime hours to request this leave.'))
+            if not allocation.overtime_id:
+                allocation.overtime_id = self.env['hr.attendance.overtime'].sudo().create({
+                    'employee_id': allocation.employee_id.id,
+                    'date': allocation.date_from,
+                    'adjustment': True,
+                    'duration': -1 * duration,
+                })
 
     def _get_accrual_plan_level_work_entry_prorata(self, level, start_period, start_date, end_period, end_date):
         self.ensure_one()

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -227,6 +227,13 @@ class TestHolidaysOvertime(TransactionCase):
         alloc.number_of_days = 2
         self.assertEqual(self.employee.total_overtime, 0)
 
+        alloc.action_refuse()
+        self.assertEqual(self.employee.total_overtime, 16)
+        alloc.action_set_to_confirm()
+        self.assertEqual(self.employee.total_overtime, 0)
+        alloc.unlink()
+        self.assertEqual(self.employee.total_overtime, 16)
+
     def test_allocation_change_leave_type_to_overtime(self):
         """Changing an allocation's leave type to an overtime-deductible type should validate overtime."""
         non_overtime_type = self.env['hr.leave.type'].create({

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -225,6 +225,13 @@ class TestHolidaysOvertime(TransactionCase):
         alloc.number_of_days = 2
         self.assertEqual(self.employee.total_overtime, 0)
 
+        alloc.action_refuse()
+        self.assertEqual(self.employee.total_overtime, 16)
+        alloc.action_set_to_confirm()
+        self.assertEqual(self.employee.total_overtime, 0)
+        alloc.unlink()
+        self.assertEqual(self.employee.total_overtime, 16)
+
     @freeze_time('2022-1-1')
     def test_leave_check_cancel(self):
         self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))


### PR DESCRIPTION
**Issue**
Employees extra hours were not deducted if an allocation was approved after being refused first.

**Steps to reproduce**
- Enable "Display Extra Hours" in settings for easier debugging
- Have a Time Off type T:
	- Requires allocation: Yes
	- Deduct Extra Hours: True
- Have an employee with some extra hours (e.g. by creating attendances)
- Create an allocation using the time off type T
- Expected: extra hours smart button on employee's page is reduced by allocation's duration
- Refuse the allocation
- Mark it as ready to approve
- Expected: extra hours for employee should be the same as before the leave was refused
- Actual: the allocation has not reduced the employee's extra hours

**Cause**
The overtime was unlinked when the allocation was refused.

**Fix**
Make sure an overtime always exists unless in `refused` state.

opw-5959319
