### PR TITLE
[FIX] website: keep attributes on custom dynamic snippets

### DIFF
--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -31,14 +31,15 @@ class IrQweb(models.AbstractModel):
     def _compile_root(self, element, compile_context):
         # Removes the attributes used by the "/website/snippet/filter_templates"
         # controller and used only to be filtered without using irQweb rendering
-        for data_filter in [
-                'data-number-of-elements', 'data-number-of-elements-sm',
-                'data-number-of-elements-fetch', 'data-row-per-slide',
-                'data-arrow-position', 'data-extra-classes',
-                'data-extra-snippet-classes', 'data-container-classes',
-                'data-content-classes', 'data-column-classes', 'data-thumb',
-            ]:
-            element.attrib.pop(data_filter, None)
+        if not self._is_static_node(element, compile_context):
+            for data_filter in [
+                    'data-number-of-elements', 'data-number-of-elements-sm',
+                    'data-number-of-elements-fetch', 'data-row-per-slide',
+                    'data-arrow-position', 'data-extra-classes',
+                    'data-extra-snippet-classes', 'data-container-classes',
+                    'data-content-classes', 'data-column-classes', 'data-thumb',
+                ]:
+                element.attrib.pop(data_filter, None)
         return super()._compile_root(element, compile_context)
 
     def _get_template(self, template):


### PR DESCRIPTION
The commit ae4824640665fc639e03a13c341f18e73060349e, added cleaning of some attributes used by filter controller for dynamic snippet. Those attributes are also saved when changed by the user. When the user creates a custom snippet based on a dynamic snippet, the attributes appears legitimately on the root of the view, but the cleaning code removes them.

This commit adds a condition to only remove those attributes only if the node is "not static" (and therefore are not causing the issue for which the cleaning code was added).

Steps to reproduce:
- Open website builder
- Drop the snippet `s_blog_posts_horizontal`, and click on it
- Save it as a custom snippet
- Drop the custom snippet
- Bug: The layout is different than the original snippet

task-5969305