### PR TITLE
[IMP] html_editor: add prefix input in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.dark.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.dark.scss
@@ -1,0 +1,5 @@
+.o-we-linkpopover {
+    .o_we_edit_link {
+        background-color: $gray-200;
+    }
+}

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -39,6 +39,20 @@
             white-space: nowrap;
         }
     }
+
+    .o_we_input_label {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: rgba($body-color, 0.7);
+        border: var(--border-width) solid var(--dark-border-subtle);
+        border-radius: var(--border-radius) 0 0 var(--border-radius);
+        width: 35px !important;
+    }
+
+    .oe_link_label_icon {
+        fill: rgba($body-color, 0.7);
+    }
 }
 
 /* rtl:begin:ignore */

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -1,11 +1,20 @@
 <templates id="template" xml:space="preserve">
 
+    <t t-name="html_editor.TextFieldsIcon">
+        <svg xmlns="http://www.w3.org/2000/svg" class="oe_link_label_icon" height="18px" width="18px" viewBox="0 -960 960 960">
+            <path d="M280-160v-520H80v-120h520v120H400v520H280Zm360 0v-320H520v-120h360v120H760v320H640Z"/>
+        </svg>
+    </t>
+
     <t t-name="html_editor.linkPopover">
         <div class="o-we-linkpopover d-flex bg-light overflow-auto shadow" t-on-keydown="this.onKeydown" role="dialog" aria-modal="true" aria-label="Link Popover">
             <div t-if="this.state.editing" class="container-fluid d-flex vertical-center p-2" t-custom-ref="editing-wrapper">
                 <div t-if="this.state.isImage" class="col p-2 o_link_popover_container">
                     <div class="input-group mb-1">
-                        <input name="o_linkpopover_url_img" t-custom-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-custom-model="this.state.url" title="URL" placeholder="Type your URL"
+                        <label for="o_linkpopover_url_img" class="o_we_input_label">
+                            <span class="fa fa-link"></span>
+                        </label>
+                        <input id="o_linkpopover_url_img" name="o_linkpopover_url_img" t-custom-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-custom-model="this.state.url" title="URL" placeholder="Type your URL"
                             t-on-keydown="this.onKeydownEnter"/>
                         <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'mx-1': this.state.type ===  ''}" t-on-click="this.onClickApply">Apply</button>
                     </div>
@@ -46,7 +55,11 @@
                 <t t-else="">
                     <div class="col p-2 o_link_popover_container">
                         <div class="input-group mb-2" t-att-class="{'d-none': !this.state.showLabel}">
+                            <label for="o_we_label_link" class="o_we_input_label">
+                                <t t-call="html_editor.TextFieldsIcon"/>
+                            </label>
                             <input t-custom-ref="label"
+                                id="o_we_label_link"
                                 class="o_we_label_link border-dark-subtle form-control form-control-sm"
                                 t-custom-model="this.state.label"
                                 title="Label"
@@ -54,7 +67,11 @@
                                 t-on-input="this.onChange"/>
                         </div>
                         <div class="input-group mb-2">
+                            <label for="o_linkpopover_url" class="o_we_input_label">
+                                <span class="fa fa-link"></span>
+                            </label>
                             <input t-custom-ref="url"
+                                id="o_linkpopover_url"
                                 name="o_linkpopover_url"
                                 class="o_we_href_input_link border-dark-subtle form-control form-control-sm"
                                 t-custom-model="this.state.url"

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -115,6 +115,17 @@ describe("should open a popover", () => {
         await waitForNone(".o-we-linkpopover", { timeout: 1500 });
         expect(".o-we-linkpopover").toHaveCount(0);
     });
+    test("clicking input prefix icon should focus associated input", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        execCommand(editor, "openLinkTools");
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover label[for='o_we_label_link']").toHaveCount(1);
+        expect(".o-we-linkpopover label[for='o_linkpopover_url']").toHaveCount(1);
+        await click(".o-we-linkpopover label[for='o_linkpopover_url']");
+        expect(".o_we_href_input_link").toBeFocused();
+        await click(".o-we-linkpopover label[for='o_we_label_link']");
+        expect(".o_we_label_link").toBeFocused();
+    });
 });
 
 describe("popover should not reposition when editing", () => {

--- a/addons/website/static/src/xml/html_editor.xml
+++ b/addons/website/static/src/xml/html_editor.xml
@@ -21,6 +21,7 @@
 
 <t t-name="website.InputURLAutoComplete">
     <AutoCompleteInLinkPopover
+        id="'o_linkpopover_url'"
         sources="this.sources"
         value="this.state.url"
         input="this.urlRef"


### PR DESCRIPTION
This PR aims to add below icons as input prefix in link popover:
- fa-link for url input.
- Google Fonts Text Fields for label input.

Clicking on any of them focuses the corresponding input field. This PR also sets right bg color for `Edit` button in dark mode.

task-6034288





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
