### PR TITLE
[REM] website_forum: `/forum/get_url_title` is no longer used

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -280,16 +280,6 @@ class WebsiteForum(WebsiteProfile):
     # Questions
     # --------------------------------------------------
 
-    @http.route('/forum/get_url_title', type='jsonrpc', auth="user", methods=['POST'], website=True)
-    def get_url_title(self, **kwargs):
-        try:
-            req = requests.get(kwargs.get('url'))
-            req.raise_for_status()
-            arch = lxml.html.fromstring(req.content)
-            return arch.find(".//title").text
-        except IOError:
-            return False
-
     @http.route(['''/forum/<model("forum.forum"):forum>/question/<model("forum.post", "[('forum_id','=',forum.id),('parent_id','=',False),('can_view', '=', True)]"):question>'''],
                 type='http', auth="public", website=True, sitemap=False)
     def old_question(self, forum, question, **post):


### PR DESCRIPTION
The only call to this route has been removed in Odoo 13.0: https://github.com/odoo/odoo/commit/1c5ffe17374b63916341908cb11446d13f65f8c9#diff-59fc987903da7cec03a1465bd2119088648d9cedd25412690618436f619031aeL542

The route can therefore be removed.
