### PR TITLE
[FIX] resource_mail: review many2many_avatar_resource in kanban to use standard behavior

### DIFF
--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -260,7 +260,7 @@ class ResourceResource(models.Model):
             If the employee is not assigned any calendar and no hours_per_week or hours_per_day are defined, he's considered as Fully flexible.
         """
         self.ensure_one()
-        return self._is_fully_flexible() or bool(not self.calendar_id and self.hours_per_week and self.hours_per_day)
+        return self._is_fully_flexible() or not self.calendar_id
 
     def _get_flexible_resources_default_work_intervals(self, start, end):
         assert start.tzinfo and end.tzinfo
@@ -399,7 +399,7 @@ class ResourceResource(models.Model):
     def _get_flexible_resource_work_hours(self, intervals, flexible_resources_hours_per_day, flexible_resources_hours_per_week, work_hours_per_day=None):
         assert self._is_flexible()
 
-        if self._is_fully_flexible():
+        if self._is_fully_flexible() or not self.hours_per_day:
             return round(sum_intervals(intervals), 2)
 
         # start and end for each Interval have the same day thanks to schedule_intervals_per_resource_id format for flexible employees

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -11,38 +11,12 @@ import {
 } from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card_resource/avatar_card_resource_popover";
-import { Domain } from "@web/core/domain";
 import { AvatarTag } from "@web/core/tags_list/avatar_tag";
+import { Many2ManyTagsAvatarFieldPopover } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
 import { Component } from "@odoo/owl";
 
-export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
-    /**
-     * @override
-     */
-    search(request) {
-        return this.orm.call(
-            this.props.resModel,
-            "search_read",
-            [this.getDomain(request), ["id", "display_name", "resource_type", "color"]],
-            {
-                context: {
-                    ...this.props.context,
-                    formatted_display_name: true,
-                },
-                limit: this.props.searchLimit + 1,
-            }
-        );
-    }
-
-    /**
-     * @override
-     */
-    getDomain(request) {
-        return Domain.and([[["name", "ilike", request]], this.props.getDomain()]).toList(
-            this.props.context
-        );
-    }
-}
+// TODO: Remove me in master
+export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {}
 
 class ResourceTag extends Component {
     static template = "resource_mail.ResourceTag";
@@ -72,6 +46,14 @@ const WithResourceFieldMixin = (T) => class ResourceFieldMixin extends T {
         Tag: ResourceTag,
     };
     static optionTemplate = "resource_mail.Many2ManyAvatarResourceField.option";
+
+    get specification() {
+        return {
+            ...super.specification,
+            resource_type: {},
+            color: {},
+        }
+    }
 
     displayAvatarCard(record) {
         return !this.env.isSmall && this.relation === "resource.resource" && record.data.resource_type === "user";
@@ -125,7 +107,11 @@ export const listMany2ManyAvatarResourceField = {
 };
 registry.category("fields").add("list.many2many_avatar_resource", listMany2ManyAvatarResourceField);
 
+export class Many2ManyTagsAvatarResourceFieldPopover extends WithResourceFieldMixin(Many2ManyTagsAvatarFieldPopover) {}
+
 export class KanbanMany2ManyAvatarResourceField extends WithResourceFieldMixin(KanbanMany2ManyTagsAvatarUserField) {
+    static PopoverClass = Many2ManyTagsAvatarResourceFieldPopover;
+
     get tags() {
         return super.tags.reverse();
     }

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -129,6 +129,10 @@ export class KanbanMany2ManyAvatarResourceField extends WithResourceFieldMixin(K
     get tags() {
         return super.tags.reverse();
     }
+
+    get placeholder() {
+        return _t("Search resources...");
+    }
 }
 export const kanbanMany2ManyAvatarResourceField = {
     ...kanbanMany2ManyTagsAvatarUserField,

--- a/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
@@ -7,8 +7,9 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { queryAll, queryFirst } from "@odoo/hoot-dom";
+import { contains as webContains } from "@web/../tests/web_test_helpers";
+import { animationFrame, beforeEach, describe, expect, test } from "@odoo/hoot";
+import { queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { defineResourceMailModels } from "./resource_mail_test_helpers";
 
 describe.current.tags("desktop");
@@ -236,6 +237,11 @@ test("many2many_avatar_resource widget in kanban view", async () => {
         { count: 0, target: card1 },
         "No text should be displayed on any avatar",
     );
+    await waitFor(
+        ".o_kanban_record:nth-child(1) .o_field_many2many_avatar_resource .o_quick_assign",
+        { visible: false },
+        "Quick assign button should be displayed on the card"
+    );
 
     await contains(
         "img.o_m2m_avatar",
@@ -247,6 +253,17 @@ test("many2many_avatar_resource widget in kanban view", async () => {
         { count: 0, target: card2 },
         "No text should be displayed on the avatar",
     );
+    await webContains(
+        ".o_kanban_record:nth-child(2) .o_field_many2many_avatar_resource .o_quick_assign",
+        { visible: false },
+        "Quick assign button should be displayed on the card"
+    ).click();
+    await animationFrame();
+    expect(".o-overlay-container input").toBeFocused();
+    expect(".o-overlay-container .o_tag").toHaveCount(1);
+    expect(".o-overlay-container .o_avatar_many2x_autocomplete").toHaveCount(3);
+    expect(".o-overlay-container .o_avatar_many2x_autocomplete i.o_material_resource.fa-wrench").toHaveCount(1);
+    expect(".o-overlay-container .o_avatar_many2x_autocomplete img").toHaveCount(2);
 
     // Second and third records in widget should display employee avatars
     const [ tagMarie, tagPierre ] = document.querySelectorAll(".many2many_tags_avatar_field_container .o_tag img");

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -73,6 +73,7 @@ export class Many2ManyTagsAvatarFieldPopover extends Many2ManyTagsAvatarField {
     static template = "web.Many2ManyTagsAvatarFieldPopover";
     static props = {
         ...Many2ManyTagsAvatarField.props,
+        specification: Object,
         close: { type: Function },
     };
 
@@ -123,7 +124,7 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
     }
 
     get popoverProps() {
-        const props = { ...this.props };
+        const props = { ...this.props, specification: this.specification };
         delete props.isEditable;
         delete props.relation;
         return props;

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -109,11 +109,12 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
         ...super.props,
         isEditable: { type: Boolean, optional: true },
     };
+    static PopoverClass = Many2ManyTagsAvatarFieldPopover;
     visibleItemsLimit = 3;
 
     setup() {
         super.setup();
-        this.popover = usePopover(Many2ManyTagsAvatarFieldPopover, {
+        this.popover = usePopover(this.constructor.PopoverClass, {
             popoverClass: "o_m2m_tags_avatar_field_popover",
             closeOnClickAway: (target) => !target.closest(".modal"),
         });

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -55,6 +55,7 @@
             <attribute name="dropdown">false</attribute>
             <attribute name="placeholder">props.placeholder</attribute>
             <attribute name="autofocus">true</attribute>
+            <attribute name="specification">props.specification</attribute>
         </Many2XAutocomplete>
     </t>
 

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -11,7 +11,9 @@ import {
     models,
     mountView,
     onRpc,
+    patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
+import { KanbanMany2ManyTagsAvatarField } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
 
 describe.current.tags("desktop");
 
@@ -207,7 +209,7 @@ test("widget many2many_tags_avatar list view - don't crash on keyboard navigatio
 });
 
 test("widget many2many_tags_avatar in kanban view", async () => {
-    expect.assertions(21);
+    expect.assertions(24);
 
     for (let id = 5; id <= 15; id++) {
         Partner._records.push({
@@ -231,6 +233,19 @@ test("widget many2many_tags_avatar in kanban view", async () => {
     Partner._views = {
         list: '<list><field name="name"/></list>',
     };
+    patchWithCleanup(KanbanMany2ManyTagsAvatarField.prototype, {
+        get specification() {
+            return {
+                ...super.specification,
+                id: {},
+            };
+        },
+    });
+    onRpc("web_name_search", ({ kwargs, model }) => {
+        expect(model).toBe("partner");
+        expect(kwargs.specification).toInclude(["id", {}]);
+        expect(kwargs.specification).toInclude(["display_name", {}]);
+    });
 
     await mountView({
         type: "kanban",


### PR DESCRIPTION
## [FIX] resource_mail: change placeholder for the many2many_avatar_resource in kanban

The default placeholder is "Search users...." which made little sense in the context of searching for resources.

## [FIX] web: give specification to AutoComplete in m2m tags popover

Before this commit, when the user uses the quick edit of m2m avatar
widget, the specification is not given to props since the popover does
not have the specification of the main component.

This commit makes sure the specification is given to popover to
correctly give them to the Autocomplete widget.

## [FIX] web: allow to change the popover to use in KanbanMany2ManyTagsAvatarFieldPopover

Before this commit, it was not possible to change the popover used in
KanbanMany2ManyAvatarFieldPopover in the case, we need to extend that
popover class used.

This commit allows to alter the popover class.

## [FIX] resource_mail: review m2m resource field widgets

This commit reviews the code in the different components for m2m
resource to use as much as possible the methods defined in the basic m2m
avatar widgets defined in web and mail.

## [FIX] resource: make sure resource without calendar set is flexible one

Before this commit, when an employee does not have a working schedule
set, neither work per day set, this employee is not considered as a
resource flexible in resource.resource record associated.

This commit makes sure this kind of employee be considered as flexible
resource.

task-6020304
