### PR TITLE
[FIX] website_sale: show correct variant image on attribute hover in shop

### DIFF
--- a/addons/website_sale/static/src/interactions/product/product_variant_preview_hover.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview_hover.js
@@ -14,6 +14,7 @@ export class ProductVariantPreviewImageHover extends Interaction {
     setup() {
         this.productImg = this.el.querySelector('.oe_product_image_img_wrapper_primary img');
         this.originalImgSrc = this.productImg.getAttribute('src');
+        this.originalImgSrcset = this.productImg.getAttribute('srcset');
     }
 
     /**
@@ -43,17 +44,27 @@ export class ProductVariantPreviewImageHover extends Interaction {
      */
     _mouseLeave() {
         if (!this.env.isSmall) {
-            this._setImgSrc(this.originalImgSrc);
+            this._setImgSrc(this.originalImgSrc, this.originalImgSrcset);
         }
     }
 
     /**
-     * Set the image source of the product to the given image source
+     * Set the product image `src` and its `srcset` to the given `src` and `srcset`.
+     *
+     * For variant-specific images, no `srcset` is provided, the existing `srcset` attribute is
+     * removed.
+     * This ensures the browser uses the `src` directly, as browsers prioritize `srcset` over `src`.
      *
      * @param {string} imageSrc
+     * @param {string} imageSrcset
      */
-    _setImgSrc(imageSrc) {
+    _setImgSrc(imageSrc, imageSrcset) {
         this.productImg.src = imageSrc;
+        if (imageSrcset) {
+            this.productImg.setAttribute('srcset', imageSrcset);
+        } else {
+            this.productImg.removeAttribute('srcset');
+        }
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce:
- Go to the shop page.
- Hover over any attribute on a product tile that displays attributes.

Issue:
- The variant image does not update on attribute hover.

Cause:
- The `srcset` attribute was introduced for website images in https://github.com/odoo/odoo/commit/36e680feca4884940e020119de6a13cd7f927516.
- Only the `src` attribute of the image is updated on hover, while the `srcset` remains unchanged.
- Since browsers prioritize `srcset` over `src`, the displayed image does not change.

Fix:
- Remove the `srcset` when hovering over an attribute to ensure the updated `src` is used.
- Restore the original `srcset` when the hover ends.

opw-6030289