### PR TITLE
[FIX] calendar : avoid current user lockout during meeting creation

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -312,14 +312,14 @@ class CalendarEvent(models.Model):
     def _compute_user_can_edit(self):
         for event in self:
             # By default, only current attendees and the organizer can edit the event.
-            editor_candidates = set(event.partner_ids.user_ids + event.user_id)
+            editor_candidates = event.partner_ids.user_ids + event.user_id
             # Right before saving the event, old partners must be able to save changes.
             if event._origin:
-                editor_candidates |= set(event._origin.partner_ids.user_ids)
+                editor_candidates |= event._origin.partner_ids.user_ids
             # Non-private events must be editable by uninvited administrators.
             if self.env.user.has_group('base.group_system') and event.privacy != 'private':
-                editor_candidates.add(self.env.user)
-            event.user_can_edit = self.env.user in editor_candidates
+                editor_candidates |= self.env.user
+            event.user_can_edit = self.env.uid in editor_candidates._origin.ids
 
     @api.depends('partner_ids')
     def _compute_invalid_email_partner_ids(self):


### PR DESCRIPTION
Steps to reproduce :
-Log in with a non-admin USER A
-Create a meeting in Calendar
-Change the Organizer to USER B
-Add USER B to the attendees list

After the onchange event, you will be locked out of the meeting edition and will not be able to change anything else, saving the form will also revert everything to its original state (USER A as organizer and sole attendee)

This is caused by a comparison mismatch when checking whether the current user was in the editor candidates set, as a real res.users(28,) would never match res.users(<NewId origin=28>,) even though they represent the same user.

Fix by working with integer IDs from the start using ._origin.ids on the recordset, which normalizes both NewId and real records to plain integers before comparison.

opw-6005787