### PR TITLE
[FIX] project: The company description should be on the same line

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -150,10 +150,10 @@
                                            invisible="not alias_email"/>
                                     <field name="privacy_visibility" widget="radio"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" placeholder="Visible to all"/>
-                                    <div class="text-muted o_input_box" invisible="access_instruction_message == ''">
+                                    <div colspan="2" class="text-muted o_input_box" invisible="access_instruction_message == ''">
                                         <i class="o_input_box_overlay_start fa fa-lightbulb-o" title="Info"/><field name="access_instruction_message" nolabel="1"/>
                                     </div>
-                                    <div class="text-muted o_input_box" invisible="privacy_visibility_warning == ''">
+                                    <div colspan="2" class="text-muted o_input_box" invisible="privacy_visibility_warning == ''">
                                         <i class="o_input_box_overlay_start fa fa-warning" title="Warning"/><field name="privacy_visibility_warning" nolabel="1"/>
                                     </div>
                                 </group>


### PR DESCRIPTION
Steps to reproduce:

- Go to Project;
- on the card "ACME - S00072 - Sales Order";
  > click on 3 dots and select the "Settings" Menu;
- Click on "Settings" tab.

=> You can see the company description don't take all available space.

task-6035875

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
