### PR TITLE
[FIX] requirements: cbor2 version with wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.9.1 ; python_version < '3.11'  # min version = 2.6.0 (Focal with security backports)
 Babel==2.10.3 ; python_version >= '3.11' and python_version < '3.13'
 Babel==2.17.0 ; python_version >= '3.13'
-cbor2==5.4.2 ; python_version < '3.12'
+cbor2==5.4.2.post1 ; python_version < '3.11'  # (Jammy)
+cbor2==5.4.6 ; python_version >= '3.11' and python_version < '3.12'  # (Bookworm)
 cbor2==5.6.2 ; python_version >= '3.12'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)
 chardet==5.2.0 ; python_version >= '3.11'


### PR DESCRIPTION
This commit sets the cbor2 library's version to match more closely the
Debian Bookworm/Ubuntu Jammy packaged versions and to match the ones
with a prebuild wheel.

Note: while the 5.4.2 already matched the one from Jammy, it didn't
provided a corresponding wheel, which the 5.4.2.post1 did fix (cf.
https://github.com/agronholm/cbor2/releases/tag/5.4.2.post1).

runbot-238903