### PR TITLE
[FIX] point_of_sale: prevent tax change via price_include_override

### DIFF
--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -12,7 +12,7 @@ class AccountTax(models.Model):
     def write(self, vals):
         forbidden_fields = {
             'amount_type', 'amount', 'type_tax_use', 'tax_group_id', 'price_include',
-            'include_base_amount', 'is_base_affected',
+            'price_include_override', 'include_base_amount', 'is_base_affected',
         }
         if forbidden_fields & set(vals.keys()):
             lines = self.env['pos.order.line'].sudo().search([

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -710,3 +710,25 @@ class TestPoSProductsWithTax(TestPoSCommon):
         with self.assertRaises(UserError):
             with Form(self.variant_product.product_tmpl_id) as product:
                 product.type = "combo"
+
+    def test_tax_change_blocked_when_open_pos_session(self):
+        """Changing a POS sale tax must be blocked when a POS session is open"""
+        tax = self.taxes['tax7']
+
+        self.open_new_session()
+        self.assertEqual(self.pos_session.state, 'opened')
+
+        self.env['pos.order'].sync_from_ui([self.create_ui_order_data([
+            (self.product1, 1),
+        ])])
+
+        self.assertTrue(self.pos_session.order_ids)
+        self.assertTrue(self.env['pos.order.line'].search([
+            ('order_id.session_id', '=', self.pos_session.id),
+            ('tax_ids', 'in', tax.ids),
+        ], limit=1))
+
+        with self.assertRaises(UserError):
+            tax.write({
+                'price_include_override': 'tax_included',
+            })

--- a/addons/pos_self_order/tests/test_self_order_prices.py
+++ b/addons/pos_self_order/tests/test_self_order_prices.py
@@ -284,7 +284,14 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'test_fiscal_position_between_frontend_and_backend')
 
+        draft_orders = self.pos_config.current_session_id.order_ids.filtered(lambda o: o.state == 'draft')
+        draft_orders.action_pos_order_cancel()
+        self.pos_config.current_session_id.action_pos_session_validate()
+
         self.tax_21.price_include_override = 'tax_excluded'
         self.tax_6.price_include_override = 'tax_excluded'
 
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, '')
+        self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'test_fiscal_position_between_frontend_and_backend')


### PR DESCRIPTION
There is a safeguard in account.tax.write prevents modifying taxes as it is forbidden to modify a tax used in a POS order not posted. This guard only applies for a predefined set of fields in account_tax.py.

After 18.0, the tax-included behavior is controlled through the `price_include_override` field instead of `price_include`. However, this field was not added in the forbidden fields, allowing users to modify tax inclusion while a POS session is open.

This bypasses the safeguard and can lead to inconsistencies, as the POS caches tax configuration at session start.

For example, changing this setting mid-session may differences between POS receipts and backend invoices.

By adding `price_include_override` to the forbidden fields,
the UserError can properly be raised.

Additional note: test_fiscal_position_between_frontend_and_backend was updated to close the POS session before changing taxes since the safeguard now correctly blocks this.

Related ticket: opw-6042367