### PR TITLE
[IMP] web: cleanup code for selection

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -493,11 +493,6 @@ export function parseServerValue(field, value) {
             return value ? deserializeDateTime(value) : false;
         }
         case "selection": {
-            if (value === false) {
-                // process selection: convert false to 0, if 0 is a valid key
-                const hasKey0 = field.selection.find((option) => option[0] === 0);
-                return hasKey0 ? 0 : value;
-            }
             return value;
         }
         case "reference": {

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -159,32 +159,6 @@ test("[Offline] SelectionField on many2one field", async () => {
     expect(".o_field_widget[name='product_id']").toHaveText("xphone");
 });
 
-test("unset selection field with 0 as key", async () => {
-    // The server doesn't make a distinction between false value (the field
-    // is unset), and selection 0, as in that case the value it returns is
-    // false. So the client must convert false to value 0 if it exists.
-    Partner._fields.selection = fields.Selection({
-        selection: [
-            [0, "Value O"],
-            [1, "Value 1"],
-        ],
-    });
-
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        resId: 1,
-        arch: /* xml */ '<form edit="0"><field name="selection" /></form>',
-    });
-
-    expect(".o_field_widget").toHaveText("Value O", {
-        message: "the displayed value should be 'Value O'",
-    });
-    expect(".o_field_widget").not.toHaveClass("o_field_empty", {
-        message: "should not have class o_field_empty",
-    });
-});
-
 test("unset selection field with string keys", async () => {
     // The server doesn't make a distinction between false value (the field
     // is unset), and selection 0, as in that case the value it returns is


### PR DESCRIPTION
Since commit 80ca24a7b11d9240bbbd505f6dcf61d6a423c8cd, the _description_selection is always a `list[tuple[str, str]]` The `0` key check is no longer needed in webclient.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
