### PR TITLE
[FIX] product_expiry: ensure expiration date updates  when changing lot

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -28,11 +28,11 @@ class StockMoveLine(models.Model):
             create_column(self._cr, "stock_move_line", "expiration_date", "timestamp")
         return super()._auto_init()
 
-    @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date')
+    @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date', 'quant_id')
     def _compute_expiration_date(self):
         for move_line in self:
-            if move_line.lot_id.expiration_date:
-                move_line.expiration_date = move_line.lot_id.expiration_date
+            if lot_id := move_line.quant_id.lot_id or move_line.lot_id:
+                move_line.expiration_date = lot_id.expiration_date
             elif move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
                     if not move_line.expiration_date:

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -518,6 +518,14 @@ class TestStockLot(TestStockCommon):
         When assigning a lot to a SML, if the lot has an expiration date,
         the latter should be applied on the SML
         """
+        self.apple_product.use_expiration_date = False
+        # Create a lot without expiration date to be sure that the date applied on the SML is the one of the lot and not a default one
+        lot_without_expiration = self.env['stock.lot'].create({
+            'name': 'Lot 2',
+            'product_id': self.apple_product.id,
+        })
+        self.assertFalse(lot_without_expiration.expiration_date)
+        self.apple_product.use_expiration_date = True
         exp_date = fields.Datetime.today() + relativedelta(days=15)
         sml_exp_date = fields.Datetime.today() + relativedelta(days=10)
 
@@ -548,6 +556,8 @@ class TestStockLot(TestStockCommon):
 
         sml.lot_id = lot
         self.assertEqual(sml.expiration_date, exp_date)
+        sml.lot_id = lot_without_expiration
+        self.assertFalse(sml.expiration_date)
 
     def test_apply_same_date_on_expiry_fields(self):
         expiration_time = 10


### PR DESCRIPTION
Steps to reproduce:
- Enable "Expiration Dates" in Inventory settings
- Create a storable product "P1"
  - Add 10 units with "Lot 1"
- Enable expiration dates on product P1
- Add 10 units with "Lot 2" and set an expiration date
- Create a delivery for 10 units of P1
  - Mark as "To Do"
  - Open the move line

-> "Lot 1" is automatically reserved

- Change the lot from "Lot 1" to "Lot 2" -> The expiration date is not updated automatically

- Save and reopen the move line -> The expiration date is correctly set

- Change again to "Lot 1"
- Save and reopen the move line -> The expiration date is not reset and incorrectly keeps the value from "Lot 2"

Cause:
The expiration date was only computed based on `lot_id`, ignoring the
`quant_id` used during reservation. Additionally, the value was not
reset when switching to a lot without an expiration date.

Solution:
- Add `quant_id` to the compute dependencies
- Compute the expiration date based on `quant_id.lot_id`
- Explicitly set an expiration date to today when the
use_expiration_date product is set to True and the lot doesn't have an
expiration date.

Result:
The expiration date is now correctly updated and cleared when changing lots on stock move lines.

opw-5999294
