### PR TITLE
[IMP] web: mock lock manager in tests

### DIFF
--- a/addons/web/static/lib/hoot/mock/navigator.js
+++ b/addons/web/static/lib/hoot/mock/navigator.js
@@ -388,6 +388,21 @@ export class MockServiceWorkerRegistration {
     async update() {}
 }
 
+// Naive lock that doesn't lock anything
+export class MockLockManager {
+    async request(name, ...args) {
+        const callback = args.length > 1 ? args[1] : args[0];
+        callback();
+    }
+
+    async query() {
+        return {
+            held: [],
+            pending: [],
+        };
+    }
+}
+
 export const currentPermissions = getPermissions();
 
 export const mockClipboard = new MockClipboard();
@@ -396,8 +411,11 @@ export const mockPermissions = new MockPermissions();
 
 export const mockServiceWorker = new MockServiceWorkerContainer();
 
+export const mockLockManager = new MockLockManager();
+
 export const mockNavigator = createMock(navigator, {
     clipboard: { value: mockClipboard },
+    locks: { value: mockLockManager },
     maxTouchPoints: { get: () => (globalThis.ontouchstart === undefined ? 0 : 1) },
     permissions: { value: mockPermissions },
     sendBeacon: { get: () => mockValues.sendBeacon },

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -322,9 +322,9 @@ class OfflineManager extends Reactive {
     // -------------------------------------------------------------------------
 
     async _syncORM() {
+        // Only one tab can execute this block at a time
         await navigator.locks.request("db-sync", async () => {
             this._syncingORM = true;
-            // Only one tab can execute this block at a time
             await this._updateScheduledORMList();
 
             for (const [index, { key, value }] of Object.values(this._ormToSync)

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -337,6 +337,8 @@ test(`[Offline] save a form view offline (click save icon)`, async () => {
     expect(".o_field_widget[name=foo] input").toHaveValue("yop");
     await contains(".o_field_widget[name=foo] input").edit("new foo");
 
+    await runAllTimers(); // execute first _syncORM triggered after a delay in the service startup
+
     offline = true;
     await contains(".o_form_button_save").click();
     expect(".o_form_renderer").not.toHaveClass("o_form_readonly"); // We can create/edit offline
@@ -403,6 +405,8 @@ test(`[Offline] save a form view offline (autosave when leaving)`, async () => {
     expect(".o_form_renderer").toHaveClass("o_form_editable");
     expect(".o_field_widget[name=foo] input").toHaveValue("yop");
     await contains(".o_field_widget[name=foo] input").edit("new foo");
+
+    await runAllTimers(); // execute first _syncORM triggered after a delay in the service startup
 
     offline = true;
     await contains(".o_breadcrumb .o_back_button").click();


### PR DESCRIPTION
This commit adds a mock for the navigator lock manager in Hoot. The mock is very naive: it simply executes the callback directly (no lock mechanism), because we don't really need it in tests. This ensures that tests don't interfere with each other.

This also fixes a memory leak that had been introduced by [1] (third commit), specifically because of this code block [2]. The leaks was due to the fact that all tests using an env triggered a call to locks.request() (after 3s), thus creating a queue of callbacks, each one of them retaining its own version of the service, env...

[1] https://github.com/odoo/odoo/pull/244545
[2] https://github.com/odoo/odoo/pull/244545/changes#diff-316285b91b4bf423de9551e7f150ccbb2f9f266490c907de559842032700d07eR64-R70

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
