### PR TITLE
[FIX] web: line height for titles

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1244,7 +1244,6 @@
 
             &:not(.o_field_widget *):not(.o_input_box_overlay_start, .o_input_box_overlay_end) {
                 &:not(.o_field_html) {
-                    line-height: calc(2.5 * var(--inputbox-spacing-unit));
                     // input boxes should always have at least the height of: line-height + vertical padding + border width
                     min-height: calc((2.5 + 2) * var(--inputbox-spacing-unit) + 2 * var(--fieldWidget-outline-width));
                 }
@@ -1258,7 +1257,7 @@
             }
         }
 
-        .o_input, textarea, select, [contenteditable] {
+        .o_input, textarea, select, [contenteditable], .o_input + .o_dropdown_button {
             border-color: transparent;
             padding: 0;
             font-size: var(--body-font-size);

--- a/addons/web/static/tests/views/fields/char_field.test.js
+++ b/addons/web/static/tests/views/fields/char_field.test.js
@@ -951,7 +951,10 @@ test("editable and readonly/empty fields have the same minimum size", async () =
             <field name="int_field"/>
         </form>`,
     });
-    const targetSize = Math.floor(queryFirst(".o_field_widget").getBoundingClientRect().height);
-    expect(Math.floor(queryFirst(".o_field_widget.o_readonly_modifier").getBoundingClientRect().height)).toBe(targetSize);
-    expect(Math.floor(queryFirst(".o_field_widget[name='int_field']").getBoundingClientRect().height)).toBe(targetSize);
+    const targetSize = queryFirst(".o_field_widget").getBoundingClientRect().height;
+    const readonlySize = queryFirst(".o_readonly_modifier").getBoundingClientRect().height;
+    const intSize = queryFirst("[name='int_field']").getBoundingClientRect().height;
+
+    expect(Math.abs(targetSize - readonlySize) <= 1).toBe(true);
+    expect(Math.abs(targetSize - intSize) <= 1).toBe(true);
 });


### PR DESCRIPTION
Before this commit, the spacing between lines was too small for multi-line `<h1>` elements.
That’s why we decided to remove the line-height property.

As a result, an issue appeared with the caret in many2x fields. For example, in the appraisal form, the title is a many2one field with the appraiser.

task-6013996

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
