### PR TITLE
[IMP] sale: search orders by child contact email

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1031,7 +1031,7 @@
                 <field name="name"
                     string="Order"
                     filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
-                <field name="partner_id" operator="child_of"/>
+                <field name="partner_id" filter_domain="['|', ('partner_id', 'child_of', self), ('partner_id.child_ids.email', 'ilike', self)]"/>
                 <field name="user_id"/>
                 <field name="team_id" string="Sales Team"/>
                 <field name="order_line" string="Product" filter_domain="[('order_line.product_id', 'ilike', self)]"/>


### PR DESCRIPTION
PURPOSE
When a customer contacts support using an email address different from the main company linked to the subscription (e.g., a child contact), it is difficult for agents to identify the correct order or subscription.

SPECIFICATIONS
Modify the search view for `partner_id` in both `sale` and `sale_subscription`. Replaced the standard `operator="child_of"` with a custom `filter_domain` that preserves top-down hierarchy searching while also performing a bottom-up search against the `email` field of any `child_ids`.

Task-6044439
ENT PR: https://github.com/odoo/enterprise/pull/111102
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
