### PR TITLE
[FIX] pos_restaurant: fix test failure due to sync race condition

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -88,15 +88,17 @@ registry.category("web_tour.tours").add("test_sync_lines_qty_update_ticket_scree
             ProductScreen.clickCustomer("A powerful Pos man!"),
 
             Chrome.clickOrders(),
+            Chrome.waitForOrdersSync(),
             TicketScreen.selectOrder("001"),
             TicketScreen.loadSelectedOrder(),
+            Chrome.waitForOrdersSync(),
 
             ProductScreen.isShown(),
             ProductScreen.clickOrderline("Coca-Cola", "1"),
             ProductScreen.clickNumpad("3"),
             ProductScreen.selectedOrderlineHas("Coca-Cola", "3"),
-            Chrome.waitForOrdersSync(),
             Chrome.clickOrders(),
+            Chrome.waitForOrdersSync(),
             TicketScreen.selectOrder("001"),
             Order.hasLine({
                 productName: "Coca-Cola",


### PR DESCRIPTION
During the tour test `test_sync_lines_qty_update_ticket_screen`, the order line quantity was sometimes incorrect after navigating to the TicketScreen.

When opening the TicketScreen and loading an order, the order is synchronized with the backend. A race condition could occur where the order was loaded with a certain quantity, triggering `sync_from_ui`, which takes some time to complete. During this delay, the test updated the order line quantity, but the sync response returned with the old quantity and overwrote the new value.

To fix this, the tour now waits for `sync_from_ui` to complete after each `Chrome.clickOrders()` and `TicketScreen.loadSelectedOrder()`.

Runbot error: 241916

---

Runbot Error: https://runbot.odoo.com/odoo/runbot.build.error/241916