### PR TITLE
[FIX] point_of_sale: crash on configurable product scan with GS1 nomenclature

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -694,6 +694,9 @@ export class PosStore extends WithLazyGetterTrap {
                     );
                     product = productPackaging && productPackaging.product_id;
                 }
+                if (!product && opts.product) {
+                    product = opts.product;
+                }
             } else {
                 product = opts.presetVariant;
             }
@@ -980,6 +983,7 @@ export class PosStore extends WithLazyGetterTrap {
             const payload = await this.openConfigurator(productTemplate, {
                 ...opts,
                 line: props.line,
+                product: values?.product_id,
             });
             if (!payload) {
                 return false;

--- a/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
@@ -92,6 +92,10 @@ registry.category("web_tour.tours").add("GS1BarcodeScanningTour", {
             ProductScreen.selectedOrderlineHas("Product 3"),
             scan_barcode("3760171283370"),
             ProductScreen.selectedOrderlineHas("Product 3", 2),
+
+            // Scanning lot number of product temoplate and variant have GS1 barcode should add the product to the order.
+            scan_barcode("010512364869541610784512"),
+            ProductScreen.selectedOrderlineHas("GS1 Variant Product", 1),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1315,6 +1315,28 @@ class TestUi(TestPointOfSaleHttpCommon):
             'barcode': '3760171283370',
         })
 
+        size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'create_variant': 'always',
+            'value_ids': [
+                Command.create({'name': 'S', 'sequence': 1}),
+                Command.create({'name': 'L', 'sequence': 2}),
+            ],
+        })
+        product_tmpl = self.env['product.template'].create({
+            'name': 'GS1 Variant Product',
+            'available_in_pos': True,
+            'tracking': 'lot',
+            'is_storable': True,
+            'attribute_line_ids': [Command.create({
+                'attribute_id': size_attribute.id,
+                'value_ids': [Command.set(size_attribute.value_ids.ids)],
+            })],
+        })
+        pos_categ = self.env['pos.category'].create({'name': 'GS1 Test'})
+        product_tmpl.pos_categ_ids = [Command.set([pos_categ.id])]
+        variant = product_tmpl.product_variant_ids[0]
+        variant.write({'barcode': '5123648695416'})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'GS1BarcodeScanningTour', login="pos_user")
 


### PR DESCRIPTION
**Steps to reproduce:**
* Install  `point_of_sale` module.
* Go to Settings:
     * Enable Lots & Serial Numbers.
     * Enable Variants.
     * Set Barcode Nomenclature to Default GS1 Nomenclature.
* Create a product:
     * Enable Track Inventory set to By Lots.
     * Under Attributes & Variants:
     * Add an attribute with two values and save.
* Generate product variants:
     * Open one variant and set barcode to 5123648695416.
* Update inventory:
     * Go to the main product (template).
     * Update On Hand Quantity:
             * Update On Hand Quantity with a lot/serial number:
               010512364869541610784512.
             * Select the variant with the defined barcode.
* Under Point of Sale tab:
    * Set a POS Category.
* Open a POS session and scan:
010512364869541610784512.

**Observed behavior:**
* Scanning the GS1 barcode in POS raises a traceback:
  *TypeError: Cannot read properties of undefined (reading
  'product_template_attribute_value_ids')*.

**Cause:**

[Scans GS1 barcode: 010512364869541610784512]
│
├─ ProductScreen._barcodeGS1Action(parsed_results)
│    • product = await _getProductByBarcode(productBarcode)  ✅ found
│    • calls `addLineToCurrentOrder(vals, { code: lotBarcode })`
│                                                              ⚠️ only `lotBarcode` passed, `productBarcode` discarded
│
├─ PosStore.addLineToCurrentOrder() → addLineToOrder()
│    • product has variants → isConfigurable() = true
│
├─ PosStore.handleConfigurableProduct()
│    • calls openConfigurator(productTemplate, { ...opts })
│      opts = { code: lotBarcode }
│
└─ PosStore.openConfigurator()
     • opts.code = lotBarcode  → truthy → enters if(opts.code) branch
     • getBy("barcode", opts.code.base_code)
     •  getBy("barcode", "784512")   ← "784512" is a LOT number, not a product barcode!
       → returns undefined ❌
     • product packaging lookup also fails → undefined ❌
     • product = undefined
     │
     └─ attributeLinesValues.map(values =>
            values.filter(value =>
                product.product_template_attribute_value_ids.includes(value)
                ^^^^^^^ undefined  → 💥 TypeError

**Fix:**
* Pass the product from `handleConfigurableProduct` to the configurator.
* If no product is found using `opts.code`, use the passed product
  instead.

---

opw-6031909
