### PR TITLE
[ADD] setup: AI assistant sandboxing

### DIFF
--- a/setup/sandboxing/README.md
+++ b/setup/sandboxing/README.md
@@ -1,0 +1,124 @@
+# Sandboxing AI Coding Assistants
+
+We advise running AI coding assistants in a sandbox for better security and privacy.
+These scripts and configurations allow you to run popular AI coding assistants with
+filesystem isolation, so the assistant can only access the files it needs to work
+on, and not your entire home directory.
+
+Without sandboxing, the AI assistant has access to your entire home directory, including
+SSH keys, GPG keys, browser profiles, credentials files, and any other secrets.
+Sandboxing restricts the visible filesystem to only the directories the assistant
+actually needs.
+
+AI assistants are powerful tools that can execute code, read and write files, and access
+the network. Running them without isolation can lead to accidental data leaks or malicious
+code execution if the assistant is compromised. By using sandboxing, you can mitigate
+these risks while still benefiting from the assistant's capabilities.
+
+## Bubblewrap
+
+These scripts use [bubblewrap](https://github.com/containers/bubblewrap) to run AI
+coding assistants with filesystem isolation, no container runtime needed.
+
+All functions of the assistant should work as normal, but the assistant will only see a
+limited view of the filesystem. The assistant will be able to edit files in the Odoo
+workspace and any other explicitly added directories, but won't be able to access files
+outside of those areas. It will also be able to run Python and JavaScript tests.
+
+### Prerequisites
+
+Install bubblewrap with your package manager. For example, on Debian/Ubuntu:
+
+```sh
+sudo apt install bubblewrap
+```
+
+It is advised to copy the scripts `bwrap-claude.sh` and `bwrap-opencode.sh` to a
+directory in your PATH (e.g. `~/.local/bin`).
+
+Both scripts pre-mount the Odoo workspace directory. By default, it is defined to `~/src/odoo`,
+meaning that the workspace should contain the directories `~/src/odoo/odoo`,
+`~/src/odoo/enterprise` and any other Odoo-related directory (e.g. design-themes).
+
+Override the default path with the environment variable `ODOO_BASE` (e.g.
+`ODOO_BASE=~/my/odoo`).
+
+Chrome, PostgreSQL, and the Odoo filestore are mounted opportunistically with
+`bind-try` and silently skipped when absent.
+
+### bwrap-opencode.sh
+
+Sandbox wrapper for [Opencode](https://opencode.ai).
+
+Install Opencode as recommended by the documentation:
+```sh
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Then, launch the sandboxed Opencode:
+
+```sh
+# Odoo dirs are pre-mounted, so no args needed for basic usage
+bwrap-opencode.sh [opencode args...]
+
+# Mount extra directories beyond Odoo
+bwrap-opencode.sh --add-dir ~/src/my-project [opencode args...]
+```
+
+`--add-dir` paths are bind-mounted read-write into the sandbox. Opencode does not
+support `--add-dir` natively, so these flags are consumed by the wrapper and **not**
+forwarded to the opencode binary.
+
+No IDE integration. See the script header for the full sandbox layout.
+
+
+### bwrap-claude.sh
+
+Sandbox wrapper for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+
+Install Claude Code as recommended by the documentation:
+```sh
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Then, launch the sandboxed Claude:
+
+```sh
+# Odoo dirs are pre-mounted, so no args needed for basic usage
+bwrap-claude.sh [claude args...]
+
+# Mount extra directories beyond Odoo
+bwrap-claude.sh --add-dir ~/src/my-project [claude args...]
+```
+
+Each `--add-dir` path is bind-mounted read-write **and** passed to Claude's own
+`--add-dir` flag, so Claude's tool access matches the sandbox boundary.
+
+For a complete sandboxing with VSCode, configure the
+[Claude Code VSCode extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code)
+and change the VSCode Claude extension setting
+`claudeCode.claudeProcessWrapper` to `bwrap-claude.sh`.
+
+In order to connect VSCode and the sandboxed Claude, type `/ide` in the Claude CLI.
+If VSCode is started, it should appear in the Claude CLI output.
+
+See the script header for the full sandbox layout.
+
+### Example: Running Odoo tests
+
+Here is an example of prompt to run the CRM tests (Python and JavaScript tours):
+
+```
+Here is how to initialize a DB named "pouet" :
+~/src/odoo/odoo/odoo-bin --addons-path=~/src/odoo/enterprise,~/src/odoo/odoo/addons -d pouet -i base --stop-after-init --logfile=~/src/odoo/log/pouet.log
+
+Then, install the CRM module:
+~/src/odoo/odoo/odoo-bin --addons-path=~/src/odoo/enterprise,~/src/odoo/odoo/addons -d pouet -i crm --stop-after-init --logfile=~/src/odoo/log/pouet.log
+
+Finally, run the tests for the CRM module:
+~/src/odoo/odoo/odoo-bin --addons-path=~/src/odoo/enterprise,~/src/odoo/odoo/addons -d pouet -u crm --test-enable --logfile=~/src/odoo/log/pouet.log
+
+Can you do this for me?
+```
+
+You can follow the logs in the file `~/src/odoo/log/pouet.log`.

--- a/setup/sandboxing/bwrap/bwrap-claude.sh
+++ b/setup/sandboxing/bwrap/bwrap-claude.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+#
+# bwrap-claude.sh - Run Claude Code inside a bubblewrap sandbox, with the
+# ability to run Odoo tests (Python and JavaScript).
+#
+# Drop-in replacement for the `claude` CLI. Provides filesystem isolation by
+# running Claude inside a bubblewrap (bwrap) container. Only explicitly
+# allowed directories are visible to Claude inside the sandbox.
+#
+# Odoo Community and Enterprise source trees are pre-mounted. The Odoo
+# filestore, PostgreSQL socket, Chrome, and fonts are mounted opportunistically
+# with bind-try so the script works even when they are absent.
+#
+# REQUIREMENTS
+#   - bubblewrap (bwrap) installed and available on PATH
+#   - Claude Code binary at ~/.local/bin/claude
+#
+#   Optional (mounts use bind-try and are silently skipped if absent):
+#   - Google Chrome or Chromium (/opt/google/chrome or /snap/chromium)
+#   - PostgreSQL (Unix socket at /var/run/postgresql)
+#   - Odoo filestore (~/.local/share/Odoo)
+#
+# USAGE
+#   bwrap-claude.sh [--add-dir <path> ...] [claude args...]
+#
+# OPTIONS
+#   --add-dir <path>
+#       Bind-mount <path> read-write into the sandbox in addition to the
+#       pre-configured Odoo directories. Also passed to Claude as --add-dir
+#       so its internal tool access matches the sandbox. All other arguments
+#       are forwarded to Claude.
+#
+# ENVIRONMENT
+#   ODOO_BASE     Path to the Odoo workspace (default: ~/src/odoo)
+#
+# SANDBOX LAYOUT
+#   Read-write mounts:
+#     ~/.cache/claude*          Claude cache directories
+#     ~/.claude, ~/.claude.json Claude config and session data
+#     ~/.local/bin/claude       Claude binary symlink (allows Claude auto-updates)
+#     ~/.local/share/claude     Claude binary versions cache
+#     $ODOO_BASE                Odoo workspace (community + enterprise)
+#     <--add-dir paths>         Extra project directories passed by the caller
+#
+#   Optional read-write mounts (bind-try, skipped if absent):
+#     ~/.local/share/Odoo       Odoo filestore
+#     /var/run/postgresql       PostgreSQL Unix socket (local DB access)
+#
+#   Read-only mounts:
+#     /usr (+ /bin, /sbin, /lib, /lib64 symlinks)
+#                               System binaries and libraries. /usr is mounted
+#                               whole so VSCode can access /usr/share/code when
+#                               Claude is launched from the IDE.
+#     /etc/alternatives         Symlink targets (Chrome binary chain)
+#     /etc/hosts                Hostname resolution
+#     /etc/passwd               User database (required for PostgreSQL auth)
+#     /etc/ssl                  TLS certificates
+#     /run/systemd/resolve      Systemd-resolved DNS
+#
+#   Optional read-only mounts (bind-try, skipped if absent):
+#     /opt/google/chrome        Chrome installation
+#     /snap/bin, /snap/chromium Snap Chromium installation
+#     /etc/fonts                Font configuration
+#     ~/.fonts, ~/.local/share/fonts  User fonts
+#
+#   Ephemeral:
+#     /dev                      Device nodes (via --dev)
+#     /proc                     Process info (via --proc)
+#     /tmp                      Temporary files (tmpfs, cleared on exit)
+#
+# NAMESPACE ISOLATION
+#   Unshared: IPC, UTS, cgroup
+#   Shared:
+#     - Network: Claude requires outbound internet access.
+#     - PID: Unsharing PID breaks VSCode's ability to attach to the Claude
+#             process for the /ide integration.
+#
+# WORKING DIRECTORY
+#   The sandbox starts in $ODOO_BASE (the first pre-configured allowed dir).
+#   This is required for the `claude /ide` command, which validates that the
+#   workspace matches the current working directory.
+#
+# RUNNING ODOO TESTS
+#   When running Odoo tests, use the --logfile option to redirect logs to a
+#   file inside $ODOO_BASE (e.g. --logfile ~/src/odoo/log/test.log). Hundreds
+#   of lines of test output in stdout won't render well in Claude's TUI.
+#
+# IDE INTEGRATION
+#   VSCode Unix domain sockets (vscode-*.sock) found in $XDG_RUNTIME_DIR are
+#   bind-mounted into the sandbox so `claude /ide` can connect to the editor.
+
+set -e
+HOME="${HOME:-/home/$(whoami)}"
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+
+# Pre-check: ensure Claude binary exists
+if [[ ! -x "$CLAUDE_BIN" ]]; then
+  echo "Claude Code not found at $CLAUDE_BIN" >&2
+  exit 1
+fi
+
+# Pre-check: ensure Claude config/cache paths exist
+CLAUDE_DIRS=(
+  "$HOME/.cache/claude"
+  "$HOME/.cache/claude-cli-nodejs"
+  "$HOME/.claude"
+  "$HOME/.local/state/claude"
+)
+CLAUDE_FILES=(
+  "$HOME/.claude.json"
+)
+for d in "${CLAUDE_DIRS[@]}"; do
+  mkdir -p "$d"
+done
+for f in "${CLAUDE_FILES[@]}"; do
+  [[ -e "$f" ]] || touch "$f"
+done
+
+# Odoo workspace
+# We assume the Community and Enterprise source trees are in the same directory.
+# For example: $HOME/src/odoo/odoo and $HOME/src/odoo/enterprise
+ODOO_BASE="${ODOO_BASE:-$HOME/src/odoo}"
+
+# Collect allowed dirs from args; intercept --add-dir from args for bwrap binding
+ALLOW_DIRS=("$ODOO_BASE")
+CLAUDE_ARGS=()
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--add-dir" ]]; then
+    shift
+    ALLOW_DIRS+=("$(cd "$1" && pwd)")
+    shift
+  else
+    CLAUDE_ARGS+=("$1")
+    shift
+  fi
+done
+
+BRAP=(
+  # Read-write bin (needed for Claude auto-updates). These 2 must already exists since they
+  # contain the binaries.
+  --bind "$HOME/.local/bin/claude" "$HOME/.local/bin/claude"
+  --bind "$HOME/.local/share/claude" "$HOME/.local/share/claude"
+  --ro-bind-try "$HOME/.vscode" "$HOME/.vscode"
+  # Network-related files
+  --ro-bind /run/systemd/resolve /run/systemd/resolve
+  --ro-bind /etc/hosts /etc/hosts
+  --ro-bind /etc/ssl /etc/ssl
+  --symlink ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+  # System binaries and libraries
+  --ro-bind /usr /usr
+  --symlink usr/bin   /bin
+  --symlink usr/sbin  /sbin
+  --symlink usr/lib   /lib
+  --symlink usr/lib64 /lib64
+  --dev /dev
+  --proc /proc
+  --tmpfs /tmp
+  # Unshare namespaces to isolate the sandbox
+  # Change to the first --add-dir path so `claude /ide` can validate the workspace against the
+  # current working directory.
+  --chdir "$ODOO_BASE"
+  # --unshare-pid => needed for VSCode integration
+  --unshare-ipc
+  --unshare-uts
+  --unshare-cgroup
+  --die-with-parent
+  --new-session
+  # Odoo: filestore and PostgreSQL socket, passwd necessary for PostgreSQL auth
+  --bind-try "$HOME/.local/share/Odoo" "$HOME/.local/share/Odoo"
+  --bind-try /var/run/postgresql /var/run/postgresql
+  --ro-bind /etc/passwd /etc/passwd
+  # Chrome / Chromium installation and symlink chain
+  --ro-bind /etc/alternatives /etc/alternatives
+  --ro-bind-try /opt/google/chrome /opt/google/chrome
+  --ro-bind-try /snap/bin /snap/bin
+  --ro-bind-try /snap/chromium /snap/chromium
+  # Chrome: fonts
+  --ro-bind-try /etc/fonts /etc/fonts
+  --ro-bind-try "$HOME/.fonts" "$HOME/.fonts"
+  --ro-bind-try "$HOME/.local/share/fonts" "$HOME/.local/share/fonts"
+  # Not needed so far, but keeping for future reference.
+  # Chrome: D-Bus (system bus + user session bus)
+  # --ro-bind-try /etc/machine-id /etc/machine-id
+  # --ro-bind-try /run/dbus /run/dbus
+  # --bind-try "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/bus" "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/bus"
+  # Chrome: shared memory for rendering
+  # --tmpfs /dev/shm
+)
+
+# Bind Claude config and cache files
+for path in "${CLAUDE_DIRS[@]}" "${CLAUDE_FILES[@]}"; do
+  BRAP+=(--bind "$path" "$path")
+done
+
+# Bind allowed directories
+for path in "${ALLOW_DIRS[@]}"; do
+  BRAP+=(--bind "$path" "$path")
+done
+
+# Bind VSCode sockets from XDG_RUNTIME_DIR for IDE integration
+for sock in "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"/vscode-*.sock; do
+  [[ -S "$sock" ]] && BRAP+=(--bind "$sock" "$sock")
+done
+
+# Pass --add-dir for each allowed dir so Claude's tool access matches the sandbox
+CLAUDE_CMD=()
+for d in "${ALLOW_DIRS[@]}"; do
+  CLAUDE_CMD+=(--add-dir "$d")
+done
+CLAUDE_CMD+=( "${CLAUDE_ARGS[@]}" )
+
+echo "Running: bwrap ${BRAP[@]} -- $CLAUDE_BIN ${CLAUDE_CMD[@]}" >&2
+exec bwrap "${BRAP[@]}" -- "$CLAUDE_BIN" "${CLAUDE_CMD[@]}"

--- a/setup/sandboxing/bwrap/bwrap-opencode.sh
+++ b/setup/sandboxing/bwrap/bwrap-opencode.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# bwrap-opencode.sh - Run Opencode inside a bubblewrap sandbox, with the
+# ability to run Odoo tests (Python and JavaScript).
+#
+# Drop-in wrapper for the `opencode` CLI. Provides filesystem isolation by
+# running Opencode inside a bubblewrap (bwrap) container. Only explicitly
+# allowed directories are visible to Opencode inside the sandbox.
+#
+# REQUIREMENTS
+#   - bubblewrap (bwrap) installed and available on PATH
+#   - Opencode binary at ~/.opencode/bin/opencode
+#
+#   Optional (mounts use bind-try and are silently skipped if absent):
+#   - Google Chrome or Chromium (/opt/google/chrome or /snap/chromium)
+#   - PostgreSQL (Unix socket at /var/run/postgresql)
+#   - Odoo filestore (~/.local/share/Odoo)
+#
+# USAGE
+#   bwrap-opencode.sh [--add-dir <path> ...] [opencode args...]
+#
+# OPTIONS
+#   --add-dir <path>
+#       Bind-mount <path> read-write into the sandbox in addition to the
+#       pre-configured Odoo directories. Opencode does not support --add-dir
+#       natively, so these are only used for bwrap bind-mounts. All other
+#       arguments are forwarded to opencode.
+#
+# ENVIRONMENT
+#   ODOO_BASE      Path to the Odoo workspace (default: ~/src/odoo)
+#
+# SANDBOX LAYOUT
+#   Read-write mounts:
+#     ~/.cache/opencode          Opencode cache
+#     ~/.config/opencode         Opencode configuration
+#     ~/.local/share/opencode    Opencode data
+#     ~/.opencode                Opencode binary
+#     $ODOO_BASE                 Odoo workspace (community + enterprise)
+#     <--add-dir paths>          Extra project directories passed by the caller
+#
+#   Optional read-write mounts (bind-try, skipped if absent):
+#     ~/.local/share/Odoo        Odoo filestore
+#     /var/run/postgresql        PostgreSQL Unix socket (local DB access)
+#
+#   Read-only mounts:
+#     /usr (+ /bin, /sbin, /lib, /lib64 symlinks)
+#                                System binaries and libraries
+#     /etc/alternatives          Symlink targets (Chrome binary chain)
+#     /etc/hosts                 Hostname resolution
+#     /etc/passwd                User database (required for PostgreSQL auth)
+#     /etc/ssl                   TLS certificates
+#     /run/systemd/resolve       Systemd-resolved DNS
+#
+#   Optional read-only mounts (bind-try, skipped if absent):
+#     /opt/google/chrome         Chrome installation
+#     /snap/bin, /snap/chromium  Snap Chromium installation
+#     /etc/fonts                 Font configuration
+#     ~/.fonts, ~/.local/share/fonts  User fonts
+#
+#   Ephemeral:
+#     /dev                       Device nodes (via --dev)
+#     /proc                      Process info (via --proc)
+#     /tmp                       Temporary files (tmpfs, cleared on exit)
+#
+# NAMESPACE ISOLATION
+#   Unshared: IPC, UTS, cgroup, PID
+#   Shared:
+#     - Network: Opencode requires outbound internet access.
+#
+# WORKING DIRECTORY
+#   The sandbox starts in $ODOO_BASE (i.e. ~/src/odoo by default).
+#
+# RUNNING ODOO TESTS
+#   When running Odoo tests, use the --logfile option to redirect logs to a
+#   file inside $ODOO_BASE (e.g. --logfile ~/src/odoo/log/test.log). Hundreds
+#   of lines of test output in stdout won't render well in Opencode's TUI.
+
+set -e
+HOME="${HOME:-/home/$(whoami)}"
+OPENCODE_BIN="${OPENCODE_BIN:-$HOME/.opencode/bin/opencode}"
+
+# Pre-check: ensure Opencode binary exists
+if [[ ! -x "$OPENCODE_BIN" ]]; then
+  echo "Opencode not found at $OPENCODE_BIN" >&2
+  exit 1
+fi
+
+# Pre-check: ensure config/cache paths exist
+OPENCODE_DIRS=(
+  "$HOME/.cache/opencode"
+  "$HOME/.config/opencode"
+  "$HOME/.local/share/opencode"
+  "$HOME/.opencode"
+)
+for d in "${OPENCODE_DIRS[@]}"; do
+  mkdir -p "$d"
+done
+
+# Odoo workspace
+# We assume the Community and Enterprise source trees are in the same directory.
+# For example: $HOME/src/odoo/odoo and $HOME/src/odoo/enterprise
+ODOO_BASE="${ODOO_BASE:-$HOME/src/odoo}"
+
+# Collect allowed dirs from args; intercept --add-dir from args for bwrap binding
+ALLOW_DIRS=("$ODOO_BASE")
+OPENCODE_ARGS=()
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--add-dir" ]]; then
+    shift
+    ALLOW_DIRS+=("$(cd "$1" && pwd)")
+    shift
+  else
+    OPENCODE_ARGS+=("$1")
+    shift
+  fi
+done
+
+BWRAP=(
+  # Network-related files
+  --ro-bind /run/systemd/resolve /run/systemd/resolve
+  --ro-bind /etc/hosts /etc/hosts
+  --ro-bind /etc/ssl /etc/ssl
+  --symlink ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+  # System binaries and libraries
+  --ro-bind /usr /usr
+  --symlink usr/bin   /bin
+  --symlink usr/sbin  /sbin
+  --symlink usr/lib   /lib
+  --symlink usr/lib64 /lib64
+  --dev /dev
+  --proc /proc
+  --tmpfs /tmp
+  # Unshare namespaces to isolate the sandbox
+  --chdir "$ODOO_BASE"
+  --unshare-all
+  --share-net
+  --die-with-parent
+  --new-session
+  # Odoo: filestore and PostgreSQL socket, passwd necessary for PostgreSQL auth
+  --bind-try "$HOME/.local/share/Odoo" "$HOME/.local/share/Odoo"
+  --bind-try /var/run/postgresql /var/run/postgresql
+  --ro-bind /etc/passwd /etc/passwd
+  # Chrome / Chromium installation and symlink chain
+  --ro-bind /etc/alternatives /etc/alternatives
+  --ro-bind-try /opt/google/chrome /opt/google/chrome
+  --ro-bind-try /snap/bin /snap/bin
+  --ro-bind-try /snap/chromium /snap/chromium
+  # Chrome: fonts
+  --ro-bind-try /etc/fonts /etc/fonts
+  --ro-bind-try "$HOME/.fonts" "$HOME/.fonts"
+  --ro-bind-try "$HOME/.local/share/fonts" "$HOME/.local/share/fonts"
+  # This does not seem to be needed, but keeping it here for future reference.
+  # Chrome: D-Bus (system bus + user session bus)
+  # --ro-bind-try /etc/machine-id /etc/machine-id
+  # --ro-bind-try /run/dbus /run/dbus
+  # --bind-try "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/bus" "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/bus"
+  # Chrome: shared memory for rendering
+  # --tmpfs /dev/shm
+)
+
+# Bind Opencode config and cache directories
+for path in "${OPENCODE_DIRS[@]}"; do
+  BWRAP+=(--bind "$path" "$path")
+done
+
+# Bind allowed directories
+for path in "${ALLOW_DIRS[@]}"; do
+  BWRAP+=(--bind "$path" "$path")
+done
+
+echo "Running: bwrap ${BWRAP[@]} -- $OPENCODE_BIN ${OPENCODE_ARGS[@]}" >&2
+exec bwrap "${BWRAP[@]}" -- "$OPENCODE_BIN" "${OPENCODE_ARGS[@]}"


### PR DESCRIPTION
We advise running AI coding assistants in a sandbox for better security and privacy. These scripts and configurations allow you to run popular AI coding assistants with filesystem isolation, so the assistant can only access the files it needs to work on, and not your entire home directory.

These scripts use [bubblewrap](https://github.com/containers/bubblewrap) to run AI coding assistants with filesystem isolation, no container runtime needed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
