### PR TITLE
[FIX] im_livechat: prevent access error when opening invite panel

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -29,7 +29,8 @@ class ResPartner(models.Model):
             )
         )
         active_livechat_partners = (
-            self.env["im_livechat.channel"].search([]).available_operator_ids.partner_id
+            # sudo: im_livechat.channel - checking whether live chat agents are available for invitation in a live chat we are members of is acceptable.
+            self.env["im_livechat.channel"].sudo().search([]).available_operator_ids.partner_id
         )
         for partner in self:
             languages = list(OrderedSet([

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -370,3 +370,19 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self.env["discuss.channel.member"].with_user(bob_user).search([("channel_id", "=", livechat_session.id)]),
             livechat_session.channel_member_ids
         )
+
+    def test_invited_user_can_search_users_for_invite(self):
+        john = new_test_user(self.env, "john")
+        bob = new_test_user(self.env, "bob")
+        channel = self.env["discuss.channel"].create(
+            {
+                "channel_type": "livechat",
+                "livechat_operator_id": self.operators[0].partner_id.id,
+                "name": "Support Channel",
+                "livechat_channel_id": self.livechat_channel.id,
+            }
+        )
+        channel.with_user(self.operators[0])._add_members(users=john)
+        data = john.partner_id.with_user(john).search_for_channel_invite("bob", channel.id)["data"]
+        self.assertIn(bob.partner_id.id, [p["id"] for p in data["res.partner"]])
+        self.assertFalse(john.has_group("im_livechat.im_livechat_group_user"))


### PR DESCRIPTION
When opening the livechat invite panel, users without livechat access rights encounter an access error.

This commit fixes the issue by ensuring active live chat partners can be retrieved for invited users.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
