### PR TITLE
[FIX] stock, {sale_,mrp}: update MTO manufacture on move dest cancel

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -431,6 +431,32 @@ class StockMove(models.Model):
                 mo_to_cancel._action_cancel()
         return res
 
+    def _log_cancel_activity(self):
+        super()._log_cancel_activity()
+        if not self:
+            return
+
+        def _render_note_exception_cancel_dest(moves):
+            values = {
+                'origin_moves': moves,
+                'origin_picking': moves.picking_id[0],
+                'moves_information': ((move, (0.0, move.product_qty)) for move in moves),
+            }
+            return self.env['ir.qweb']._render('stock.exception_on_picking', values)
+
+        cancelled_ids = set(self.ids)
+        impacted_origins = self.move_orig_ids.filtered(lambda m: m.state not in ('done', 'cancel'))
+        documents = {}
+        for move in impacted_origins:
+            production = move.production_id
+            if not production:
+                continue
+            cancelled_dests = move.move_dest_ids.filtered(lambda m: m.id in cancelled_ids)
+            if not cancelled_dests:
+                continue
+            documents[move.production_id, move.production_id.user_id or self.env.user] = cancelled_dests
+        return self.env['stock.picking']._log_activity(_render_note_exception_cancel_dest, documents)
+
     def _prepare_move_split_vals(self, qty):
         defaults = super()._prepare_move_split_vals(qty)
         defaults['workorder_id'] = False
@@ -497,7 +523,7 @@ class StockMove(models.Model):
 
     def _get_upstream_documents_and_responsibles(self, visited):
         if self.production_id and self.production_id.state not in ('done', 'cancel'):
-            return [(self.production_id, self.production_id.user_id, visited)]
+            return [(self.production_id, self.production_id.user_id or self.env.user, visited)]
         else:
             return super(StockMove, self)._get_upstream_documents_and_responsibles(visited)
 

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2742,3 +2742,56 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(so.mrp_production_count, 2)
         self.assertEqual(so.mrp_production_ids[0].mrp_production_child_count, 1)
         self.assertEqual(so.mrp_production_ids[1].mrp_production_child_count, 1)
+
+    def test_sale_mto_manufacture_quantity_update_propagation(self):
+        """
+        Check that in MTO the quantity update on an SO is propagated on the MO
+        and that an activity is scheduled on operation cancellation.
+        """
+        product = self.product
+        product.route_ids = self.env.ref('stock.route_warehouse0_mto')
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'bom_line_ids': [Command.create({
+                'product_id': self.component_a.id, 'product_qty': 1.0,
+            })],
+        })
+        sale_order, sale_order_to_cancel = sale_orders = self.env['sale.order'].create([{
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 3,
+            })],
+        } for _ in range(2)])
+        sale_orders.action_confirm()
+
+        production = sale_order.stock_reference_ids.production_ids
+        self.assertRecordValues(production, [
+            {'product_qty': 3.0, 'product_uom_id': product.uom_id.id}
+        ])
+        # Cancel the delivery which adds a warning in the chatter but does not cancel the MO
+        delivery = sale_order.picking_ids
+        delivery.action_cancel()
+        # Check that an activity was linked on the the MO
+        self.assertRecordValues(production.activity_ids, [
+            {'user_id': self.env.user.id, 'display_name': 'Exception'}
+        ])
+        self.assertRegex(production.activity_ids.note, fr"Exception\(s\) occurred on the picking.*\n.*{delivery.name.replace('/', '.')}.*\n.*Manual actions may be needed")
+        # Update the selling demand to 10 units, this should create a delivery for
+        # 10 units and MTO should adapt existing MO for an additinal 10 units
+        with Form(sale_order) as so_form:
+            with so_form.order_line.edit(0) as order_line:
+                order_line.product_uom_qty = 10.0
+        self.assertRecordValues(sale_order.stock_reference_ids.production_ids, [
+            {'product_qty': 13.0, 'product_uom_id': product.uom_id.id}
+        ])
+
+        # Check that cancelling the SO, propagates the cancellation on the delivery
+        # and scheduled a signle activity on the MO (the one of the SO, not the DO)
+        sale_order_to_cancel.action_cancel()
+        self.assertEqual(sale_order_to_cancel.picking_ids.state, 'cancel')
+        production_2 = sale_order_to_cancel.stock_reference_ids.production_ids
+        self.assertRecordValues(production_2.activity_ids, [
+            {'user_id': self.env.user.id, 'display_name': 'Exception'}
+        ])
+        self.assertRegex(production_2.activity_ids.note, fr"Exception\(s\) occurred on the sale order\(s\).*\n.*{sale_order_to_cancel.name}.*\n.*Manual actions may be needed")

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -255,7 +255,7 @@ class SaleOrder(models.Model):
             if sale_order.state == 'sale' and sale_order.order_line:
                 sale_order_lines_quantities = {order_line: (order_line.product_uom_qty, 0) for order_line in sale_order.order_line}
                 documents = self.env['stock.picking'].with_context(include_draft_documents=True)._log_activity_get_documents(sale_order_lines_quantities, 'move_ids', 'UP')
-        self.picking_ids.filtered(lambda p: p.state != 'done').action_cancel()
+        self.picking_ids.filtered(lambda p: p.state != 'done').with_context(skip_cancel_activity=True).action_cancel()
         if documents:
             filtered_documents = {}
             for (parent, responsible), rendering_context in documents.items():

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -335,7 +335,7 @@ class SaleOrderLine(models.Model):
             triggering_rule_ids = []
             seen_wh_ids = set()
             for move in sorted_moves:
-                if move.warehouse_id.id not in seen_wh_ids:
+                if move.warehouse_id.id not in seen_wh_ids and move.rule_id:
                     triggering_rule_ids.append(move.rule_id.id)
                     seen_wh_ids.add(move.warehouse_id.id)
         if self.env.context.get('accrual_entry_date'):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2067,11 +2067,17 @@ Please change the quantity done or the rounding precision in your settings.""",
                         'procure_method': 'make_to_stock',
                         'move_orig_ids': [Command.unlink(move.id)]
                     })
+        if not self.env.context.get('skip_cancel_activity'):
+            # log an activity on the non-cancelled origin to warn the user that some actions might be required
+            moves_to_cancel._log_cancel_activity()
         moves_to_cancel.write({
             'move_orig_ids': [(5, 0, 0)],
             'procure_method': 'make_to_stock',
         })
         return True
+
+    def _log_cancel_activity(self):
+        return
 
     def _skip_push(self):
         return self.is_inventory or (


### PR DESCRIPTION
### Issues:

Cancelling the move dest of a manufacturing order does not cancel the MO nor log's an activity warning for the responsible to update the manufacturing demand manually.

Additionally, when selling MTO manufactured products, cancelling the delivery and then changing the sol's demand will update the MO for an incorrect amount.

### Steps to reproduce:

- In the settings: Enable Multi-Steps Routes
- Inventory > Configuration > Warehouse Management > Routes
- Unarchive the MTO route
- Create an MTO product with BOM
- Create and confirm an SO for 3 units of that product
- Cancel the delivery of 3 units
> There is no notification on the unrelevant MO linked to the SO
- Adapt the quantity of the SOL from 3 to 10
#### > A Delivery is created for 8 units and the MO's demand is updated from 3 to 11

### Expected behavior:

Since the the SOL demand is updated to 10 units and none are currently delivered, a delivery for 10 units should be created and the MTO behavior should therefore add 10 units to be manufactured.

### Cause of the issue:

Adapting the quantity on the sale order from 3 to 10 will launch a call of the `_action_launch_stock_rule` with a `previous_product_uom_qty` of 3. The purpose of this call being to create and run a procurement to fulfill the new demand:
https://github.com/odoo/odoo/blob/abb5777cc8324cff0cdf841a8ae42413060dcf92/addons/sale_stock/models/sale_order_line.py#L388-L402
The demand of this procurement is therefore matching the new quantity of the sol minus the qty that is already handled by other procurements (determined by the `_get_qty_procurement` method): https://github.com/odoo/odoo/blob/abb5777cc8324cff0cdf841a8ae42413060dcf92/addons/sale_stock/models/sale_order_line.py#L310-L320
Note that this `_get_qty_procurement` call should determine the qty that is already planned to be delivered to and returned by the customer. In particular, this `_get_qty_procurement` call should return a value of 0.0 because the entire delivery has been cancelled and nothing is expected to be returned from the customer. However, the call will return an unexpected value of `-3.0` units which will in turn provide a procurement to the customer location for `5 - (-3) =  8` units and hence lead to the creation of a delivery for 8 units and adapt the MO by MTO for 8 additional units.

The discrepancy happening in the `_get_qty_procurement` is due to two recent changes. To begin with, since the 19.0 version the `move_finished_ids` of the production is linked to the sol (part of its `move_ids`) because of these lines:
https://github.com/odoo/odoo/blob/abb5777cc8324cff0cdf841a8ae42413060dcf92/addons/sale_stock/models/stock.py#L134-L139 This change ensuring that MO created by MTO is linked to the SO see 2713876dbc70d3984e584a9037a2206dcda4e84a for more details.

As such, the move of the produced product can now be part of the moves initially considered in the `_get_outgoing_incoming_moves` and that should be filtered out to not be accounted in the qty handled by the current sol:
https://github.com/odoo/odoo/blob/abb5777cc8324cff0cdf841a8ae42413060dcf92/addons/sale_stock/models/sale_order_line.py#L322-L331

Now, the reason this production move is not excluded from the incoming move pool is because of the change of this other fix: 37f1377344864770cd2a745dd4cb6999af07bbdf https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/sale_stock/models/sale_order_line.py#L353-L358 To be more precise, while the move is not not a refund, it satisfies the second part of the condition that `move.rule_id.id in triggering_rule_ids` for the incorrect reason that the move has no `rule_id` so that and that `move.rule_id.id` is False and the `triggering_rule_ids` contains the False value but this key is irrelevant and should never have been added as the purpose of the `triggering_rule_ids` list is to keep track of rules starting a push chain.

opw-6010109
opw-5885741

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
