### PR TITLE
[IMP] account: add document selector in accounting send wizard

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments_selector_documents.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments_selector_documents.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.MailComposerAttachmentSelector" t-inherit-mode="extension">
+        <xpath expr="//FileUploader" position="after">
+            <button t-if="props.record.resModel === 'account.move.send.wizard'"
+                    type="button"
+                    class="btn btn-light w-auto o_account_documents_button ms-1"
+                    title="Add from Documents"
+                    t-on-click="openDocumentsDialog">
+                <i class="o_add_documents_icon"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/addons/account/static/src/components/mail_attachments/mail_attachments_selector_documents_patch.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments_selector_documents_patch.js
@@ -1,0 +1,70 @@
+import { patch } from "@web/core/utils/patch";
+import { MailAttachments } from "@account/components/mail_attachments/mail_attachments_selector";
+import { useService } from "@web/core/utils/hooks";
+import { SelectAddDocumentCreateDialog } from "@documents/views/view_dialogs/select_add_document_create_dialog";
+
+patch(MailAttachments.prototype, {
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        this.orm = useService("orm");
+    },
+
+    openDocumentsDialog() {
+        const data = this.props.record.data;
+        const resId = JSON.parse(data.res_ids || "[]")[0];
+
+        const closeDocumentsDialog = this.dialog.add(SelectAddDocumentCreateDialog, {
+            resModel: "documents.document",
+            title: "Search: Documents",
+            noCreate: true,
+            domain: [
+                ["type", "=", "binary"],
+                ["shortcut_document_id", "=", false],
+            ],
+            context: {
+                list_view_ref: "documents.documents_view_list_add_documents_attachment",
+                documents_search_panel_no_trash: true,
+                documents_view_secondary: true,
+            },
+
+            chatterParams: {
+                thread: {
+                    model: data.model,
+                    id: resId,
+                },
+
+                composer: {
+                    attachments: this.attachments,
+                    composerText: this.props.record.data.body || "",
+                },
+
+                pasteDocumentsLink: async (resIds) => {
+
+                    const records = await this.orm.read(
+                        "documents.document",
+                        resIds,
+                        ["display_name", "access_url"]
+                    );
+
+                    const linksHtml = records
+                        .map(r => `<a href="${r.access_url}" target="_blank">${r.display_name}</a>`)
+                        .join("<br/>");
+
+                    const appendedHtml = `<p><br/><strong>Attached Documents:</strong><br/>${linksHtml}</p>`;
+
+                    const currentBody = this.props.record.data.body || "";
+                    const newBody = currentBody + appendedHtml;
+
+                    await this.props.record.update({
+                        body: newBody,
+                    });
+
+                    closeDocumentsDialog();
+                },
+            },
+        });
+    },
+
+});

--- a/addons/account/static/src/scss/account_move_send_wizard.scss
+++ b/addons/account/static/src/scss/account_move_send_wizard.scss
@@ -8,3 +8,31 @@
         max-width: 325px;
     }
 }
+
+.o_field_mail_attachments_selector {
+    display: flex;
+    align-items: center;
+}
+
+.o_account_documents_button {
+    padding: 2px 6px;
+}
+
+.o_account_documents_button .o_add_documents_icon {
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    vertical-align: middle;
+
+    background-image: url('/documents/static/description/icon.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+
+    filter: grayscale(1);
+    transition: filter 0.2s ease;
+}
+
+.o_account_documents_button:hover .o_add_documents_icon {
+    filter: none;
+}


### PR DESCRIPTION
The standard mail composer (e.g., used in Quotations) allows users to add files or paste links directly from the Documents app. However, this functionality was missing in the custom `account.move.send` wizard used for Invoicing and Accounting.

This commit introduces the 'Add from Documents' feature to the Accounting Send & Print wizard.

task- 5905930

