### PR TITLE
[FIX] html_editor: traceback when toggle title has no next sibling

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -2,7 +2,7 @@ import { getEmbeddedProps } from "@html_editor/others/embedded_component_utils";
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { closestBlock } from "@html_editor/utils/blocks";
-import { isEmptyBlock, isParagraphRelatedElement } from "@html_editor/utils/dom_info";
+import { isEmptyBlock, isParagraphRelatedElement, isTextNode } from "@html_editor/utils/dom_info";
 import {
     childNodes,
     children,
@@ -322,8 +322,8 @@ export class ToggleBlockPlugin extends Plugin {
         }
         let nextEl;
         if (content.parentElement.matches(".d-none")) {
-            nextEl = toggle.nextSibling;
-            if (nextEl.matches?.(toggleSelector)) {
+            nextEl = toggle.nextElementSibling;
+            if (nextEl?.matches(toggleSelector)) {
                 this.explodeToggle(nextEl);
                 nextEl = toggle.nextSibling;
             }
@@ -334,16 +334,15 @@ export class ToggleBlockPlugin extends Plugin {
                 nextEl = content.firstChild;
             }
         }
-        if (!isParagraphRelatedElement(nextEl)) {
-            return;
+        if (nextEl && (isTextNode(nextEl) || isParagraphRelatedElement(nextEl))) {
+            title.append(nextEl);
+            this.dependencies.selection.setCursorEnd(block);
+            this.dependencies.delete.deleteForward(
+                this.dependencies.selection.getEditableSelection(),
+                "character"
+            );
+            return true;
         }
-        title.append(nextEl);
-        this.dependencies.selection.setCursorEnd(block);
-        this.dependencies.delete.deleteForward(
-            this.dependencies.selection.getEditableSelection(),
-            "character"
-        );
-        return true;
     }
 
     handleDeleteForwardBeforeToggle({ startContainer, startOffset }) {

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -450,6 +450,88 @@ describe("deleteForward applied to toggle", () => {
             `)
         );
     });
+    test("toggle closed, end of title: should not do anything if sibling node is not available", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>invisible</p>
+                    </div>
+                </div>
+            `),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld[]</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>invisible</p>
+                        </div>
+                    </div>
+                </div>
+            `)
+        );
+    });
+    test("toggle open, end of title: should append sibling text node content to title", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        test
+                        <table><tbody><tr><td>a</td></tr></tbody></table>
+                    </div>
+                </div>
+            `),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld[]test</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <table><tbody><tr><td>a</td></tr></tbody></table>
+                        </div>
+                    </div>
+                </div>
+            `)
+        );
+    });
 });
 describe("Enter applied to toggle title", () => {
     test("start of title: should create new toggle before", async () => {


### PR DESCRIPTION
Steps to Reproduce:
- Go to To-Do → Create New
- Create a toggle list
- Type something in the title
- Press the delete button

Description of the issue:
- A traceback occurs.

Cause:
- In `handleDeleteForwardTitleEnd`, there is a check to verify whether the toggle title’s next sibling matches the toggle selector. However, when there is no next sibling, calling `matches()` results in a traceback.

Solution:
- Only check `matches()` if the next sibling exists.

task-6040479