### PR TITLE
[FIX] point_of_sale: fix payment method overflow

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -136,7 +136,7 @@
     </t>
 
     <t t-name="point_of_sale.PaymentScreenMethods">
-        <div class="paymentmethods-container mb-3" t-att-class="ui.isSmall ? 'my-2 rounded-3' : 'flex-grow-1'">
+        <div class="paymentmethods-container mb-3" t-att-class="ui.isSmall ? 'my-2 rounded-3' : 'overflow-y-auto flex-grow-1'">
             <div class="paymentmethods  gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-300': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
                     <div class="button paymentmethod btn btn-light btn-lg lh-lg flex-fill"


### PR DESCRIPTION
Description of the issue/feature this PR 
Currently, when the number of payment methods exceeds the available space, the payment methods overflow and breaks the UI in large screens.

Current behavior before PR:
How it looks currently in large screen
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/937dec13-50e3-4f7b-b573-4e526f683617" />

Desired behavior after PR is merged:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/09f01d39-700d-47a7-86aa-3451ac77e553" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
