### PR TITLE
[FIX] sale_stock: update delivered qty 3 comp dropship chain

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -345,7 +345,7 @@ class SaleOrderLine(models.Model):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
 
         for move in moves:
-            if not move._is_dropshipped_returned() and (
+            if (not move._is_dropshipped_returned() or move._is_dropshipped()) and (
                 (strict and move.location_dest_id._is_outgoing()) or (
                 not strict and move.rule_id.id in triggering_rule_ids and
                 (move.location_final_id or move.location_dest_id)._is_outgoing()


### PR DESCRIPTION
**Steps to reproduce:**

- Make sure you have 3 companies (comp A, B and C)
- Navigate to Settings/Users & Companies/ Companies 
- for each company in the 'Inter Company Transactions' tab: 
check 'generate Sale Orders', 'generate purchase orders' and 
'synchronize Deliveries to your receipts' then select a warehouse 
and a receipt operation type

From company A
- create a storable product
- in the Purchase tab, set the company B as a vendor

From company B 
- in the Purchase tab of the product, set company C as a vendor

From company C
- set a positive on hand quantity

From Company A
- create a SO for 1 quantity of your product
- on the sale order line, unhide de route_id column and 
set it to dropship
- confirm the SO and the linked PO

From company B
- on the SO created with company A as customer (you might need to 
remove the 'my quotations filter to find it), set the dropship 
route in the route_id column of the sale order line
- confirm the SO and the linked PO

From company C
- confirm SO created with company B as customer
- validate the delivery

From company B
- validate the dropship

**Current behavior:**
the quantity delivered on the sale order line is 0 

**Expected behavior:**
it should be 1

**Cause of the issue:**
inside _compute_qty_delivered, we fetch the incoming 
and outgoing moves using _get_outgoing_incoming_moves()
https://github.com/odoo/odoo/blob/b936b64ed0217909ff96a1b28d1370f5064be46a/addons/sale_stock/models/sale_order_line.py#L200
There, for the move of the dropship picking, inside the 
if condition, move._is_dropshipped_returned() will be True
https://github.com/odoo/odoo/blob/b936b64ed0217909ff96a1b28d1370f5064be46a/addons/sale_stock/models/sale_order_line.py#L348-L354
That's because the move is going from transit to transit
https://github.com/odoo/odoo/blob/b936b64ed0217909ff96a1b28d1370f5064be46a/addons/stock_account/models/stock_move.py#L186-L195
So it will not be added to the outgoing moves and 
qty_delivered will stay 0.

**fix**
is_dropshipped_returned should not prevent the move 
to be added to the outgoing moves if is_dropshipped() is 
aslo true (i.e. it's a transit to transit move)

opw-5023215