### PR TITLE
[IMP] purchase: add log note for unit price change

### DIFF
--- a/addons/purchase/data/mail_templates.xml
+++ b/addons/purchase/data/mail_templates.xml
@@ -3,12 +3,31 @@
 
     <template id="track_po_line_template">
         <div>
-            <strong>The ordered quantity has been updated.</strong>
+            <strong>
+                <t t-if="product_qty is not None and price_unit is not None">
+                    The ordered quantity and unit price have been updated.
+                </t>
+                <t t-elif="product_qty is not None">
+                    The ordered quantity has been updated.
+                </t>
+                <t t-elif="price_unit is not None">
+                    The unit price has been updated.
+                </t>
+            </strong>
+
             <ul>
                 <li><t t-out="line.product_id.display_name"/>:</li>
-                Ordered Quantity: <t t-out="line.product_qty" /> -&gt; <t t-out="float(product_qty)"/><br/>
-                <t t-if='line.order_id.product_id.type != "consu"'>
-                    Received Quantity: <t t-out="line.qty_received" /><br/>
+                <t t-if="product_qty is not None">
+                    Ordered Quantity: <t t-out="line.product_qty"/> -&gt; <t t-out="product_qty"/><br/>
+                </t>
+                <t t-if="price_unit is not None">
+                    Unit Price:
+                    <t t-out="line.price_unit"
+                        t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"/>
+                    -&gt;
+                    <t t-out="price_unit"
+                        t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"/>
+                    <br/>
                 </t>
                 Billed Quantity: <t t-out="line.qty_invoiced"/>
             </ul>

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -318,16 +318,26 @@ class PurchaseOrderLine(models.Model):
         if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
             raise UserError(_("You cannot change the type of a purchase order line. Instead you should delete the current line and create a new line of the proper type."))
 
-        if 'product_qty' in values:
+        if any(field in values for field in ('product_qty', 'price_unit')):
             precision = self.env['decimal.precision'].precision_get('Product Unit')
             for line in self:
+                if line.order_id.state != 'purchase':
+                    continue
+                render_values = {}
                 if (
-                    line.order_id.state == "purchase"
-                    and float_compare(line.product_qty, values["product_qty"], precision_digits=precision) != 0
+                    'product_qty' in values
+                    and float_compare(line.product_qty, values['product_qty'], precision_digits=precision) != 0
                 ):
+                    render_values['product_qty'] = float_round(values['product_qty'], precision_digits=precision)
+                if (
+                    'price_unit' in values
+                    and float_compare(line.price_unit, values['price_unit'], precision_digits=precision) != 0
+                ):
+                    render_values['price_unit'] = values['price_unit']
+                if render_values:
                     line.order_id.message_post_with_source(
                         'purchase.track_po_line_template',
-                        render_values={'line': line, 'product_qty': values['product_qty']},
+                        render_values={**render_values, 'line': line},
                         subtype_xmlid='mail.mt_note',
                     )
 


### PR DESCRIPTION
When updating the unit price on a confirmed Purchase Order line,
the system currently logs it as a change in the total amount, making it
unclear whether the change came from quantity, price, or discount.

- This improvement adds a dedicated chatter log for unit price changes,
  similar to quantity updates, so users can clearly identify that
  the change was specifically due to a unit price update.

- Also, rounded the product qty value using precision to ensure
  it is logged accurately according to the defined precision.

- Removed the received quantity log, as a dedicated log note already exists.
  It also does not provide meaningful information for non-consumable products.


TaskId-5469871