### PR TITLE
[REF] {l10n_*,}hr_payroll{,_account}: generate_payslip ref

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -884,12 +884,11 @@ class HrEmployee(models.Model):
         for employee_id in contract_versions_by_employee:
             for contract_versions in contract_versions_by_employee[employee_id].values():
                 effective_date = date_end if use_latest_version else date_start
-                if use_latest_version:
-                    if effective_date:
-                        correct_versions = contract_versions.filtered(lambda v: v.date_version <= effective_date)
-                        contracts_by_employee[employee_id] |= correct_versions[-1] if correct_versions else contract_versions[0]
-                    else:
-                        contracts_by_employee[employee_id] |= contract_versions[-1] if use_latest_version else contract_versions[0]
+                if effective_date:
+                    correct_versions = contract_versions.filtered(lambda v: v.date_version <= effective_date)
+                    contracts_by_employee[employee_id] |= correct_versions[-1] if correct_versions else contract_versions[0]
+                else:
+                    contracts_by_employee[employee_id] |= contract_versions[-1] if use_latest_version else contract_versions[0]
         return contracts_by_employee
 
     def _get_contract_versions(self, date_start=None, date_end=None, domain=None):
@@ -913,7 +912,7 @@ class HrEmployee(models.Model):
         version_domain = Domain('contract_date_start', '!=', False)
         if self.ids:
             version_domain &= Domain('employee_id', 'in', self.ids)
-        elif not any(self._ids):  # onchange
+        elif not any(self._ids) and self._origin.ids:  # onchange
             version_domain &= Domain('employee_id', 'in', self._origin.ids)
         if date_start:
             version_domain &= Domain('contract_date_end', '=', False) | Domain('contract_date_end', '>=', date_start)

--- a/addons/hr/tests/test_hr_contract_versions.py
+++ b/addons/hr/tests/test_hr_contract_versions.py
@@ -194,7 +194,7 @@ class TestHrContractVersions(TransactionCase):
             date(2025, 4, 1),
             None,
             False,
-            expected_contract_versions[0]
+            expected_contract_versions[1]
         )
 
     def test_1contract_5version_w_date_start_date_end(self):
@@ -539,7 +539,7 @@ class TestHrContractVersions(TransactionCase):
             date(2025, 4, 15),
             date(2025, 6, 15),
             False,
-            [contract_1_version[0], contract_2_version[0]]
+            [contract_1_version[1], contract_2_version[0]]
         )
         # the first before the end date, of the contract active in the range
         self.assert_get_contracts(


### PR DESCRIPTION
generate_payslip in payruns is old and not pretty:
- args are only used in tests
- logic in it can be simplified

task-6023878