### PR TITLE
[FIX] l10n_it_edi: bank account import missing

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -6,7 +6,10 @@ from datetime import datetime
 import logging
 import unicodedata
 from lxml import etree
+import string
 import uuid
+
+from stdnum.it import codicefiscale, iva
 
 from odoo import _, api, Command, fields, models, modules
 from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
@@ -1086,6 +1089,89 @@ class AccountMove(models.Model):
             'type_tax_use_domain': [('type_tax_use', '=', 'purchase' if incoming else 'sale')],
         }, []
 
+    def _l10n_it_edi_get_payment_info(self, tree):
+        """ Map XML payment data from node //DatiPagamento/DettaglioPagamento to dict """
+        payment_info = []
+        amount_total = 0.0
+        for node in tree.xpath('//DatiPagamento/DettaglioPagamento'):
+            amount = get_float(node, './ImportoPagamento')
+            payment_info.append({
+                'acc_number': get_text(node, './IBAN') or False,
+                'payment_mode': get_text(node, './ModalitaPagamento') or False,
+                'invoice_date_due': get_date(node, './DataScadenzaPagamento') or False,
+                'amount': amount,
+                'payment_code': get_text(node, './CodicePagamento') or False,
+            })
+            amount_total += amount
+        return {
+            'info': payment_info,
+            'amount_total': amount_total,
+        }
+
+    def _l10n_it_edi_get_partner_info(self, node):
+        """ Map the XML partner data to dict from one of the nodes:
+            - CedentePrestatore (seller)
+            - CessionarioCommittente (buyer)
+
+            The Codice Fiscale can have two forms:
+                - personal: GTTPLA84T04F205G
+                - equal to the company VAT: 01234567890
+
+            A company may be part of a VAT group:
+                - the VAT is shared and the Codice Fiscale is the old VAT number before grouping
+                - Both VAT and Codice Fiscale must be specified
+
+            So in case:
+                - Partner is domestic (country == IT)
+                - VAT is not specified
+                - the Codice Fiscale looks like 01234567890
+            we also set it as VAT number
+        """
+        personal_data_node = node.xpath('./DatiAnagrafici/Anagrafica')[0]
+
+        # name
+        company_name = get_text(personal_data_node, './Denominazione')
+        first_name = get_text(personal_data_node, './Nome')
+        last_name = get_text(personal_data_node, './Cognome')
+        name = company_name or f"{last_name} {first_name}"
+
+        # address
+        address_node = node.xpath('./Sede')[0]  # it is mandatory
+        address = get_text(address_node, './Indirizzo')
+        address_no = get_text(address_node, './NumeroCivico')
+        full_address = f"{address} {address_no}".rstrip()
+
+        # country_code, VAT and codice_fiscale
+        codice_fiscale = get_text(node, './DatiAnagrafici/CodiceFiscale') or False
+        vat_no_prefix = get_text(node, './DatiAnagrafici/IdFiscaleIVA/IdCodice') or False
+        is_company = True
+        if vat_no_prefix:
+            # Take country from VAT node
+            country_code = get_text(node, './DatiAnagrafici/IdFiscaleIVA/IdPaese').upper()
+        else:
+            # Take country from address, that's a mandatory field
+            country_code = get_text(node, './Sede/Nazione').upper()
+            # Italian Codice Fiscale may be used as VAT number if it is not a personal one
+            if country_code == 'IT':
+                if codicefiscale._code_re.match(codice_fiscale):
+                    is_company = False
+                else:
+                    if iva.is_valid(codice_fiscale):
+                        vat_no_prefix = codice_fiscale
+
+        return {
+            'country_code': country_code,
+            'vat': f"{country_code}{vat_no_prefix}" if vat_no_prefix else '/',
+            'codice_fiscale': codice_fiscale,
+            'is_company': is_company,
+            'name': name,
+            'phone': get_text(node, './Contatti/Telefono') or False,
+            'email': get_text(node, './Contatti/Email') or False,
+            'street': string.capwords(full_address) or False,
+            'city': string.capwords(get_text(address_node, './Comune')) or False,
+            'zip_code': get_text(address_node, './CAP') or False,
+        }
+
     def _l10n_it_edi_import_invoice(self, invoice, data, is_new):
         """ Decodes a l10n_it_edi move into an Odoo move.
 
@@ -1149,25 +1235,29 @@ class AccountMove(models.Model):
             # Collect extra info from the XML that may be used by submodules to further put information on the invoice lines
             extra_info, message_to_log = self._l10n_it_edi_get_extra_info(company, document_type, tree, incoming=incoming)
 
-            # Partner
+            # Partner -------------------------------------------
+            Partner = self.env['res.partner'].with_company(company)
             partner_info = buyer_seller_info[partner_role]
-            vat = get_text(tree, partner_info['vat_xpath'])
-            codice_fiscale = get_text(tree, partner_info['codice_fiscale_xpath'])
-            email = get_text(tree, '//DatiTrasmissione//Email') if partner_info['role'] == 'seller' else ''
-            if partner := self._l10n_it_edi_search_partner(company, vat, codice_fiscale, email):
-                self.partner_id = partner
-            else:
-                message = Markup("<br/>").join((
-                    _("Partner not found, useful informations from XML file:"),
-                    self._compose_info_message(tree, partner_info['section_xpath'])
-                ))
-                message_to_log.append(message)
+            partner_node = tree.xpath(partner_info['section_xpath'])[0]
+            partner_info = self._l10n_it_edi_get_partner_info(partner_node)
+            partner_cf = partner_info.get('codice_fiscale')
 
-            # Payment code
-            if payment_code := get_text(tree, './/DettaglioPagamento[1]/CodicePagamento'):
-                self.payment_reference = payment_code
+            # Italy has a TIN (Codice Fiscale) that is more unique (key) than VAT
+            self.partner_id = partner_cf and Partner.search([
+                *Partner._check_company_domain(company),
+                ('l10n_it_codice_fiscale', '=like', partner_cf),
+            ], limit=1)
 
-            # Document Number
+            # If not found by Codice Fiscale, search for VAT or create, just like all other EDIs do
+            if not self.partner_id:
+                import_partner_args = {k: v for k, v in partner_info.items() if k not in ('codice_fiscale', 'is_company')}
+                self.partner_id, logs = self.env['account.edi.common']._import_partner(company_id=company, **import_partner_args)
+                if logs:
+                    self.partner_id.is_company = partner_info.get('is_company')
+                    self.partner_id.l10n_it_codice_fiscale = partner_info.get('codice_fiscale', False)
+                    message_to_log.extend(logs)
+
+            # Document Number -----------------------------------
             if number := get_text(tree, './/DatiGeneraliDocumento//Numero'):
                 self.ref = number
 
@@ -1207,58 +1297,27 @@ class AccountMove(models.Model):
                 ))
                 message_to_log.append(message)
 
-            # Due date. <2.4.2.5>
-            if due_date := get_date(tree, './/DatiPagamento/DettaglioPagamento/DataScadenzaPagamento'):
-                self.invoice_date_due = fields.Date.to_string(due_date)
-            else:
-                message_to_log.append(_("Payment due date invalid in XML file: %s", str(due_date)))
-
             # Information related to the purchase order <2.1.2>
             if (po_refs := get_text(tree, '//DatiGenerali/DatiOrdineAcquisto/IdDocumento', many=True)):
                 self.invoice_origin = ", ".join(po_refs)
 
-            # Total amount. <2.4.2.6>
-            if amount_total := sum(float(x) for x in get_text(tree, './/ImportoPagamento', many=True) if x):
-                message_to_log.append(_("Total amount from the XML File: %s", amount_total))
-
-            # Bank account. <2.4.2.13>
+            # Payment / Bank --------------------------------------
             if self.move_type not in ('out_invoice', 'in_refund'):
-                if acc_number := get_text(tree, './/DatiPagamento/DettaglioPagamento/IBAN'):
-                    if self.partner_id and self.partner_id.commercial_partner_id:
-                        bank = self.env['res.partner.bank'].search([
-                            ('acc_number', '=', acc_number),
-                            ('partner_id', '=', self.partner_id.commercial_partner_id.id),
-                            ('company_id', 'in', [self.company_id.id, False])
-                        ], order='company_id', limit=1)
-                    else:
-                        bank = self.env['res.partner.bank'].search([
-                            ('acc_number', '=', acc_number),
-                            ('company_id', 'in', [self.company_id.id, False])
-                        ], order='company_id', limit=1)
-                    if bank:
-                        self.partner_bank_id = bank
-                    else:
-                        message = Markup("<br/>").join((
-                            _("Bank account not found, useful informations from XML file:"),
-                            self._compose_info_message(tree, [
-                                './/DatiPagamento//Beneficiario',
-                                './/DatiPagamento//IstitutoFinanziario',
-                                './/DatiPagamento//IBAN',
-                                './/DatiPagamento//ABI',
-                                './/DatiPagamento//CAB',
-                                './/DatiPagamento//BIC',
-                                './/DatiPagamento//ModalitaPagamento'
-                            ])
-                        ))
-                        message_to_log.append(message)
-            elif elements := tree.xpath('.//DatiPagamento/DettaglioPagamento'):
-                message = Markup("<br/>").join((
-                    _("Bank account not found, useful informations from XML file:"),
-                    self._compose_info_message(tree, './/DatiPagamento')
-                ))
-                message_to_log.append(message)
+                payments_info = self._l10n_it_edi_get_payment_info(tree)
+                if payments_info['info']:
+                    message_to_log.append(_("Total amount from the XML File: %s", payments_info['amount_total']))
+                    payment_due_dates = []
+                    for payment_info in payments_info['info']:
+                        # Search / Create the bank account if iban is present
+                        if iban := payment_info.get('acc_number'):
+                            self.env['account.edi.common'].with_company(company)._import_partner_bank(self, [iban])
+                        # Set payment data on the bill
+                        self.payment_reference = self.payment_reference or payment_info.get('payment_code', False)
+                        payment_due_dates.append(payment_info.get('invoice_date_due'))
+                    if payment_due_dates := [x for x in payment_due_dates if x]:
+                        self.invoice_date_due = max(payment_due_dates)
 
-            # Invoice lines. <2.2.1>
+            # Invoice lines ---------------------------------------
             tag_name = './/DettaglioLinee' if not extra_info['simplified'] else './/DatiBeniServizi'
             for element in tree.xpath(tag_name):
                 move_line = self.invoice_line_ids.create({

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -5,7 +5,10 @@ from collections import defaultdict
 from datetime import datetime
 import logging
 from lxml import etree
+import string
 import uuid
+
+from stdnum.it import codicefiscale, iva
 
 from odoo import _, api, Command, fields, models, modules
 from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
@@ -1085,6 +1088,89 @@ class AccountMove(models.Model):
             'type_tax_use_domain': [('type_tax_use', '=', 'purchase' if incoming else 'sale')],
         }, []
 
+    def _l10n_it_edi_get_payment_info(self, tree):
+        """ Map XML payment data from node //DatiPagamento/DettaglioPagamento to dict """
+        payment_info = []
+        amount_total = 0.0
+        for node in tree.xpath('//DatiPagamento/DettaglioPagamento'):
+            amount = get_float(node, './ImportoPagamento')
+            payment_info.append({
+                'acc_number': get_text(node, './IBAN') or False,
+                'payment_mode': get_text(node, './ModalitaPagamento') or False,
+                'invoice_date_due': get_date(node, './DataScadenzaPagamento') or False,
+                'amount': amount,
+                'payment_code': get_text(node, './CodicePagamento') or False,
+            })
+            amount_total += amount
+        return {
+            'info': payment_info,
+            'amount_total': amount_total,
+        }
+
+    def _l10n_it_edi_get_partner_info(self, node):
+        """ Map the XML partner data to dict from one of the nodes:
+            - CedentePrestatore (seller)
+            - CessionarioCommittente (buyer)
+
+            The Codice Fiscale can have two forms:
+                - personal: GTTPLA84T04F205G
+                - equal to the company VAT: 01234567890
+
+            A company may be part of a VAT group:
+                - the VAT is shared and the Codice Fiscale is the old VAT number before grouping
+                - Both VAT and Codice Fiscale must be specified
+
+            So in case:
+                - Partner is domestic (country == IT)
+                - VAT is not specified
+                - the Codice Fiscale looks like 01234567890
+            we also set it as VAT number
+        """
+        personal_data_node = node.xpath('./DatiAnagrafici/Anagrafica')[0]
+
+        # name
+        company_name = get_text(personal_data_node, './Denominazione')
+        first_name = get_text(personal_data_node, './Nome')
+        last_name = get_text(personal_data_node, './Cognome')
+        name = company_name or f"{last_name} {first_name}"
+
+        # address
+        address_node = node.xpath('./Sede')[0]  # it is mandatory
+        address = get_text(address_node, './Indirizzo')
+        address_no = get_text(address_node, './NumeroCivico')
+        full_address = f"{address} {address_no}".rstrip()
+
+        # country_code, VAT and codice_fiscale
+        codice_fiscale = get_text(node, './DatiAnagrafici/CodiceFiscale') or False
+        vat_no_prefix = get_text(node, './DatiAnagrafici/IdFiscaleIVA/IdCodice') or False
+        is_company = True
+        if vat_no_prefix:
+            # Take country from VAT node
+            country_code = get_text(node, './DatiAnagrafici/IdFiscaleIVA/IdPaese').upper()
+        else:
+            # Take country from address, that's a mandatory field
+            country_code = get_text(node, './Sede/Nazione').upper()
+            # Italian Codice Fiscale may be used as VAT number if it is not a personal one
+            if country_code == 'IT':
+                if codicefiscale._code_re.match(codice_fiscale):
+                    is_company = False
+                else:
+                    if iva.is_valid(codice_fiscale):
+                        vat_no_prefix = codice_fiscale
+
+        return {
+            'country_code': country_code,
+            'vat': f"{country_code}{vat_no_prefix}" if vat_no_prefix else '/',
+            'codice_fiscale': codice_fiscale,
+            'is_company': is_company,
+            'name': name,
+            'phone': get_text(node, './Contatti/Telefono') or False,
+            'email': get_text(node, './Contatti/Email') or False,
+            'street': string.capwords(full_address) or False,
+            'city': string.capwords(get_text(address_node, './Comune')) or False,
+            'zip_code': get_text(address_node, './CAP') or False,
+        }
+
     def _l10n_it_edi_import_invoice(self, invoice, data, is_new):
         """ Decodes a l10n_it_edi move into an Odoo move.
 
@@ -1148,25 +1234,27 @@ class AccountMove(models.Model):
             # Collect extra info from the XML that may be used by submodules to further put information on the invoice lines
             extra_info, message_to_log = self._l10n_it_edi_get_extra_info(company, document_type, tree, incoming=incoming)
 
-            # Partner
+            # Partner -------------------------------------------
+            Partner = self.env['res.partner'].with_company(company)
             partner_info = buyer_seller_info[partner_role]
-            vat = get_text(tree, partner_info['vat_xpath'])
-            codice_fiscale = get_text(tree, partner_info['codice_fiscale_xpath'])
-            email = get_text(tree, '//DatiTrasmissione//Email') if partner_info['role'] == 'seller' else ''
-            if partner := self._l10n_it_edi_search_partner(company, vat, codice_fiscale, email):
-                self.partner_id = partner
-            else:
-                message = Markup("<br/>").join((
-                    _("Partner not found, useful informations from XML file:"),
-                    self._compose_info_message(tree, partner_info['section_xpath'])
-                ))
-                message_to_log.append(message)
+            partner_node = tree.xpath(partner_info['section_xpath'])[0]
+            partner_info = self._l10n_it_edi_get_partner_info(partner_node)
+            partner_cf = partner_info.get('codice_fiscale')
 
-            # Payment code
-            if payment_code := get_text(tree, './/DettaglioPagamento[1]/CodicePagamento'):
-                self.payment_reference = payment_code
+            # Italy has a TIN (Codice Fiscale) that is more unique (key) than VAT
+            self.partner_id = partner_cf and Partner.search([
+                *Partner._check_company_domain(company),
+                ('l10n_it_codice_fiscale', '=like', partner_cf),
+            ], limit=1)
 
-            # Document Number
+            # If not found by Codice Fiscale, search for VAT or create, just like all other EDIs do
+            if not self.partner_id:
+                import_partner_args = {k: v for k, v in partner_info.items() if k not in ('codice_fiscale', 'is_company')}
+                self.partner_id, _logs = self.env['account.edi.common']._import_partner(company_id=company, **import_partner_args)
+                self.partner_id.is_company = partner_info.get('is_company')
+                self.partner_id.l10n_it_codice_fiscale = partner_info.get('codice_fiscale', False)
+
+            # Document Number -----------------------------------
             if number := get_text(tree, './/DatiGeneraliDocumento//Numero'):
                 self.ref = number
 
@@ -1206,58 +1294,27 @@ class AccountMove(models.Model):
                 ))
                 message_to_log.append(message)
 
-            # Due date. <2.4.2.5>
-            if due_date := get_date(tree, './/DatiPagamento/DettaglioPagamento/DataScadenzaPagamento'):
-                self.invoice_date_due = fields.Date.to_string(due_date)
-            else:
-                message_to_log.append(_("Payment due date invalid in XML file: %s", str(due_date)))
-
             # Information related to the purchase order <2.1.2>
             if (po_refs := get_text(tree, '//DatiGenerali/DatiOrdineAcquisto/IdDocumento', many=True)):
                 self.invoice_origin = ", ".join(po_refs)
 
-            # Total amount. <2.4.2.6>
-            if amount_total := sum(float(x) for x in get_text(tree, './/ImportoPagamento', many=True) if x):
-                message_to_log.append(_("Total amount from the XML File: %s", amount_total))
-
-            # Bank account. <2.4.2.13>
+            # Payment / Bank --------------------------------------
             if self.move_type not in ('out_invoice', 'in_refund'):
-                if acc_number := get_text(tree, './/DatiPagamento/DettaglioPagamento/IBAN'):
-                    if self.partner_id and self.partner_id.commercial_partner_id:
-                        bank = self.env['res.partner.bank'].search([
-                            ('acc_number', '=', acc_number),
-                            ('partner_id', '=', self.partner_id.commercial_partner_id.id),
-                            ('company_id', 'in', [self.company_id.id, False])
-                        ], order='company_id', limit=1)
-                    else:
-                        bank = self.env['res.partner.bank'].search([
-                            ('acc_number', '=', acc_number),
-                            ('company_id', 'in', [self.company_id.id, False])
-                        ], order='company_id', limit=1)
-                    if bank:
-                        self.partner_bank_id = bank
-                    else:
-                        message = Markup("<br/>").join((
-                            _("Bank account not found, useful informations from XML file:"),
-                            self._compose_info_message(tree, [
-                                './/DatiPagamento//Beneficiario',
-                                './/DatiPagamento//IstitutoFinanziario',
-                                './/DatiPagamento//IBAN',
-                                './/DatiPagamento//ABI',
-                                './/DatiPagamento//CAB',
-                                './/DatiPagamento//BIC',
-                                './/DatiPagamento//ModalitaPagamento'
-                            ])
-                        ))
-                        message_to_log.append(message)
-            elif elements := tree.xpath('.//DatiPagamento/DettaglioPagamento'):
-                message = Markup("<br/>").join((
-                    _("Bank account not found, useful informations from XML file:"),
-                    self._compose_info_message(tree, './/DatiPagamento')
-                ))
-                message_to_log.append(message)
+                payments_info = self._l10n_it_edi_get_payment_info(tree)
+                if payments_info['info']:
+                    message_to_log.append(_("Total amount from the XML File: %s", payments_info['amount_total']))
+                    for payment_info in payments_info['info']:
+                        # Search / Create the bank account if iban is present
+                        if iban := payment_info.get('acc_number'):
+                            self.env['account.edi.common'].with_company(company)._import_partner_bank(self, [iban])
+                        # Set payment data on the bill
+                        self.invoice_date_due = min(
+                            (x for x in (self.invoice_date_due, payment_info.get('invoice_date_due')) if x),
+                            default=False,
+                        )
+                        self.payment_reference = self.payment_reference or payment_info.get('payment_code', False)
 
-            # Invoice lines. <2.2.1>
+            # Invoice lines ---------------------------------------
             tag_name = './/DettaglioLinee' if not extra_info['simplified'] else './/DatiBeniServizi'
             for element in tree.xpath(tag_name):
                 move_line = self.invoice_line_ids.create({

--- a/addons/l10n_it_edi/tests/import_xmls/IT01234567889_FPR03.xml
+++ b/addons/l10n_it_edi/tests/import_xmls/IT01234567889_FPR03.xml
@@ -19,7 +19,7 @@
                     <IdPaese>IT</IdPaese>
                     <IdCodice>00313371213</IdCodice>
                 </IdFiscaleIVA>
-                <CodiceFiscale>93026890017</CodiceFiscale>
+                <CodiceFiscale>00313371213</CodiceFiscale>
                 <Anagrafica>
                     <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
                 </Anagrafica>
@@ -32,6 +32,10 @@
                 <Provincia>SS</Provincia>
                 <Nazione>IT</Nazione>
             </Sede>
+            <Contatti>
+                <Telefono>321321312</Telefono>
+                <Email>vacinna@tulullu.it</Email>
+            </Contatti>
         </CedentePrestatore>
         <CessionarioCommittente>
             <DatiAnagrafici>
@@ -108,6 +112,7 @@
                 <PrezzoTotale>25.00</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
             </DettaglioLinee>
+            <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <ImponibileImporto>29.00</ImponibileImporto>
                 <Imposta>6.38</Imposta>
@@ -119,7 +124,12 @@
             <DettaglioPagamento>
                 <ModalitaPagamento>MP01</ModalitaPagamento>
                 <DataScadenzaPagamento>2015-01-30</DataScadenzaPagamento>
-                <ImportoPagamento>36.48</ImportoPagamento>
+                <ImportoPagamento>23.48</ImportoPagamento>
+            </DettaglioPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP01</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-02-28</DataScadenzaPagamento>
+                <ImportoPagamento>13.00</ImportoPagamento>
             </DettaglioPagamento>
         </DatiPagamento>
     </FatturaElettronicaBody>

--- a/addons/l10n_it_edi/tests/import_xmls/IT01234567889_FPR03.xml
+++ b/addons/l10n_it_edi/tests/import_xmls/IT01234567889_FPR03.xml
@@ -19,7 +19,7 @@
                     <IdPaese>IT</IdPaese>
                     <IdCodice>00313371213</IdCodice>
                 </IdFiscaleIVA>
-                <CodiceFiscale>93026890017</CodiceFiscale>
+                <CodiceFiscale>00313371213</CodiceFiscale>
                 <Anagrafica>
                     <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
                 </Anagrafica>
@@ -32,6 +32,10 @@
                 <Provincia>SS</Provincia>
                 <Nazione>IT</Nazione>
             </Sede>
+            <Contatti>
+                <Telefono>321321312</Telefono>
+                <Email>vacinna@tulullu.it</Email>
+            </Contatti>
         </CedentePrestatore>
         <CessionarioCommittente>
             <DatiAnagrafici>
@@ -108,6 +112,7 @@
                 <PrezzoTotale>25.00</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
             </DettaglioLinee>
+            <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <ImponibileImporto>29.00</ImponibileImporto>
                 <Imposta>6.38</Imposta>

--- a/addons/l10n_it_edi/tests/import_xmls/IT01234567890_FPR02.xml
+++ b/addons/l10n_it_edi/tests/import_xmls/IT01234567890_FPR02.xml
@@ -103,7 +103,6 @@
             <CondizioniPagamento>TP01</CondizioniPagamento>
             <DettaglioPagamento>
                 <ModalitaPagamento>MP01</ModalitaPagamento>
-                <DataScadenzaPagamento>2015-01-30</DataScadenzaPagamento>
                 <ImportoPagamento>-6.10</ImportoPagamento>
             </DettaglioPagamento>
         </DatiPagamento>

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -24,12 +24,40 @@ class TestItEdiImport(TestItEdi):
         xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
         <FatturaElettronicaHeader>
           <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
             <ProgressivoInvio>TWICE_TEST</ProgressivoInvio>
           </DatiTrasmissione>
+          <CedentePrestatore>
+            <DatiAnagrafici>
+              <CodiceFiscale>10062090963</CodiceFiscale>
+              <Anagrafica>
+                <Denominazione>DITTA ALPHA</Denominazione>
+              </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+          </CedentePrestatore>
           <CessionarioCommittente>
             <DatiAnagrafici>
               <CodiceFiscale>01234560157</CodiceFiscale>
+              <Anagrafica>
+                <Denominazione>DITTA BETA</Denominazione>
+              </Anagrafica>
             </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Teulada</Indirizzo>
+                <CAP>20100</CAP>
+                <Comune>Milano</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
           </CessionarioCommittente>
           </FatturaElettronicaHeader>
           <FatturaElettronicaBody>
@@ -354,6 +382,93 @@ class TestItEdiImport(TestItEdi):
                 },
             ],
         }], applied_xml)
+
+    def test_receive_bill_bank_account_01(self):
+        """ When importing a vendor bill, if IBAN is present and the partner's found,
+            the related bank account must be linked or created.
+        """
+        banksy_partner = self.env['res.partner'].create({
+            'name': 'Banksy',
+            'vat': 'IT00313371213',
+            'l10n_it_codice_fiscale': '00313371213',
+            'country_id': self.env.ref('base.it').id,
+            'company_id': self.company.id,
+            'invoice_edi_format': 'it_edi_xml',
+            'is_company': False,
+        })
+
+        iban = "IT75F0200839061000400xxxxx"
+        applied_xml = f"""
+            <xpath expr="//FatturaElettronicaBody/DatiPagamento/DettaglioPagamento" position="inside">
+                <IBAN>{iban}</IBAN>
+            </xpath>
+        """
+
+        # Import but don't check yet
+        invoice = self._assert_import_invoice('IT01234567889_FPR03.xml', [{}], applied_xml)
+
+        # Check the created bank account
+        partner_bank_account = self.env['res.partner.bank'].search([
+            ('acc_number', '=', iban),
+            ('partner_id', '=', banksy_partner.id),
+            ('company_id', '=', self.company.id),
+        ])
+        self.assertEqual(partner_bank_account, banksy_partner.bank_ids)
+        self.assertFalse(partner_bank_account.allow_out_payment)
+
+        # Check the bank account being correct and linked to the invoice
+        self.assertRecordValues(invoice, [{
+            'partner_id': banksy_partner.id,
+            'partner_bank_id': partner_bank_account.id,
+            'invoice_date_due': fields.Date.from_string('2015-02-28'),
+        }])
+
+        banksy_partner.invalidate_recordset(['is_company'])
+        self.assertFalse(invoice.partner_id.is_company)
+
+    def test_receive_bill_bank_account_02(self):
+        """ When importing a vendor bill, if IBAN is present but the partner's not found, then:
+            - Partner is created
+            - Account is created
+        """
+        self.italian_partner_a.l10n_it_codice_fiscale = '00465840031'
+        existing_partners = self.env['res.partner'].search([])
+        iban = "IT75F0200839061000400xxxxx"
+        invoice = self._assert_import_invoice('IT01234567889_FPR03.xml', [{}], f"""
+            <xpath expr="//FatturaElettronicaBody/DatiPagamento/DettaglioPagamento" position="inside">
+                <IBAN>{iban}</IBAN>
+            </xpath>
+        """)
+        self.assertRecordValues(invoice.partner_id, [{
+            'name': "SOCIETA' ALPHA SRL",
+            'street': 'Viale Roma 543',
+            'city': 'Sassari',
+            'zip': '07100',
+            'phone': '321321312',
+            'email': 'vacinna@tulullu.it',
+            'is_company': True,
+        }])
+        self.assertTrue(invoice.partner_id not in existing_partners)
+        self.assertRecordValues(invoice.partner_bank_id, [{'acc_number': iban, 'allow_out_payment': False}])
+
+    def test_receive_bill_bank_account_03(self):
+        """Partner retrieved by ``name``, not ``l10n_it_codice_fiscale``
+           ``is_company`` must stay False, and not be updated to True
+        """
+        self.italian_partner_a.l10n_it_codice_fiscale = '00465840031'
+        alpha_partner = self.env['res.partner'].create({
+            'name': "SOCIETA' ALPHA SRL",
+            'country_id': self.env.ref('base.it').id,
+            'company_id': self.company.id,
+            'invoice_edi_format': 'it_edi_xml',
+            'is_company': False,
+        })
+
+        # Import but don't check yet
+        self._assert_import_invoice('IT01234567889_FPR03.xml', [{}])
+
+        alpha_partner.invalidate_recordset(['is_company'])
+        self.assertFalse(alpha_partner.is_company)
 
     def test_receive_bill_with_multiple_discounts_in_line(self):
         applied_xml = """

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -24,12 +24,40 @@ class TestItEdiImport(TestItEdi):
         xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
         <FatturaElettronicaHeader>
           <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
             <ProgressivoInvio>TWICE_TEST</ProgressivoInvio>
           </DatiTrasmissione>
+          <CedentePrestatore>
+            <DatiAnagrafici>
+              <CodiceFiscale>10062090963</CodiceFiscale>
+              <Anagrafica>
+                <Denominazione>DITTA ALPHA</Denominazione>
+              </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+          </CedentePrestatore>
           <CessionarioCommittente>
             <DatiAnagrafici>
               <CodiceFiscale>01234560157</CodiceFiscale>
+              <Anagrafica>
+                <Denominazione>DITTA BETA</Denominazione>
+              </Anagrafica>
             </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Teulada</Indirizzo>
+                <CAP>20100</CAP>
+                <Comune>Milano</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
           </CessionarioCommittente>
           </FatturaElettronicaHeader>
           <FatturaElettronicaBody>
@@ -354,6 +382,68 @@ class TestItEdiImport(TestItEdi):
                 },
             ],
         }], applied_xml)
+
+    def test_receive_bill_bank_account_01(self):
+        """ When importing a vendor bill, if IBAN is present and the partner's found,
+            the related bank account must be linked or created.
+        """
+        banksy_partner = self.env['res.partner'].create({
+            'name': 'Banksy',
+            'vat': 'IT00313371213',
+            'l10n_it_codice_fiscale': '00313371213',
+            'country_id': self.env.ref('base.it').id,
+            'company_id': self.company.id,
+            'invoice_edi_format': 'it_edi_xml',
+        })
+
+        iban = "IT75F0200839061000400xxxxx"
+        applied_xml = f"""
+            <xpath expr="//FatturaElettronicaBody/DatiPagamento/DettaglioPagamento" position="inside">
+                <IBAN>{iban}</IBAN>
+            </xpath>
+        """
+
+        # Import but don't check yet
+        invoice = self._assert_import_invoice('IT01234567889_FPR03.xml', [{}], applied_xml)
+
+        # Check the created bank account
+        partner_bank_account = self.env['res.partner.bank'].search([
+            ('acc_number', '=', iban),
+            ('partner_id', '=', banksy_partner.id),
+            ('company_id', '=', self.company.id),
+        ])
+        self.assertEqual(partner_bank_account, banksy_partner.bank_ids)
+
+        # Check the bank account being correct and linked to the invoice
+        self.assertRecordValues(invoice, [{
+            'partner_id': banksy_partner.id,
+            'partner_bank_id': partner_bank_account.id,
+        }])
+
+    def test_receive_bill_bank_account_02(self):
+        """ When importing a vendor bill, if IBAN is present but the partner's not found, then:
+            - Partner is created
+            - Account is created
+            - Bank is not created (when there's no name or BIC)
+        """
+        self.italian_partner_a.l10n_it_codice_fiscale = '00465840031'
+        existing_partners = self.env['res.partner'].search([])
+        iban = "IT75F0200839061000400xxxxx"
+        invoice = self._assert_import_invoice('IT01234567889_FPR03.xml', [{}], f"""
+            <xpath expr="//FatturaElettronicaBody/DatiPagamento/DettaglioPagamento" position="inside">
+                <IBAN>{iban}</IBAN>
+            </xpath>
+        """)
+        self.assertRecordValues(invoice.partner_id, [{
+            'name': "SOCIETA' ALPHA SRL",
+            'street': 'Viale Roma 543',
+            'city': 'Sassari',
+            'zip': '07100',
+            'phone': '321321312',
+            'email': 'vacinna@tulullu.it',
+        }])
+        self.assertTrue(invoice.partner_id not in existing_partners)
+        self.assertRecordValues(invoice.partner_bank_id, [{'acc_number': iban}])
 
     def test_receive_bill_with_multiple_discounts_in_line(self):
         applied_xml = """


### PR DESCRIPTION
The Italian EDI import didn't create new bank account by itself. IBAN info was just logged in the chatter, leaving it up for the accountant to create the bank account record.

The bank account should be created and assigned to the corresponding commercial partner and set to not trusted yet.

Enterprise PR: odoo/enterprise#112794

Task [link](https://www.odoo.com/odoo/project.task/6046189)
task-6046189