### PR TITLE
[REF] *: run rendering context migration script on inline xml

### DIFF
--- a/addons/api_doc/static/src/components/doc_error_dialog.js
+++ b/addons/api_doc/static/src/components/doc_error_dialog.js
@@ -7,23 +7,23 @@ export class DocErrorDialog extends Component {
         <div class="alert error mt-1 d-flex flex-column" role="alert">
             <div class="d-flex align-items-center mb-2">
                 <i class="pe-2 fa fa-exclamation-triangle fa-lg" aria-hidden="true"/>
-                <h5 class="m-0 text-danger">Error while loading models: <strong t-out="props.name"/></h5>
+                <h5 class="m-0 text-danger">Error while loading models: <strong t-out="this.props.name"/></h5>
             </div>
-            <t t-if="props.traceback">
-                <div t-if="state.showTraceback" class="overflow-auto position-relative" style="max-height: 500px;">
+            <t t-if="this.props.traceback">
+                <div t-if="this.state.showTraceback" class="overflow-auto position-relative" style="max-height: 500px;">
                     <button
                         class="btn bg-100 position-absolute top-0 end-0"
                         t-custom-ref="copyButton"
-                        t-on-click="onClickClipboard"
+                        t-on-click="this.onClickClipboard"
                     >
                         <span class="fa fa-clipboard"/>
                     </button>
-                    <pre class="small text-break p-4" t-out="props.traceback"/>
+                    <pre class="small text-break p-4" t-out="this.props.traceback"/>
                 </div>
                 <button
                     class="btn btn-sm mt-2 align-self-center"
-                    t-on-click="toggleTraceback"
-                    t-out="state.showTraceback ? 'Hide Details' : 'Show Technical Details'"
+                    t-on-click="this.toggleTraceback"
+                    t-out="this.state.showTraceback ? 'Hide Details' : 'Show Technical Details'"
                 />
             </t>
         </div>

--- a/addons/api_doc/static/src/components/doc_loading_indicator.js
+++ b/addons/api_doc/static/src/components/doc_loading_indicator.js
@@ -2,10 +2,10 @@ import { Component, xml } from "@odoo/owl";
 
 export class DocLoadingIndicator extends Component {
     static template = xml`
-        <div t-if="!props.isLoaded" class="o-doc-load-wrapper o-fade-in position-relative h-100 w-100 bg-2 rounded">
+        <div t-if="!this.props.isLoaded" class="o-doc-load-wrapper o-fade-in position-relative h-100 w-100 bg-2 rounded">
             <div class="o-doc-load-activity position-absolute h-100"></div>
         </div>
-        <div t-else="" t-att-class="props.class">
+        <div t-else="" t-att-class="this.props.class">
             <t t-slot="default"/>
         </div>
     `;

--- a/addons/auth_password_policy/static/src/password_meter.js
+++ b/addons/auth_password_policy/static/src/password_meter.js
@@ -5,11 +5,11 @@ import { Component, xml } from "@odoo/owl";
 export class Meter extends Component {
     static template = xml`
         <div class="o_password_meter_container d-flex align-items-center">
-            <span t-out="passwordStrengthParams.text"
-                t-attf-class="me-2 #{passwordStrengthParams.className}"/>
+            <span t-out="this.passwordStrengthParams.text"
+                t-attf-class="me-2 #{this.passwordStrengthParams.className}"/>
             <meter class="o_password_meter"
                 min="0" low="0.5" high="0.99" max="1" optimum="1"
-                t-att-title="title" t-att-value="value"/>
+                t-att-title="this.title" t-att-value="this.value"/>
         </div>
     `;
     static props = {

--- a/addons/delivery_mondialrelay/static/src/components/mondialrelay_field.js
+++ b/addons/delivery_mondialrelay/static/src/components/mondialrelay_field.js
@@ -17,7 +17,7 @@ function corsIgnoredErrorHandler(env, error) {
 }
 
 export class MondialRelayField extends Component {
-    static template = xml`<div t-if="enabled" t-custom-ref="root"/>`;
+    static template = xml`<div t-if="this.enabled" t-custom-ref="root"/>`;
     static props = {...standardFieldProps};
     setup() {
         this.root = useRef("root");

--- a/addons/html_builder/static/src/core/img.js
+++ b/addons/html_builder/static/src/core/img.js
@@ -35,21 +35,20 @@ export class Image extends Component {
         svgCheck: true,
     };
     static template = xml`
-        <t t-if="state.loaded">
-            <svg t-if="isSvg(props.src)" t-custom-ref="svg"
-                xmlns="http://www.w3.org/2000/svg"
-                t-att-width="svg.width"
-                t-att-viewBox="svg.viewBox"
-                t-att-fill="svg.fill"
+        <t t-if="this.state.loaded">
+            <svg xmlns="http://www.w3.org/2000/svg" t-if="this.isSvg(this.props.src)" t-custom-ref="svg"
+                t-att-width="this.svg.width"
+                t-att-viewBox="this.svg.viewBox"
+                t-att-fill="this.svg.fill"
                 class="hb-svg d-flex m-auto"
-                t-att-class="props.class"
-                t-att-style="props.style"
+                t-att-class="this.props.class"
+                t-att-style="this.props.style"
                 t-att="props.attrs"/>
             <img t-else=""
-                t-att-src="props.src"
-                t-att-class="props.class"
-                t-att-style="props.style"
-                t-att-alt="props.alt"
+                t-att-src="this.props.src"
+                t-att-class="this.props.class"
+                t-att-style="this.props.style"
+                t-att-alt="this.props.alt"
                 t-att="props.attrs"/>
         </t>
         `;

--- a/addons/html_builder/static/tests/builder_action.test.js
+++ b/addons/html_builder/static/tests/builder_action.test.js
@@ -72,7 +72,7 @@ test("Prepare is triggered on props updated", async () => {
     let prepareDeferred = Promise.withResolvers();
     prepareDeferred.resolve();
     class TestOption extends BaseOptionComponent {
-        static template = xml`<BuilderCheckbox action="'customAction'" actionParam="state.param"/>`;
+        static template = xml`<BuilderCheckbox action="'customAction'" actionParam="this.state.param"/>`;
         setup() {
             super.setup();
             this.state = useState({ param: "old param" });

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
@@ -98,7 +98,7 @@ test("dependency definition should not be outdated", async () => {
     class TestMany2One extends BaseOptionComponent {
         static template = xml`
             <BuilderMany2One action="'testAction'" model="'test'" limit="10" id="'test_many2one_opt'"/>
-            <BuilderRow t-if="getItemValueJSON('test_many2one_opt')?.id === 2"><span>Dependant</span></BuilderRow>
+            <BuilderRow t-if="this.getItemValueJSON('test_many2one_opt')?.id === 2"><span>Dependant</span></BuilderRow>
         `;
         setup() {
             super.setup();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
@@ -56,7 +56,7 @@ test("update default prop", async () => {
     addBuilderOption({
         selector: ".parent-target",
         Component: class extends BaseOptionComponent {
-            static template = xml`<BuilderTextInput action="'customAction'" default="state.default"/>`;
+            static template = xml`<BuilderTextInput action="'customAction'" default="this.state.default"/>`;
 
             setup() {
                 this.state = useState(state);

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -32,7 +32,7 @@ export function patchWithCleanupImg() {
     const defaultImg =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z9DwHwAGBQKA3H7sNwAAAABJRU5ErkJggg==";
     patchWithCleanup(Image, {
-        template: xml`<img t-att-data-src="props.src" t-att-alt="props.alt" t-att-class="props.class" t-att-style="props.style" t-att="props.attrs" src="${defaultImg}"/>`,
+        template: xml`<img t-att-data-src="this.props.src" t-att-alt="this.props.alt" t-att-class="this.props.class" t-att-style="this.props.style" t-att="props.attrs" src="${defaultImg}"/>`,
     });
     patchWithCleanup(Image.prototype, {
         loadImage: () => {},
@@ -102,14 +102,14 @@ class BuilderContainer extends Component {
         <div class="d-flex h-100 w-100" t-ref="container">
             <div class="o_website_preview flex-grow-1" t-ref="website_preview">
                 <div class="o_iframe_container">
-                    <iframe class="h-100 w-100" t-ref="iframe" t-on-load="onLoad"/>
+                    <iframe class="h-100 w-100" t-ref="iframe" t-on-load="this.onLoad"/>
                     <div t-if="this.state.isMobile" class="o_mobile_preview_layout">
                         <img alt="phone" src="/html_builder/static/img/phone.svg"/>
                     </div>
                 </div>
             </div>
-            <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
-            <div t-if="state.isEditing" t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar}" class="o-website-builder_sidebar border-start border-dark">
+            <LocalOverlayContainer localOverlay="this.overlayRef" identifier="this.env.localOverlayContainerKey"/>
+            <div t-if="this.state.isEditing" t-att-class="{'o_builder_sidebar_open': this.state.isEditing and this.state.showSidebar}" class="o-website-builder_sidebar border-start border-dark">
                 <Builder t-props="this.getBuilderProps()"/>
             </div>
         </div>`;

--- a/addons/html_builder/static/tests/img.test.js
+++ b/addons/html_builder/static/tests/img.test.js
@@ -25,7 +25,7 @@ test("ImgGroup's inner Image components should not be blocked before src load", 
         static components = { ImgGroup, Image };
         static template = xml`
             <ImgGroup>
-                <t t-foreach="Object.keys(defs)" t-as="key" t-key="key">
+                <t t-foreach="Object.keys(this.defs)" t-as="key" t-key="key">
                     <Image src="''" class="key"/>
                 </t>
             </ImgGroup>`;

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -21,7 +21,7 @@ describe("useDomState", () => {
         addBuilderOption({
             selector: ".test-options-target",
             Component: class extends BaseOptionComponent {
-                static template = xml`<div t-att-data-letter="getLetter()"/>`;
+                static template = xml`<div t-att-data-letter="this.getLetter()"/>`;
                 setup() {
                     super.setup(...arguments);
                     this.state = useDomState(async () => {
@@ -82,7 +82,7 @@ describe("waitSidebarUpdated", () => {
         class TestSubComponent extends BaseOptionComponent {
             static template = xml`
                 <div class="test-value-sub">
-                    <t t-out="state.value"/>
+                    <t t-out="this.state.value"/>
                 </div>
             `;
             setup() {
@@ -97,7 +97,7 @@ describe("waitSidebarUpdated", () => {
         class TestOptionComponent extends BaseOptionComponent {
             static template = xml`
                 <div class="test-value-parent">
-                    <t t-out="state.value"/>
+                    <t t-out="this.state.value"/>
                 </div>
                 <div class="test-button-1">
                     <BuilderButton action="'testAction'" actionValue="'b'">b</BuilderButton>
@@ -105,7 +105,7 @@ describe("waitSidebarUpdated", () => {
                 <div class="test-button-2">
                     <BuilderButton id="'button_2_opt'" action="'testAction'" actionValue="'c'">c</BuilderButton>
                 </div>
-                <t t-if="state.showOther and isActiveItem('button_2_opt')">
+                <t t-if="this.state.showOther and this.isActiveItem('button_2_opt')">
                     <TestSubComponent/>
                 </t>
             `;
@@ -256,7 +256,7 @@ test("System should not crash if an asynchronous useDomState is working with rem
     let useDomStateStarted;
     let editingElRemoved;
     class TestOptionComponent extends BaseOptionComponent {
-        static template = xml`<BuilderButton t-if="state.showOption" classAction="'y'">Click</BuilderButton>`;
+        static template = xml`<BuilderButton t-if="this.state.showOption" classAction="'y'">Click</BuilderButton>`;
         setup() {
             super.setup();
             this.state = useDomState(async (el) => {

--- a/addons/html_editor/static/src/components/switch/switch.js
+++ b/addons/html_editor/static/src/components/switch/switch.js
@@ -15,17 +15,17 @@ export class Switch extends Component {
         onChange: NO_OP,
     };
     static template = xml`
-    <label t-att-class="'o_switch' + extraClasses">
+    <label t-att-class="'o_switch' + this.extraClasses">
         <input type="checkbox"
                 name="switch"
                 class="visually-hidden"
-                t-att-checked="props.value"
-                t-att-disabled="props.disabled"
-                t-on-change="(ev) => props.onChange(ev.target.checked)"
-                t-on-keyup="onKeyup"/>
+                t-att-checked="this.props.value"
+                t-att-disabled="this.props.disabled"
+                t-on-change="(ev) => this.props.onChange(ev.target.checked)"
+                t-on-keyup="this.onKeyup"/>
         <span/>
-        <span t-if="props.label" t-out="props.label" class="ms-2"/>
-        <span t-if="props.description" class="text-muted ms-2" t-out="props.description"/>
+        <span t-if="this.props.label" t-out="this.props.label" class="ms-2"/>
+        <span t-if="this.props.description" class="text-muted ms-2" t-out="this.props.description"/>
     </label>
     `;
 

--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -7,8 +7,8 @@ import { useActiveElement } from "@web/core/ui/ui_service";
 
 export class EditorOverlay extends Component {
     static template = xml`
-        <div t-custom-ref="root" class="overlay" t-att-class="props.className" t-on-pointerdown.stop="() => {}">
-            <t t-component="props.Component" t-props="props.props"/>
+        <div t-custom-ref="root" class="overlay" t-att-class="this.props.className" t-on-pointerdown.stop="() => {}">
+            <t t-component="this.props.Component" t-props="this.props.props"/>
         </div>`;
 
     static props = {

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -23,7 +23,7 @@ export const IMAGE_MIMETYPES = [
 export const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".jpe", ".png", ".svg", ".gif", ".webp"];
 
 class RemoveButton extends Component {
-    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-1 transition-base" t-att-title="removeTitle" role="img" t-att-aria-label="removeTitle" t-on-click="this.remove"/>`;
+    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-1 transition-base" t-att-title="this.removeTitle" role="img" t-att-aria-label="this.removeTitle" t-on-click="this.remove"/>`;
     static props = ["model?", "remove"];
     setup() {
         this.removeTitle = _t("This file is attached to the current record.");

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -26,10 +26,10 @@ export const base64Img =
 
 class TestEditor extends Component {
     static template = xml`
-        <t t-if="props.styleContent">
-            <style t-out="props.styleContent"></style>
+        <t t-if="this.props.styleContent">
+            <style t-out="this.props.styleContent"></style>
         </t>
-        <Wysiwyg t-props="wysiwygProps" />`;
+        <Wysiwyg t-props="this.wysiwygProps" />`;
     static components = { Wysiwyg };
     static props = ["wysiwygProps", "content", "styleContent?", "onMounted?", "onWillDestroy?"];
 

--- a/addons/html_editor/static/tests/_helpers/embedded_component.js
+++ b/addons/html_editor/static/tests/_helpers/embedded_component.js
@@ -10,7 +10,7 @@ import { Component, useRef, useState, xml } from "@odoo/owl";
 export class Counter extends Component {
     static props = ["*"];
     static template = xml`
-        <span t-ref="root" class="counter" t-on-click="increment">Counter:<t t-out="state.value"/></span>`;
+        <span t-ref="root" class="counter" t-on-click="this.increment">Counter:<t t-out="this.state.value"/></span>`;
 
     state = useState({ value: 0 });
     ref = useRef("root");
@@ -34,8 +34,8 @@ export class EmbeddedWrapper extends Component {
     static props = ["*"];
     static template = xml`
         <t>
-            <div t-if="editableDescendants.shallow" class="shallow" t-ref="shallow"/>
-            <div t-if="!state.switch">
+            <div t-if="this.editableDescendants.shallow" class="shallow" t-ref="shallow"/>
+            <div t-if="!this.state.switch">
                 <div class="deep" t-ref="deep"/>
             </div>
             <div t-else="">
@@ -56,7 +56,7 @@ export class EmbeddedWrapper extends Component {
 export class OffsetCounter extends Component {
     static props = ["*"];
     static template = xml`
-        <span class="counter" t-on-click="increment">Counter:<t t-out="counterValue"/></span>`;
+        <span class="counter" t-on-click="this.increment">Counter:<t t-out="this.counterValue"/></span>`;
 
     setup() {
         this.embeddedState = useEmbeddedState(this.props.host);
@@ -94,7 +94,7 @@ export const offsetCounter = {
 export class SavedCounter extends Component {
     static props = ["*"];
     static template = xml`
-        <span class="counter" t-on-click="increment">Counter:<t t-out="counterValue"/></span>`;
+        <span class="counter" t-on-click="this.increment">Counter:<t t-out="this.counterValue"/></span>`;
 
     setup() {
         this.embeddedState = useEmbeddedState(this.props.host);
@@ -122,7 +122,7 @@ export const savedCounter = {
 export class CollaborativeObject extends Component {
     static props = ["*"];
     static template = xml`
-        <div class="obj"><t t-out="collaborativeObject"/></div>`;
+        <div class="obj"><t t-out="this.collaborativeObject"/></div>`;
 
     setup() {
         this.embeddedState = useEmbeddedState(this.props.host);
@@ -154,7 +154,7 @@ export const collaborativeObject = {
 export class NamedCounter extends Component {
     static props = ["*"];
     static template = xml`
-        <span class="counter" t-on-click="increment"><t t-out="props.name"/>:<t t-out="counterValue"/></span>`;
+        <span class="counter" t-on-click="this.increment"><t t-out="this.props.name"/>:<t t-out="this.counterValue"/></span>`;
 
     setup() {
         this.embeddedState = useEmbeddedState(this.props.host);

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -1626,7 +1626,7 @@ describe("Collaboration with embedded components", () => {
         test("A pending change applied after collaborative changes only update modified properties of that change (other properties are left untouched)", async () => {
             class NamedCounter extends SavedCounter {
                 static template = xml`
-                    <span class="counter" t-on-click="increment"><t t-esc="embeddedState.name"/>:<t t-esc="counterValue"/></span>`;
+                    <span class="counter" t-on-click="this.increment"><t t-esc="this.embeddedState.name"/>:<t t-esc="this.counterValue"/></span>`;
             }
             const namedCounter = {
                 ...savedCounter,

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -310,8 +310,8 @@ describe("Mount and Destroy embedded components", () => {
         class RecursiveComponent extends Component {
             static template = xml`
                 <div>
-                    <div t-on-click="increment" t-att-class="'click count-' + props.index">Count:<t t-out="state.value"/></div>
-                    <div t-ref="innerEditable" t-att-class="'innerEditable-' + props.index"/>
+                    <div t-on-click="this.increment" t-att-class="'click count-' + this.props.index">Count:<t t-out="this.state.value"/></div>
+                    <div t-ref="innerEditable" t-att-class="'innerEditable-' + this.props.index"/>
                 </div>
             `;
             static props = {
@@ -775,8 +775,8 @@ describe("Mount processing", () => {
         const delayedWillStart = new Deferred();
         class LabeledCounter extends Counter {
             static template = xml`
-                <span t-ref="root" class="counter" t-on-click="increment">
-                    <span t-ref="label"/>:<t t-out="state.value"/>
+                <span t-ref="root" class="counter" t-on-click="this.increment">
+                    <span t-ref="label"/>:<t t-out="this.state.value"/>
                 </span>
             `;
             static props = {
@@ -885,8 +885,8 @@ describe("Mount processing", () => {
 
         class EmbeddedCounter extends Counter {
             static template = xml`
-                <span class="counter" t-on-click="increment">
-                    <t t-out="state.value"/>
+                <span class="counter" t-on-click="this.increment">
+                    <t t-out="this.state.value"/>
                 </span>
             `;
             setup() {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -206,7 +206,7 @@ test("html field in readonly updated by onchange", async () => {
 test("html field in readonly with embedded components", async () => {
     patchWithCleanup(Counter, {
         template: xml`
-            <span t-ref="root" class="counter" t-on-click="increment"><t t-out="props.name || ''"/>:<t t-out="state.value"/></span>`,
+            <span t-ref="root" class="counter" t-on-click="this.increment"><t t-out="this.props.name || ''"/>:<t t-out="this.state.value"/></span>`,
     });
     const unpatch = patch(Counter.prototype, {
         setup() {

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -124,7 +124,7 @@ class Wysiwygs extends Component {
         <div>
             <t t-foreach="this.props.peerIds" t-as="peerId" t-key="peerId">
                 <Wysiwyg
-                    config="getConfig({peerId, content: this.props.content})"
+                    config="this.getConfig({peerId, content: this.props.content})"
                     t-key="peerId"
                     iframe="true"
                     onLoad="(editor) => this.onLoad(peerId, editor)"

--- a/addons/im_livechat/static/src/embed/frontend/livechat_root.js
+++ b/addons/im_livechat/static/src/embed/frontend/livechat_root.js
@@ -12,7 +12,7 @@ import { OverlayContainer } from "@web/core/overlay/overlay_container";
 export class LivechatRoot extends Component {
     static template = xml`
         <ChatHub/>
-        <OverlayContainer overlays="overlayService.overlays"/>
+        <OverlayContainer overlays="this.overlayService.overlays"/>
     `;
     static components = { ChatHub, LivechatButton, OverlayContainer };
     static props = {};

--- a/addons/lunch/static/src/components/lunch_dashboard.js
+++ b/addons/lunch/static/src/components/lunch_dashboard.js
@@ -65,7 +65,7 @@ export class LunchOrderLine extends Component {
 
 export class LunchAlert extends Component {
     static props = ["message"];
-    static template = xml`<t t-out="message"/>`;
+    static template = xml`<t t-out="this.message"/>`;
     get message() {
         return markup(this.props.message);
     }

--- a/addons/mail/static/src/core/common/relative_time.js
+++ b/addons/mail/static/src/core/common/relative_time.js
@@ -8,7 +8,7 @@ const HOUR = 60 * MINUTE;
 
 export class RelativeTime extends Component {
     static props = ["datetime"];
-    static template = xml`<t t-out="relativeTime"/>`;
+    static template = xml`<t t-out="this.relativeTime"/>`;
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/tabs.js
+++ b/addons/mail/static/src/core/common/tabs.js
@@ -93,7 +93,7 @@ export class InternalTabHeader extends Component {
  * API simple.
  */
 export class TabHeader extends Component {
-    static template = xml`<InternalTabHeader id="props.id" title="props.title" headerRefs="env.tabsContext.headerRefs"><t t-slot="default"/></InternalTabHeader>`;
+    static template = xml`<InternalTabHeader id="this.props.id" title="this.props.title" headerRefs="this.env.tabsContext.headerRefs"><t t-slot="default"/></InternalTabHeader>`;
     static components = { InternalTabHeader };
     static props = TAB_HEADER_PROPS;
 }

--- a/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
+++ b/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
@@ -6,8 +6,8 @@ export class ChannelActionDialog extends Component {
     static components = { Dialog };
     static props = ["title", "contentComponent", "contentProps", "close?", "contentClass?"];
     static template = xml`
-        <Dialog size="'md'" title="props.title" footer="false" contentClass="'o-bg-body o-discuss-ChannelActionDialog '+ props.contentClass" bodyClass="'p-1'">
-            <t t-component="props.contentComponent" t-props="props.contentProps"/>
+        <Dialog size="'md'" title="this.props.title" footer="false" contentClass="'o-bg-body o-discuss-ChannelActionDialog '+ this.props.contentClass" bodyClass="'p-1'">
+            <t t-component="this.props.contentComponent" t-props="this.props.contentProps"/>
         </Dialog>
     `;
 }

--- a/addons/mail/static/src/discuss/voice_message/common/composer_actions_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/composer_actions_patch.js
@@ -25,9 +25,9 @@ registerComposerAction("voice-recording", {
     component: class VoiceMessageRecordingButton extends Component {
         static props = ["composer", "state"];
         static template = xml`
-            <button class="o-mail-VoiceRecorder d-flex align-items-center btn border-0 o-recording rounded-start-0 rounded-end user-select-none p-0" t-att-title="title" t-att-disabled="props.state.isActionPending or props.composer.voiceAttachment" t-on-click="props.state.onClick">
-                <div class="o-mail-VoiceRecorder-elapsed o-active recording ms-2 me-1" t-att-class="{ 'text-danger': props.state.limitWarning }" style="font-variant-numeric: tabular-nums;">
-                    <span class="d-flex text-truncate" t-out="props.state.elapsed"/>
+            <button class="o-mail-VoiceRecorder d-flex align-items-center btn border-0 o-recording rounded-start-0 rounded-end user-select-none p-0" t-att-title="this.title" t-att-disabled="this.props.state.isActionPending or this.props.composer.voiceAttachment" t-on-click="this.props.state.onClick">
+                <div class="o-mail-VoiceRecorder-elapsed o-active recording ms-2 me-1" t-att-class="{ 'text-danger': this.props.state.limitWarning }" style="font-variant-numeric: tabular-nums;">
+                    <span class="d-flex text-truncate" t-out="this.props.state.elapsed"/>
                 </div>
                 <span class="rounded-circle p-1"><i class="fa fa-fw fa-circle text-danger o-mail-VoiceRecorder-dot"/></span>
             </button>

--- a/addons/point_of_sale/static/src/app/components/centered_icon/centered_icon.js
+++ b/addons/point_of_sale/static/src/app/components/centered_icon/centered_icon.js
@@ -10,9 +10,9 @@ export class CenteredIcon extends Component {
         class: "",
     };
     static template = xml`
-        <div t-attf-class="{{props.class}} d-flex flex-column align-items-center justify-content-center">
-            <i t-attf-class="fa {{props.icon}}" role="img" />
-            <h3 t-if="props.text" t-out="props.text" class="w-75 mt-2 text-center"/>
+        <div t-attf-class="{{this.props.class}} d-flex flex-column align-items-center justify-content-center">
+            <i t-attf-class="fa {{this.props.icon}}" role="img" />
+            <h3 t-if="this.props.text" t-out="this.props.text" class="w-75 mt-2 text-center"/>
         </div>
     `;
 }

--- a/addons/point_of_sale/static/src/app/components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/components/list_container/list_container.js
@@ -13,9 +13,9 @@ class ListContainerDialog extends Component {
         close: Function,
     };
     static template = xml`
-        <Dialog title="title" footer="false">
+        <Dialog title="this.title" footer="false">
             <div class="list-container-items d-flex p-2 flex-wrap" style="gap: 0.5rem;">
-                <t t-foreach="props.items" t-as="item" t-key="item_index">
+                <t t-foreach="this.props.items" t-as="item" t-key="item_index">
                     <t t-slot="default" item="item" />
                 </t>
             </div>
@@ -38,21 +38,21 @@ export class ListContainer extends Component {
         class: "",
     };
     static template = xml`
-        <div class="d-flex gap-1 align-items-center flex-grow-1" t-attf-class="{{props.class}}" t-att-class="{'overflow-hidden': !isUiSmall}">
-            <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg flex-shrink-0 lh-lg" t-on-click="props.onClickPlus">
+        <div class="d-flex gap-1 align-items-center flex-grow-1" t-attf-class="{{this.props.class}}" t-att-class="{'overflow-hidden': !this.isUiSmall}">
+            <button t-if="this.props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg flex-shrink-0 lh-lg" t-on-click="this.props.onClickPlus">
                 <i class="fa fa-fw fa-plus-circle" aria-hidden="true"/>
             </button>
-            <span t-if="props.onClickPlus" class="navbar-separator mx-1"/>
+            <span t-if="this.props.onClickPlus" class="navbar-separator mx-1"/>
             <div class="overflow-hidden flex-grow-1">
                 <div t-custom-ref="container" class="list-container-items d-flex align-items-center gap-1">
-                    <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible order-2': shouldBeInvisible(item_index)}">
+                    <div t-if="!this.props.forceSmall" t-foreach="this.props.items" t-as="item" t-key="item_index" t-att-class="{'invisible order-2': this.shouldBeInvisible(item_index)}">
                         <t t-slot="default" item="item"/>
                     </div>
-                    <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
+                    <button t-if="this.sizing.isLarger or this.props.forceSmall" t-on-click="this.toggle"
                         class="btn btn-lg btn-secondary order-1 flex-shrink-0 fw-bolder lh-lg"
-                        t-att-class="props.forceSmall ? '' : 'px-3 fw-bold'">
-                        <i t-if="props.forceSmall" class="fa fa-fw fa-caret-down"/>
-                        <t t-else="">+<t t-out="hiddenCount"/></t>
+                        t-att-class="this.props.forceSmall ? '' : 'px-3 fw-bold'">
+                        <i t-if="this.props.forceSmall" class="fa fa-fw fa-caret-down"/>
+                        <t t-else="">+<t t-out="this.hiddenCount"/></t>
                     </button>
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
@@ -45,8 +45,8 @@ class QrDialog extends Component {
     static template = xml`
         <Dialog header="false" footer="false" size="'sm'">
             <div class="d-flex flex-column align-items-center">
-                <img id="CustomerDisplayqrCode" t-att-src="props.qrData" alt="Customer QR Code" class="img-fluid mb-3 square w-100"/>
-                <button t-on-click="close" class="button btn btn-secondary h1 mb-3 rounded-3">
+                <img id="CustomerDisplayqrCode" t-att-src="this.props.qrData" alt="Customer QR Code" class="img-fluid mb-3 square w-100"/>
+                <button t-on-click="this.close" class="button btn btn-secondary h1 mb-3 rounded-3">
                     Close
                 </button>
             </div>

--- a/addons/point_of_sale/static/src/app/services/alert_service.js
+++ b/addons/point_of_sale/static/src/app/services/alert_service.js
@@ -3,8 +3,8 @@ import { registry } from "@web/core/registry";
 
 class Alert extends Component {
     static template = xml`
-        <div t-attf-class="alert pos-navbar-height fixed-top p-1 rounded-0 alert-{{props.type}} fade show d-flex align-items-center justify-content-center" role="alert">
-            <strong class="flex-grow-1 text-center" t-out="props.message" />
+        <div t-attf-class="alert pos-navbar-height fixed-top p-1 rounded-0 alert-{{this.props.type}} fade show d-flex align-items-center justify-content-center" role="alert">
+            <strong class="flex-grow-1 text-center" t-out="this.props.message" />
         </div>
     `;
     static props = {

--- a/addons/point_of_sale/static/tests/generic_components/mount_generic_components.test.js
+++ b/addons/point_of_sale/static/tests/generic_components/mount_generic_components.test.js
@@ -21,8 +21,8 @@ test("test that generic components can be mounted; the goal is to ensure that th
             <div class="test-container">
                 <OdooLogo />
                 <CenteredIcon icon="'fa-smile'"/>
-                <Input tModel="[state, 'number']"/>
-                <NumericInput tModel="[state, 'number']" />
+                <Input tModel="[this.state, 'number']"/>
+                <NumericInput tModel="[this.state, 'number']" />
             </div>
         `;
         setup() {

--- a/addons/point_of_sale/static/tests/unit/tools/lazy_getter.test.js
+++ b/addons/point_of_sale/static/tests/unit/tools/lazy_getter.test.js
@@ -82,8 +82,8 @@ class AppStore extends WithLazyGetterTrap {
 class WithStore extends Component {
     static props = {};
     static template = xml`
-        <span t-att-class="property">
-            <t t-out="constructor.name" />: <t t-out="this.store[property]" />
+        <span t-att-class="this.property">
+            <t t-out="this.constructor.name" />: <t t-out="this.store[this.property]" />
         </span>
     `;
 
@@ -133,8 +133,8 @@ class Root extends Component {
     static components = { A, B, C, D, AB, ABC, BC, CD };
     static props = {};
     static template = xml`
-        <t t-foreach="constructor.components" t-as="key" t-key="key">
-            <t t-component="constructor.components[key]" />
+        <t t-foreach="this.constructor.components" t-as="key" t-key="key">
+            <t t-component="this.constructor.components[key]" />
         </t>
     `;
 }

--- a/addons/portal/static/src/chatter/portal/portal_chatter.js
+++ b/addons/portal/static/src/chatter/portal/portal_chatter.js
@@ -7,8 +7,8 @@ import { useService } from "@web/core/utils/hooks";
 
 export class PortalChatter extends Component {
     static template = xml`
-        <Chatter threadId="props.resId" threadModel="props.resModel" composer="props.composer" twoColumns="props.twoColumns"/>
-        <div class="position-fixed" style="z-index:1030"><OverlayContainer overlays="overlayService.overlays"/></div>
+        <Chatter threadId="this.props.resId" threadModel="this.props.resModel" composer="this.props.composer" twoColumns="this.props.twoColumns"/>
+        <div class="position-fixed" style="z-index:1030"><OverlayContainer overlays="this.overlayService.overlays"/></div>
     `;
     static components = { Chatter, OverlayContainer };
     static props = ["resId", "resModel", "composer", "twoColumns", "displayRating"];

--- a/addons/pos_self_order/static/src/app/router.js
+++ b/addons/pos_self_order/static/src/app/router.js
@@ -22,7 +22,7 @@ function parseParams(matches, paramSpecs) {
 
 export class Router extends Component {
     static props = { slots: Object, pos_config_id: Number };
-    static template = xml`<t t-slot="{{activeSlot}}" t-props="slotProps"/>`;
+    static template = xml`<t t-slot="{{this.activeSlot}}" t-props="this.slotProps"/>`;
 
     setup() {
         this.router = useService("router");

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -25,8 +25,8 @@ defineSpreadsheetModels();
 class FilterValueWrapper extends Component {
     static template = xml`
         <FilterValue
-            t-props="props"
-            globalFilterValue="globalFilterValue"
+            t-props="this.props"
+            globalFilterValue="this.globalFilterValue"
         />`;
     static components = { FilterValue };
     static props = FilterValue.props;

--- a/addons/spreadsheet/static/tests/helpers/ui.js
+++ b/addons/spreadsheet/static/tests/helpers/ui.js
@@ -9,7 +9,7 @@ import { PublicReadonlySpreadsheet } from "@spreadsheet/public_readonly_app/publ
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 
 class Parent extends Component {
-    static template = xml`<Spreadsheet model="props.model"/>`;
+    static template = xml`<Spreadsheet model="this.props.model"/>`;
     static components = { Spreadsheet };
     static props = { model: Model };
     setup() {

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_search_bar_menu.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_search_bar_menu.test.js
@@ -15,7 +15,7 @@ describe.current.tags("headless");
 defineSpreadsheetModels();
 
 class DashboardSearchBarMenuWrapper extends Component {
-    static template = xml`<DashboardSearchBarMenu t-props="props" />`;
+    static template = xml`<DashboardSearchBarMenu t-props="this.props" />`;
     static components = { DashboardSearchBarMenu };
     static props = {
         ...DashboardSearchBarMenu.props,

--- a/addons/web/static/lib/hoot/tests/core/expect.test.js
+++ b/addons/web/static/lib/hoot/tests/core/expect.test.js
@@ -522,7 +522,7 @@ describe(parseUrl(import.meta.url), () => {
             class TextComponent extends Component {
                 static props = {};
                 static template = xml`
-                    <div class="with">With<t t-out="nbsp" />nbsp</div>
+                    <div class="with">With<t t-out="this.nbsp" />nbsp</div>
                     <div class="without">Without nbsp</div>
                 `;
 

--- a/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
@@ -2103,7 +2103,7 @@ describe(parseUrl(import.meta.url), () => {
             class extends Component {
                 static props = {};
                 static template = xml`
-                    <button t-on-click.synthetic="onClick">Click me</button>
+                    <button t-on-click.synthetic="this.onClick">Click me</button>
                 `;
 
                 onClick() {
@@ -2122,7 +2122,7 @@ describe(parseUrl(import.meta.url), () => {
             class extends Component {
                 static props = {};
                 static template = xml`
-                    <button t-on-click.synthetic="onClick">Click me</button>
+                    <button t-on-click.synthetic="this.onClick">Click me</button>
                 `;
 
                 onClick() {

--- a/addons/web/static/lib/hoot/tests/ui/hoot_technical_value.test.js
+++ b/addons/web/static/lib/hoot/tests/ui/hoot_technical_value.test.js
@@ -19,7 +19,7 @@ const mountTechnicalValue = async (defaultValue) => {
     class TechnicalValueParent extends Component {
         static components = { HootTechnicalValue };
         static props = {};
-        static template = xml`<HootTechnicalValue value="state.value" />`;
+        static template = xml`<HootTechnicalValue value="this.state.value" />`;
 
         setup() {
             this.state = useState(state);

--- a/addons/web/static/lib/hoot/tests/ui/hoot_test_result.test.js
+++ b/addons/web/static/lib/hoot/tests/ui/hoot_test_result.test.js
@@ -23,7 +23,7 @@ const mountTestResults = async (testFn, props) => {
         static components = { HootTestResult };
         static props = { test: Test, open: [Boolean, { value: "always" }] };
         static template = xml`
-            <HootTestResult test="props.test" open="props.open">
+            <HootTestResult test="this.props.test" open="this.props.open">
                 Toggle
             </HootTestResult>
         `;

--- a/addons/web/static/lib/hoot/ui/hoot_buttons.js
+++ b/addons/web/static/lib/hoot/ui/hoot_buttons.js
@@ -37,21 +37,21 @@ export class HootButtons extends Component {
     static props = {};
 
     static template = xml`
-        <t t-set="isRunning" t-value="runnerState.status === 'running'" />
-        <t t-set="showAll" t-value="env.runner.hasRemovableFilter" />
-        <t t-set="showFailed" t-value="runnerState.failedIds.size" />
+        <t t-set="isRunning" t-value="this.runnerState.status === 'running'" />
+        <t t-set="showAll" t-value="this.env.runner.hasRemovableFilter" />
+        <t t-set="showFailed" t-value="this.runnerState.failedIds.size" />
         <div
             class="${HootButtons.name} relative"
-            t-on-pointerenter="onPointerEnter"
-            t-on-pointerleave="onPointerLeave"
+            t-on-pointerenter="this.onPointerEnter"
+            t-on-pointerleave="this.onPointerLeave"
         >
             <div class="flex rounded gap-px overflow-hidden">
             <button
                 type="button"
                 class="flex items-center bg-btn gap-2 px-2 py-1 transition-colors"
-                t-on-click.stop="onRunClick"
+                t-on-click.stop="this.onRunClick"
                 t-att-title="isRunning ? 'Stop (Esc)' : 'Run'"
-                t-att-disabled="state.disable"
+                t-att-disabled="this.state.disable"
             >
                 <i t-attf-class="fa fa-{{ isRunning ? 'stop' : 'play' }}" />
                 <span t-out="isRunning ? 'Stop' : 'Run'" />
@@ -60,13 +60,13 @@ export class HootButtons extends Component {
                 <button
                     type="button"
                     class="bg-btn px-2 py-1 transition-colors animate-slide-left"
-                    t-on-click.stop="onToggleClick"
+                    t-on-click.stop="this.onToggleClick"
                 >
-                    <i class="fa fa-caret-down transition" t-att-class="{ 'rotate-180': state.open }" />
+                    <i class="fa fa-caret-down transition" t-att-class="{ 'rotate-180': this.state.open }" />
                 </button>
             </t>
             </div>
-            <t t-if="state.open">
+            <t t-if="this.state.open">
                 <div
                     class="
                         w-fit absolute animate-slide-down
@@ -85,16 +85,16 @@ export class HootButtons extends Component {
                         <HootLink
                             class="'p-3 whitespace-nowrap transition-colors hover:bg-gray-300 dark:hover:bg-gray-700'"
                             title="'Run failed tests'"
-                            ids="{ id: runnerState.failedIds }"
-                            onClick="onRunFailedClick"
+                            ids="{ id: this.runnerState.failedIds }"
+                            onClick="this.onRunFailedClick"
                         >
                             Run <strong class="text-rose">failed</strong> tests
                         </HootLink>
                         <HootLink
                             class="'p-3 whitespace-nowrap transition-colors hover:bg-gray-300 dark:hover:bg-gray-700'"
                             title="'Run failed suites'"
-                            ids="{ id: getFailedSuiteIds() }"
-                            onClick="onRunFailedClick"
+                            ids="{ id: this.getFailedSuiteIds() }"
+                            onClick="this.onRunFailedClick"
                         >
                             Run <strong class="text-rose">failed</strong> suites
                         </HootLink>

--- a/addons/web/static/lib/hoot/ui/hoot_config_menu.js
+++ b/addons/web/static/lib/hoot/ui/hoot_config_menu.js
@@ -33,19 +33,19 @@ export class HootConfigMenu extends Component {
     static components = { HootCopyButton };
     static props = {};
     static template = xml`
-        <form class="contents" t-on-submit.prevent="refresh">
+        <form class="contents" t-on-submit.prevent="this.refresh">
             <h3 class="pb-1 border-b text-gray border-gray">Behavior</h3>
-            <t t-if="hasPresets()">
+            <t t-if="this.hasPresets()">
                 <div class="flex items-center gap-1">
-                    <t t-set="hasCorrectViewPort" t-value="env.runner.checkPresetForViewPort()" />
+                    <t t-set="hasCorrectViewPort" t-value="this.env.runner.checkPresetForViewPort()" />
                     <t t-set="highlightClass" t-value="hasCorrectViewPort ? 'text-primary' : 'text-amber'" />
                     <span class="me-auto">Preset</span>
-                    <t t-foreach="env.runner.presets" t-as="presetKey" t-key="presetKey">
-                        <t t-set="preset" t-value="env.runner.presets[presetKey]" />
+                    <t t-foreach="this.env.runner.presets" t-as="presetKey" t-key="presetKey">
+                        <t t-set="preset" t-value="this.env.runner.presets[presetKey]" />
                         <button
                             type="button"
                             class="border rounded transition-colors hover:bg-gray-300 dark:hover:bg-gray-700"
-                            t-att-class="{ ['border-primary ' + highlightClass]: config.preset === presetKey }"
+                            t-att-class="{ ['border-primary ' + highlightClass]: this.config.preset === presetKey }"
                             t-att-title="presetKey ? preset.label : 'No preset'"
                             t-on-click.stop="() => this.onPresetChange(presetKey)"
                         >
@@ -59,11 +59,11 @@ export class HootConfigMenu extends Component {
                 title="Determines the order of the tests execution"
             >
                 <span class="me-auto">Execution order</span>
-                <t t-foreach="executionOrders" t-as="order" t-key="order.value">
+                <t t-foreach="this.executionOrders" t-as="order" t-key="order.value">
                     <button
                         type="button"
                         class="border rounded transition-colors hover:bg-gray-300 dark:hover:bg-gray-700"
-                        t-att-class="{ 'text-primary border-primary': config.order === order.value }"
+                        t-att-class="{ 'text-primary border-primary': this.config.order === order.value }"
                         t-att-title="order.title"
                         t-on-click.stop="() => this.setExecutionOrder(order.value)"
                     >
@@ -71,7 +71,7 @@ export class HootConfigMenu extends Component {
                     </button>
                 </t>
             </div>
-            <t t-if="config.order === 'random'">
+            <t t-if="this.config.order === 'random'">
                 <small class="flex items-center p-1 pt-0 gap-1">
                     <span class="text-gray whitespace-nowrap ms-1">Seed:</span>
                     <input
@@ -83,11 +83,11 @@ export class HootConfigMenu extends Component {
                     <button
                         type="button"
                         title="Generate new random seed"
-                        t-on-click.stop="resetSeed"
+                        t-on-click.stop="this.resetSeed"
                     >
                         <i class="fa fa-repeat" />
                     </button>
-                    <HootCopyButton text="config.random.toString()" />
+                    <HootCopyButton text="this.config.random.toString()" />
                 </small>
             </t>
             <label
@@ -109,7 +109,7 @@ export class HootConfigMenu extends Component {
                 <input
                     type="text"
                     class="outline-none border-b border-primary px-1 w-full"
-                    t-model="config.networkDelay"
+                    t-model="this.config.networkDelay"
                 />
             </label>
             <label
@@ -119,7 +119,7 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-model="config.manual"
+                    t-model="this.config.manual"
                 />
                 <span>Run tests manually</span>
             </label>
@@ -130,12 +130,12 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-att-checked="config.bail"
-                    t-on-change="onBailChange"
+                    t-att-checked="this.config.bail"
+                    t-on-change="this.onBailChange"
                 />
                 <span>Bail</span>
             </label>
-            <t t-if="config.bail">
+            <t t-if="this.config.bail">
                 <small class="flex items-center p-1 pt-0 gap-1">
                     <span class="text-gray whitespace-nowrap ms-1">Failed tests:</span>
                     <input
@@ -153,12 +153,12 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-att-checked="config.loglevel"
-                    t-on-change="onLogLevelChange"
+                    t-att-checked="this.config.loglevel"
+                    t-on-change="this.onLogLevelChange"
                 />
                 <span>Log level</span>
             </label>
-            <t t-if="config.loglevel">
+            <t t-if="this.config.loglevel">
                 <small class="flex items-center p-1 pt-0 gap-1">
                     <span class="text-gray whitespace-nowrap ms-1">Level:</span>
                     <select
@@ -166,7 +166,7 @@ export class HootConfigMenu extends Component {
                         class="outline-none w-full bg-base text-base border-b border-primary px-1"
                         t-model.number="config.loglevel"
                     >
-                        <t t-foreach="LOG_LEVELS" t-as="level" t-key="level.value">
+                        <t t-foreach="this.LOG_LEVELS" t-as="level" t-key="level.value">
                             <option
                                 t-att-value="level.value"
                                 t-out="level.label"
@@ -182,7 +182,7 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-model="config.notrycatch"
+                    t-model="this.config.notrycatch"
                 />
                 <span>No try/catch</span>
             </label>
@@ -191,39 +191,39 @@ export class HootConfigMenu extends Component {
             <h3 class="mt-2 pb-1 border-b text-gray border-gray">Display</h3>
             <div class="flex items-center gap-1">
                 <span class="me-auto">Events</span>
-                <t t-foreach="CASE_EVENT_TYPES" t-as="sType" t-key="sType">
-                    <t t-set="isDisplayed" t-value="isEventDisplayed(sType)" />
-                    <t t-set="eventColor" t-value="isDisplayed ? CASE_EVENT_TYPES[sType].color : 'gray'" />
+                <t t-foreach="this.CASE_EVENT_TYPES" t-as="sType" t-key="sType">
+                    <t t-set="isDisplayed" t-value="this.isEventDisplayed(sType)" />
+                    <t t-set="eventColor" t-value="isDisplayed ? this.CASE_EVENT_TYPES[sType].color : 'gray'" />
                     <button
                         type="button"
                         t-attf-class="p-1 border-b-2 transition-color text-{{ eventColor }} border-{{ eventColor }}"
                         t-attf-title="{{ isDisplayed ? 'Hide' : 'Show' }} {{ sType }} events"
                         t-on-click.stop="(ev) => this.toggleEventType(ev, sType)"
                     >
-                        <i class="fa" t-att-class="CASE_EVENT_TYPES[sType].icon" />
+                        <i class="fa" t-att-class="this.CASE_EVENT_TYPES[sType].icon" />
                     </button>
                 </t>
             </div>
             <button
                 type="button"
                 class="flex items-center gap-1"
-                t-on-click.stop="toggleSortResults"
+                t-on-click.stop="this.toggleSortResults"
             >
                 <span class="me-auto">Sort by duration</span>
                 <span
                     class="flex items-center gap-1 transition-colors"
-                    t-att-class="{ 'text-primary': uiState.sortResults }"
+                    t-att-class="{ 'text-primary': this.uiState.sortResults }"
                 >
-                    <t t-if="uiState.sortResults === 'asc'">
+                    <t t-if="this.uiState.sortResults === 'asc'">
                         ascending
                     </t>
-                    <t t-elif="uiState.sortResults === 'desc'">
+                    <t t-elif="this.uiState.sortResults === 'desc'">
                         descending
                     </t>
                     <t t-else="">
                         none
                     </t>
-                    <i t-attf-class="fa fa-sort-numeric-{{ uiState.sortResults or 'desc' }}" />
+                    <i t-attf-class="fa fa-sort-numeric-{{ this.uiState.sortResults or 'desc' }}" />
                 </span>
             </button>
             <label
@@ -233,7 +233,7 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-model="config.headless"
+                    t-model="this.config.headless"
                 />
                 <span>Headless</span>
             </label>
@@ -244,7 +244,7 @@ export class HootConfigMenu extends Component {
                 <input
                     type="checkbox"
                     class="appearance-none border border-primary rounded-xs w-4 h-4"
-                    t-model="config.fun"
+                    t-model="this.config.fun"
                 />
                 <span>Enable incentives</span>
             </label>
@@ -252,16 +252,16 @@ export class HootConfigMenu extends Component {
                 type="button"
                 class="flex items-center gap-1 hover:bg-gray-300 dark:hover:bg-gray-700"
                 title="Toggle the color scheme of the UI"
-                t-on-click.stop="toggleColorScheme"
+                t-on-click.stop="this.toggleColorScheme"
             >
-                <i t-attf-class="fa fa-{{ color.scheme === 'light' ? 'moon' : 'sun' }}-o w-4 h-4" />
+                <i t-attf-class="fa fa-{{ this.color.scheme === 'light' ? 'moon' : 'sun' }}-o w-4 h-4" />
                 Color scheme
             </button>
 
             <!-- Refresh button -->
             <button
                 class="flex bg-btn justify-center rounded mt-1 p-1 transition-colors"
-                t-att-disabled="doesNotNeedRefresh()"
+                t-att-disabled="this.doesNotNeedRefresh()"
             >
                 Apply and refresh
             </button>

--- a/addons/web/static/lib/hoot/ui/hoot_copy_button.js
+++ b/addons/web/static/lib/hoot/ui/hoot_copy_button.js
@@ -18,13 +18,13 @@ export class HootCopyButton extends Component {
     };
 
     static template = xml`
-        <t t-if="hasClipboard()">
+        <t t-if="this.hasClipboard()">
             <button
                 type="button"
                 class="text-gray-400 hover:text-gray-500"
-                t-att-class="{ 'text-emerald': state.copied }"
+                t-att-class="{ 'text-emerald': this.state.copied }"
                 title="copy to clipboard"
-                t-on-click.stop="onClick"
+                t-on-click.stop="this.onClick"
             >
                 <i class="fa fa-clipboard" />
             </button>

--- a/addons/web/static/lib/hoot/ui/hoot_debug_toolbar.js
+++ b/addons/web/static/lib/hoot/ui/hoot_debug_toolbar.js
@@ -157,29 +157,29 @@ export class HootDebugToolBar extends Component {
     static template = xml`
         <div
             class="${HootDebugToolBar.name} absolute start-0 bottom-0 max-w-full max-h-full flex p-4 z-4"
-            t-att-class="{ 'w-full': state.open }"
+            t-att-class="{ 'w-full': this.state.open }"
             t-ref="root"
         >
             <div class="flex flex-col w-full overflow-hidden rounded shadow bg-gray-200 dark:bg-gray-800">
                 <div class="flex items-center gap-2 px-2">
                     <i
                         class="fa fa-bug text-cyan p-2"
-                        t-att-class="{ 'cursor-move': !state.open }"
+                        t-att-class="{ 'cursor-move': !this.state.open }"
                         t-ref="handle"
                     />
                     <div class="flex gap-px rounded my-1 overflow-hidden min-w-fit">
                         <button
                             class="bg-btn px-2 py-1"
                             title="Exit debug mode (Ctrl + Esc)"
-                            t-on-click.stop="exitDebugMode"
+                            t-on-click.stop="this.exitDebugMode"
                         >
                             <i class="fa fa-sign-out" />
                         </button>
-                        <t t-if="done">
+                        <t t-if="this.done">
                             <button
                                 class="bg-btn px-2 py-1 animate-slide-left"
                                 title="Restart test (F5)"
-                                t-on-click.stop="refresh"
+                                t-on-click.stop="this.refresh"
                             >
                                 <i class="fa fa-refresh" />
                             </button>
@@ -187,25 +187,25 @@ export class HootDebugToolBar extends Component {
                     </div>
                     <button
                         class="flex flex-1 items-center gap-1 truncate"
-                        t-on-click.stop="toggleOpen"
+                        t-on-click.stop="this.toggleOpen"
                         title="Click to toggle details"
                     >
                         status:
                         <strong
-                            t-attf-class="text-{{ info.className }}"
-                            t-out="info.status"
+                            t-attf-class="text-{{ this.info.className }}"
+                            t-out="this.info.status"
                         />
                         <span class="hidden sm:flex items-center gap-1">
                             <span class="text-gray">-</span>
                             assertions:
                             <span class="contents text-emerald">
-                                <strong t-out="info.passed" />
+                                <strong t-out="this.info.passed" />
                                 passed
                             </span>
-                            <t t-if="info.failed">
+                            <t t-if="this.info.failed">
                                 <span class="text-gray">/</span>
                                 <span class="contents text-rose">
-                                    <strong t-out="info.failed" />
+                                    <strong t-out="this.info.failed" />
                                     failed
                                 </span>
                             </t>
@@ -214,19 +214,19 @@ export class HootDebugToolBar extends Component {
                         time:
                         <span
                             class="text-primary"
-                            t-out="formatTime(props.test.lastResults?.duration, 'ms')"
+                            t-out="this.formatTime(this.props.test.lastResults?.duration, 'ms')"
                         />
                     </button>
-                    <button class="p-2" t-on-click="toggleConfig">
+                    <button class="p-2" t-on-click="this.toggleConfig">
                         <i class="fa fa-cog" />
                     </button>
                 </div>
-                <t t-if="state.open">
+                <t t-if="this.state.open">
                     <div class="flex flex-col w-full sm:flex-row overflow-auto">
-                        <HootTestResult open="'always'" test="props.test" t-key="done">
-                            <HootTestPath canCopy="true" full="true" test="props.test" />
+                        <HootTestResult open="'always'" test="this.props.test" t-key="this.done">
+                            <HootTestPath canCopy="true" full="true" test="this.props.test" />
                         </HootTestResult>
-                        <t t-if="state.configOpen">
+                        <t t-if="this.state.configOpen">
                             <div class="flex flex-col gap-1 p-3 overflow-y-auto">
                                 <HootConfigMenu />
                             </div>

--- a/addons/web/static/lib/hoot/ui/hoot_dropdown.js
+++ b/addons/web/static/lib/hoot/ui/hoot_dropdown.js
@@ -18,22 +18,22 @@ import { useAutofocus, useHootKey, useWindowListener } from "../hoot_utils";
 /** @extends {Component<HootDropdownProps, import("../hoot").Environment>} */
 export class HootDropdown extends Component {
     static template = xml`
-        <div class="${HootDropdown.name} relative" t-att-class="props.className" t-ref="root">
+        <div class="${HootDropdown.name} relative" t-att-class="this.props.className" t-ref="root">
             <button
                 t-ref="toggler"
                 class="flex rounded p-2 transition-colors"
-                t-att-class="props.buttonClassName"
+                t-att-class="this.props.buttonClassName"
             >
                 <t t-slot="toggler" open="state.open" />
             </button>
-            <t t-if="state.open">
+            <t t-if="this.state.open">
                 <div
                     class="
                         hoot-dropdown absolute animate-slide-down
                         flex flex-col end-0 p-3 gap-2
                         bg-base text-base mt-1 shadow rounded z-2"
                 >
-                    <button class="fixed end-2 top-2 p-1 text-rose sm:hidden" t-on-click="() => state.open = false">
+                    <button class="fixed end-2 top-2 p-1 text-rose sm:hidden" t-on-click="() => this.state.open = false">
                         <i class="fa fa-times w-5 h-5" />
                     </button>
                     <t t-slot="menu" open="state.open" />

--- a/addons/web/static/lib/hoot/ui/hoot_job_buttons.js
+++ b/addons/web/static/lib/hoot/ui/hoot_job_buttons.js
@@ -22,10 +22,10 @@ export class HootJobButtons extends Component {
     };
 
     static template = xml`
-        <t t-set="type" t-value="getType()" />
-        <div class="${HootJobButtons.name} items-center gap-1" t-att-class="props.hidden ? 'hidden' : 'flex'">
+        <t t-set="type" t-value="this.getType()" />
+        <div class="${HootJobButtons.name} items-center gap-1" t-att-class="this.props.hidden ? 'hidden' : 'flex'">
             <HootLink
-                ids="{ id: props.job.id }"
+                ids="{ id: this.props.job.id }"
                 class="'hoot-btn-link border border-primary text-emerald rounded transition-colors'"
                 title="'Run this ' + type + ' only'"
             >
@@ -33,7 +33,7 @@ export class HootJobButtons extends Component {
             </HootLink>
             <t t-if="type === 'test'">
                 <HootLink
-                    ids="{ id: props.job.id }"
+                    ids="{ id: this.props.job.id }"
                     options="{ debug: true }"
                     class="'hoot-btn-link border border-primary text-emerald rounded transition-colors'"
                     title="'Run this ' + type + ' only in debug mode'"
@@ -42,7 +42,7 @@ export class HootJobButtons extends Component {
                 </HootLink>
             </t>
             <HootLink
-                ids="{ id: props.job.id }"
+                ids="{ id: this.props.job.id }"
                 options="{ ignore: true }"
                 class="'hoot-btn-link border border-primary text-rose rounded transition-colors'"
                 title="'Ignore ' + type"

--- a/addons/web/static/lib/hoot/ui/hoot_link.js
+++ b/addons/web/static/lib/hoot/ui/hoot_link.js
@@ -38,14 +38,14 @@ const {
 export class HootLink extends Component {
     static template = xml`
         <a
-            t-att-class="props.class"
-            t-att-href="state.href"
-            t-att-target="props.target"
-            t-att-title="props.title"
-            t-att-style="props.style"
-            t-on-click.stop="onClick"
-            t-on-focus="updateHref"
-            t-on-pointerenter="updateHref"
+            t-att-class="this.props.class"
+            t-att-href="this.state.href"
+            t-att-target="this.props.target"
+            t-att-title="this.props.title"
+            t-att-style="this.props.style"
+            t-on-click.stop="this.onClick"
+            t-on-focus="this.updateHref"
+            t-on-pointerenter="this.updateHref"
         >
             <t t-slot="default" />
         </a>

--- a/addons/web/static/lib/hoot/ui/hoot_log_counters.js
+++ b/addons/web/static/lib/hoot/ui/hoot_log_counters.js
@@ -21,22 +21,22 @@ export class HootLogCounters extends Component {
         },
     };
     static template = xml`
-        <t t-if="props.logs.error">
+        <t t-if="this.props.logs.error">
             <span
                 class="flex items-center gap-1 text-rose"
-                t-attf-title="{{ props.logs.error }} error log(s) (check the console)"
+                t-attf-title="{{ this.props.logs.error }} error log(s) (check the console)"
             >
                 <i class="fa fa-times-circle" />
-                <strong t-out="props.logs.error" />
+                <strong t-out="this.props.logs.error" />
             </span>
         </t>
-        <t t-if="props.logs.warn">
+        <t t-if="this.props.logs.warn">
             <span
                 class="flex items-center gap-1 text-amber"
-                t-attf-title="{{ props.logs.warn }} warning log(s) (check the console)"
+                t-attf-title="{{ this.props.logs.warn }} warning log(s) (check the console)"
             >
                 <i class="fa fa-exclamation-triangle" />
-                <strong t-out="props.logs.warn" />
+                <strong t-out="this.props.logs.warn" />
             </span>
         </t>
     `;

--- a/addons/web/static/lib/hoot/ui/hoot_main.js
+++ b/addons/web/static/lib/hoot/ui/hoot_main.js
@@ -68,10 +68,10 @@ export class HootMain extends Component {
     static props = {};
 
     static template = xml`
-        <t t-if="env.runner.headless">
+        <t t-if="this.env.runner.headless">
             <div style="${HEADLESS_CONTAINER_STYLE}">
                 Running in headless mode
-                <a style="${HEADLESS_LINK_STYLE}" t-att-href="createUrl({ headless: null })">
+                <a style="${HEADLESS_LINK_STYLE}" t-att-href="this.createUrl({ headless: null })">
                     Run with UI
                 </a>
             </div>
@@ -79,7 +79,7 @@ export class HootMain extends Component {
         <t t-else="">
             <main
                 class="${HootMain.name} flex flex-col w-full h-full bg-base relative"
-                t-att-class="{ 'hoot-animations': env.runner.config.fun }"
+                t-att-class="{ 'hoot-animations': this.env.runner.config.fun }"
             >
                 <header class="flex flex-col bg-gray-200 dark:bg-gray-800">
                     <nav class="hoot-controls py-1 px-2">
@@ -107,8 +107,8 @@ export class HootMain extends Component {
                     <HootReporting />
                 </div>
             </main>
-            <t t-if="state.debugTest">
-                <HootDebugToolBar test="state.debugTest" />
+            <t t-if="this.state.debugTest">
+                <HootDebugToolBar test="this.state.debugTest" />
             </t>
         </t>
     `;

--- a/addons/web/static/lib/hoot/ui/hoot_reporting.js
+++ b/addons/web/static/lib/hoot/ui/hoot_reporting.js
@@ -101,10 +101,10 @@ export class HootReporting extends Component {
             ${issueTemplate("globalWarnings", "amber")}
 
             <!-- Test results -->
-            <t t-set="resultStart" t-value="uiState.resultsPage * uiState.resultsPerPage" />
-            <t t-foreach="filteredResults.slice(resultStart, resultStart + uiState.resultsPerPage)" t-as="result" t-key="result.id">
+            <t t-set="resultStart" t-value="this.uiState.resultsPage * this.uiState.resultsPerPage" />
+            <t t-foreach="this.filteredResults.slice(resultStart, resultStart + this.uiState.resultsPerPage)" t-as="result" t-key="result.id">
                 <HootTestResult
-                    open="state.openTests.includes(result.test.id)"
+                    open="this.state.openTests.includes(result.test.id)"
                     test="result.test"
                 >
                     <div class="flex items-center gap-2 overflow-hidden">
@@ -120,10 +120,10 @@ export class HootReporting extends Component {
                                 skipped
                             </t>
                             <t t-else="">
-                                <t t-if="result.test.status === Test.ABORTED">
+                                <t t-if="result.test.status === this.Test.ABORTED">
                                     aborted after
                                 </t>
-                                <t t-out="formatTime(result.test.duration, 'ms')" />
+                                <t t-out="this.formatTime(result.test.duration, 'ms')" />
                             </t>
                         </small>
                         <HootJobButtons job="result.test" />
@@ -132,9 +132,9 @@ export class HootReporting extends Component {
             </t>
 
             <!-- "No test" panel -->
-            <t t-if="!filteredResults.length">
+            <t t-if="!this.filteredResults.length">
                 <div class="flex items-center justify-center h-full">
-                    <t t-set="message" t-value="getEmptyMessage()" />
+                    <t t-set="message" t-value="this.getEmptyMessage()" />
                     <t t-if="message">
                         <em class="p-5 rounded bg-gray-200 dark:bg-gray-800 whitespace-nowrap text-gray">
                             No
@@ -154,16 +154,16 @@ export class HootReporting extends Component {
                             </t>.
                         </em>
                     </t>
-                    <t t-elif="!runnerReporting.tests">
+                    <t t-elif="!this.runnerReporting.tests">
                         <div class="flex flex-col gap-3 p-5 rounded bg-gray-200 dark:bg-gray-800">
                             <h3 class="border-b border-gray pb-1">
                                 Test runner is ready
                             </h3>
                             <div class="flex items-center gap-2">
-                                <t t-if="config.manual">
+                                <t t-if="this.config.manual">
                                     <button
                                         class="bg-btn px-2 py-1 transition-colors rounded"
-                                        t-on-click="onRunClick"
+                                        t-on-click="this.onRunClick"
                                     >
                                         <strong>Start</strong>
                                     </button>
@@ -185,56 +185,56 @@ export class HootReporting extends Component {
                     <t t-else="">
                         <div class="flex flex-col gap-3 p-5 rounded bg-gray-200 dark:bg-gray-800">
                             <h3 class="border-b border-gray pb-1">
-                                <strong class="text-primary" t-out="runnerReporting.tests" />
+                                <strong class="text-primary" t-out="this.runnerReporting.tests" />
                                 /
-                                <span class="text-primary" t-out="runnerState.tests.length" />
+                                <span class="text-primary" t-out="this.runnerState.tests.length" />
                                 tests completed
                             </h3>
                             <ul class="flex flex-col gap-2">
-                                <t t-if="runnerReporting.passed">
+                                <t t-if="this.runnerReporting.passed">
                                     <li class="flex gap-1">
                                         <button
                                             class="flex items-center gap-1 text-emerald"
                                             t-on-click.stop="() => this.filterResults('passed')"
                                         >
                                             <i class="fa fa-check-circle" />
-                                            <strong t-out="runnerReporting.passed" />
+                                            <strong t-out="this.runnerReporting.passed" />
                                         </button>
                                         tests passed
                                     </li>
                                 </t>
-                                <t t-if="runnerReporting.failed">
+                                <t t-if="this.runnerReporting.failed">
                                     <li class="flex gap-1">
                                         <button
                                             class="flex items-center gap-1 text-rose"
                                             t-on-click.stop="() => this.filterResults('failed')"
                                         >
                                             <i class="fa fa-times-circle" />
-                                            <strong t-out="runnerReporting.failed" />
+                                            <strong t-out="this.runnerReporting.failed" />
                                         </button>
                                         tests failed
                                     </li>
                                 </t>
-                                <t t-if="runnerReporting.skipped">
+                                <t t-if="this.runnerReporting.skipped">
                                     <li class="flex gap-1">
                                         <button
                                             class="flex items-center gap-1 text-cyan"
                                             t-on-click.stop="() => this.filterResults('skipped')"
                                         >
                                             <i class="fa fa-pause-circle" />
-                                            <strong t-out="runnerReporting.skipped" />
+                                            <strong t-out="this.runnerReporting.skipped" />
                                         </button>
                                         tests skipped
                                     </li>
                                 </t>
-                                <t t-if="runnerReporting.todo">
+                                <t t-if="this.runnerReporting.todo">
                                     <li class="flex gap-1">
                                         <button
                                             class="flex items-center gap-1 text-purple"
                                             t-on-click.stop="() => this.filterResults('todo')"
                                         >
                                             <i class="fa fa-exclamation-circle" />
-                                            <strong t-out="runnerReporting.todo" />
+                                            <strong t-out="this.runnerReporting.todo" />
                                         </button>
                                         tests to do
                                     </li>

--- a/addons/web/static/lib/hoot/ui/hoot_search.js
+++ b/addons/web/static/lib/hoot/ui/hoot_search.js
@@ -314,12 +314,12 @@ export class HootSearch extends Component {
     static props = {};
 
     static template = xml`
-        <t t-set="hasIncludeValue" t-value="getHasIncludeValue()" />
-        <t t-set="isRunning" t-value="runnerState.status === 'running'" />
-        <search class="${HootSearch.name} flex-1" t-ref="root" t-on-keydown="onKeyDown">
-            <form class="relative" t-on-submit.prevent="refresh">
+        <t t-set="hasIncludeValue" t-value="this.getHasIncludeValue()" />
+        <t t-set="isRunning" t-value="this.runnerState.status === 'running'" />
+        <search class="${HootSearch.name} flex-1" t-ref="root" t-on-keydown="this.onKeyDown">
+            <form class="relative" t-on-submit.prevent="this.refresh">
                 <div class="hoot-search-bar flex border rounded items-center bg-base px-1 gap-1 w-full transition-colors">
-                    <t t-foreach="getCategoryCounts()" t-as="count" t-key="count.category">
+                    <t t-foreach="this.getCategoryCounts()" t-as="count" t-key="count.category">
                         <button
                             type="button"
                             class="flex border border-primary rounded"
@@ -339,28 +339,28 @@ export class HootSearch extends Component {
                     <input
                         type="search"
                         class="w-full rounded p-1 outline-none"
-                        t-att-autofocus="!config.manual"
+                        t-att-autofocus="!this.config.manual"
                         placeholder="Filter suites, tests or tags"
                         t-ref="search-input"
-                        t-att-class="{ 'text-gray': !config.filter }"
+                        t-att-class="{ 'text-gray': !this.config.filter }"
                         t-att-disabled="isRunning"
-                        t-att-value="state.query"
-                        t-on-change="onSearchInputChange"
-                        t-on-input="onSearchInputInput"
-                        t-on-keydown="onSearchInputKeyDown"
+                        t-att-value="this.state.query"
+                        t-on-change="this.onSearchInputChange"
+                        t-on-input="this.onSearchInputInput"
+                        t-on-keydown="this.onSearchInputKeyDown"
                     />
                     <label
                         class="hoot-search-icon cursor-pointer p-1"
                         title="Use exact match (Alt + X)"
                         tabindex="0"
-                        t-on-keydown="onExactKeyDown"
+                        t-on-keydown="this.onExactKeyDown"
                     >
                         <input
                             type="checkbox"
                             class="hidden"
-                            t-att-checked="hasExactFilter()"
+                            t-att-checked="this.hasExactFilter()"
                             t-att-disabled="isRunning"
-                            t-on-change="toggleExact"
+                            t-on-change="this.toggleExact"
                         />
                         <i class="fa fa-quote-right text-gray transition-colors" />
                     </label>
@@ -368,35 +368,35 @@ export class HootSearch extends Component {
                         class="hoot-search-icon cursor-pointer p-1"
                         title="Use regular expression (Alt + R)"
                         tabindex="0"
-                        t-on-keydown="onRegExpKeyDown"
+                        t-on-keydown="this.onRegExpKeyDown"
                     >
                         <input
                             type="checkbox"
                             class="hidden"
-                            t-att-checked="hasRegExpFilter()"
+                            t-att-checked="this.hasRegExpFilter()"
                             t-att-disabled="isRunning"
-                            t-on-change="toggleRegExp"
+                            t-on-change="this.toggleRegExp"
                         />
                         <i class="fa fa-asterisk text-gray transition-colors" />
                     </label>
                     <label
                         class="hoot-search-icon cursor-pointer p-1"
                         title="Debug mode (Alt + D)"
-                        t-on-keydown="onDebugKeyDown"
+                        t-on-keydown="this.onDebugKeyDown"
                     >
                         <input
                             type="checkbox"
                             class="hidden"
-                            t-att-checked="config.debugTest"
+                            t-att-checked="this.config.debugTest"
                             t-att-disabled="isRunning"
-                            t-on-change="toggleDebug"
+                            t-on-change="this.toggleDebug"
                         />
                         <i class="fa fa-bug text-gray transition-colors" />
                     </label>
                 </div>
-                <t t-if="state.showDropdown">
+                <t t-if="this.state.showDropdown">
                     <div class="hoot-dropdown-lg flex flex-col animate-slide-down bg-base text-base absolute mt-1 p-3 shadow rounded z-2">
-                        <t t-if="state.empty">
+                        <t t-if="this.state.empty">
                             ${TEMPLATE_SEARCH_DASHBOARD}
                         </t>
                         <t t-else="">

--- a/addons/web/static/lib/hoot/ui/hoot_side_bar.js
+++ b/addons/web/static/lib/hoot/ui/hoot_side_bar.js
@@ -55,19 +55,19 @@ export class HootSideBarSuite extends Component {
     };
 
     static template = xml`
-        <t t-if="props.hasSuites">
+        <t t-if="this.props.hasSuites">
             <i
                 class="fa fa-chevron-right text-xs transition"
                 t-att-class="{
-                    'rotate-90': props.unfolded,
-                    'opacity-25': !props.reporting.failed and !props.reporting.tests
+                    'rotate-90': this.props.unfolded,
+                    'opacity-25': !this.props.reporting.failed and !this.props.reporting.tests
                 }"
             />
         </t>
-        <span t-ref="root" t-att-class="getClassName()" t-out="props.name" />
-        <t t-if="props.multi">
+        <span t-ref="root" t-att-class="this.getClassName()" t-out="this.props.name" />
+        <t t-if="this.props.multi">
             <strong class="text-amber whitespace-nowrap me-1">
-                x<t t-out="props.multi" />
+                x<t t-out="this.props.multi" />
             </strong>
         </t>
     `;
@@ -112,7 +112,7 @@ export class HootSideBarCounter extends Component {
     };
 
     static template = xml`
-        <t t-set="info" t-value="getCounterInfo()" />
+        <t t-set="info" t-value="this.getCounterInfo()" />
         <span
             t-attf-class="${HootSideBarCounter.name} {{ info[1] ? info[0] : 'text-gray' }} {{ info[1] ? 'font-bold' : '' }}"
             t-out="info[1]"
@@ -147,7 +147,7 @@ export class HootSideBar extends Component {
     static template = xml`
         <div
             class="${HootSideBar.name} flex-col w-64 h-full resize-x shadow bg-gray-200 dark:bg-gray-800 z-1 hidden md:flex"
-            t-on-click.stop="onClick"
+            t-on-click.stop="this.onClick"
         >
             <form class="flex p-2 items-center gap-1">
                 <div class="hoot-search-bar border rounded bg-base w-full">
@@ -156,21 +156,21 @@ export class HootSideBar extends Component {
                         type="search"
                         placeholder="Search suites"
                         t-ref="search-input"
-                        t-model="state.filter"
-                        t-on-keydown="onSearchInputKeydown"
+                        t-model="this.state.filter"
+                        t-on-keydown="this.onSearchInputKeydown"
                     />
                 </div>
-                <t t-if="env.runner.hasFilter">
+                <t t-if="this.env.runner.hasFilter">
                     <button
                         type="button"
                         class="text-primary p-1 transition-colors"
-                        t-att-title="state.hideEmpty ? 'Show all suites' : 'Hide other suites'"
-                        t-on-click.stop="toggleHideEmpty"
+                        t-att-title="this.state.hideEmpty ? 'Show all suites' : 'Hide other suites'"
+                        t-on-click.stop="this.toggleHideEmpty"
                     >
-                        <i t-attf-class="fa fa-{{ state.hideEmpty ? 'eye' : 'eye-slash' }}" />
+                        <i t-attf-class="fa fa-{{ this.state.hideEmpty ? 'eye' : 'eye-slash' }}" />
                     </button>
                 </t>
-                <t t-set="expanded" t-value="unfoldedIds.size === env.runner.suites.size" />
+                <t t-set="expanded" t-value="this.unfoldedIds.size === this.env.runner.suites.size" />
                 <button
                     type="button"
                     class="text-primary p-1 transition-colors"
@@ -181,11 +181,11 @@ export class HootSideBar extends Component {
                 </button>
             </form>
             <ul class="overflow-x-hidden overflow-y-auto" t-ref="suites-list">
-                <t t-foreach="filteredSuites" t-as="suite" t-key="suite.id">
+                <t t-foreach="this.filteredSuites" t-as="suite" t-key="suite.id">
                     <li class="flex items-center h-7 animate-slide-down">
                         <button
                             class="${SUITE_CLASSNAME} flex items-center w-full h-full gap-1 px-2 overflow-hidden hover:bg-gray-300 dark:hover:bg-gray-700"
-                            t-att-class="{ 'bg-gray-300 dark:bg-gray-700': uiState.selectedSuiteId === suite.id }"
+                            t-att-class="{ 'bg-gray-300 dark:bg-gray-700': this.uiState.selectedSuiteId === suite.id }"
                             t-attf-style="margin-left: {{ (suite.path.length - 1) + 'rem' }};"
                             t-attf-title="{{ suite.fullName }}\n- {{ suite.totalTestCount }} tests\n- {{ suite.totalSuiteCount }} suites"
                             t-on-click.stop="(ev) => this.toggleItem(suite)"
@@ -195,20 +195,20 @@ export class HootSideBar extends Component {
                                 <HootSideBarSuite
                                     multi="suite.config.multi"
                                     name="suite.name"
-                                    hasSuites="hasSuites(suite)"
+                                    hasSuites="this.hasSuites(suite)"
                                     reporting="suite.reporting"
-                                    selected="uiState.selectedSuiteId === suite.id"
-                                    unfolded="unfoldedIds.has(suite.id)"
+                                    selected="this.uiState.selectedSuiteId === suite.id"
+                                    unfolded="this.unfoldedIds.has(suite.id)"
                                 />
                                 <span class="text-gray">
                                     (<t t-out="suite.totalTestCount" />)
                                 </span>
                             </div>
                             <HootJobButtons hidden="true" job="suite" />
-                            <t t-if="env.runner.state.suites.includes(suite)">
+                            <t t-if="this.env.runner.state.suites.includes(suite)">
                                 <HootSideBarCounter
                                     reporting="suite.reporting"
-                                    statusFilter="uiState.statusFilter"
+                                    statusFilter="this.uiState.statusFilter"
                                 />
                             </t>
                         </button>

--- a/addons/web/static/lib/hoot/ui/hoot_status_panel.js
+++ b/addons/web/static/lib/hoot/ui/hoot_status_panel.js
@@ -117,105 +117,105 @@ export class HootStatusPanel extends Component {
     static template = xml`
         <div
             class="${HootStatusPanel.name} flex items-center justify-between gap-3 px-3 py-1 min-h-10 bg-gray-300 dark:bg-gray-700"
-            t-att-class="state.className"
+            t-att-class="this.state.className"
         >
             <div class="flex items-center gap-2 overflow-hidden">
-                <t t-if="runnerState.status === 'ready'">
+                <t t-if="this.runnerState.status === 'ready'">
                     Ready
                 </t>
-                <t t-elif="runnerState.status === 'running'">
-                    <i t-if="state.debug" class="text-cyan fa fa-bug" title="Debugging" />
+                <t t-elif="this.runnerState.status === 'running'">
+                    <i t-if="this.state.debug" class="text-cyan fa fa-bug" title="Debugging" />
                     <div
                         t-else=""
                         class="animate-spin shrink-0 grow-0 w-4 h-4 border-2 border-emerald border-t-transparent rounded-full"
                         role="status"
                         title="Running"
                     />
-                    <strong class="text-primary" t-out="env.runner.totalTime" />
+                    <strong class="text-primary" t-out="this.env.runner.totalTime" />
                 </t>
                 <t t-else="">
                     <span class="hidden md:block">
-                        <strong class="text-primary" t-out="runnerReporting.tests" />
+                        <strong class="text-primary" t-out="this.runnerReporting.tests" />
                         tests completed
-                        (total time: <strong class="text-primary" t-out="env.runner.totalTime" />
-                        <t t-if="env.runner.aborted">, run aborted by user</t>)
+                        (total time: <strong class="text-primary" t-out="this.env.runner.totalTime" />
+                        <t t-if="this.env.runner.aborted">, run aborted by user</t>)
                     </span>
                     <span class="md:hidden flex items-center gap-1">
                         <i class="fa fa-clock-o" />
-                        <strong class="text-primary" t-out="env.runner.totalTime" />
+                        <strong class="text-primary" t-out="this.env.runner.totalTime" />
                     </span>
                 </t>
-                <t t-if="runnerState.currentTest">
-                    <HootTestPath test="runnerState.currentTest" />
+                <t t-if="this.runnerState.currentTest">
+                    <HootTestPath test="this.runnerState.currentTest" />
                 </t>
-                <t t-if="state.timer">
-                    <span class="text-cyan" t-out="formatTime(state.timer, 's')" />
+                <t t-if="this.state.timer">
+                    <span class="text-cyan" t-out="this.formatTime(this.state.timer, 's')" />
                 </t>
             </div>
             <div class="flex items-center gap-1">
-                <t t-if="runnerReporting.passed">
-                    <t t-set="color" t-value="!uiState.statusFilter or uiState.statusFilter === 'passed' ? 'emerald' : 'gray'" />
+                <t t-if="this.runnerReporting.passed">
+                    <t t-set="color" t-value="!this.uiState.statusFilter or this.uiState.statusFilter === 'passed' ? 'emerald' : 'gray'" />
                     <button
                         t-attf-class="text-{{ color }} transition-colors flex items-center gap-1 p-1 font-bold"
                         t-on-click.stop="() => this.filterResults('passed')"
-                        t-attf-title="Show {{ runnerReporting.passed }} passed tests"
+                        t-attf-title="Show {{ this.runnerReporting.passed }} passed tests"
                     >
                         <i class="fa fa-check-circle" />
-                        <t t-out="runnerReporting.passed" />
+                        <t t-out="this.runnerReporting.passed" />
                     </button>
                 </t>
-                <t t-if="runnerReporting.failed">
-                    <t t-set="color" t-value="!uiState.statusFilter or uiState.statusFilter === 'failed' ? 'rose' : 'gray'" />
+                <t t-if="this.runnerReporting.failed">
+                    <t t-set="color" t-value="!this.uiState.statusFilter or this.uiState.statusFilter === 'failed' ? 'rose' : 'gray'" />
                     <button
                         t-attf-class="text-{{ color }} transition-colors flex items-center gap-1 p-1 font-bold"
                         t-on-click.stop="() => this.filterResults('failed')"
-                        t-attf-title="Show {{ runnerReporting.failed }} failed tests"
+                        t-attf-title="Show {{ this.runnerReporting.failed }} failed tests"
                     >
                         <i class="fa fa-times-circle" />
-                        <t t-out="runnerReporting.failed" />
+                        <t t-out="this.runnerReporting.failed" />
                     </button>
                 </t>
-                <t t-if="runnerReporting.skipped">
-                    <t t-set="color" t-value="!uiState.statusFilter or uiState.statusFilter === 'skipped' ? 'cyan' : 'gray'" />
+                <t t-if="this.runnerReporting.skipped">
+                    <t t-set="color" t-value="!this.uiState.statusFilter or this.uiState.statusFilter === 'skipped' ? 'cyan' : 'gray'" />
                     <button
                         t-attf-class="text-{{ color }} transition-colors flex items-center gap-1 p-1 font-bold"
                         t-on-click.stop="() => this.filterResults('skipped')"
-                        t-attf-title="Show {{ runnerReporting.skipped }} skipped tests"
+                        t-attf-title="Show {{ this.runnerReporting.skipped }} skipped tests"
                     >
                         <i class="fa fa-pause-circle" />
-                        <t t-out="runnerReporting.skipped" />
+                        <t t-out="this.runnerReporting.skipped" />
                     </button>
                 </t>
-                <t t-if="runnerReporting.todo">
-                    <t t-set="color" t-value="!uiState.statusFilter or uiState.statusFilter === 'todo' ? 'purple' : 'gray'" />
+                <t t-if="this.runnerReporting.todo">
+                    <t t-set="color" t-value="!this.uiState.statusFilter or this.uiState.statusFilter === 'todo' ? 'purple' : 'gray'" />
                     <button
                         t-attf-class="text-{{ color }} transition-colors flex items-center gap-1 p-1 font-bold"
                         t-on-click.stop="() => this.filterResults('todo')"
-                        t-attf-title="Show {{ runnerReporting.todo }} tests to do"
+                        t-attf-title="Show {{ this.runnerReporting.todo }} tests to do"
                     >
                         <i class="fa fa-exclamation-circle" />
-                        <t t-out="runnerReporting.todo" />
+                        <t t-out="this.runnerReporting.todo" />
                     </button>
                 </t>
-                <t t-if="uiState.totalResults gt uiState.resultsPerPage">
-                    <t t-set="lastPage" t-value="getLastPage()" />
+                <t t-if="this.uiState.totalResults gt this.uiState.resultsPerPage">
+                    <t t-set="lastPage" t-value="this.getLastPage()" />
                     <div class="flex gap-1 animate-slide-left">
                         <button
                             class="px-1 transition-color"
                             title="Previous page"
-                            t-att-disabled="uiState.resultsPage === 0"
-                            t-on-click.stop="previousPage"
+                            t-att-disabled="this.uiState.resultsPage === 0"
+                            t-on-click.stop="this.previousPage"
                         >
                             <i class="fa fa-chevron-left" />
                         </button>
-                        <strong class="text-primary" t-out="uiState.resultsPage + 1" />
+                        <strong class="text-primary" t-out="this.uiState.resultsPage + 1" />
                         <span class="text-gray">/</span>
                         <t t-out="lastPage + 1" />
                         <button
                             class="px-1 transition-color"
                             title="Next page"
-                            t-att-disabled="uiState.resultsPage === lastPage"
-                            t-on-click.stop="nextPage"
+                            t-att-disabled="this.uiState.resultsPage === lastPage"
+                            t-on-click.stop="this.nextPage"
                         >
                             <i class="fa fa-chevron-right" />
                         </button>

--- a/addons/web/static/lib/hoot/ui/hoot_tag_button.js
+++ b/addons/web/static/lib/hoot/ui/hoot_tag_button.js
@@ -21,23 +21,23 @@ export class HootTagButton extends Component {
     };
 
     static template = xml`
-        <t t-if="props.inert">
+        <t t-if="this.props.inert">
             <span
                 class="rounded-full px-2"
-                t-att-style="style"
-                t-att-title="title"
+                t-att-style="this.style"
+                t-att-title="this.title"
             >
-                <small class="text-xs font-bold" t-out="props.tag.name" />
+                <small class="text-xs font-bold" t-out="this.props.tag.name" />
             </span>
         </t>
         <t t-else="">
             <HootLink
-                ids="{ tag: props.tag.name }"
+                ids="{ tag: this.props.tag.name }"
                 class="'rounded-full px-2'"
-                style="style"
-                title="title"
+                style="this.style"
+                title="this.title"
             >
-                <small class="text-xs font-bold hidden md:inline" t-out="props.tag.name" />
+                <small class="text-xs font-bold hidden md:inline" t-out="this.props.tag.name" />
                 <span class="md:hidden">&#8205;</span>
             </HootLink>
         </t>

--- a/addons/web/static/lib/hoot/ui/hoot_technical_value.js
+++ b/addons/web/static/lib/hoot/ui/hoot_technical_value.js
@@ -68,24 +68,24 @@ export class HootTechnicalValue extends Component {
     };
 
     static template = xml`
-        <t t-if="isMarkup">
-            <t t-if="value.type === 'technical'">
-                <pre class="hoot-technical" t-att-class="value.className">
-                    <t t-foreach="value.content" t-as="subValue" t-key="subValue_index">
+        <t t-if="this.isMarkup">
+            <t t-if="this.value.type === 'technical'">
+                <pre class="hoot-technical" t-att-class="this.value.className">
+                    <t t-foreach="this.value.content" t-as="subValue" t-key="subValue_index">
                         <HootTechnicalValue value="subValue" />
                     </t>
                 </pre>
             </t>
             <t t-else="">
-                <t t-if="value.tagName === 't'" t-out="value.content" />
-                <t t-else="" t-tag="value.tagName" t-att-class="value.className" t-out="value.content" />
+                <t t-if="this.value.tagName === 't'" t-out="this.value.content" />
+                <t t-else="" t-tag="this.value.tagName" t-att-class="this.value.className" t-out="this.value.content" />
             </t>
         </t>
-        <t t-elif="isNode(value)">
-            <t t-set="elParts" t-value="toSelector(value, { object: true })" />
+        <t t-elif="this.isNode(this.value)">
+            <t t-set="elParts" t-value="this.toSelector(this.value, { object: true })" />
             <button
                 class="hoot-html"
-                t-on-click.stop="log"
+                t-on-click.stop="this.log"
             >
                 <t>&lt;<t t-out="elParts.tag" /></t>
                 <t t-if="elParts.id">
@@ -97,35 +97,35 @@ export class HootTechnicalValue extends Component {
                 <t>/&gt;</t>
             </button>
         </t>
-        <t t-elif="SPECIAL_SYMBOLS.includes(value)">
+        <t t-elif="this.SPECIAL_SYMBOLS.includes(this.value)">
             <span class="italic">
-                &lt;<t t-out="symbolValue(value)" />&gt;
+                &lt;<t t-out="this.symbolValue(this.value)" />&gt;
             </span>
         </t>
-        <t t-elif="typeof value === 'symbol'">
+        <t t-elif="typeof this.value === 'symbol'">
             <span>
-                Symbol(<span class="hoot-string" t-out="stringify(symbolValue(value))" />)
+                Symbol(<span class="hoot-string" t-out="this.stringify(this.symbolValue(this.value))" />)
             </span>
         </t>
-        <t t-elif="value and typeof value === 'object'">
-            <t t-set="labelSize" t-value="getLabelAndSize()" />
+        <t t-elif="this.value and typeof this.value === 'object'">
+            <t t-set="labelSize" t-value="this.getLabelAndSize()" />
             <pre class="hoot-technical">
                 <button
                     class="hoot-object inline-flex items-center gap-1 me-1"
-                    t-on-click.stop="onClick"
+                    t-on-click.stop="this.onClick"
                 >
                     <t t-if="labelSize[1] > 0">
                         <i
                             class="fa fa-caret-right"
-                            t-att-class="{ 'rotate-90': state.open }"
+                            t-att-class="{ 'rotate-90': this.state.open }"
                         />
                     </t>
                     <t t-out="labelSize[0]" />
-                    <t t-if="state.promiseState">
+                    <t t-if="this.state.promiseState">
                         &lt;
-                        <span class="text-gray" t-out="state.promiseState[0]" />
-                        <t t-if="state.promiseState[0] !== 'pending'">
-                            : <HootTechnicalValue value="state.promiseState[1]" />
+                        <span class="text-gray" t-out="this.state.promiseState[0]" />
+                        <t t-if="this.state.promiseState[0] !== 'pending'">
+                            : <HootTechnicalValue value="this.state.promiseState[1]" />
                         </t>
                         &gt;
                     </t>
@@ -133,14 +133,14 @@ export class HootTechnicalValue extends Component {
                         (<t t-out="labelSize[1]" />)
                     </t>
                 </button>
-                <t t-if="state.open and labelSize[1] > 0">
-                    <t t-if="isIterable(value)">
+                <t t-if="this.state.open and labelSize[1] > 0">
+                    <t t-if="this.isIterable(this.value)">
                         <t>[</t>
                         <ul class="ps-4">
-                            <t t-foreach="value" t-as="subValue" t-key="subValue_index">
+                            <t t-foreach="this.value" t-as="subValue" t-key="subValue_index">
                                 <li class="flex">
                                     <HootTechnicalValue value="subValue" />
-                                    <t t-out="displayComma(subValue)" />
+                                    <t t-out="this.displayComma(subValue)" />
                                 </li>
                             </t>
                         </ul>
@@ -149,12 +149,12 @@ export class HootTechnicalValue extends Component {
                     <t t-else="">
                         <t>{</t>
                         <ul class="ps-4">
-                            <t t-foreach="value" t-as="key" t-key="key">
+                            <t t-foreach="this.value" t-as="key" t-key="key">
                                 <li class="flex">
                                     <span class="hoot-key" t-out="key" />
                                     <span class="me-1">:</span>
-                                    <HootTechnicalValue value="value[key]" />
-                                    <t t-out="displayComma(value[key])" />
+                                    <HootTechnicalValue value="this.value[key]" />
+                                    <t t-out="this.displayComma(this.value[key])" />
                                 </li>
                             </t>
                         </ul>
@@ -164,8 +164,8 @@ export class HootTechnicalValue extends Component {
             </pre>
         </t>
         <t t-else="">
-            <span t-attf-class="hoot-{{ getTypeOf(value) }}">
-                <t t-out="typeof value === 'string' ? stringify(explicitValue) : explicitValue" />
+            <span t-attf-class="hoot-{{ this.getTypeOf(this.value) }}">
+                <t t-out="typeof this.value === 'string' ? this.stringify(this.explicitValue) : this.explicitValue" />
             </span>
         </t>
     `;

--- a/addons/web/static/lib/hoot/ui/hoot_test_path.js
+++ b/addons/web/static/lib/hoot/ui/hoot_test_path.js
@@ -29,21 +29,21 @@ export class HootTestPath extends Component {
     };
 
     static template = xml`
-        <t t-set="statusInfo" t-value="getStatusInfo()" />
+        <t t-set="statusInfo" t-value="this.getStatusInfo()" />
         <div class="flex items-center gap-1 whitespace-nowrap overflow-hidden">
-            <t t-if="props.showStatus">
+            <t t-if="this.props.showStatus">
                 <span
                     t-attf-class="inline-flex min-w-3 min-h-3 rounded-full bg-{{ statusInfo.className }}"
                     t-att-title="statusInfo.text"
                 />
             </t>
             <span class="flex items-center overflow-hidden">
-                <t t-if="uiState.selectedSuiteId and !props.full">
+                <t t-if="this.uiState.selectedSuiteId and !this.props.full">
                     <span class="text-gray font-bold p-1 select-none hidden md:inline">...</span>
                     <span class="select-none hidden md:inline">/</span>
                 </t>
-                <t t-foreach="getTestPath()" t-as="suite" t-key="suite.id">
-                    <t t-if="props.inert">
+                <t t-foreach="this.getTestPath()" t-as="suite" t-key="suite.id">
+                    <t t-if="this.props.inert">
                         <span
                             class="text-gray whitespace-nowrap font-bold p-1 hidden md:inline transition-colors"
                             t-out="suite.name"
@@ -66,22 +66,22 @@ export class HootTestPath extends Component {
                 </t>
                 <span
                     class="text-primary truncate font-bold p-1"
-                    t-att-class="{ 'text-cyan': props.test.config.skip }"
-                    t-att-title="props.test.name"
-                    t-out="props.test.name"
+                    t-att-class="{ 'text-cyan': this.props.test.config.skip }"
+                    t-att-title="this.props.test.name"
+                    t-out="this.props.test.name"
                 />
-                <t t-if="props.canCopy">
-                    <HootCopyButton text="props.test.name" altText="props.test.id" />
+                <t t-if="this.props.canCopy">
+                    <HootCopyButton text="this.props.test.name" altText="this.props.test.id" />
                 </t>
-                <t t-if="results.length > 1">
+                <t t-if="this.results.length > 1">
                     <strong class="text-amber whitespace-nowrap mx-1">
-                        x<t t-out="results.length" />
+                        x<t t-out="this.results.length" />
                     </strong>
                 </t>
             </span>
-            <t t-if="props.test.tags.length">
+            <t t-if="this.props.test.tags.length">
                 <ul class="flex items-center gap-1">
-                    <t t-foreach="props.test.tags.slice(0, 5)" t-as="tag" t-key="tag.name">
+                    <t t-foreach="this.props.test.tags.slice(0, 5)" t-as="tag" t-key="tag.name">
                         <li class="flex">
                             <HootTagButton tag="tag" />
                         </li>

--- a/addons/web/static/lib/hoot/ui/hoot_test_result.js
+++ b/addons/web/static/lib/hoot/ui/hoot_test_result.js
@@ -238,41 +238,41 @@ export class HootTestResult extends Component {
             class="${HootTestResult.name}
                 flex flex-col w-full border-b overflow-hidden
                 border-gray-300 dark:border-gray-600"
-            t-att-class="getClassName()"
+            t-att-class="this.getClassName()"
         >
             <button
                 type="button"
                 class="px-3 flex items-center justify-between"
-                t-on-click.stop="toggleDetails"
+                t-on-click.stop="this.toggleDetails"
             >
                 <t t-slot="default" />
             </button>
-            <t t-if="state.showDetails and !props.test.config.skip">
-                <t t-foreach="filteredResults" t-as="indexedResult" t-key="indexedResult[0]">
+            <t t-if="this.state.showDetails and !this.props.test.config.skip">
+                <t t-foreach="this.filteredResults" t-as="indexedResult" t-key="indexedResult[0]">
                     <t t-set="index" t-value="indexedResult[0]" />
                     <t t-set="result" t-value="indexedResult[1]" />
-                    <t t-if="results.length > 1">
+                    <t t-if="this.results.length > 1">
                         <div class="flex justify-between mx-2 my-1">
                             <span t-attf-class="text-{{ result.pass ? 'emerald' : 'rose' }}">
-                                <t t-out="ordinal(index)" /> run:
+                                <t t-out="this.ordinal(index)" /> run:
                             </span>
-                            <t t-set="timestamp" t-value="formatTime(result.duration, 'ms')" />
+                            <t t-set="timestamp" t-value="this.formatTime(result.duration, 'ms')" />
                             <small class="text-gray flex items-center" t-att-title="timestamp">
                                 <t t-out="timestamp" />
                             </small>
                         </div>
                     </t>
                     <div class="hoot-result-detail grid gap-1 rounded overflow-x-auto p-1 mx-2 animate-slide-down">
-                        <t t-if="!filteredEvents[index].length">
+                        <t t-if="!this.filteredEvents[index].length">
                             <em class="text-gray px-2 py-1">No test event to show</em>
                         </t>
-                        <t t-foreach="filteredEvents[index]" t-as="event" t-key="event_index">
-                            <t t-set="sType" t-value="getTypeName(event.type)" />
-                            <t t-set="eventIcon" t-value="CASE_EVENT_TYPES[sType].icon" />
+                        <t t-foreach="this.filteredEvents[index]" t-as="event" t-key="event_index">
+                            <t t-set="sType" t-value="this.getTypeName(event.type)" />
+                            <t t-set="eventIcon" t-value="this.CASE_EVENT_TYPES[sType].icon" />
                             <t t-set="eventColor" t-value="
                                 'pass' in event ?
                                     (event.pass ? 'emerald' : 'rose') :
-                                    CASE_EVENT_TYPES[sType].color"
+                                    this.CASE_EVENT_TYPES[sType].color"
                             />
                             <t t-if="sType === 'error'">
                                 ${ERROR_TEMPLATE}
@@ -288,9 +288,9 @@ export class HootTestResult extends Component {
                         <button
                             type="button"
                             class="flex items-center px-1 gap-1 text-sm hover:text-primary"
-                            t-on-click.stop="toggleCode"
+                            t-on-click.stop="this.toggleCode"
                         >
-                            <t t-if="state.showCode">
+                            <t t-if="this.state.showCode">
                                 Hide source code
                             </t>
                             <t t-else="">
@@ -298,12 +298,12 @@ export class HootTestResult extends Component {
                             </t>
                         </button>
                     </nav>
-                    <t t-if="state.showCode">
+                    <t t-if="this.state.showCode">
                         <div class="m-2 mt-0 rounded animate-slide-down overflow-auto">
                             <pre
                                 class="language-javascript"
                                 style="margin: 0"
-                            ><code class="language-javascript" t-out="props.test.code" /></pre>
+                            ><code class="language-javascript" t-out="this.props.test.code" /></pre>
                         </div>
                     </t>
                 </div>

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -90,7 +90,7 @@ export class AssetsLoadingError extends Error {}
  * Utility component that loads an asset bundle before instanciating a component
  */
 export class LazyComponent extends Component {
-    static template = xml`<t t-component="Component" t-props="componentProps"/>`;
+    static template = xml`<t t-component="this.Component" t-props="this.componentProps"/>`;
     static props = {
         Component: String,
         bundle: String,

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -3,7 +3,7 @@ import { Component, markRaw, xml } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
 class DialogWrapper extends Component {
-    static template = xml`<t t-component="props.subComponent" t-props="props.subProps" />`;
+    static template = xml`<t t-component="this.props.subComponent" t-props="this.props.subProps" />`;
     static props = ["*"];
     setup() {
         useChildSubEnv({ dialogData: this.props.subEnv });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -652,7 +652,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
 class PickerMobile extends Component {
     static props = [...PICKER_PROPS, "onClose?"];
     static template = xml`
-        <t t-component="props.PickerComponent" t-props="pickerProps"/>
+        <t t-component="this.props.PickerComponent" t-props="this.pickerProps"/>
     `;
 
     get pickerProps() {
@@ -670,7 +670,7 @@ class PickerMobileInDialog extends PickerMobile {
     static template = xml`
         <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-0 h-50 bg-100'" bodyClass="'p-1'">
             <div class="h-100" t-custom-ref="root">
-                <t t-component="props.PickerComponent" t-props="pickerProps"/>
+                <t t-component="this.props.PickerComponent" t-props="this.pickerProps"/>
             </div>
         </Dialog>
     `;

--- a/addons/web/static/src/core/main_components_container.js
+++ b/addons/web/static/src/core/main_components_container.js
@@ -17,7 +17,7 @@ export class MainComponentsContainer extends Component {
     static props = {};
     static template = xml`
     <div class="o-main-components-container" t-att-class="{'o_rtl': this.isRTL}">
-        <t t-foreach="Components.entries" t-as="C" t-key="C[0]">
+        <t t-foreach="this.Components.entries" t-as="C" t-key="C[0]">
             <ErrorHandler onError="error => this.handleComponentError(error, C)">
                 <t t-component="C[1].Component" t-props="C[1].props"/>
             </ErrorHandler>

--- a/addons/web/static/src/core/notebook/notebook.js
+++ b/addons/web/static/src/core/notebook/notebook.js
@@ -13,8 +13,8 @@ import { KeepLast } from "@web/core/utils/concurrency";
  *
  *      e.g.:
  *          PageTemplate.template = xml`
-                    <h1 t-out="props.heading" />
-                    <p t-out="props.text" />`;
+                    <h1 t-out="this.props.heading" />
+                    <p t-out="this.props.text" />`;
 
  *      `pages` could be:
  *      [

--- a/addons/web/static/src/core/notifications/notification_container.js
+++ b/addons/web/static/src/core/notifications/notification_container.js
@@ -11,7 +11,7 @@ export class NotificationContainer extends Component {
 
     static template = xml`
         <div class="o_notification_manager">
-            <t t-foreach="notifications" t-as="notification" t-key="notification">
+            <t t-foreach="this.notifications" t-as="notification" t-key="notification">
                 <Transition leaveDuration="0" immediate="true" name="'o_notification_fade'" t-slot-scope="transition">
                     <Notification t-props="notification_value.props" className="(notification_value.props.className || '') + ' ' + transition.className"/>
                 </Transition>

--- a/addons/web/static/src/core/transition.js
+++ b/addons/web/static/src/core/transition.js
@@ -122,7 +122,7 @@ export function useTransition({
  * to be created. @see useTransition
  */
 export class Transition extends Component {
-    static template = xml`<t t-slot="default" t-if="transition.shouldMount" className="transition.className"/>`;
+    static template = xml`<t t-slot="default" t-if="this.transition.shouldMount" className="transition.className"/>`;
     static props = {
         name: String,
         visible: { type: Boolean, optional: true },

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -191,8 +191,8 @@ function sortKeysDeep(obj) {
 
 class RawRecordDialog extends Component {
     static template = xml`
-        <Dialog title="props.title">
-            <pre t-out="content"/>
+        <Dialog title="this.props.title">
+            <pre t-out="this.content"/>
         </Dialog>
     `;
     static components = { Dialog };

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -19,7 +19,7 @@ import { StatusBarButtons } from "./status_bar_buttons/status_bar_buttons";
 import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 
 export class FormRenderer extends Component {
-    static template = xml`<t t-call="{{ templates.FormRenderer }}" t-call-context="{ __comp__: Object.assign(Object.create(this), { this: this }) }" />`;
+    static template = xml`<t t-call="{{ this.templates.FormRenderer }}" t-call-context="{ __comp__: Object.assign(Object.create(this), { this: this }) }" />`;
     static components = {
         Field,
         FormLabel,

--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -178,8 +178,8 @@ function computeOptimalDateWidths() {
 
     const template = xml`
         <div class="invisible" style="font-variant-numeric: tabular-nums;">
-            <div t-foreach="Object.keys(values)" t-as="key" t-key="key" t-att-class="key">
-                <div t-foreach="values[key]" t-as="value" t-key="value_index">
+            <div t-foreach="Object.keys(this.values)" t-as="key" t-key="key" t-att-class="key">
+                <div t-foreach="this.values[key]" t-as="value" t-key="value_index">
                     <span t-out="value"/>
                 </div>
             </div>

--- a/addons/web/static/src/webclient/actions/action_container.js
+++ b/addons/web/static/src/webclient/actions/action_container.js
@@ -9,7 +9,7 @@ export class ActionContainer extends Component {
     static template = xml`
         <t t-name="web.ActionContainer">
           <div class="o_action_manager">
-            <t t-if="info.Component" t-component="info.Component" className="'o_action'" t-props="info.componentProps" t-key="info.id"/>
+            <t t-if="this.info.Component" t-component="this.info.Component" className="'o_action'" t-props="this.info.componentProps" t-key="this.info.id"/>
           </div>
         </t>`;
 

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -121,7 +121,7 @@ const EMBEDDED_ACTIONS_CTX_KEYS = [
 ];
 
 // only register this template once for all dynamic classes ControllerComponent
-const ControllerComponentTemplate = xml`<t t-component="Component" t-props="componentProps"/>`;
+const ControllerComponentTemplate = xml`<t t-component="this.Component" t-props="this.componentProps"/>`;
 
 export function makeActionManager(env, router = _router) {
     const breadcrumbCache = {};

--- a/addons/web/static/tests/_framework/search_test_helpers.js
+++ b/addons/web/static/tests/_framework/search_test_helpers.js
@@ -74,8 +74,8 @@ function filterPropsForComponent(Component, props) {
 export async function mountWithSearch(componentConstructor, searchProps = {}, config = {}) {
     class ComponentWithSearch extends Component {
         static template = xml`
-            <WithSearch t-props="withSearchProps" t-slot-scope="search">
-                <t t-component="component" t-props="getProps(search)"/>
+            <WithSearch t-props="this.withSearchProps" t-slot-scope="search">
+                <t t-component="this.component" t-props="this.getProps(search)"/>
             </WithSearch>
         `;
         static components = { WithSearch };

--- a/addons/web/static/tests/_framework/view_test_helpers.js
+++ b/addons/web/static/tests/_framework/view_test_helpers.js
@@ -74,7 +74,7 @@ class ViewDialog extends Component {
 
     static template = xml`
         <Dialog>
-            <View t-props="props.viewProps" />
+            <View t-props="this.props.viewProps" />
         </Dialog>
     `;
 

--- a/addons/web/static/tests/_framework/webclient_test_helpers.js
+++ b/addons/web/static/tests/_framework/webclient_test_helpers.js
@@ -7,7 +7,7 @@ import { mountWithCleanup } from "./component_test_helpers";
 class TestClientAction extends Component {
     static template = xml`
         <div class="test_client_action">
-            ClientAction_<t t-out="props.action.params?.description"/>
+            ClientAction_<t t-out="this.props.action.params?.description"/>
         </div>`;
     static props = ["*"];
 }

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -68,7 +68,7 @@ function item(label, onSelect, data = {}) {
 test("can be rendered", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -93,7 +93,7 @@ test("can be rendered", async () => {
 test.todo("select option with onChange", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="state.value" sources="sources" onChange.bind="onChange" />`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources" onChange.bind="this.onChange" />`;
         static props = [];
 
         state = useState({ value: "" });
@@ -135,7 +135,7 @@ test.todo("select option with onChange", async () => {
 test("select option", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="state.value" sources="sources"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources"/>`;
         static props = [];
 
         state = useState({ value: "Hello" });
@@ -169,8 +169,8 @@ test("autocomplete with resetOnSelect='true'", async () => {
         static components = { AutoComplete };
         static template = xml`
             <div>
-                <div class= "test_value" t-out="state.value"/>
-                <AutoComplete value="''" sources="sources" resetOnSelect="true"/>
+                <div class="test_value" t-out="this.state.value"/>
+                <AutoComplete value="''" sources="this.sources" resetOnSelect="true"/>
             </div>
         `;
         static props = [];
@@ -202,7 +202,7 @@ test("autocomplete with resetOnSelect='true'", async () => {
 test("open dropdown on input", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -219,7 +219,7 @@ test("open dropdown on input", async () => {
 test("cancel result on escape keydown", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources" autoSelect="true"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources" autoSelect="true"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -242,7 +242,7 @@ test("cancel result on escape keydown", async () => {
 test("select input text on first focus", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Bar'" sources="sources"/>`;
+        static template = xml`<AutoComplete value="'Bar'" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(() => [item("Bar")]);
@@ -260,7 +260,7 @@ test("scroll outside should cancel result", async () => {
         static template = xml`
             <div class="autocomplete_container overflow-auto" style="max-height: 100px;">
                 <div style="height: 1000px;">
-                    <AutoComplete value="'Hello'" sources="sources" autoSelect="true"/>
+                    <AutoComplete value="'Hello'" sources="this.sources" autoSelect="true"/>
                 </div>
             </div>
         `;
@@ -289,7 +289,7 @@ test("scroll inside should keep dropdown open", async () => {
         static template = xml`
             <div class="autocomplete_container overflow-auto" style="max-height: 100px;">
                 <div style="height: 1000px;">
-                    <AutoComplete value="'Hello'" sources="sources"/>
+                    <AutoComplete value="'Hello'" sources="this.sources"/>
                 </div>
             </div>
         `;
@@ -312,7 +312,7 @@ test("scroll inside should keep dropdown open", async () => {
 test("losing focus should cancel result", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources" autoSelect="true"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources" autoSelect="true"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -335,7 +335,7 @@ test("losing focus should cancel result", async () => {
 test("click out after clearing input", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -361,7 +361,7 @@ test("open twice should not display previous results", async () => {
     let def = new Deferred();
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="''" sources="sources"/>`;
+        static template = xml`<AutoComplete value="''" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(async (request) => {
@@ -409,7 +409,7 @@ test("open twice should not display previous results", async () => {
 test("press enter on autocomplete with empty source", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="''" sources="sources"/>`;
+        static template = xml`<AutoComplete value="''" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources(() => []);
@@ -436,7 +436,7 @@ test("press enter on autocomplete with empty source (2)", async () => {
 
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="''" sources="sources"/>`;
+        static template = xml`<AutoComplete value="''" sources="this.sources"/>`;
         static props = [];
 
         sources = buildSources((request) =>
@@ -467,7 +467,7 @@ test.tags("desktop");
 test("autofocus=true option work as expected", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete value="'Hello'" sources="sources" autofocus="true"/>`;
+        static template = xml`<AutoComplete value="'Hello'" sources="this.sources" autofocus="true"/>`;
         static props = [];
 
         sources = buildSources(() => [item("World"), item("Hello")]);
@@ -482,8 +482,8 @@ test("autocomplete in edition keep edited value before select option", async () 
     class Parent extends Component {
         static components = { AutoComplete };
         static template = xml`
-            <button class="myButton" t-on-mouseover="onHover">My button</button>
-            <AutoComplete value="this.state.value" sources="sources"/>
+            <button class="myButton" t-on-mouseover="this.onHover">My button</button>
+            <AutoComplete value="this.state.value" sources="this.sources"/>
         `;
         static props = [];
 
@@ -524,7 +524,7 @@ test("autocomplete in edition keep edited value before blur", async () => {
     class Parent extends Component {
         static components = { AutoComplete };
         static template = xml`
-            <button class="myButton" t-on-mouseover="onHover">My button</button>
+            <button class="myButton" t-on-mouseover="this.onHover">My button</button>
             <AutoComplete value="this.state.value" sources="[]"/>
         `;
         static props = [];
@@ -559,10 +559,10 @@ test("correct sequence of blur, focus and select", async () => {
         static components = { AutoComplete };
         static template = xml`
             <AutoComplete
-                value="state.value"
-                sources="sources"
-                onBlur.bind="onBlur"
-                onChange.bind="onChange"
+                value="this.state.value"
+                sources="this.sources"
+                onBlur.bind="this.onBlur"
+                onChange.bind="this.onChange"
                 autoSelect="true"
             />
         `;
@@ -622,7 +622,7 @@ test("correct sequence of blur, focus and select", async () => {
 
 test("autocomplete always closes on click away", async () => {
     class Parent extends Component {
-        static template = xml`<AutoComplete value="state.value" sources="sources" autoSelect="true"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources" autoSelect="true"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -651,7 +651,7 @@ test("autocomplete trim spaces for search", async () => {
     const ITEMS = [item("World"), item("Hello")];
 
     class Parent extends Component {
-        static template = xml`<AutoComplete value="state.value" sources="sources"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -665,7 +665,7 @@ test("autocomplete trim spaces for search", async () => {
 
 test("tab and shift+tab close the dropdown", async () => {
     class Parent extends Component {
-        static template = xml`<AutoComplete value="state.value" sources="sources"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -692,7 +692,7 @@ test("tab and shift+tab close the dropdown", async () => {
 
 test("Clicking away selects the first option when selectOnBlur is true", async () => {
     class Parent extends Component {
-        static template = xml`<AutoComplete value="state.value" sources="sources" selectOnBlur="true"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources" selectOnBlur="true"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -720,7 +720,7 @@ test("Clicking away selects the first option when selectOnBlur is true", async (
 
 test("selectOnBlur doesn't interfere with selecting by mouse clicking", async () => {
     class Parent extends Component {
-        static template = xml`<AutoComplete value="state.value" sources="sources" selectOnBlur="true"/>`;
+        static template = xml`<AutoComplete value="this.state.value" sources="this.sources" selectOnBlur="true"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -752,7 +752,7 @@ test("autocomplete scrolls when moving with arrows", async () => {
                     max-height: 100px;
                 }
             </style>
-            <AutoComplete value="state.value" sources="sources" autoSelect="true"/>
+            <AutoComplete value="this.state.value" sources="this.sources" autoSelect="true"/>
         `;
         static components = { AutoComplete };
         static props = [];
@@ -809,7 +809,7 @@ test("autocomplete scrolls when moving with arrows", async () => {
 test("source with option slot", async () => {
     class Parent extends Component {
         static template = xml`
-            <AutoComplete value="''" sources="sources">
+            <AutoComplete value="''" sources="this.sources">
                 <t t-set-slot="use_this_slot" t-slot-scope="scope">
                     <div class="slot_item">
                         <t t-esc="scope.data.id"/>: <t t-esc="scope.label"/>
@@ -837,7 +837,7 @@ test("source with option slot", async () => {
 test("unselectable options are... not selectable", async () => {
     class Parent extends Component {
         static template = xml`
-            <AutoComplete value="''" sources="sources"/>
+            <AutoComplete value="''" sources="this.sources"/>
         `;
         static components = { AutoComplete };
         static props = [];
@@ -893,7 +893,7 @@ test("unselectable options are... not selectable", async () => {
 test.tags("desktop");
 test("items are selected only when the mouse moves, not just on enter", async () => {
     class Parent extends Component {
-        static template = xml`<AutoComplete value="''" sources="sources"/>`;
+        static template = xml`<AutoComplete value="''" sources="this.sources"/>`;
         static components = { AutoComplete };
         static props = [];
 
@@ -937,7 +937,7 @@ test("items are selected only when the mouse moves, not just on enter", async ()
 test("do not attempt to scroll if element is null", async () => {
     const def = new Deferred();
     class Parent extends Component {
-        static template = xml`<AutoComplete value="''" sources="sources" />`;
+        static template = xml`<AutoComplete value="''" sources="this.sources" />`;
         static components = { AutoComplete };
         static props = [];
 

--- a/addons/web/static/tests/core/checkbox.test.js
+++ b/addons/web/static/tests/core/checkbox.test.js
@@ -32,7 +32,7 @@ test("call onChange prop when some change occurs", async () => {
     class Parent extends Component {
         static components = { CheckBox };
         static props = {};
-        static template = xml`<CheckBox onChange="onChange" />`;
+        static template = xml`<CheckBox onChange="this.onChange" />`;
         onChange(checked) {
             value = checked;
         }
@@ -69,7 +69,7 @@ test("can toggle value by pressing ENTER", async () => {
     class Parent extends Component {
         static components = { CheckBox };
         static props = {};
-        static template = xml`<CheckBox onChange.bind="onChange" value="state.value" />`;
+        static template = xml`<CheckBox onChange.bind="this.onChange" value="this.state.value" />`;
 
         setup() {
             this.state = useState({ value: false });
@@ -99,7 +99,7 @@ test("toggling through multiple ways", async () => {
     class Parent extends Component {
         static components = { CheckBox };
         static props = {};
-        static template = xml`<CheckBox onChange.bind="onChange" value="state.value" />`;
+        static template = xml`<CheckBox onChange.bind="this.onChange" value="this.state.value" />`;
 
         setup() {
             this.state = useState({ value: false });

--- a/addons/web/static/tests/core/code_editor.test.js
+++ b/addons/web/static/tests/core/code_editor.test.js
@@ -90,12 +90,12 @@ test("CodeEditor shouldn't accepts markup values", async () => {
 
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor value="props.value" />`;
+        static template = xml`<CodeEditor value="this.props.value" />`;
         static props = ["*"];
     }
     class GrandParent extends Component {
         static components = { Parent };
-        static template = xml`<Parent value="state.value"/>`;
+        static template = xml`<Parent value="this.state.value"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ value: `<div>Some Text</div>` });
@@ -115,7 +115,7 @@ test("CodeEditor shouldn't accepts markup values", async () => {
 test("onChange props called when code is edited", async () => {
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor maxLines="10" onChange.bind="onChange" />`;
+        static template = xml`<CodeEditor maxLines="10" onChange.bind="this.onChange" />`;
         static props = ["*"];
         onChange(value) {
             expect.step(value);
@@ -132,9 +132,9 @@ test("onChange props not called when value props is updated", async () => {
         static components = { CodeEditor };
         static template = xml`
             <CodeEditor
-                value="state.value"
+                value="this.state.value"
                 maxLines="10"
-                onChange.bind="onChange"
+                onChange.bind="this.onChange"
             />
         `;
         static props = ["*"];
@@ -165,8 +165,8 @@ test("Default value correctly set and updates", async () => {
         static template = xml`
             <CodeEditor
                 mode="'xml'"
-                value="state.value"
-                onChange.bind="onChange"
+                value="this.state.value"
+                onChange.bind="this.onChange"
                 maxLines="200"
             />
         `;
@@ -222,7 +222,7 @@ test("Mode props update imports the mode", async () => {
 
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor maxLines="10" mode="state.mode" />`;
+        static template = xml`<CodeEditor maxLines="10" mode="this.state.mode" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ mode: "xml" });
@@ -260,7 +260,7 @@ test("Theme props updates imports the theme", async () => {
 
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor maxLines="10" theme="state.theme" />`;
+        static template = xml`<CodeEditor maxLines="10" theme="this.state.theme" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ theme: "" });
@@ -313,7 +313,7 @@ test("initial value cannot be undone", async () => {
 test("code editor can take an initial cursor position", async () => {
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor maxLines="2" value="value" initialCursorPosition="initialPosition" onChange="onChange"/>`;
+        static template = xml`<CodeEditor maxLines="2" value="this.value" initialCursorPosition="this.initialPosition" onChange="this.onChange"/>`;
         static props = ["*"];
 
         setup() {
@@ -365,7 +365,7 @@ test("code editor can take an initial cursor position", async () => {
 test("qweb mode readonly attributes", async () => {
     class Parent extends Component {
         static components = { CodeEditor };
-        static template = xml`<CodeEditor maxLines="10" mode="props.state.mode" value="props.state.value" modeOptions="props.state.modeOptions" initialCursorPosition="props.state.initialCursorPosition"/>`;
+        static template = xml`<CodeEditor maxLines="10" mode="this.props.state.mode" value="this.props.state.value" modeOptions="this.props.state.modeOptions" initialCursorPosition="this.props.state.initialCursorPosition"/>`;
         static props = ["*"];
     }
 

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -147,7 +147,7 @@ test("keyboard navigation", async () => {
 
 class AdditionalTab extends Component {
     static template = xml`
-        <div class="container" t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut">
+        <div class="container" t-on-mouseover="this.props.onColorPointerOver" t-on-mouseout="this.props.onColorPointerOut">
             <button class="o_color_picker_button btn p-1 m-1" data-color="#FFFF00" style="background-color: #ffff00; width: auto">
                 <div>Hover me</div>
             </button>
@@ -288,7 +288,7 @@ test("should preserve color slider when picking max lightness color", async () =
     class TestColorPicker extends Component {
         static template = xml`
             <div style="width: 222px">
-                <CustomColorPicker selectedColor="state.color" onColorPreview.bind="onColorChange" onColorSelect.bind="onColorChange"/>
+                <CustomColorPicker selectedColor="this.state.color" onColorPreview.bind="this.onColorChange" onColorSelect.bind="this.onColorChange"/>
             </div>`;
         static components = { CustomColorPicker };
         static props = ["*"];

--- a/addons/web/static/tests/core/colorlist.test.js
+++ b/addons/web/static/tests/core/colorlist.test.js
@@ -6,7 +6,7 @@ import { ColorList } from "@web/core/colorlist/colorlist";
 
 class Parent extends Component {
     static template = xml`
-        <t t-component="Component" t-props="componentProps"/>
+        <t t-component="this.Component" t-props="this.componentProps"/>
         <div class="outsideDiv">Outside div</div>
     `;
     static props = ["*"];

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -257,7 +257,7 @@ test("command with a Custom Component", async () => {
     class CustomComponent extends Component {
         static template = xml`
             <div class="o_command_custom">
-                <span t-out="props.name"/>
+                <span t-out="this.props.name"/>
             </div>
         `;
         static props = ["*"];

--- a/addons/web/static/tests/core/commands/command_service.test.js
+++ b/addons/web/static/tests/core/commands/command_service.test.js
@@ -29,7 +29,7 @@ class TestComponent extends Component {
 
 class Parent extends Component {
     static template = xml`
-      <t t-component="props.componentInfo.Component" t-if="props.componentInfo.Component" />
+      <t t-component="this.props.componentInfo.Component" t-if="this.props.componentInfo.Component" />
     `;
     static props = ["*"];
 }
@@ -355,7 +355,7 @@ test("data-hotkey added to command palette", async () => {
         static components = { TestComponent };
         static template = xml`
             <div>
-                <button title="Aria Stark" data-hotkey="a" t-on-click="onClick">visible</button>
+                <button title="Aria Stark" data-hotkey="a" t-on-click="this.onClick">visible</button>
                 <input title="Bran Stark" type="text" data-hotkey="b" />
                 <button title="Sansa Stark" data-hotkey="c" style="display: none;" />
                 <TestComponent />
@@ -403,8 +403,8 @@ test("access to hotkeys from the command palette", async () => {
         static components = { TestComponent };
         static template = xml`
             <div>
-                <button title="B" data-hotkey="b" t-on-click="onClickB">visible</button>
-                <button title="C" data-hotkey="c" t-on-click="onClickC">visible</button>
+                <button title="B" data-hotkey="b" t-on-click="this.onClickB">visible</button>
+                <button title="C" data-hotkey="c" t-on-click="this.onClickC">visible</button>
                 <TestComponent />
             </div>
         `;

--- a/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
@@ -172,7 +172,7 @@ test("close popover when owner component is unmounted", async() => {
     class DateTimeToggler extends Component {
         static components = { Child };
         static props = [];
-        static template = xml`<Child t-if="!state.hidden"/>`;
+        static template = xml`<Child t-if="!this.state.hidden"/>`;
 
         setup() {
             this.state = useState({

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -20,7 +20,7 @@ const { DateTime } = luxon;
 
 class DateTimeInputComp extends Component {
     static components = { DateTimeInput };
-    static template = xml`<DateTimeInput t-props="props" />`;
+    static template = xml`<DateTimeInput t-props="this.props" />`;
     static props = ["*"];
 }
 
@@ -220,7 +220,7 @@ describe("DateTimeInput (date)", () => {
     test("popover should be inside a bottom sheet", async () => {
         class Root extends Component {
             static components = { DateTimeInput };
-            static template = xml`<div class="d-flex"><DateTimeInput t-props="props" /></div>`;
+            static template = xml`<div class="d-flex"><DateTimeInput t-props="this.props" /></div>`;
             static props = ["*"];
         }
         await mountWithCleanup(Root, {

--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -1176,7 +1176,7 @@ test("range value, select date for first value after second value", async () => 
 
 test("focus proper month when changing props out of current month", async () => {
     class Parent extends Component {
-        static template = xml`<DateTimePicker value="state.current"/>`;
+        static template = xml`<DateTimePicker value="this.state.current"/>`;
         static components = { DateTimePicker };
         static props = ["*"];
         setup() {

--- a/addons/web/static/tests/core/components/pager.test.js
+++ b/addons/web/static/tests/core/components/pager.test.js
@@ -7,7 +7,7 @@ import { contains, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_
 import { config as transitionConfig } from "@web/core/transition";
 
 class PagerController extends Component {
-    static template = xml`<Pager t-props="state" />`;
+    static template = xml`<Pager t-props="this.state" />`;
     static components = { Pager };
     static props = ["*"];
     setup() {

--- a/addons/web/static/tests/core/components/time_picker.test.js
+++ b/addons/web/static/tests/core/components/time_picker.test.js
@@ -288,7 +288,7 @@ test("false, null and undefined are accepted values", async () => {
     class Parent extends Component {
         static components = { TimePicker };
         static props = {};
-        static template = xml`<TimePicker value="state.value"/>`;
+        static template = xml`<TimePicker value="this.state.value"/>`;
 
         setup() {
             this.state = useState({
@@ -319,7 +319,7 @@ test("click-out triggers onChange", async () => {
                 <Dropdown>
                     <button class="open">Open</button>
                     <t t-set-slot="content">
-                        <TimePicker onChange.bind="onChange"/>
+                        <TimePicker onChange.bind="this.onChange"/>
                     </t>
                 </Dropdown>
                 <button class="outside">Outside</button>
@@ -354,7 +354,7 @@ test("changing the props value updates the input", async () => {
     class Parent extends Component {
         static components = { TimePicker };
         static props = {};
-        static template = xml`<TimePicker value="state.value" onChange.bind="onChange"/>`;
+        static template = xml`<TimePicker value="this.state.value" onChange.bind="this.onChange"/>`;
 
         setup() {
             this.state = useState({
@@ -400,7 +400,7 @@ test("ensure placeholder is customizable", async () => {
     class Parent extends Component {
         static components = { TimePicker };
         static props = {};
-        static template = xml`<TimePicker placeholder="state.placeholder"/>`;
+        static template = xml`<TimePicker placeholder="this.state.placeholder"/>`;
 
         setup() {
             this.state = useState({ placeholder: undefined });

--- a/addons/web/static/tests/core/dialog.test.js
+++ b/addons/web/static/tests/core/dialog.test.js
@@ -43,7 +43,7 @@ test("hotkeys work on dialogs", async () => {
             <Dialog title="'Wow(l) Effect'">
                 Hello!
                 <t t-set-slot="footer">
-                    <button t-on-click="onClickOk">Ok</button>
+                    <button t-on-click="this.onClickOk">Ok</button>
                 </t>
             </Dialog>
         `;
@@ -188,7 +188,7 @@ test("embed an arbitrary component in a dialog is possible", async () => {
     expect.assertions(4);
     class SubComponent extends Component {
         static template = xml`
-            <div class="o_subcomponent" t-out="props.text" t-on-click="_onClick"/>
+            <div class="o_subcomponent" t-out="this.props.text" t-on-click="this._onClick"/>
         `;
         static props = ["*"];
         _onClick() {
@@ -200,7 +200,7 @@ test("embed an arbitrary component in a dialog is possible", async () => {
         static components = { Dialog, SubComponent };
         static template = xml`
             <Dialog>
-                <SubComponent text="'Wow(l) Effect'" onClicked="_onSubcomponentClicked"/>
+                <SubComponent text="'Wow(l) Effect'" onClicked="this._onSubcomponentClicked"/>
             </Dialog>
         `;
         static props = ["*"];

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -53,7 +53,7 @@ test("Simple rendering and close a single dialog", async () => {
 test("rendering with two dialogs", async () => {
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static template = xml`<Dialog title="this.props.title">content</Dialog>`;
         static props = ["*"];
     }
     expect(".o_dialog").toHaveCount(0);
@@ -75,7 +75,7 @@ test("rendering with two dialogs", async () => {
 test("multiple dialogs can become the UI active element", async () => {
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static template = xml`<Dialog title="this.props.title">content</Dialog>`;
         static props = ["*"];
     }
     getService("dialog").add(CustomDialog, { title: "Hello" });
@@ -107,8 +107,8 @@ test("a popover with an autofocus child can become the UI active element", async
     }
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">
-            <button class="btn test" t-on-click="showPopover">show</button>
+        static template = xml`<Dialog title="this.props.title">
+            <button class="btn test" t-on-click="this.showPopover">show</button>
         </Dialog>`;
         static props = ["*"];
         setup() {
@@ -148,7 +148,7 @@ test("Interactions between multiple dialogs", async () => {
 
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static template = xml`<Dialog title="this.props.title">content</Dialog>`;
         static props = ["*"];
     }
 
@@ -206,7 +206,7 @@ test("dialog component crashes", async () => {
 test("two dialogs, close the first one, closeAll", async () => {
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static template = xml`<Dialog title="this.props.title">content</Dialog>`;
         static props = ["*"];
     }
     expect(".o_dialog").toHaveCount(0);
@@ -233,7 +233,7 @@ test("two dialogs, close the first one, closeAll", async () => {
 test("two dialogs, close the first one twice, then closeAll", async () => {
     class CustomDialog extends Component {
         static components = { Dialog };
-        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static template = xml`<Dialog title="this.props.title">content</Dialog>`;
         static props = ["*"];
     }
     expect(".o_dialog").toHaveCount(0);

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -60,7 +60,7 @@ async function makeDomainSelector(params = {}) {
 
     class Parent extends Component {
         static components = { DomainSelector };
-        static template = xml`<DomainSelector t-props="domainSelectorProps"/>`;
+        static template = xml`<DomainSelector t-props="this.domainSelectorProps"/>`;
         static props = ["*"];
         setup() {
             this.domainSelectorProps = {
@@ -458,9 +458,9 @@ test("multi selection", async () => {
         static template = xml`
             <DomainSelector
                 resModel="'partner'"
-                domain="domain"
+                domain="this.domain"
                 readonly="false"
-                update.bind="update"
+                update.bind="this.update"
             />
         `;
         static props = ["*"];
@@ -504,7 +504,7 @@ test("parse -1", async () => {
     class Parent extends Component {
         static components = { DomainSelector };
         static template = xml`
-            <DomainSelector resModel="'partner'" domain="domain" readonly="false"/>
+            <DomainSelector resModel="'partner'" domain="this.domain" readonly="false"/>
         `;
         static props = ["*"];
         setup() {
@@ -519,7 +519,7 @@ test("parse 3-1", async () => {
     class Parent extends Component {
         static components = { DomainSelector };
         static template = xml`
-            <DomainSelector resModel="'partner'" domain="domain" readonly="false"/>
+            <DomainSelector resModel="'partner'" domain="this.domain" readonly="false"/>
         `;
         static props = ["*"];
         setup() {
@@ -620,10 +620,10 @@ test("debug input in model field selector popover", async () => {
         static template = xml`
             <DomainSelector
                 resModel="'partner'"
-                domain="domain"
+                domain="this.domain"
                 readonly="false"
                 isDebugMode="true"
-                update.bind="update"
+                update.bind="this.update"
             />
         `;
         static props = ["*"];
@@ -831,7 +831,7 @@ test("support of connector '!' (mode readonly)", async () => {
 
     class Parent extends Component {
         static components = { DomainSelector };
-        static template = xml`<DomainSelector resModel="'partner'" domain="state.domain"/>`;
+        static template = xml`<DomainSelector resModel="'partner'" domain="this.state.domain"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ domain: `[]` });
@@ -949,7 +949,7 @@ test("support of connector '!' (debug mode)", async () => {
 
     class Parent extends Component {
         static components = { DomainSelector };
-        static template = xml`<DomainSelector resModel="'partner'" isDebugMode="true" domain="state.domain"/>`;
+        static template = xml`<DomainSelector resModel="'partner'" isDebugMode="true" domain="this.state.domain"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ domain: `[]` });
@@ -997,10 +997,10 @@ test("support properties", async () => {
         static template = xml`
             <DomainSelector
                 resModel="'partner'"
-                domain="domain"
+                domain="this.domain"
                 readonly="false"
                 isDebugMode="true"
-                update.bind="update"
+                update.bind="this.update"
             />
         `;
         static components = { DomainSelector };
@@ -1171,7 +1171,7 @@ test("support properties (mode readonly)", async () => {
 
     class Parent extends Component {
         static components = { DomainSelector };
-        static template = xml`<DomainSelector resModel="'partner'" domain="state.domain"/>`;
+        static template = xml`<DomainSelector resModel="'partner'" domain="this.state.domain"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ domain: `[]` });

--- a/addons/web/static/tests/core/domain_selector/domain_selector_dialog.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector_dialog.test.js
@@ -27,7 +27,7 @@ async function makeDomainSelectorDialog(params = {}) {
 
     class Parent extends Component {
         static components = { DomainSelectorDialog };
-        static template = xml`<DomainSelectorDialog t-props="domainSelectorProps"/>`;
+        static template = xml`<DomainSelectorDialog t-props="this.domainSelectorProps"/>`;
         static props = ["*"];
         setup() {
             this.domainSelectorProps = {

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -39,7 +39,7 @@ class SimpleDropdown extends Component {
     static props = [];
     static template = xml`
         <div class="outside">outside</div>
-        <Dropdown t-props="dropdownProps">
+        <Dropdown t-props="this.dropdownProps">
             <button>Dropdown</button>
             <t t-set-slot="content">
                 <DropdownItem class="'item-a'">Item A</DropdownItem>
@@ -55,15 +55,15 @@ class MultiLevelDropdown extends Component {
     static props = [];
     static template = xml`
         <div class="outside">outside</div>
-        <Dropdown t-props="dropdownProps">
+        <Dropdown t-props="this.dropdownProps">
             <button class="dropdown-a">A</button>
             <t t-set-slot="content">
                 <DropdownItem class="'item-a'">Item A</DropdownItem>
-                <Dropdown t-props="dropdownProps">
+                <Dropdown t-props="this.dropdownProps">
                     <button class="dropdown-b">B</button>
                     <t t-set-slot="content">
                         <DropdownItem class="'item-b'">Item B</DropdownItem>
-                        <Dropdown t-props="dropdownProps">
+                        <Dropdown t-props="this.dropdownProps">
                             <button class="dropdown-c">C</button>
                             <t t-set-slot="content">
                                 <DropdownItem class="'item-c'">Item C</DropdownItem>
@@ -80,7 +80,7 @@ class NoBottomSheetDropdown extends Component {
     static components = { Dropdown, DropdownItem };
     static props = [];
     static template = xml`
-        <Dropdown t-props="dropdownProps" bottomSheet="false">
+        <Dropdown t-props="this.dropdownProps" bottomSheet="false">
             <button>Dropdown</button>
             <t t-set-slot="content">
                 <DropdownItem class="'item-a'">Item A</DropdownItem>
@@ -243,7 +243,7 @@ test("hold position on hover", async () => {
             parentState = this.state;
         }
         static template = xml`
-            <div t-if="state.filler" class="filler" style="height: 100px;"/>
+            <div t-if="this.state.filler" class="filler" style="height: 100px;"/>
             <Dropdown holdOnHover="true">
                 <button>Hello</button>
                 <t t-set-slot="content">World</t>
@@ -324,9 +324,9 @@ test("dropdowns keynav", async () => {
                 <Dropdown>
                     <button data-hotkey="m">Toggle</button>
                     <t t-set-slot="content">
-                        <DropdownItem class="'item1'" onSelected="() => onItemSelected(1)">item1</DropdownItem>
-                        <DropdownItem class="'item2'" attrs="{'data-hotkey': '2'}" onSelected="() => onItemSelected(2)">item2</DropdownItem>
-                        <DropdownItem class="'item3'" onSelected="() => onItemSelected(3)">item3</DropdownItem>
+                        <DropdownItem class="'item1'" onSelected="() => this.onItemSelected(1)">item1</DropdownItem>
+                        <DropdownItem class="'item2'" attrs="{'data-hotkey': '2'}" onSelected="() => this.onItemSelected(2)">item2</DropdownItem>
+                        <DropdownItem class="'item3'" onSelected="() => this.onItemSelected(3)">item3</DropdownItem>
                     </t>
                 </Dropdown>
             `;
@@ -412,7 +412,7 @@ test("dropdowns keynav is not impacted by bootstrap", async () => {
         static components = { Dropdown };
         static props = [];
         static template = xml`
-                <Dropdown state="dropdown">
+                <Dropdown state="this.dropdown">
                     <button>Open</button>
                     <t t-set-slot="content">
                         <select><option>foo</option></select>
@@ -693,10 +693,10 @@ test("Dropdown with CheckboxItem: toggle value", async () => {
                     <button>Click to open</button>
                     <t t-set-slot="content">
                         <CheckboxItem
-                            class="{ selected: state.checked }"
-                            checked="state.checked"
+                            class="{ selected: this.state.checked }"
+                            checked="this.state.checked"
                             closingMode="'none'"
-                            onSelected.bind="onSelected">
+                            onSelected.bind="this.onSelected">
                             My checkbox item
                         </CheckboxItem>
                     </t>
@@ -752,7 +752,7 @@ test("don't close dropdown outside the active element", async () => {
                     <Dropdown>
                         <button class="parent-toggle">Dropdown</button>
                         <t t-set-slot="content">
-                            <button class="parent-item" t-on-click="clicked">Click me</button>
+                            <button class="parent-item" t-on-click="this.clicked">Click me</button>
                         </t>
                     </Dropdown>
                     <div class="outside-parent">Outside Parent</div>
@@ -808,7 +808,7 @@ test("t-if t-else as toggler", async () => {
         static props = [];
         static template = xml`
                 <Dropdown>
-                    <button t-if="state.foo === 'bar'">Coucou</button>
+                    <button t-if="this.state.foo === 'bar'">Coucou</button>
                     <a t-else="">ByeBye</a>
                     <t t-set-slot="content">
                         Hello
@@ -1141,22 +1141,22 @@ test("multi-level dropdown: keynav", async () => {
                 <Dropdown>
                     <button class="first" data-hotkey="1">First</button>
                     <t t-set-slot="content">
-                        <DropdownItem class="'first-first'" onSelected="() => onItemSelected('first-first')">O</DropdownItem>
+                        <DropdownItem class="'first-first'" onSelected="() => this.onItemSelected('first-first')">O</DropdownItem>
                         <Dropdown>
                             <button class="second">Second</button>
                             <t t-set-slot="content">
-                                <DropdownItem class="'second-first'" onSelected="() => onItemSelected('second-first')">O</DropdownItem>
+                                <DropdownItem class="'second-first'" onSelected="() => this.onItemSelected('second-first')">O</DropdownItem>
                                 <Dropdown>
                                     <button class="third">Third</button>
                                     <t t-set-slot="content">
-                                        <DropdownItem class="'third-first'" onSelected="() => onItemSelected('third-first')">O</DropdownItem>
-                                        <DropdownItem class="'third-last'" onSelected="() => onItemSelected('third-last')">O</DropdownItem>
+                                        <DropdownItem class="'third-first'" onSelected="() => this.onItemSelected('third-first')">O</DropdownItem>
+                                        <DropdownItem class="'third-last'" onSelected="() => this.onItemSelected('third-last')">O</DropdownItem>
                                     </t>
                                 </Dropdown>
-                                <DropdownItem class="'second-last'" onSelected="() => onItemSelected('second-last')">O</DropdownItem>
+                                <DropdownItem class="'second-last'" onSelected="() => this.onItemSelected('second-last')">O</DropdownItem>
                             </t>
                         </Dropdown>
-                        <DropdownItem class="'first-last'" onSelected="() => onItemSelected('first-last')">O</DropdownItem>
+                        <DropdownItem class="'first-last'" onSelected="() => this.onItemSelected('first-last')">O</DropdownItem>
                     </t>
                 </Dropdown>
             `;
@@ -1350,7 +1350,7 @@ test("multi-level dropdown: submenu keeps position when patched", async () => {
                         <Dropdown>
                             <button class="two">two</button>
                             <t t-set-slot="content">
-                                <DropdownItem t-if="state.foo" class="three">three</DropdownItem>
+                                <DropdownItem t-if="this.state.foo" class="this.three">three</DropdownItem>
                             </t>
                         </Dropdown>
                     </t>

--- a/addons/web/static/tests/core/effects/effect_service.test.js
+++ b/addons/web/static/tests/core/effects/effect_service.test.js
@@ -74,7 +74,7 @@ test("rendering a rainbowman with a custom component", async () => {
     const props = { foo: "bar" };
 
     class Custom extends Component {
-        static template = xml`<div class="custom">foo is <t t-out="props.foo"/></div>`;
+        static template = xml`<div class="custom">foo is <t t-out="this.props.foo"/></div>`;
         static props = ["*"];
         setup() {
             expect(this.props).toEqual(props);

--- a/addons/web/static/tests/core/errors/error_service.test.js
+++ b/addons/web/static/tests/core/errors/error_service.test.js
@@ -198,7 +198,7 @@ test("originalError is the root cause of the error chain", async () => {
     });
 
     class ErrHandler extends Component {
-        static template = xml`<t t-component="props.comp"/>`;
+        static template = xml`<t t-component="this.props.comp"/>`;
         static props = ["*"];
         setup() {
             onError(async (err) => {

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -64,7 +64,7 @@ async function makeExpressionEditor(params = {}) {
     const props = { ...params };
     class Parent extends Component {
         static components = { ExpressionEditor };
-        static template = xml`<ExpressionEditor t-props="expressionEditorProps"/>`;
+        static template = xml`<ExpressionEditor t-props="this.expressionEditorProps"/>`;
         static props = ["*"];
         setup() {
             this.expressionEditorProps = {

--- a/addons/web/static/tests/core/expression_editor/expression_editor_dialog.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor_dialog.test.js
@@ -28,7 +28,7 @@ async function makeExpressionEditorDialog(params = {}) {
 
     class Parent extends Component {
         static components = { ExpressionEditorDialog };
-        static template = xml`<ExpressionEditorDialog t-props="expressionEditorProps"/>`;
+        static template = xml`<ExpressionEditorDialog t-props="this.expressionEditorProps"/>`;
         static props = ["*"];
         setup() {
             this.expressionEditorProps = {

--- a/addons/web/static/tests/core/field_service.test.js
+++ b/addons/web/static/tests/core/field_service.test.js
@@ -392,7 +392,7 @@ test("async method loadFields is protected", async () => {
     class Parent extends Component {
         static components = { Child };
         static template = xml`
-            <t t-if="state.displayChild">
+            <t t-if="this.state.displayChild">
                 <Child />
             </t>
         `;

--- a/addons/web/static/tests/core/file_upload.test.js
+++ b/addons/web/static/tests/core/file_upload.test.js
@@ -16,11 +16,11 @@ import { Component, xml } from "@odoo/owl";
 
 class FileUploadProgressTestRecord extends FileUploadProgressRecord {
     static template = xml`
-        <t t-set="progressTexts" t-value="getProgressTexts()"/>
+        <t t-set="progressTexts" t-value="this.getProgressTexts()"/>
         <div class="file_upload">
             <div class="file_upload_progress_text_left" t-out="progressTexts.left"/>
             <div class="file_upload_progress_text_right" t-out="progressTexts.right"/>
-            <FileUploadProgressBar fileUpload="props.fileUpload"/>
+            <FileUploadProgressBar fileUpload="this.props.fileUpload"/>
         </div>
     `;
 }
@@ -30,7 +30,7 @@ class Parent extends Component {
     };
     static template = xml`
         <div class="parent">
-            <FileUploadProgressContainer fileUploads="fileUploadService.uploads" shouldDisplay="props.shouldDisplay" Component="FileUploadProgressTestRecord"/>
+            <FileUploadProgressContainer fileUploads="this.fileUploadService.uploads" shouldDisplay="this.props.shouldDisplay" Component="this.FileUploadProgressTestRecord"/>
         </div>
     `;
     static props = ["*"];

--- a/addons/web/static/tests/core/hotkey_sevice.test.js
+++ b/addons/web/static/tests/core/hotkey_sevice.test.js
@@ -127,7 +127,7 @@ test("[accesskey] attrs replaced by [data-hotkey], part 2", async () => {
         static components = { UIOwnershipTakerComponent };
         static template = xml`
             <main>
-                <UIOwnershipTakerComponent t-if="state.foo" />
+                <UIOwnershipTakerComponent t-if="this.state.foo" />
                 <div t-on-click="() => { this.step('click'); }" accesskey="a">foo</div>
             </main>
         `;
@@ -187,7 +187,7 @@ test("data-hotkey", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-                <button t-on-click="onClick" data-hotkey="b">a</button>
+                <button t-on-click="this.onClick" data-hotkey="b">a</button>
             </div>
         `;
         static props = ["*"];
@@ -216,7 +216,7 @@ test("invisible data-hotkeys are not enabled. ", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-                <button t-on-click="onClick" data-hotkey="b" class="myButton">a</button>
+                <button t-on-click="this.onClick" data-hotkey="b" class="myButton">a</button>
             </div>
         `;
         static props = ["*"];
@@ -298,8 +298,8 @@ test("the overlay of hotkeys is correctly displayed", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-            <button t-on-click="onClick" data-hotkey="b">b</button>
-            <button t-on-click="onClick" data-hotkey="c">c</button>
+            <button t-on-click="this.onClick" data-hotkey="b">b</button>
+            <button t-on-click="this.onClick" data-hotkey="c">c</button>
             </div>
         `;
         static props = ["*"];
@@ -330,8 +330,8 @@ test("the overlay of hotkeys is correctly displayed on MacOs", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-                <button t-on-click="onClick" data-hotkey="b">b</button>
-                <button t-on-click="onClick" data-hotkey="c">c</button>
+                <button t-on-click="this.onClick" data-hotkey="b">b</button>
+                <button t-on-click="this.onClick" data-hotkey="c">c</button>
             </div>
         `;
         static props = ["*"];
@@ -418,7 +418,7 @@ test("MacOS usability", async () => {
 test("[data-hotkey] alt is required", async () => {
     const key = "a";
     class TestComponent extends Component {
-        static template = xml`<div><button t-on-click="onClick" data-hotkey="${key}">a</button></div>`;
+        static template = xml`<div><button t-on-click="this.onClick" data-hotkey="${key}">a</button></div>`;
         static props = ["*"];
         onClick() {
             expect.step(key);
@@ -473,7 +473,7 @@ test("registration allows repeat if specified", async () => {
 test("[data-hotkey] never allow repeat", async () => {
     const key = "a";
     class TestComponent extends Component {
-        static template = xml`<div><button t-on-click="onClick" data-hotkey="${key}">a</button></div>`;
+        static template = xml`<div><button t-on-click="this.onClick" data-hotkey="${key}">a</button></div>`;
         static props = ["*"];
         onClick() {
             expect.step(key);
@@ -507,7 +507,7 @@ test("hotkeys evil 👹", async () => {
 
 test("component can register many hotkeys", async () => {
     class MyComponent extends Component {
-        static template = xml`<div><button t-on-click="onClick" data-hotkey="c">c</button></div>`;
+        static template = xml`<div><button t-on-click="this.onClick" data-hotkey="c">c</button></div>`;
         static props = ["*"];
         setup() {
             useHotkey("a", () => expect.step("callback:a"));
@@ -531,8 +531,8 @@ test("many components can register same hotkeys (call order matters)", async () 
         const Comp = class extends Component {
             static template = xml`
                 <div>
-                    <button t-on-click="onClick" data-hotkey="c">c</button>
-                    <button t-on-click="onClick" data-hotkey="z">z</button>
+                    <button t-on-click="this.onClick" data-hotkey="c">c</button>
+                    <button t-on-click="this.onClick" data-hotkey="z">z</button>
                 </div>
             `;
             static props = ["*"];
@@ -578,7 +578,7 @@ test("many components can register same hotkeys (call order matters)", async () 
 
 test("registrations and elements belong to the correct UI owner", async () => {
     class MyComponent1 extends Component {
-        static template = xml`<div><button data-hotkey="b" t-on-click="onClick">b</button></div>`;
+        static template = xml`<div><button data-hotkey="b" t-on-click="this.onClick">b</button></div>`;
         static props = ["*"];
         setup() {
             useHotkey("a", () => expect.step("MyComponent1 subscription"));
@@ -589,7 +589,7 @@ test("registrations and elements belong to the correct UI owner", async () => {
     }
 
     class MyComponent2 extends Component {
-        static template = xml`<div t-ref="active"><button data-hotkey="b" t-on-click="onClick">b</button></div>`;
+        static template = xml`<div t-ref="active"><button data-hotkey="b" t-on-click="this.onClick">b</button></div>`;
         static props = ["*"];
         setup() {
             useHotkey("a", () => expect.step("MyComponent2 subscription"));
@@ -624,7 +624,7 @@ test("replace the overlayModifier for non-MacOs", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-                <button t-on-click="onClick" data-hotkey="b">b</button>
+                <button t-on-click="this.onClick" data-hotkey="b">b</button>
             </div>
         `;
         static props = ["*"];
@@ -651,7 +651,7 @@ test("replace the overlayModifier for MacOs", async () => {
     class MyComponent extends Component {
         static template = xml`
             <div>
-            <button t-on-click="onClick" data-hotkey="b">b</button>
+            <button t-on-click="this.onClick" data-hotkey="b">b</button>
             </div>
         `;
         static props = ["*"];
@@ -851,7 +851,7 @@ test("operating area and UI active element", async () => {
         static components = { UIOwnershipTakerComponent };
         static template = xml`
             <main>
-                <UIOwnershipTakerComponent t-if="state.foo" />
+                <UIOwnershipTakerComponent t-if="this.state.foo" />
                 <div class="one" tabindex="0">one</div>
                 <div class="two" tabindex="0" t-ref="area">two</div>
             </main>

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -251,7 +251,7 @@ test("[cache] update the cache if hash are different - js", async () => {
         expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
     });
     class MyTestComponent extends Component {
-        static template = xml`<div id="main" t-translation-context="web"><t t-out="otherText"/></div>`;
+        static template = xml`<div id="main" t-translation-context="web"><t t-out="this.otherText"/></div>`;
         static props = ["*"];
 
         get otherText() {

--- a/addons/web/static/tests/core/macro.test.js
+++ b/addons/web/static/tests/core/macro.test.js
@@ -34,7 +34,7 @@ class TestComponent extends Component {
             <p><button class="btn inc" t-on-click="() => this.state.value++">increment</button></p>
             <p><button class="btn dec" t-on-click="() => this.state.value--">decrement</button></p>
             <p><button class="btn double" t-on-click="() => this.state.value = 2*this.state.value">double</button></p>
-            <span class="value"><t t-out="state.value"/></span>
+            <span class="value"><t t-out="this.state.value"/></span>
             <input />
         </div>`;
     static props = ["*"];

--- a/addons/web/static/tests/core/main_components_container.test.js
+++ b/addons/web/static/tests/core/main_components_container.test.js
@@ -45,7 +45,7 @@ test("unmounts erroring main component", async () => {
     });
     let compA;
     class MainComponentA extends Component {
-        static template = xml`<span><t t-if="state.shouldThrow" t-out="error"/>MainComponentA</span>`;
+        static template = xml`<span><t t-if="this.state.shouldThrow" t-out="this.error"/>MainComponentA</span>`;
         static props = ["*"];
         setup() {
             compA = this;
@@ -97,7 +97,7 @@ test("unmounts erroring main component: variation", async () => {
 
     let compB;
     class MainComponentB extends Component {
-        static template = xml`<span><t t-if="state.shouldThrow" t-out="error"/>MainComponentB</span>`;
+        static template = xml`<span><t t-if="this.state.shouldThrow" t-out="this.error"/>MainComponentB</span>`;
         static props = ["*"];
         setup() {
             compB = this;

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -73,7 +73,7 @@ test("creating a field chain from scratch", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 isDebugMode="false"
                 update="(path) => this.onUpdate(path)"
             />
@@ -316,7 +316,7 @@ test("Using back button in popover", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 update="(path) => this.onUpdate(path)"
             />
         `;
@@ -470,7 +470,7 @@ test("Edit path in popover debug input", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 isDebugMode="true"
                 update="(pathInfo) => this.onUpdate(pathInfo)"
             />
@@ -582,7 +582,7 @@ test("start on complex path and click prev", async () => {
 test("support of invalid paths (allowEmpty=false)", async () => {
     class Parent extends Component {
         static components = { ModelFieldSelector };
-        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="state.path" />`;
+        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="this.state.path" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ path: `` });
@@ -627,7 +627,7 @@ test("support of invalid paths (allowEmpty=false)", async () => {
 test("support of invalid paths (allowEmpty=true)", async () => {
     class Parent extends Component {
         static components = { ModelFieldSelector };
-        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="state.path" allowEmpty="true" />`;
+        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="this.state.path" allowEmpty="true" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ path: `` });
@@ -674,7 +674,7 @@ test("debug input", async () => {
     let num = 1;
     class Parent extends Component {
         static components = { ModelFieldSelector };
-        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" isDebugMode="true" path="state.path" update.bind="update"/>`;
+        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" isDebugMode="true" path="this.state.path" update.bind="this.update"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ path: `` });
@@ -730,7 +730,7 @@ test("debug input", async () => {
 test("focus on search input", async () => {
     class Parent extends Component {
         static components = { ModelFieldSelector };
-        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="state.path" update.bind="update"/>`;
+        static template = xml`<ModelFieldSelector resModel="'partner'" readonly="false" path="this.state.path" update.bind="this.update"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({ path: `foo` });
@@ -755,7 +755,7 @@ test("support properties", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 isDebugMode="true"
                 update="(path, fieldInfo) => this.onUpdate(path)"
             />
@@ -849,7 +849,7 @@ test("clear button (allowEmpty=true)", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 allowEmpty="true"
                 isDebugMode="true"
                 update="(path, fieldInfo) => this.onUpdate(path)"
@@ -902,9 +902,9 @@ test("Modify path in popover debug input and click away", async () => {
             <ModelFieldSelector
                 readonly="false"
                 resModel="'partner'"
-                path="path"
+                path="this.path"
                 isDebugMode="true"
-                update.bind="update"
+                update.bind="this.update"
             />
         `;
         static props = ["*"];

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -221,7 +221,7 @@ test("insert item before current", async () => {
         static props = [];
         static template = xml`
             <div class="container" t-ref="containerRef">
-                <t t-foreach="state.items" t-as="item" t-key="item">
+                <t t-foreach="this.state.items" t-as="item" t-key="item">
                     <div class="o-navigable" t-attf-class="item-{{item}}" tabindex="0" t-out="item"/>
                 </t>
             </div>
@@ -288,7 +288,7 @@ test("non-navigable dom update does NOT cause re-focus", async () => {
             <button class="outside" t-ref="outsideRef">outside target</button>
             <div class="container" t-ref="containerRef">
                 <button class="o-navigable one" t-on-click="() => this.onClick(1)">target one</button>
-                <div class="test-non-navigable" t-if="state.show">
+                <div class="test-non-navigable" t-if="this.state.show">
                 </div>
             </div>
         `;

--- a/addons/web/static/tests/core/notebook.test.js
+++ b/addons/web/static/tests/core/notebook.test.js
@@ -147,8 +147,8 @@ test("notebook set vertically", async () => {
 test("notebook pages rendered by a template component", async () => {
     class NotebookPageRenderer extends Component {
         static template = xml`
-                <h3 t-out="props.heading"></h3>
-                <p t-out="props.text" />
+                <h3 t-out="this.props.heading"></h3>
+                <p t-out="this.props.text" />
             `;
         static props = {
             heading: String,
@@ -157,7 +157,7 @@ test("notebook pages rendered by a template component", async () => {
     }
 
     class Parent extends Component {
-        static template = xml`<Notebook defaultPage="'page_three'" pages="pages">
+        static template = xml`<Notebook defaultPage="'page_three'" pages="this.pages">
                 <t t-set-slot="page_one" title="'Page 1'" isVisible="true">
                     <h3>Page 1</h3>
                     <p>First page set directly as a slot</p>
@@ -213,7 +213,7 @@ test("each page is different", async () => {
     }
 
     class Parent extends Component {
-        static template = xml`<Notebook pages="pages"/>`;
+        static template = xml`<Notebook pages="this.pages"/>`;
         static components = { Notebook };
         static props = ["*"];
         setup() {
@@ -327,7 +327,7 @@ test("icons can be given for each page tab", async () => {
     class Parent extends Component {
         static components = { Notebook };
         static template = xml`
-            <Notebook defaultPage="'1'" icons="icons">
+            <Notebook defaultPage="'1'" icons="this.icons">
                 <t t-set-slot="1" title="'page1'" isVisible="true">
                     <div class="page1" />
                 </t>

--- a/addons/web/static/tests/core/overlay_service.test.js
+++ b/addons/web/static/tests/core/overlay_service.test.js
@@ -66,7 +66,7 @@ test("multiple overlays", async () => {
     await mountWithCleanup(MainComponentsContainer);
     class MyComp extends Component {
         static template = xml`
-            <div class="overlayed" t-att-class="props.className"></div>
+            <div class="overlayed" t-att-class="this.props.className"></div>
         `;
         static props = ["*"];
     }
@@ -100,7 +100,7 @@ test("sequence", async () => {
     await mountWithCleanup(MainComponentsContainer);
     class MyComp extends Component {
         static template = xml`
-            <div class="overlayed" t-att-class="props.className"></div>
+            <div class="overlayed" t-att-class="this.props.className"></div>
         `;
         static props = ["*"];
     }
@@ -137,8 +137,8 @@ test("allow env as option", async () => {
         static props = ["*"];
         static template = xml`
             <ul class="outer">
-                <li>A=<t t-out="env.A"/></li>
-                <li>B=<t t-out="env.B"/></li>
+                <li>A=<t t-out="this.env.A"/></li>
+                <li>B=<t t-out="this.env.B"/></li>
             </ul>
         `;
         setup() {

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -417,7 +417,7 @@ test("popover repositions when content changes", async () => {
         static template = xml`
             <div id="popover">
                 <button t-on-click="() => this.state.expanded = true">Expand</button>
-                <div t-if="state.expanded" style="height: 200px; width: 200px;">
+                <div t-if="this.state.expanded" style="height: 200px; width: 200px;">
                     Large content that changes the popover dimensions
                 </div>
             </div>
@@ -484,7 +484,7 @@ test("arrow follows target and can get sucked", async () => {
         static props = ["*"];
         static template = xml`
             <div class="popover-container" t-ref="popover-container">
-                <div class="popover-target" t-ref="popover-target" t-on-click="openPopover"/>
+                <div class="popover-target" t-ref="popover-target" t-on-click="this.openPopover"/>
             </div>
         `;
         setup() {

--- a/addons/web/static/tests/core/popover/popover_hook.test.js
+++ b/addons/web/static/tests/core/popover/popover_hook.test.js
@@ -7,7 +7,7 @@ import { contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
 test("close popover when component is unmounted", async () => {
     const target = getFixture();
     class Comp extends Component {
-        static template = xml`<div t-att-id="props.id">in popover</div>`;
+        static template = xml`<div t-att-id="this.props.id">in popover</div>`;
         static props = ["*"];
     }
 

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -776,7 +776,7 @@ function shrinkPopperTest(position, offset, onPositioned, popperStyle = {}) {
             static template = xml`
                 <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 450px; margin: 25px;">
                     <div id="target" t-ref="target" style="background-color: royalblue; width: 50px; height: 50px; margin-top: ${offset}px;"/>
-                    <div id="popper" t-ref="popper" t-att-style="popperStyle">
+                    <div id="popper" t-ref="popper" t-att-style="this.popperStyle">
                         <div id="popper-content" style="background-color: seagreen; height: 500px; width: 50px;"/>
                     </div>
                 </div>

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -35,7 +35,7 @@ defineModels([Partner, Users]);
 async function mountMultiRecordSelector(props) {
     class Parent extends Component {
         static components = { MultiRecordSelector };
-        static template = xml`<MultiRecordSelector t-props="recordProps" />`;
+        static template = xml`<MultiRecordSelector t-props="this.recordProps" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ resIds: props.resIds });

--- a/addons/web/static/tests/core/record_selectors/record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/record_selector.test.js
@@ -29,7 +29,7 @@ defineModels([Partner]);
 async function mountRecordSelector(props) {
     class Parent extends Component {
         static components = { RecordSelector };
-        static template = xml`<RecordSelector t-props="recordProps" />`;
+        static template = xml`<RecordSelector t-props="this.recordProps" />`;
         static props = ["*"];
         setup() {
             this.state = useState({ resId: props.resId });

--- a/addons/web/static/tests/core/resizable_panel.test.js
+++ b/addons/web/static/tests/core/resizable_panel.test.js
@@ -130,7 +130,7 @@ test("minWidth props can be updated", async () => {
         static components = { ResizablePanel };
         static template = xml`
             <div class="d-flex">
-                <ResizablePanel minWidth="props.state.minWidth">
+                <ResizablePanel minWidth="this.props.state.minWidth">
                     <div style="width: 10px;" class="text-break">
                         A cool paragraph
                     </div>

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -29,7 +29,7 @@ async function mountSingleApp(ComponentClass, props) {
     class TestComponent extends Component {
         static props = { components: { type: Array } };
         static template = xml`
-            <t t-foreach="props.components" t-as="comp" t-key="comp.component.name">
+            <t t-foreach="this.props.components" t-as="comp" t-key="comp.component.name">
                 <t t-component="comp.component" t-props="comp.props"/>
             </t>
         `;
@@ -56,9 +56,9 @@ class Parent extends Component {
     static components = { SelectMenu };
     static template = xml`
         <SelectMenu
-            choices="choices"
-            value="state.value"
-            onSelect.bind="onSelect"
+            choices="this.choices"
+            value="this.state.value"
+            onSelect.bind="this.onSelect"
         />
     `;
     setup() {
@@ -114,10 +114,10 @@ test("Selecting a choice calls onSelect and the displayed value is updated", asy
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                groups="groups"
-                choices="choices"
-                value="state.value"
-                onSelect.bind="onSelect"
+                groups="this.groups"
+                choices="this.choices"
+                value="this.state.value"
+                onSelect.bind="this.onSelect"
             />
         `;
         setup() {
@@ -188,7 +188,7 @@ test("Search input should be present as a toggler, but cannot be edited if searc
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices" searchable="false" />
+            <SelectMenu choices="this.choices" searchable="false" />
         `;
         setup() {
             this.choices = [
@@ -207,7 +207,7 @@ test("Search input should be present in a dropdown with a custom toggler", async
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices">
+            <SelectMenu choices="this.choices">
                 <span class="select_menu_test">Select something</span>
             </SelectMenu>
         `;
@@ -230,7 +230,7 @@ test("Search input should behave as a toggler only and an input should be presen
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices" />
+            <SelectMenu choices="this.choices" />
         `;
         setup() {
             this.choices = [
@@ -371,8 +371,8 @@ test("Clear the input calls 'onSelect' with null value and appears only when val
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                choices="choices"
-                value="state.value"
+                choices="this.choices"
+                value="this.state.value"
                 onSelect.bind="this.onSelect"
             />
         `;
@@ -403,8 +403,8 @@ test("When the 'required' props is set to true, the input cannot be cleared", as
         static template = xml`
             <SelectMenu
                 required="true"
-                choices="choices"
-                value="state.value"
+                choices="this.choices"
+                value="this.state.value"
             />
         `;
         setup() {
@@ -432,8 +432,8 @@ test("When the 'required' props is set to true, the clear button is not shown", 
         static template = xml`
             <SelectMenu
                 required="true"
-                choices="choices"
-                value="state.value"
+                choices="this.choices"
+                value="this.state.value"
             >
                 <span class="select_menu_test">Select something</span>
             </SelectMenu>
@@ -464,7 +464,7 @@ test("Items are sorted based on their label by default", async () => {
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                choices="choices"
+                choices="this.choices"
             />
         `;
         setup() {
@@ -485,7 +485,7 @@ test("autoSort props set to false", async () => {
     class MyParent extends Component {
         static props = ["*"];
         static components = { SelectMenu };
-        static template = xml`<SelectMenu choices="choices" autoSort="false"/>`;
+        static template = xml`<SelectMenu choices="this.choices" autoSort="false"/>`;
         setup() {
             this.choices = [
                 { label: "Hello", value: "hello" },
@@ -505,7 +505,7 @@ test("Custom toggler using default slot", async () => {
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices">
+            <SelectMenu choices="this.choices">
                 <span class="select_menu_test">Select something</span>
             </SelectMenu>
         `;
@@ -528,7 +528,7 @@ test("Custom choice template using a slot", async () => {
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices">
+            <SelectMenu choices="this.choices">
                 <span class="select_menu_test">Select something</span>
                 <t t-set-slot="choice" t-slot-scope="choice">
                     <span class="coolClass" t-out="choice.data.label" />
@@ -553,7 +553,7 @@ test("Custom slot for the bottom area sends the current search value", async () 
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices">
+            <SelectMenu choices="this.choices">
                 <span class="select_menu_test">Select something</span>
                 <t t-set-slot="bottomArea" t-slot-scope="select">
                     <div t-if="select.data.searchValue" class="px-2">
@@ -593,7 +593,7 @@ test("Groups properly added in the select", async () => {
     class MyParent extends Component {
         static props = ["*"];
         static components = { SelectMenu };
-        static template = xml`<SelectMenu groups="groups"/>`;
+        static template = xml`<SelectMenu groups="this.groups"/>`;
         setup() {
             this.groups = [
                 {
@@ -890,10 +890,10 @@ test("Props onInput is executed when the search changes", async () => {
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                choices="state.choices"
-                value="state.value"
-                onInput.bind="onInput"
-                onSelect.bind="onSelect"
+                choices="this.state.choices"
+                value="this.state.value"
+                onInput.bind="this.onInput"
+                onSelect.bind="this.onSelect"
             />
         `;
         setup() {
@@ -946,10 +946,10 @@ test("Choices are updated and filtered when props change", async () => {
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                choices="state.choices"
-                value="state.value"
-                onInput.bind="onInput"
-                onSelect.bind="onSelect"
+                choices="this.state.choices"
+                value="this.state.value"
+                onInput.bind="this.onInput"
+                onSelect.bind="this.onSelect"
             />
         `;
         setup() {
@@ -1007,10 +1007,10 @@ test("SelectMenu group items only after being opened", async () => {
         static props = ["*"];
         static template = xml`
             <SelectMenu
-                choices="state.choices"
-                groups="state.groups"
-                value="state.value"
-                onInput.bind="onInput"
+                choices="this.state.choices"
+                groups="this.state.groups"
+                value="this.state.value"
+                onInput.bind="this.onInput"
             />
         `;
         setup() {
@@ -1078,10 +1078,10 @@ test("search value is cleared when reopening the menu", async () => {
         static props = ["*"];
         static template = xml`
             <SelectMenu
-                choices="state.choices"
-                groups="state.groups"
-                value="state.value"
-                onInput.bind="onInput"
+                choices="this.state.choices"
+                groups="this.state.groups"
+                value="this.state.value"
+                onInput.bind="this.onInput"
             />
         `;
         setup() {
@@ -1114,7 +1114,7 @@ test("Groups can be member of sections", async () => {
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices" groups="groups" sections="sections" />
+            <SelectMenu choices="this.choices" groups="this.groups" sections="this.sections" />
         `;
         setup() {
             this.choices = [{ label: "Hello", value: "hello" }];
@@ -1172,7 +1172,7 @@ test("Can add custom data to choices", async () => {
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices">
+            <SelectMenu choices="this.choices">
                 <t t-set-slot="choice" t-slot-scope="choice">
                     <span class="coolClass" t-out="choice.data.custom" />
                 </t>
@@ -1244,8 +1244,8 @@ test("Fetch choices", async () => {
         static template = xml`
             <SelectMenu
                 value="this.state.value"
-                onInput.bind="loadChoice"
-                choices="state.choices"
+                onInput.bind="this.loadChoice"
+                choices="this.state.choices"
             />
         `;
         setup() {
@@ -1272,7 +1272,7 @@ test("In the BottomSheet, a 'Clear' button is present", async () => {
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                choices="choices"
+                choices="this.choices"
                 value="'test'"
                 onSelect.bind="this.onSelect"
             />
@@ -1299,8 +1299,8 @@ test("Ensure items are properly sorted", async () => {
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                groups="state.groups"
-                choices="state.choices"
+                groups="this.state.groups"
+                choices="this.state.choices"
             />
         `;
 
@@ -1383,7 +1383,7 @@ test("prevent glitch on open or focusout", async () => {
         static components = { SelectMenu };
         static props = ["*"];
         static template = xml`
-            <SelectMenu t-props="props">${slots}</SelectMenu>`;
+            <SelectMenu t-props="this.props">${slots}</SelectMenu>`;
     }
     await mountSingleApp(Wrapper, {
         choices: [

--- a/addons/web/static/tests/core/tags_list.test.js
+++ b/addons/web/static/tests/core/tags_list.test.js
@@ -10,7 +10,7 @@ test("Limiting the visible tags displays a counter", async () => {
         static props = ["*"];
         static components = { TagsList };
         static template = xml`
-            <TagsList tags="tags" visibleItemsLimit="state.visibleItemsLimit" t-slot-scope="tag">
+            <TagsList tags="this.tags" visibleItemsLimit="this.state.visibleItemsLimit" t-slot-scope="tag">
                 <span class="o_tag" t-out="tag.text"/>
             </TagsList>
         `;

--- a/addons/web/static/tests/core/tooltip/tooltip_service.test.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_service.test.js
@@ -61,7 +61,7 @@ test("remove element with opened tooltip", async () => {
         static props = ["*"];
         static template = xml`
             <div>
-                <button t-if="state.visible" data-tooltip="hello">Action</button>
+                <button t-if="this.state.visible" data-tooltip="hello">Action</button>
             </div>`;
         setup() {
             this.state = useState({ visible: true });
@@ -209,7 +209,7 @@ test("tooltip with a template and info", async () => {
         static template = xml`
             <button
                 data-tooltip-template="my_tooltip_template"
-                t-att-data-tooltip-info="info">
+                t-att-data-tooltip-info="this.info">
                 Action
             </button>
         `;
@@ -242,7 +242,7 @@ test.tags("desktop");
 test("empty tooltip, no template", async () => {
     class MyComponent extends Component {
         static props = ["*"];
-        static template = xml`<button t-att-data-tooltip="tooltip">Action</button>`;
+        static template = xml`<button t-att-data-tooltip="this.tooltip">Action</button>`;
         get tooltip() {
             return "";
         }

--- a/addons/web/static/tests/core/transition.test.js
+++ b/addons/web/static/tests/core/transition.test.js
@@ -10,7 +10,7 @@ test("useTransition hook (default params)", async () => {
         disabled: false,
     });
     class Parent extends Component {
-        static template = xml`<div t-if="transition.shouldMount" t-att-class="transition.className"/>`;
+        static template = xml`<div t-if="this.transition.shouldMount" t-att-class="this.transition.className"/>`;
         static props = ["*"];
         setup() {
             this.transition = useTransition({
@@ -42,7 +42,7 @@ test("useTransition hook (initially visible and immediate=true)", async () => {
         disabled: false,
     });
     class Parent extends Component {
-        static template = xml`<div t-if="transition.shouldMount" t-att-class="transition.className"/>`;
+        static template = xml`<div t-if="this.transition.shouldMount" t-att-class="this.transition.className"/>`;
         static props = ["*"];
         setup() {
             this.transition = useTransition({
@@ -79,7 +79,7 @@ test("useTransition hook (initially not visible)", async () => {
         disabled: false,
     });
     class Parent extends Component {
-        static template = xml`<div t-if="transition.shouldMount" t-att-class="transition.className"/>`;
+        static template = xml`<div t-if="this.transition.shouldMount" t-att-class="this.transition.className"/>`;
         static props = ["*"];
         setup() {
             this.transition = useTransition({
@@ -114,7 +114,7 @@ test("Transition HOC", async () => {
     });
     class Parent extends Component {
         static template = xml`
-            <Transition name="'test'" visible="state.show" immediate="true" t-slot-scope="transition" onLeave="onLeave">
+            <Transition name="'test'" visible="this.state.show" immediate="true" t-slot-scope="transition" onLeave="this.onLeave">
                 <div t-att-class="transition.className"/>
             </Transition>
         `;

--- a/addons/web/static/tests/core/ui_service.test.js
+++ b/addons/web/static/tests/core/ui_service.test.js
@@ -44,7 +44,7 @@ test("a component can be the  UI active element: simple usage", async () => {
         static template = xml`
             <div>
                 <h1>My Component</h1>
-                <div t-if="hasRef" id="owner" t-ref="delegatedRef">
+                <div t-if="this.hasRef" id="owner" t-ref="delegatedRef">
                 <input type="text"/>
             </div>
             </div>
@@ -189,9 +189,9 @@ test("UI active element: trap focus - first or last tabable changes", async () =
                 <input type="text" name="outer"/>
                 <div id="idActiveElement" t-ref="delegatedRef">
                     <div>
-                        <input type="text" name="a" t-if="show.a"/>
+                        <input type="text" name="a" t-if="this.show.a"/>
                         <input type="text" name="b"/>
-                        <input type="text" name="c" t-if="show.c"/>
+                        <input type="text" name="c" t-if="this.show.c"/>
                     </div>
                 </div>
             </div>

--- a/addons/web/static/tests/core/utils/components.test.js
+++ b/addons/web/static/tests/core/utils/components.test.js
@@ -13,7 +13,7 @@ test("ErrorHandler component", async () => {
     class Parent extends Component {
         static template = xml`
             <div>
-                <t t-if="flag">
+                <t t-if="this.flag">
                     <ErrorHandler onError="() => this.handleError()">
                         <Boom/>
                     </ErrorHandler>

--- a/addons/web/static/tests/core/utils/draggable.test.js
+++ b/addons/web/static/tests/core/utils/draggable.test.js
@@ -445,7 +445,7 @@ test("allowDisconnected option", async () => {
     class List extends Component {
         static template = xml`
             <div t-ref="root" class="root">
-                <button class="handle" t-if="state.hasHandle">Handle</button>
+                <button class="handle" t-if="this.state.hasHandle">Handle</button>
                 <ul class="list list-unstyled m-0 d-flex flex-column">
                     <li t-foreach="[1, 2, 3]" t-as="i" t-key="i" t-out="i" class="item w-50 h-100" />
                 </ul>
@@ -481,7 +481,7 @@ test("draggable in iframe", async () => {
     class List extends Component {
         static template = xml`
         <div t-ref="root" class="root">
-            <iframe class="mydroppable" t-att-srcdoc="srcdoc" />
+            <iframe class="mydroppable" t-att-srcdoc="this.srcdoc" />
         </div>`;
         static props = ["*"];
         setup() {
@@ -548,7 +548,7 @@ test("dragging element in iframe offset", async () => {
             <div style="width: 50px;height:500px;"/>
             <div class="d-flex flex-row">
                 <div style="width: 500px;height:50px;"/>
-                <iframe class="mydroppable" t-att-srcdoc="srcdoc"/>
+                <iframe class="mydroppable" t-att-srcdoc="this.srcdoc"/>
             </div>
         </div>`;
         static props = ["*"];

--- a/addons/web/static/tests/core/utils/hooks.test.js
+++ b/addons/web/static/tests/core/utils/hooks.test.js
@@ -33,7 +33,7 @@ describe("useAutofocus", () => {
             static props = ["*"];
             static template = xml`
                 <span>
-                    <input type="text" t-ref="autofocus" t-att-value="state.text" />
+                    <input type="text" t-ref="autofocus" t-att-value="this.state.text" />
                 </span>
             `;
             setup() {
@@ -61,7 +61,7 @@ describe("useAutofocus", () => {
             static props = ["*"];
             static template = xml`
                 <span>
-                    <input type="number" t-ref="autofocus" t-att-value="state.counter" />
+                    <input type="number" t-ref="autofocus" t-att-value="this.state.counter" />
                 </span>
             `;
             setup() {
@@ -89,7 +89,7 @@ describe("useAutofocus", () => {
             static props = ["*"];
             static template = xml`
                 <span>
-                    <input t-if="state.showInput" type="text" t-ref="autofocus" />
+                    <input t-if="this.state.showInput" type="text" t-ref="autofocus" />
                 </span>
             `;
             setup() {
@@ -174,7 +174,7 @@ describe("useAutofocus", () => {
             static template = xml`
                 <span>
                     <input type="text" t-ref="first" />
-                    <input t-if="state.showSecond" type="text" t-ref="second" />
+                    <input t-if="this.state.showSecond" type="text" t-ref="second" />
                 </span>
             `;
             setup() {
@@ -234,7 +234,7 @@ describe("useAutofocus", () => {
             static props = ["*"];
             static template = xml`
                     <div>
-                        <input type="text" t-ref="autofocus" t-att-value="state.text" />
+                        <input type="text" t-ref="autofocus" t-att-value="this.state.text" />
                     </div>
                 `;
             setup() {
@@ -281,7 +281,7 @@ describe("useBus", () => {
         class Parent extends Component {
             static components = { MyComponent };
             static props = ["*"];
-            static template = xml`<MyComponent t-if="state.child" />`;
+            static template = xml`<MyComponent t-if="this.state.child" />`;
 
             setup() {
                 this.state = useState(state);
@@ -358,7 +358,7 @@ describe("useService", () => {
         class Parent extends Component {
             static components = { MyComponent };
             static props = ["*"];
-            static template = xml`<MyComponent t-if="state.child" />`;
+            static template = xml`<MyComponent t-if="this.state.child" />`;
 
             setup() {
                 this.state = useState(state);
@@ -626,7 +626,7 @@ describe("useChildRef and useForwardRefToParent", () => {
 
         class Parent extends Component {
             static props = ["*"];
-            static template = xml`<div><Child someRef="someRef"/></div>`;
+            static template = xml`<div><Child someRef="this.someRef"/></div>`;
             static components = { Child };
             setup() {
                 this.someRef = useChildRef();
@@ -650,7 +650,7 @@ describe("useChildRef and useForwardRefToParent", () => {
 
         class Parent extends Component {
             static props = ["*"];
-            static template = xml`<div><Child t-if="state.hasChild" someRef="someRef"/></div>`;
+            static template = xml`<div><Child t-if="this.state.hasChild" someRef="this.someRef"/></div>`;
             static components = { Child };
             setup() {
                 this.someRef = useChildRef();

--- a/addons/web/static/tests/core/utils/sortable.test.js
+++ b/addons/web/static/tests/core/utils/sortable.test.js
@@ -635,7 +635,7 @@ test("dragged element is removed from the DOM while being dragged", async () => 
         static template = xml`
             <div t-ref="root" class="root">
                 <ul class="list">
-                    <li t-foreach="state.items" t-as="i" t-key="i" t-out="i" class="item" />
+                    <li t-foreach="this.state.items" t-as="i" t-key="i" t-out="i" class="item" />
                 </ul>
             </div>`;
         setup() {

--- a/addons/web/static/tests/core/utils/timing.test.js
+++ b/addons/web/static/tests/core/utils/timing.test.js
@@ -418,7 +418,7 @@ describe("throttleForAnimationScrollEvent", () => {
 describe("useDebounced", () => {
     test("cancels on component destroy", async () => {
         class TestComponent extends Component {
-            static template = xml`<button class="c" t-on-click="debounced">C</button>`;
+            static template = xml`<button class="c" t-on-click="this.debounced">C</button>`;
             static props = ["*"];
             setup() {
                 this.debounced = useDebounced(() => expect.step("debounced"), 1000);
@@ -475,7 +475,7 @@ describe("useDebounced", () => {
 
     test("execBeforeUnmount option (callback resolved before component destroy)", async () => {
         class TestComponent extends Component {
-            static template = xml`<button class="c" t-on-click="debounced">C</button>`;
+            static template = xml`<button class="c" t-on-click="this.debounced">C</button>`;
             static props = ["*"];
             setup() {
                 this.debounced = useDebounced(() => expect.step("debounced"), 1000, {
@@ -503,7 +503,7 @@ describe("useDebounced", () => {
 describe("useThrottleForAnimation", () => {
     test("cancels on component destroy", async () => {
         class TestComponent extends Component {
-            static template = xml`<button class="c" t-on-click="throttled">C</button>`;
+            static template = xml`<button class="c" t-on-click="this.throttled">C</button>`;
             static props = ["*"];
             setup() {
                 this.throttled = useThrottleForAnimation(() => expect.step("throttled"), 1000);

--- a/addons/web/static/tests/core/virtual_grid_hook.test.js
+++ b/addons/web/static/tests/core/virtual_grid_hook.test.js
@@ -44,7 +44,7 @@ function getTestComponent(virtualGridParams) {
     class Item extends Component {
         static props = ["row", "col"];
         static template = xml`
-            <div class="item" t-att-data-row-id="props.row.id" t-att-data-col-id="props.col.id" t-att-style="style" t-out="content"/>
+            <div class="item" t-att-data-row-id="this.props.row.id" t-att-data-col-id="this.props.col.id" t-att-style="this.style" t-out="this.content"/>
         `;
         get content() {
             return `${this.props.row.id}|${this.props.col.id}`;
@@ -61,9 +61,9 @@ function getTestComponent(virtualGridParams) {
         static components = { Item };
         static template = xml`
             <div class="scrollable" t-ref="scrollable" style="${CONTAINER_STYLE}" dir="${localization.direction}">
-                <div class="inner" t-att-style="innerStyle">
-                    <t t-foreach="virtualRows" t-as="row" t-key="row.id">
-                        <t t-foreach="virtualColumns" t-as="col" t-key="col.id">
+                <div class="inner" t-att-style="this.innerStyle">
+                    <t t-foreach="this.virtualRows" t-as="row" t-key="row.id">
+                        <t t-foreach="this.virtualColumns" t-as="col" t-key="col.id">
                             <Item row="row" col="col"/>
                         </t>
                     </t>

--- a/addons/web/static/tests/env.test.js
+++ b/addons/web/static/tests/env.test.js
@@ -223,7 +223,7 @@ test(`mountComponent uses the env when provided and doesn't start the services`,
 
 test(`mountComponent: can pass props to the root component`, async () => {
     class Root extends Component {
-        static template = xml`<t t-esc="props.text"/>`;
+        static template = xml`<t t-esc="this.props.text"/>`;
         static props = ["*"];
     }
 

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -72,7 +72,7 @@ test(`can be updated with different resId`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" resId="state.resId" fieldNames="['foo']" t-slot-scope="data">
+            <Record resModel="'foo'" resId="this.state.resId" fieldNames="['foo']" t-slot-scope="data">
                 <Field name="'foo'" record="data.record"/>
                 <button class="my-btn" t-on-click="() => this.state.resId++">Next</button>
             </Record>
@@ -130,7 +130,7 @@ test(`predefined fields and values`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -165,7 +165,7 @@ test(`Record with onRootLoaded props`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" t-slot-scope="data" hooks="this.hooks">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -200,7 +200,7 @@ test(`Record with onRecordChanged props`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data" hooks="this.hooks">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -246,7 +246,7 @@ test(`Record with onWillSaveRecord and onRecordSavedProps`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" resId="1" fieldNames="['foo']" mode="'edit'" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" resId="1" fieldNames="['foo']" mode="'edit'" t-slot-scope="data" hooks="this.hooks">
                 <button class="save" t-on-click="() => data.record.save()">Save</button>
                 <Field name="'foo'" record="data.record"/>
             </Record>
@@ -282,7 +282,7 @@ test(`can access record changes`, async () => {
         static components = { Record, Field };
         static template = xml`
             <Record resModel="'foo'" fieldNames="['foo']" t-slot-scope="data">
-                <button class="do_something" t-on-click="() => doSomething(data.record)">
+                <button class="do_something" t-on-click="() => this.doSomething(data.record)">
                     Do something
                 </button>
                 <Field name="'foo'" record="data.record"/>
@@ -320,7 +320,7 @@ test(`handles many2one fields: value is an object`, async () => {
         static props = ["*"];
         static components = { Record, Many2OneField };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data" hooks="this.hooks">
                 <Many2OneField name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -380,7 +380,7 @@ test(`handles many2one fields: value is a pair id, display_name`, async () => {
         static props = ["*"];
         static components = { Record, Many2OneField };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data" hooks="this.hooks">
                 <Many2OneField name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -439,7 +439,7 @@ test(`handles many2one fields: value is an id`, async () => {
         static props = ["*"];
         static components = { Record, Many2OneField };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data">
                 <Many2OneField name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -479,7 +479,7 @@ test(`handles many2one fields: value is an object with id only`, async () => {
         static props = ["*"];
         static components = { Record, Many2OneField };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data">
                 <Many2OneField name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -519,7 +519,7 @@ test(`handles x2many fields`, async () => {
         static props = ["*"];
         static components = { Record, Many2ManyTagsField };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['tags']" activeFields="activeFields" fields="fields" values="values" t-slot-scope="data">
+            <Record resModel="'foo'" fieldNames="['tags']" activeFields="this.activeFields" fields="this.fields" values="this.values" t-slot-scope="data">
                 <Many2ManyTagsField name="'tags'" record="data.record"/>
             </Record>
         `;
@@ -561,7 +561,7 @@ test(`supports passing dynamic values -- full control to the user of Record`, as
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'foo'" fieldNames="['foo']" fields="fields" values="{ foo: values.foo }" t-slot-scope="data" hooks="hooks">
+            <Record resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="{ foo: this.values.foo }" t-slot-scope="data" hooks="this.hooks">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -610,9 +610,9 @@ test(`can switch records`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <a id="increment" t-on-click="() => state.num++" t-out="state.num"/>
-            <a id="next" t-on-click="next">NEXT</a>
-            <Record resId="state.currentId" resModel="'foo'" fieldNames="['foo']" fields="fields" t-slot-scope="data">
+            <a id="increment" t-on-click="() => this.state.num++" t-out="this.state.num"/>
+            <a id="next" t-on-click="this.next">NEXT</a>
+            <Record resId="this.state.currentId" resModel="'foo'" fieldNames="['foo']" fields="this.fields" t-slot-scope="data">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -654,8 +654,8 @@ test(`can switch records with values`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <a id="next" t-on-click="next">NEXT</a>
-            <Record resId="state.currentId" resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data">
+            <a id="next" t-on-click="this.next">NEXT</a>
+            <Record resId="this.state.currentId" resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data">
                 <Field name="'foo'" record="data.record"/>
             </Record>
         `;
@@ -724,13 +724,13 @@ test(`faulty useRecordObserver in widget`, async () => {
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <t t-if="!state.error">
-                <Record resId="1" resModel="'foo'" fieldNames="['foo']" fields="fields" values="values" t-slot-scope="data">
+            <t t-if="!this.state.error">
+                <Record resId="1" resModel="'foo'" fieldNames="['foo']" fields="this.fields" values="this.values" t-slot-scope="data">
                     <Field name="'foo'" record="data.record"/>
                 </Record>
             </t>
             <t t-else="">
-                <div class="error" t-out="state.error.message"/>
+                <div class="error" t-out="this.state.error.message"/>
             </t>
         `;
 
@@ -789,9 +789,9 @@ test(`don't duplicate a useRecordObserver effect when switching back and forth b
         static props = ["*"];
         static components = { Record, Field };
         static template = xml`
-            <a id="setRecord" t-on-click="setRecord">SET</a>
-            <a id="toggleRecord" t-on-click="toggleRecord">TOGGLE</a>
-            <Field name="'foo'" record="records[state.recordIndex]"/>
+            <a id="setRecord" t-on-click="this.setRecord">SET</a>
+            <a id="toggleRecord" t-on-click="this.toggleRecord">TOGGLE</a>
+            <Field name="'foo'" record="this.records[this.state.recordIndex]"/>
         `;
 
         setup() {

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1998,7 +1998,7 @@ describe("components", () => {
     test("can insert a component with props with t-component", async () => {
         let isCDestroyed = false;
         class C extends Component {
-            static template = xml`<p>component<span t-out="props.prop"></span></p>`;
+            static template = xml`<p>component<span t-out="this.props.prop"></span></p>`;
             static props = {
                 prop: { optional: true, type: String },
             };
@@ -2031,7 +2031,7 @@ describe("components", () => {
     test("can receive the selected element with t-component", async () => {
         let isCDestroyed = false;
         class C extends Component {
-            static template = xml`<p>component<span t-out="props.prop"></span></p>`;
+            static template = xml`<p>component<span t-out="this.props.prop"></span></p>`;
             static props = {
                 prop: { optional: true, type: String },
             };
@@ -2108,7 +2108,7 @@ describe("components", () => {
 
     test("can insert a component with props with mountComponent", async () => {
         class C extends Component {
-            static template = xml`<p>component<span t-out="props.prop"></span></p>`;
+            static template = xml`<p>component<span t-out="this.props.prop"></span></p>`;
             static props = {
                 prop: { optional: true, type: String },
             };

--- a/addons/web/static/tests/public/public_component_interaction.test.js
+++ b/addons/web/static/tests/public/public_component_interaction.test.js
@@ -11,7 +11,7 @@ const publicComponentRegistry = registry.category("public_components");
 
 test(`render Public Component`, async () => {
     class MyPublicComp extends Component {
-        static template = xml`<div class="my_public_comp" t-out="value"/>`;
+        static template = xml`<div class="my_public_comp" t-out="this.value"/>`;
         static props = ["*"];
         setup() {
             const { info } = this.props;

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -283,8 +283,8 @@ test("search input is focused when being toggled", async () => {
     class Parent extends Component {
         static template = xml`
             <div>
-                <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
-                <SearchBar toggler="searchBarToggler"/>
+                <t t-component="this.searchBarToggler.component" t-props="this.searchBarToggler.props"/>
+                <SearchBar toggler="this.searchBarToggler"/>
             </div>
         `;
         static components = { SearchBar };

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -53,7 +53,7 @@ class TestComponent extends Component {
     static components = { SearchBarMenu, SearchPanel };
     static template = xml`
         <div class="o_test_component">
-            <SearchPanel t-if="env.searchModel.display.searchPanel" />
+            <SearchPanel t-if="this.env.searchModel.display.searchPanel" />
             <SearchBarMenu />
         </div>
     `;

--- a/addons/web/static/tests/search/with_search.test.js
+++ b/addons/web/static/tests/search/with_search.test.js
@@ -261,7 +261,7 @@ test("react to prop 'domain' changes", async () => {
     class Parent extends Component {
         static props = ["*"];
         static template = xml`
-            <WithSearch t-props="searchState" t-slot-scope="search">
+            <WithSearch t-props="this.searchState" t-slot-scope="search">
                 <TestComponent domain="search.domain"/>
             </WithSearch>
         `;
@@ -317,7 +317,7 @@ test("search defaults are removed from context at reload", async function () {
     class Parent extends Component {
         static props = ["*"];
         static template = xml`
-            <WithSearch t-props="searchState" t-slot-scope="search">
+            <WithSearch t-props="this.searchState" t-slot-scope="search">
                 <TestComponent
                     context="search.context"
                 />

--- a/addons/web/static/tests/t_custom_click.test.js
+++ b/addons/web/static/tests/t_custom_click.test.js
@@ -5,7 +5,7 @@ import { contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
 
 test(`main button click`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick) {
             expect.step("clicked on plop");
@@ -22,7 +22,7 @@ test(`main button click`, async () => {
 
 test(`handler is bound`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         setup() {
             this.test = "bind";
@@ -41,7 +41,7 @@ test(`handler is bound`, async () => {
 
 test(`detect if middle Click`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick) {
             expect.step(`isMiddleClick: ${isMiddleClick}`);
@@ -56,7 +56,7 @@ test(`detect if middle Click`, async () => {
 
 test(`detect if middle Click (ctrl+click)`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick) {
             expect.step(`isMiddleClick: ${isMiddleClick}`);
@@ -72,7 +72,7 @@ test(`detect if middle Click (ctrl+click)`, async () => {
 
 test(`main button (arrow function)`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick, text) {
             expect.step(`clickend on plop`);
@@ -89,7 +89,7 @@ test(`main button (arrow function)`, async () => {
 
 test(`handler is bound (arrow function)`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         setup() {
             this.test = "bind";
@@ -109,7 +109,7 @@ test(`handler is bound (arrow function)`, async () => {
 
 test(`detect if middle Click (arrow function)`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="(ev, isMiddleClick) => this.plop(ev, isMiddleClick, 'test')" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick, text) {
             expect.step(`isMiddleClick: ${isMiddleClick}`);
@@ -126,7 +126,7 @@ test(`detect if middle Click (arrow function)`, async () => {
 
 test(`"stop" and "prevent" modifiers`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-on-click="noClick"><div t-custom-click.stop.prevent="plop" class="clickMe"><t t-out="props.text"/></div></div>`;
+        static template = xml`<div t-on-click="this.noClick"><div t-custom-click.stop.prevent="plop" class="clickMe"><t t-out="this.props.text"/></div></div>`;
         static props = ["*"];
         plop(ev, isMiddleClick) {
             expect.step(`isMiddleClick: ${isMiddleClick}`);
@@ -146,7 +146,7 @@ test(`"stop" and "prevent" modifiers`, async () => {
 
 test(`"synthetic" modifier`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click.synthetic="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click.synthetic="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop(ev) {
             expect(ev.currentTarget).toBe(document);
@@ -161,7 +161,7 @@ test(`"synthetic" modifier`, async () => {
 
 test(`Secondary button clicked`, async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="props.text"/></div>`;
+        static template = xml`<div t-custom-click="plop" class="clickMe"><t t-out="this.props.text"/></div>`;
         static props = ["*"];
         plop() {
             expect.step("Shoudn't be called");

--- a/addons/web/static/tests/views/fields/float_field.test.js
+++ b/addons/web/static/tests/views/fields/float_field.test.js
@@ -424,7 +424,7 @@ test("field with enable_formatting option as false in editable list view", async
 
 test("float field can be updated by another field/widget", async () => {
     class MyWidget extends Component {
-        static template = xml`<button t-on-click="onClick">do it</button>`;
+        static template = xml`<button t-on-click="this.onClick">do it</button>`;
         static props = ["*"];
         onClick() {
             const val = this.props.record.data.float_field;

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -1501,7 +1501,7 @@ test("standalone many2one field", async () => {
     class Comp extends Component {
         static components = { Record, Field };
         static template = xml`
-            <Record resModel="'coucou'" fields="fields" fieldNames="['partner_id']" values="values" mode="'edit'" t-slot-scope="scope">
+            <Record resModel="'coucou'" fields="this.fields" fieldNames="['partner_id']" values="this.values" mode="'edit'" t-slot-scope="scope">
                 <Field name="'partner_id'" record="scope.record" canOpen="false" />
             </Record>
         `;

--- a/addons/web/static/tests/views/fields/numeric_fields.test.js
+++ b/addons/web/static/tests/views/fields/numeric_fields.test.js
@@ -252,7 +252,7 @@ test("useNumpadDecimal should synchronize handlers on input elements", async () 
         static template = xml`
             <main t-ref="numpadDecimal">
                 <input type="text" placeholder="input 1" />
-                <input t-if="state.showOtherInput" type="text" placeholder="input 2" />
+                <input t-if="this.state.showOtherInput" type="text" placeholder="input 2" />
             </main>
         `;
         static props = ["*"];

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -13734,7 +13734,7 @@ test("one2many custom which can clear the relation", async () => {
         static template = xml`
             <div>
                 <span t-esc="this.props.record.data[this.props.name].count"/>
-                <button t-on-click="clear">Clear</button>
+                <button t-on-click="this.clear">Clear</button>
             </div>`;
 
         clear() {
@@ -13771,7 +13771,7 @@ test("one2many custom which can set the relation", async () => {
         static template = xml`
             <div>
                 <span t-esc="this.props.record.data[this.props.name].count"/>
-                <button t-on-click="set">Set</button>
+                <button t-on-click="this.set">Set</button>
             </div>`;
 
         set() {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -5236,7 +5236,7 @@ test(`discard changes on a new (dirty) form view`, async () => {
 test(`discard has to wait for changes in each field`, async () => {
     const def = new Deferred();
     class CustomField extends Component {
-        static template = xml`<input t-ref="input" t-att-value="value" t-on-blur="onBlur" t-on-input="onInput" />`;
+        static template = xml`<input t-ref="input" t-att-value="this.value" t-on-blur="this.onBlur" t-on-input="this.onInput" />`;
         static props = {
             ...standardFieldProps,
         };
@@ -9905,7 +9905,7 @@ test(`rainbowman attributes correctly passed on button click`, async () => {
 test(`basic support for widgets`, async () => {
     class MyComponent extends Component {
         static props = ["*"];
-        static template = xml`<div t-esc="value"/>`;
+        static template = xml`<div t-esc="this.value"/>`;
         get value() {
             return JSON.stringify(this.props.record.data);
         }
@@ -9944,7 +9944,7 @@ test(`widget with class attribute`, async () => {
 test(`widget with readonly attribute`, async () => {
     class MyComponent extends Component {
         static props = ["*"];
-        static template = xml`<span t-esc="value"/>`;
+        static template = xml`<span t-esc="this.value"/>`;
         get value() {
             return this.props.readonly ? "readonly" : "not readonly";
         }
@@ -10037,7 +10037,7 @@ test("support header button as widgets in submenu on form statusbar on mobile", 
 test(`basic support for widgets: onchange update`, async () => {
     class MyWidget extends Component {
         static props = ["*"];
-        static template = xml`<t t-esc="state.dataToDisplay" />`;
+        static template = xml`<t t-esc="this.state.dataToDisplay" />`;
         setup() {
             this.state = useState({
                 dataToDisplay: this.props.record.data.foo,
@@ -11128,7 +11128,7 @@ test(`fieldDependencies support for fields`, async () => {
     fieldsRegistry.add("custom_field", {
         component: class CustomField extends Component {
             static props = ["*"];
-            static template = xml`<span t-esc="props.record.data.int_field"/>`;
+            static template = xml`<span t-esc="this.props.record.data.int_field"/>`;
         },
         fieldDependencies: [{ name: "int_field", type: "integer" }],
     });
@@ -11148,7 +11148,7 @@ test(`fieldDependencies support for fields: dependence on a relational field`, a
     registry.category("fields").add("custom_field", {
         component: class CustomField extends Component {
             static props = ["*"];
-            static template = xml`<span t-esc="props.record.data.product_id.display_name"/>`;
+            static template = xml`<span t-esc="this.props.record.data.product_id.display_name"/>`;
         },
         fieldDependencies: [{ name: "product_id", type: "many2one", relation: "product" }],
     });
@@ -12001,7 +12001,7 @@ test(`coming to an action with an error from a form view with a dirty x2m`, asyn
         static props = ["*"];
         static template = xml`
             <div class="test_widget">
-                <button t-on-click="onClick">MyButton</button>
+                <button t-on-click="this.onClick">MyButton</button>
             </div>
         `;
         setup() {
@@ -12083,7 +12083,7 @@ test(`coming to an action with an error from a form view with a record in creati
         static props = ["*"];
         static template = xml`
                 <div class="test_widget">
-                    <button t-on-click="onClick">MyButton</button>
+                    <button t-on-click="this.onClick">MyButton</button>
                 </div>`;
         setup() {
             this.actionService = useService("action");
@@ -12263,7 +12263,7 @@ test(`widget update several fields including an x2m`, async () => {
     };
     class TestWidget extends Component {
         static props = ["*"];
-        static template = xml`<div><button t-on-click="onClick">Click</button></div>`;
+        static template = xml`<div><button t-on-click="this.onClick">Click</button></div>`;
 
         onClick() {
             this.props.record.update({
@@ -12564,7 +12564,7 @@ test(`custom x2many with relatedFields and list view not inline`, async () => {
 test(`custom many2one with relatedFields`, async () => {
     class CustomMany2One extends Component {
         static template = xml`
-            <t t-set="value" t-value="props.record.data[props.name]"/>
+            <t t-set="value" t-value="this.props.record.data[this.props.name]"/>
             <div class="content">
                 <div t-esc="value.id"/>
                 <div t-esc="value.display_name"/>
@@ -12675,7 +12675,7 @@ test(`field with special data`, async () => {
 test(`field with special data (with persistent Cache)`, async () => {
     class MyWidget extends Component {
         static props = ["*"];
-        static template = xml`<div class="my_widget">MyWidget <t t-esc="specialData.data.test"/></div>`;
+        static template = xml`<div class="my_widget">MyWidget <t t-esc="this.specialData.data.test"/></div>`;
         setup() {
             this.specialData = useSpecialData((orm, props) => {
                 const { record } = props;
@@ -12852,7 +12852,7 @@ test(`an empty json object does not pass the required check`, async () => {
     class JsonField extends Component {
         static props = ["*"];
         static supportedTypes = ["json"];
-        static template = xml`<span><input t-on-change="onChange"/></span>`;
+        static template = xml`<span><input t-on-change="this.onChange"/></span>`;
 
         onChange(ev) {
             this.props.record.update({ [this.props.name]: JSON.parse(ev.target.value) });
@@ -13098,7 +13098,7 @@ test(`cog menu action is executed with up to date context`, async () => {
     });
 
     class MyField extends CharField {
-        static template = xml`<button class="my_btn" t-on-click="onClick">Reload</button>`;
+        static template = xml`<button class="my_btn" t-on-click="this.onClick">Reload</button>`;
         onClick() {
             this.props.record.model.load({ context: { x: "z" } });
         }
@@ -13139,7 +13139,7 @@ test(`cog menu action is executed with up to date context`, async () => {
 test("CogMenu receives the model in env", async () => {
     class CogItem extends Component {
         static props = ["*"];
-        static template = xml`<button class="test-cog" t-on-click="onClick">Test</button>`;
+        static template = xml`<button class="test-cog" t-on-click="this.onClick">Test</button>`;
         onClick() {
             expect.step([`cog clicked`, this.env.model.root.resModel, this.env.model.root.resId]);
         }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5632,7 +5632,7 @@ test("resequence a record twice", async () => {
 
 test("basic support for widgets (being Owl Components)", async () => {
     class MyComponent extends Component {
-        static template = xml`<div t-att-class="props.class" t-esc="value"/>`;
+        static template = xml`<div t-att-class="this.props.class" t-esc="this.value"/>`;
         static props = ["*"];
         get value() {
             return JSON.stringify(this.props.record.data);
@@ -5663,7 +5663,7 @@ test("basic support for widgets (being Owl Components)", async () => {
 
 test("kanban card: record value should be updated", async () => {
     class MyComponent extends Component {
-        static template = xml`<div><button t-on-click="onClick">CLick</button></div>`;
+        static template = xml`<div><button t-on-click="this.onClick">CLick</button></div>`;
         static props = ["*"];
         onClick() {
             this.props.record.update({ foo: "yolo" });
@@ -6520,7 +6520,7 @@ test("kanban view with monetary and currency fields without widget", async () =>
 
 test("kanban widget can extract props from attrs", async () => {
     class TestWidget extends Component {
-        static template = xml`<div class="o-test-widget-option" t-esc="props.title"/>`;
+        static template = xml`<div class="o-test-widget-option" t-esc="this.props.title"/>`;
         static props = ["*"];
     }
     const testWidget = {
@@ -7109,7 +7109,7 @@ test("no leak of TransactionInProgress (not grouped case)", async () => {
 test("fieldDependencies support for fields", async () => {
     const customField = {
         component: class CustomField extends Component {
-            static template = xml`<span t-esc="props.record.data.int_field"/>`;
+            static template = xml`<span t-esc="this.props.record.data.int_field"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "int_field", type: "integer" }],
@@ -7136,7 +7136,7 @@ test("fieldDependencies support for fields", async () => {
 test("fieldDependencies support for fields: dependence on a relational field", async () => {
     const customField = {
         component: class CustomField extends Component {
-            static template = xml`<span t-esc="props.record.data.product_id.display_name"/>`;
+            static template = xml`<span t-esc="this.props.record.data.product_id.display_name"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "product_id", type: "many2one", relation: "product" }],

--- a/addons/web/static/tests/views/layout.test.js
+++ b/addons/web/static/tests/views/layout.test.js
@@ -56,7 +56,7 @@ test(`Simple rendering`, async () => {
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout className="'o_view_sample_data'" display="props.display">
+            <Layout className="'o_view_sample_data'" display="this.props.display">
                 <div class="toy_content"/>
             </Layout>
         `;
@@ -77,7 +77,7 @@ test(`Simple rendering: with search`, async () => {
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout display="props.display">
+            <Layout display="this.props.display">
                 <t t-set-slot="control-panel-actions">
                     <div class="toy_search_bar"/>
                 </t>
@@ -138,7 +138,7 @@ test(`Nested layouts`, async () => {
     class ToyC extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout className="'toy_c'" display="display">
+            <Layout className="'toy_c'" display="this.display">
                 <div class="toy_c_content"/>
             </Layout>
         `;
@@ -161,7 +161,7 @@ test(`Nested layouts`, async () => {
     class ToyB extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout className="'toy_b'" display="props.display">
+            <Layout className="'toy_b'" display="this.props.display">
                 <t t-set-slot="control-panel-actions">
                     <div class="toy_b_breadcrumbs"/>
                 </t>
@@ -183,11 +183,11 @@ test(`Nested layouts`, async () => {
     class ToyA extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout className="'toy_a'" display="props.display">
+            <Layout className="'toy_a'" display="this.props.display">
                 <t t-set-slot="control-panel-actions">
                     <div class="toy_a_search"/>
                 </t>
-                <ToyB display="props.display"/>
+                <ToyB display="this.props.display"/>
             </Layout>
         `;
         static components = { Layout, ToyB };
@@ -211,7 +211,7 @@ test(`Custom control panel`, async () => {
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout display="props.display">
+            <Layout display="this.props.display">
                 <div class="o_toy_content"/>
             </Layout>
         `;
@@ -240,7 +240,7 @@ test(`Custom search panel`, async () => {
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout display="props.display">
+            <Layout display="this.props.display">
                 <div class="o_toy_content"/>
             </Layout>
         `;
@@ -271,7 +271,7 @@ test(`Simple rendering: with dynamically displayed search`, async () => {
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
-            <Layout display="display">
+            <Layout display="this.display">
                 <t t-set-slot="control-panel-actions">
                     <div class="toy_search_bar"/>
                 </t>

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -12202,7 +12202,7 @@ test(`discard has to wait for changes in each field in multi edit`, async () => 
     const def = new Deferred();
 
     class CustomField extends Component {
-        static template = xml`<input t-ref="input" t-att-value="value" t-on-blur="onBlur" t-on-input="onInput"/>`;
+        static template = xml`<input t-ref="input" t-att-value="this.value" t-on-blur="this.onBlur" t-on-input="this.onInput"/>`;
         static props = {
             ...standardFieldProps,
         };
@@ -16744,7 +16744,7 @@ test(`fieldDependencies support for fields`, async () => {
 
     registry.category("fields").add("custom_field", {
         component: class CustomField extends Component {
-            static template = xml`<span t-out="props.record.data.int_field"/>`;
+            static template = xml`<span t-out="this.props.record.data.int_field"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "int_field", type: "integer" }],
@@ -16761,7 +16761,7 @@ test(`fieldDependencies support for fields`, async () => {
 test(`fieldDependencies support for fields: dependence on a relational field`, async () => {
     registry.category("fields").add("custom_field", {
         component: class CustomField extends Component {
-            static template = xml`<span t-out="props.record.data.m2o.id"/>`;
+            static template = xml`<span t-out="this.props.record.data.m2o.id"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "m2o", type: "many2one", relation: "bar" }],
@@ -17128,7 +17128,7 @@ test(`optional field selection do not unselect current row`, async () => {
 
 test(`view widgets are rendered in list view`, async () => {
     class TestWidget extends Component {
-        static template = xml`<div class="test_widget" t-out="props.record.data.bar"/>`;
+        static template = xml`<div class="test_widget" t-out="this.props.record.data.bar"/>`;
         static props = ["*"];
     }
     registry.category("view_widgets").add("test_widget", { component: TestWidget });
@@ -17151,7 +17151,7 @@ test(`view widgets are rendered in list view`, async () => {
 
 test(`view widget with options in list view`, async () => {
     class TestWidget extends Component {
-        static template = xml`<div class="test_widget" t-out="props.x"/>`;
+        static template = xml`<div class="test_widget" t-out="this.props.x"/>`;
         static props = ["*"];
     }
     registry.category("view_widgets").add("test_widget", {

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -24,7 +24,7 @@ const viewRegistry = registry.category("views");
 
 class ToyController extends Component {
     static props = ["*"];
-    static template = xml`<div t-attf-class="{{class}} {{props.className}}"><t t-call="{{ template }}"/></div>`;
+    static template = xml`<div t-attf-class="{{this.class}} {{this.props.className}}"><t t-call="{{ this.template }}"/></div>`;
     setup() {
         this.class = "toy";
         this.template = xml`${this.props.arch.outerHTML}`;
@@ -1133,7 +1133,7 @@ test("react to prop 'domain' changes", async function () {
     viewRegistry.add("toy", { type: "toy", Controller: ToyController }, { force: true });
     class Parent extends Component {
         static props = ["*"];
-        static template = xml`<View t-props="state"/>`;
+        static template = xml`<View t-props="this.state"/>`;
         static components = { View };
         setup() {
             this.state = useState({

--- a/addons/web/static/tests/views/view_button_hook.test.js
+++ b/addons/web/static/tests/views/view_button_hook.test.js
@@ -28,7 +28,7 @@ test("action can be prevented", async () => {
     let executeInHandler;
 
     class MyComponent extends Component {
-        static template = xml`<div t-ref="root" t-on-click="onClick" class="myComponent">Some text</div>`;
+        static template = xml`<div t-ref="root" t-on-click="this.onClick" class="myComponent">Some text</div>`;
         static props = ["*"];
         setup() {
             const rootRef = useRef("root");
@@ -122,7 +122,7 @@ test("execute action in new window", async () => {
     });
 
     class MyComponent extends Component {
-        static template = xml`<div t-ref="root" t-on-click="onClick" class="myComponent">Some text</div>`;
+        static template = xml`<div t-ref="root" t-on-click="this.onClick" class="myComponent">Some text</div>`;
         static props = ["*"];
         setup() {
             const rootRef = useRef("root");

--- a/addons/web/static/tests/views/view_components/view_scale_selector.test.js
+++ b/addons/web/static/tests/views/view_components/view_scale_selector.test.js
@@ -9,7 +9,7 @@ import { ViewScaleSelector } from "@web/views/view_components/view_scale_selecto
 test("basic ViewScaleSelector component usage", async () => {
     class Parent extends Component {
         static components = { ViewScaleSelector };
-        static template = xml`<ViewScaleSelector t-props="compProps" />`;
+        static template = xml`<ViewScaleSelector t-props="this.compProps" />`;
         static props = ["*"];
         setup() {
             this.state = useState({
@@ -72,7 +72,7 @@ test("basic ViewScaleSelector component usage", async () => {
 test("ViewScaleSelector with only one scale available", async () => {
     class Parent extends Component {
         static components = { ViewScaleSelector };
-        static template = xml`<ViewScaleSelector t-props="compProps" />`;
+        static template = xml`<ViewScaleSelector t-props="this.compProps" />`;
         static props = ["*"];
         setup() {
             this.state = useState({
@@ -101,7 +101,7 @@ test("ViewScaleSelector with only one scale available", async () => {
 test("ViewScaleSelector show weekends button is disabled when scale is day", async () => {
     class Parent extends Component {
         static components = { ViewScaleSelector };
-        static template = xml`<ViewScaleSelector t-props="compProps"/>`;
+        static template = xml`<ViewScaleSelector t-props="this.compProps"/>`;
         static props = ["*"];
         setup() {
             this.state = useState({

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -25,7 +25,7 @@ const actionRegistry = registry.category("actions");
 class TestClientAction extends Component {
     static template = xml`
         <div class="test_client_action">
-            ClientAction_<t t-out="props.action.params?.description"/>
+            ClientAction_<t t-out="this.props.action.params?.description"/>
         </div>`;
     static props = ["*"];
     setup() {
@@ -249,7 +249,7 @@ test("ClientAction receives breadcrumbs and exports title", async () => {
     expect.assertions(4);
 
     class ClientAction extends Component {
-        static template = xml`<div class="my_action" t-on-click="onClick">client action</div>`;
+        static template = xml`<div class="my_action" t-on-click="this.onClick">client action</div>`;
         static props = ["*"];
         setup() {
             this.breadcrumbTitle = "myAction";
@@ -305,7 +305,7 @@ test("ClientAction with extractProps", async () => {
         },
     ]);
     class ClientAction extends Component {
-        static template = xml`<div class="my_client_action" t-out="props.myProp"/>`;
+        static template = xml`<div class="my_client_action" t-out="this.props.myProp"/>`;
         static props = ["*"];
         static extractProps(action) {
             return { myProp: action.params.my_prop };

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -64,7 +64,7 @@ defineActions([
 test("error in a client action (at rendering)", async () => {
     expect.assertions(9);
     class Boom extends Component {
-        static template = xml`<div><t t-out="a.b.c"/></div>`;
+        static template = xml`<div><t t-out="this.a.b.c"/></div>`;
         static props = ["*"];
     }
     actionRegistry.add("Boom", Boom);
@@ -97,8 +97,8 @@ test("error in a client action (after the first rendering)", async () => {
     class Boom extends Component {
         static template = xml`
             <div>
-                <t t-if="boom" t-out="a.b.c"/>
-                <button t-else="" class="my_button" t-on-click="onClick">Click Me</button>
+                <t t-if="this.boom" t-out="this.a.b.c"/>
+                <button t-else="" class="my_button" t-on-click="this.onClick">Click Me</button>
             </div>`;
         static props = ["*"];
         setup() {

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -187,7 +187,7 @@ defineModels([Partner]);
 class TestClientAction extends Component {
     static template = xml`
         <div class="test_client_action">
-            ClientAction_<t t-out="props.action.params?.description"/>
+            ClientAction_<t t-out="this.props.action.params?.description"/>
         </div>
     `;
     static props = ["*"];

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -156,7 +156,7 @@ defineModels([Partner, Pony, User]);
 class TestClientAction extends Component {
     static template = xml`
         <div class="test_client_action">
-            ClientAction_<t t-out="props.action.params?.description"/>
+            ClientAction_<t t-out="this.props.action.params?.description"/>
         </div>
     `;
     static props = ["*"];
@@ -215,8 +215,8 @@ test(`do action keeps menu in url`, async () => {
 test(`actions can push state`, async () => {
     class ClientActionPushes extends Component {
         static template = xml`
-            <div class="test_client_action" t-on-click="_actionPushState">
-                ClientAction_<t t-out="props.params and props.params.description"/>
+            <div class="test_client_action" t-on-click="this._actionPushState">
+                ClientAction_<t t-out="this.props.params and this.props.params.description"/>
             </div>
         `;
         static props = ["*"];
@@ -250,8 +250,8 @@ test(`actions can push state`, async () => {
 test(`actions override previous state`, async () => {
     class ClientActionPushes extends Component {
         static template = xml`
-            <div class="test_client_action" t-on-click="_actionPushState">
-                ClientAction_<t t-out="props.params and props.params.description"/>
+            <div class="test_client_action" t-on-click="this._actionPushState">
+                ClientAction_<t t-out="this.props.params and this.props.params.description"/>
             </div>
         `;
         static props = ["*"];
@@ -288,8 +288,8 @@ test(`actions override previous state`, async () => {
 test(`actions override previous state from menu click`, async () => {
     class ClientActionPushes extends Component {
         static template = xml`
-            <div class="test_client_action" t-on-click="_actionPushState">
-                ClientAction_<t t-out="props.params and props.params.description"/>
+            <div class="test_client_action" t-on-click="this._actionPushState">
+                ClientAction_<t t-out="this.props.params and this.props.params.description"/>
             </div>
         `;
         static props = ["*"];

--- a/addons/web/static/tests/webclient/actions/target.test.js
+++ b/addons/web/static/tests/webclient/actions/target.test.js
@@ -397,7 +397,7 @@ describe("new", () => {
 
         class ClientAction extends Component {
             static template = xml`
-                <div class="my_action" t-on-click="onClick">
+                <div class="my_action" t-on-click="this.onClick">
                     My Action
                 </div>`;
             static props = ["*"];

--- a/addons/web/static/tests/webclient/webclient.test.js
+++ b/addons/web/static/tests/webclient/webclient.test.js
@@ -35,7 +35,7 @@ test.tags("desktop");
 test("control-click <a href/> in a standalone component", async () => {
     class MyComponent extends Component {
         static props = {};
-        static template = xml`<a href="#" class="MyComponent" t-on-click="onclick">Some link</a>`;
+        static template = xml`<a href="#" class="MyComponent" t-on-click="this.onclick">Some link</a>`;
 
         /** @param {MouseEvent} ev */
         onclick(ev) {
@@ -76,7 +76,7 @@ test("control-click propagation stopped on <a href/>", async () => {
 
     class MyComponent extends Component {
         static props = {};
-        static template = xml`<a href="#" class="MyComponent" t-on-click="onclick">Some link</a>`;
+        static template = xml`<a href="#" class="MyComponent" t-on-click="this.onclick">Some link</a>`;
 
         /** @param {MouseEvent} ev */
         onclick(ev) {

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -293,9 +293,9 @@ test("Tour backward when the pointed element disappear", async () => {
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="fool w-100" t-on-click="() => { state.bool = true; }">You fool</button>
-            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
-            <button class="bar w-100" t-if="!state.bool">Bar</button>
+            <button class="fool w-100" t-on-click="() => { this.state.bool = true; }">You fool</button>
+            <button class="foo w-100" t-if="this.state.bool" t-on-click="() => { this.state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!this.state.bool">Bar</button>
         `;
     }
 
@@ -351,9 +351,9 @@ test("Tour backward when the pointed element disappear and ignore warn step", as
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="fool" t-on-click="() => { state.bool = true; }">You fool</button>
-            <button class="foo" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
-            <button class="bar" t-if="!state.bool">Bar</button>
+            <button class="fool" t-on-click="() => { this.state.bool = true; }">You fool</button>
+            <button class="foo" t-if="this.state.bool" t-on-click="() => { this.state.bool = false; }">Foo</button>
+            <button class="bar" t-if="!this.state.bool">Bar</button>
         `;
     }
 
@@ -400,8 +400,8 @@ test("Tour started by the URL", async () => {
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
-            <button class="bar w-100" t-if="!state.bool">Bar</button>
+            <button class="foo w-100" t-if="this.state.bool" t-on-click="() => { this.state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!this.state.bool">Bar</button>
         `;
     }
 
@@ -437,8 +437,8 @@ test("Log a warning if step ignored", async () => {
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
-            <button class="bar w-100" t-if="!state.bool">Bar</button>
+            <button class="foo w-100" t-if="this.state.bool" t-on-click="() => { this.state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!this.state.bool">Bar</button>
         `;
     }
 
@@ -682,9 +682,9 @@ test("Don't backward when action manager is busy", async () => {
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="fool w-100" t-on-click="() => { state.bool = true; }">You fool</button>
-            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
-            <button class="bar w-100" t-if="!state.bool">Bar</button>
+            <button class="fool w-100" t-on-click="() => { this.state.bool = true; }">You fool</button>
+            <button class="foo w-100" t-if="this.state.bool" t-on-click="() => { this.state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!this.state.bool">Bar</button>
         `;
     }
 

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -366,7 +366,7 @@ test("Edit contenteditable", async () => {
 test("Selecting item in autocomplete field through Enter", async () => {
     class Dummy extends Component {
         static components = { AutoComplete };
-        static template = xml`<AutoComplete id="'autocomplete'" value="'World'" sources="sources"/>`;
+        static template = xml`<AutoComplete id="'autocomplete'" value="'World'" sources="this.sources"/>`;
         static props = ["*"];
 
         sources = [

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -296,7 +296,7 @@ class HighlightToolbarButton extends Component {
         getSelection: Function,
     };
     static template = xml`
-        <button t-custom-ref="root" t-attf-class="btn btn-light o-select-highlight {{highlightState.highlightId ? 'active' : ''}}" t-on-click="openHighlightConfigurator" t-att-title="props.title">
+        <button t-custom-ref="root" t-attf-class="btn btn-light o-select-highlight {{this.highlightState.highlightId ? 'active' : ''}}" t-on-click="this.openHighlightConfigurator" t-att-title="this.props.title">
             <i class="fa oi oi-text-effect oi-fw py-1"/>
         </button>
     `;

--- a/addons/website/static/src/interactions/_example.js
+++ b/addons/website/static/src/interactions/_example.js
@@ -9,8 +9,8 @@ import { useService } from "@web/core/utils/hooks";
 export class Counter extends Component {
     static selector = "#wrapwrap h1";
     static template = xml`
-        <div class="btn btn-primary" t-on-click="increment">
-            Counter. Value=<t t-out="state.value"/>
+        <div class="btn btn-primary" t-on-click="this.increment">
+            Counter. Value=<t t-out="this.state.value"/>
         </div>`;
     static props = {};
 

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -131,7 +131,7 @@ test("use isActiveItem base on BuilderButton with 'websiteConfig'", async () => 
         selector: ".test-options-target",
         template: xml`
             <BuilderButton id="'a'" action="'websiteConfig'" actionParam="{views: ['test_template_1']}">1</BuilderButton>
-            <div t-if="isActiveItem('a')" class="test">a</div>
+            <div t-if="this.isActiveItem('a')" class="test">a</div>
         `,
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
@@ -159,7 +159,7 @@ test("use isActiveItem base on BuilderCheckbox with 'websiteConfig'", async () =
         selector: ".test-options-target",
         template: xml`
             <BuilderCheckbox id="'a'" action="'websiteConfig'" actionParam="{views: ['test_template_1']}"/>
-            <div t-if="isActiveItem('a')" class="test">a</div>
+            <div t-if="this.isActiveItem('a')" class="test">a</div>
         `,
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_component.test.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_component.test.js
@@ -7,7 +7,7 @@ import { Component, xml } from "@odoo/owl";
 test("LazyComponent loads the required bundle", async () => {
     class Test extends Component {
         static template = xml`
-            <LazyComponent bundle="'test_assetsbundle.lazy_test_component'" Component="'LazyTestComponent'" props="childProps"/>
+            <LazyComponent bundle="'test_assetsbundle.lazy_test_component'" Component="'LazyTestComponent'" props="this.childProps"/>
         `;
         static components = { LazyComponent };
         static props = ["*"];


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Enterprise PR: https://github.com/odoo/enterprise/pull/111117
Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables