### PR TITLE
[FIX] website: activate only the corresponding header aligment view

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
@@ -1,6 +1,7 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { onWillStart } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+
 export class HeaderNavigationOption extends BaseOptionComponent {
     static id = "header_navigation_option";
     static template = "website.HeaderNavigationOption";
@@ -9,20 +10,9 @@ export class HeaderNavigationOption extends BaseOptionComponent {
     setup() {
         super.setup();
 
-        this.keys = [
-            "website.template_header_default",
-            "website.template_header_hamburger",
-            "website.template_header_boxed",
-            "website.template_header_stretch",
-            "website.template_header_vertical",
-            "website.template_header_search",
-            "website.template_header_sales_one",
-            "website.template_header_sales_two",
-            "website.template_header_sales_three",
-            "website.template_header_sales_four",
-            "website.template_header_sidebar",
-        ];
-
+        this.headerTemplates = this.getResource("header_templates_providers")
+            .flatMap((provider) => provider())
+            .map((template) => `website.template_header_` + template.key);
         this.currentActiveViews = {};
         onWillStart(async () => {
             this.currentActiveViews = await this.getCurrentActiveViews();
@@ -38,14 +28,24 @@ export class HeaderNavigationOption extends BaseOptionComponent {
         return false;
     }
     async getCurrentActiveViews() {
-        const actionParams = { views: this.keys };
+        const actionParams = { views: this.headerTemplates };
         await this.dependencies.customizeWebsite.loadConfigKey(actionParams);
         const currentActiveViews = {};
-        for (const key of this.keys) {
+        for (const key of this.headerTemplates) {
             const isActive = this.dependencies.customizeWebsite.getConfigKey(key);
             currentActiveViews[key] = isActive;
         }
         return currentActiveViews;
+    }
+
+    getAlignmentView(direction) {
+        if (!direction || direction === "left") {
+            return [];
+        }
+        // We find the active template, and make a corresponding alignment view
+        return this.headerTemplates
+            .filter((view) => this.currentActiveViews[view])
+            .map((template) => template + `_align_${direction}`);
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
@@ -6,37 +6,6 @@
         <span class="options-container-label ps-2 py-2">Navigation</span>
     </div>
 
-    <t t-set="align_left_views" t-value="[
-    ]"/>
-
-    <t t-set="align_center_views" t-value="[
-        'website.template_header_hamburger_mobile_align_center',
-        'website.template_header_default_align_center',
-        'website.template_header_boxed_align_center',
-        'website.template_header_stretch_align_center',
-        'website.template_header_search_align_center',
-        'website.template_header_sales_one_align_center',
-        'website.template_header_sales_two_align_center',
-        'website.template_header_sales_three_align_center',
-        'website.template_header_sales_four_align_center',
-        'website.template_header_sidebar_align_center',
-        'website.template_header_vertical_align_center',
-    ]"/>
-
-    <t t-set="align_right_views" t-value="[
-        'website.template_header_hamburger_mobile_align_right',
-        'website.template_header_default_align_right',
-        'website.template_header_boxed_align_right',
-        'website.template_header_stretch_align_right',
-        'website.template_header_search_align_right',
-        'website.template_header_sales_one_align_right',
-        'website.template_header_sales_two_align_right',
-        'website.template_header_sales_three_align_right',
-        'website.template_header_sales_four_align_right',
-        'website.template_header_sidebar_align_right',
-        'website.template_header_vertical_align_right',
-    ]"/>
-
     <BuilderRow label.translate="Desktop Menu" tooltip.translate="Change the burger button position/menu items alignment">
         <!-- Reason why we enable this option for those templates only:
             website.template_header_hamburger => Hamburger Icon Position
@@ -58,13 +27,13 @@
         </BuilderButtonGroup>
 
         <BuilderSelect action="'websiteConfig'">
-            <BuilderSelectItem actionParam="{ views: align_left_views }">
+            <BuilderSelectItem actionParam="{ views: this.getAlignmentView('left') }">
                 <span><i class="fa fa-align-left fa-fw"></i></span>
             </BuilderSelectItem>
-            <BuilderSelectItem actionParam="{ views: align_center_views }">
+            <BuilderSelectItem actionParam="{ views: this.getAlignmentView('center') }">
                 <span><i class="fa fa-align-center fa-fw"></i></span>
             </BuilderSelectItem>
-            <BuilderSelectItem actionParam="{ views: align_right_views }">
+            <BuilderSelectItem actionParam="{ views: this.getAlignmentView('right') }">
                 <span><i class="fa fa-align-right fa-fw"></i></span>
             </BuilderSelectItem>
         </BuilderSelect>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -933,7 +933,7 @@
     </xpath>
 </template>
 
-<template id="template_header_vertical_align_center" inherit_id="website.template_header_vertical" active="False">
+<template id="template_header_vertical_align_center" inherit_id="website.template_header_vertical" active="True">
     <xpath expr="//t[@t-call='website.navbar_nav_wrapper']" position="attributes">
         <attribute name="_wrapper_class.f">justify-content-center</attribute>
     </xpath>
@@ -1286,7 +1286,7 @@
     </xpath>
 </template>
 
-<template id="template_header_sales_three_align_right" inherit_id="website.template_header_sales_three" active="False">
+<template id="template_header_sales_three_align_right" inherit_id="website.template_header_sales_three" active="True">
     <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
         <attribute name="_nav_class.f">justify-content-end</attribute>
     </xpath>


### PR DESCRIPTION
This commit fixes 2 issues:
1. Wrong alignment of 'Vertical' and 'Menu - Sale 3' headers
2. Activation of alignment views for every header

Steps to reproduce issue 1:
- Go in the web editor
- Select the header
- Change the template to Vertical or Menu Sale 3
=> Menu is aligned on the left, not centered (or on the right for Menu
Sale 3).
Its corresponding views should be active by default.

Also, after commit [1], when we change a desktop menu alignment, it
activates corresponding views for every header, but this is not the
wanted behavior, as we'd like to have different alignments for different
headers.

[1]: https://github.com/odoo/odoo/commit/950a5286562ca583a139a14abbaa0851adf6f3b2

task-5900220