### PR TITLE
[FIX] Fleet: Fixing 'available' fleet filter domain

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -230,7 +230,7 @@
                 <field string="Status" name="state_id"/>
                 <field string="Properties" name="vehicle_properties"/>
                 <filter string="Available" name="available"
-                    domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', ('plan_to_change_vehicle', '=', True)]"/>
+                    domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), ('plan_to_change_vehicle', '=', True)]"/>
                 <filter name="planned" string="Planned for Change" domain="[('plan_to_change_vehicle', '=', True)]"/>
                 <separator/>
                 <filter string="Bikes" name="bikes" domain="[('vehicle_type', '=', 'bike')]"/>


### PR DESCRIPTION
Steps:
- Go to fleet app
- Use 'available' filter

Cause: Due to recent changes of merging car and bike vehicle types under a single vehicle field, the 'available' filter domain became obselete and failed due to searching for the individual vehicle types.

Solution: Revised the domain of the filter in order to query all the vehicles that have no current or future driver and are available for selection within the company.

Task: 6013274


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
