### PR TITLE
[FIX] website_forum: add a timeout to /forum/get_url_title

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -201,7 +201,7 @@ class WebsiteForum(WebsiteProfile):
     @http.route('/forum/get_url_title', type='json', auth="user", methods=['POST'], website=True)
     def get_url_title(self, **kwargs):
         try:
-            req = requests.get(kwargs.get('url'))
+            req = requests.get(kwargs.get('url'), timeout=10)
             req.raise_for_status()
             arch = lxml.html.fromstring(req.content)
             return arch.find(".//title").text


### PR DESCRIPTION
Add a timeout to the requests done by /forum/get_url_title to avoid blocking indefinitely
