### PR TITLE
[FIX] purchase_stock: Check picking type destination for final location

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -248,7 +248,11 @@ class PurchaseOrder(models.Model):
             if self.dest_address_id:
                 return self.dest_address_id.property_stock_customer
             return self.picking_type_id.default_location_dest_id
-        return self.picking_type_id.warehouse_id.lot_stock_id
+        wh_stock_loc = self.picking_type_id.warehouse_id.lot_stock_id
+        default_dest_loc = self.picking_type_id.default_location_dest_id
+        if default_dest_loc and default_dest_loc._child_of(wh_stock_loc):
+            return default_dest_loc
+        return wh_stock_loc
 
     @api.model
     def _get_picking_type(self, company_id):

--- a/addons/purchase_stock/tests/test_routes.py
+++ b/addons/purchase_stock/tests/test_routes.py
@@ -68,3 +68,42 @@ class TestRoutes(TransactionCase):
         wh.reception_steps = 'two_steps'
         self.assertEqual(wh.reception_steps, 'two_steps')
 
+    def test_po_final_location(self):
+        """
+        When confirming PO with Operation Type is a sublocation, computation
+        of the final location should take that into account so as to not
+        interfere with forecasted quantity.
+        """
+
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        sub_location = self.env['stock.location'].create({
+            'name': 'test sub location',
+            'location_id': warehouse.lot_stock_id.id,
+        })
+
+        warehouse.in_type_id.default_location_dest_id = sub_location
+
+        product = self.env['product.product'].create({
+            'name': 'test product',
+            'is_storable': True,
+        })
+
+        partner = self.env['res.partner'].create({'name': 'test vendor'})
+
+        po = self.env['purchase.order'].create({
+            'partner_id': partner.id,
+            'picking_type_id': warehouse.in_type_id.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 10.0,
+                'price_unit': 20.0,
+            })],
+        })
+        po.button_confirm()
+
+        move = po.picking_ids.move_ids
+        self.assertEqual(move.location_dest_id, sub_location, "destination on move should be the sub-location")
+        self.assertEqual(move.location_final_id, sub_location, "location_final_id should be the sub-location")
+
+        forecast = product.with_context(location=sub_location.id).virtual_available
+        self.assertEqual(forecast, 10.0, "forecasted quantity should increment to 10.0 units")


### PR DESCRIPTION
### **Description of the issue/feature this PR addresses:**

**Issue:** In Odoo 18/19, purchase move lines default to the WH's main stock location (`lot_stock_id`) as the `location_final_id`. However, when a user configures a sub-location on the Receipt Operation Type, the picking destination is correct, but the move lines are defaulted to the main warehouse. This mismatch causes the Forecasted Quantity to not increment for the intended sub-location

**Solution:** Prioritize the `default_location_dest_id` before falling back to the default stock location

opw-6032018

### **Current behavior before PR:** 
When confirming a PO, the `location_final_id` on stock moves defaults to the `lot_stock_id`, regardless of the specific destination set on the Operation Type. This causes a mismatch in 1-step receiving flows where a sub-location (e.g., WH/Stock/Test) is intended, since the move lines revert to the root warehouse location (WH/Stock). Thus, the forecasted quantity for the specific sub-location doesn't increment as expected.

### **Desired behavior after PR is merged:** 
The `_get_final_location_record` method will now evaluate if the Operation Type's `default_location_dest_id` is a child of the warehouse's main stock. If it is, the sub-location is used as the `location_final_id` for the moves and move lines. This ensures that the forecasted quantity reflects the intended destination upon PO confirmation while still maintaining the fallback to the warehouse root for standard multi-step routes.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
