### PR TITLE
[IMP] account,l10n_ma,l10n_in: default outstanding accounts on bank journals

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -1052,6 +1052,29 @@ class AccountJournal(models.Model):
             }
         )
 
+    def _update_payment_method_lines_account_for_bank_journals(self, payment_type, chart_template=None):
+        """ Update the payment method lines account for bank journals based on the chart template. Used in localizations """
+        bank_journals = self.filtered(lambda j: j.type == "bank" and j.company_id.chart_template == chart_template)
+        if not bank_journals:
+            return
+
+        account_xmlid = 'account_journal_payment_debit_account_id' if payment_type == 'inbound' else 'account_journal_payment_credit_account_id'
+        lines_to_update = bank_journals[f"{payment_type}_payment_method_line_ids"].filtered(
+            lambda l: l.payment_method_id.code == 'manual'
+        )
+        if not lines_to_update:
+            return
+
+        account_company_map = {
+            company: self.env['account.chart.template']
+                .with_company(company)
+                .ref(account_xmlid, raise_if_not_found=False)
+            for company in lines_to_update.mapped('company_id')
+        }
+        for company, lines in lines_to_update.grouped('company_id').items():
+            if account := account_company_map[company]:
+                lines.payment_account_id = account
+
     @api.depends('currency_id')
     def _compute_display_name(self):
         for journal in self:

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -1059,6 +1059,38 @@ class AccountJournal(models.Model):
             }
         )
 
+    def _assign_outsanding_account_to_payment_method_lines(self, payment_type, payment_method_codes=None, chart_template=None):
+        """ Link bank journal payment method lines to their corresponding outstanding account for the specified chart template.
+
+        :param payment_type: Payment direction, either ``'inbound'`` or ``'outbound'``.
+        :param payment_method_codes: Optional list of payment method codes used to restrict
+            the payment method lines that are updated.
+        :param chart_template: Chart template used to select the relevant bank journals
+            and determine the outstanding account.
+        """
+        bank_journals = self.filtered(lambda j: j.type == "bank" and j.company_id.chart_template == chart_template)
+        if not bank_journals:
+            return
+
+        lines_to_update = bank_journals[f"{payment_type}_payment_method_line_ids"]
+        if payment_method_codes:
+            lines_to_update = lines_to_update.filtered(
+                lambda l: l.payment_method_id.code in payment_method_codes
+            )
+        if not lines_to_update:
+            return
+
+        account_xmlid = 'account_journal_payment_debit_account_id' if payment_type == 'inbound' else 'account_journal_payment_credit_account_id'
+        account_company_map = {
+            company: self.env['account.chart.template']
+                .with_company(company)
+                .ref(account_xmlid, raise_if_not_found=False)
+            for company in lines_to_update.mapped('company_id')
+        }
+        for company, lines in lines_to_update.grouped('company_id').items():
+            if account := account_company_map[company]:
+                lines.payment_account_id = account
+
     @api.depends('currency_id')
     def _compute_display_name(self):
         for journal in self:

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -139,8 +139,8 @@ class AccountChartTemplate(models.AbstractModel):
             # We call these helper methods again in _post_load_data to ensure all payment method lines
             # are correctly assigned once all COA data is fully available.
             bank_journals = company.bank_journal_ids
-            bank_journals._update_payment_method_lines("inbound")
-            bank_journals._update_payment_method_lines("outbound")
+            bank_journals._update_payment_method_lines_account_for_bank_journals("inbound", "in")
+            bank_journals._update_payment_method_lines_account_for_bank_journals("outbound", "in")
 
     def _load(self, template_code, company, install_demo, force_create=True):
         res = super()._load(template_code, company, install_demo, force_create)

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -139,8 +139,8 @@ class AccountChartTemplate(models.AbstractModel):
             # We call these helper methods again in _post_load_data to ensure all payment method lines
             # are correctly assigned once all COA data is fully available.
             bank_journals = company.bank_journal_ids
-            bank_journals._update_payment_method_lines("inbound")
-            bank_journals._update_payment_method_lines("outbound")
+            bank_journals._assign_outsanding_account_to_payment_method_lines("inbound", payment_method_codes=['manual'], chart_template="in")
+            bank_journals._assign_outsanding_account_to_payment_method_lines("outbound", payment_method_codes=['manual'], chart_template="in")
 
     def _load(self, template_code, company, install_demo, force_create=True):
         res = super()._load(template_code, company, install_demo, force_create)

--- a/addons/l10n_ma/models/__init__.py
+++ b/addons/l10n_ma/models/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_journal
 from . import base_document_layout
 from . import template_ma
 from . import res_partner

--- a/addons/l10n_ma/models/account_journal.py
+++ b/addons/l10n_ma/models/account_journal.py
@@ -2,12 +2,12 @@ from odoo import models
 
 
 class AccountJournal(models.Model):
-    _inherit = "account.journal"
+    _inherit = 'account.journal'
 
     def _compute_inbound_payment_method_line_ids(self):
         super()._compute_inbound_payment_method_line_ids()
-        self._update_payment_method_lines_account_for_bank_journals("inbound", "in")
+        self._update_payment_method_lines_account_for_bank_journals('inbound', 'ma')
 
     def _compute_outbound_payment_method_line_ids(self):
         super()._compute_outbound_payment_method_line_ids()
-        self._update_payment_method_lines_account_for_bank_journals("outbound", "in")
+        self._update_payment_method_lines_account_for_bank_journals('outbound', 'ma')

--- a/addons/l10n_ma/models/account_journal.py
+++ b/addons/l10n_ma/models/account_journal.py
@@ -2,12 +2,12 @@ from odoo import models
 
 
 class AccountJournal(models.Model):
-    _inherit = "account.journal"
+    _inherit = 'account.journal'
 
     def _compute_inbound_payment_method_line_ids(self):
         super()._compute_inbound_payment_method_line_ids()
-        self._assign_outsanding_account_to_payment_method_lines("inbound", payment_method_codes=['manual'], chart_template="in")
+        self._assign_outsanding_account_to_payment_method_lines('inbound', chart_template='ma')
 
     def _compute_outbound_payment_method_line_ids(self):
         super()._compute_outbound_payment_method_line_ids()
-        self._assign_outsanding_account_to_payment_method_lines("outbound", payment_method_codes=['manual'], chart_template="in")
+        self._assign_outsanding_account_to_payment_method_lines('outbound', chart_template='ma')

--- a/addons/l10n_ma/models/template_ma.py
+++ b/addons/l10n_ma/models/template_ma.py
@@ -49,3 +49,15 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_stock_variation_id': 'pcg_61241',
             },
         }
+
+    def _post_load_data(self, template_code, company, template_data):
+        super()._post_load_data(template_code, company, template_data)
+        if template_code == 'ma':
+            # The COA (Chart of Accounts) data is loaded after the initial compute methods are called.
+            # During initial journal setup, the payment methods and accounts may not exist yet,
+            # causing the payment method lines to not be properly configured.
+            # We call these helper methods again in _post_load_data to ensure all payment method lines
+            # are correctly assigned once all COA data is fully available.
+            bank_journals = company.bank_journal_ids
+            bank_journals._update_payment_method_lines_account_for_bank_journals('inbound', 'ma')
+            bank_journals._update_payment_method_lines_account_for_bank_journals('outbound', 'ma')

--- a/addons/l10n_ma/models/template_ma.py
+++ b/addons/l10n_ma/models/template_ma.py
@@ -49,3 +49,15 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_stock_variation_id': 'pcg_61241',
             },
         }
+
+    def _post_load_data(self, template_code, company, template_data):
+        super()._post_load_data(template_code, company, template_data)
+        if template_code == 'ma':
+            # The COA (Chart of Accounts) data is loaded after the initial compute methods are called.
+            # During initial journal setup, the payment methods and accounts may not exist yet,
+            # causing the payment method lines to not be properly configured.
+            # We call these helper methods again in _post_load_data to ensure all payment method lines
+            # are correctly assigned once all COA data is fully available.
+            bank_journals = company.bank_journal_ids
+            bank_journals._assign_outsanding_account_to_payment_method_lines('inbound', chart_template='ma')
+            bank_journals._assign_outsanding_account_to_payment_method_lines('outbound', chart_template='ma')


### PR DESCRIPTION
Reason:
- Moroccan companies usually use cash basis accounting. And the cash basis
  entries are only made when the invoices are reconciled with the bank
  transactions. However, in Morocco, there is no Moroccan bank available for
  bank synchronization.

Before this commit:
- We are not assigning the outstanding accounts on the bank journals by default.
- Which is causing the issues when the user creates a payment without an entry
  and without having any bank transactions to reconcile it with. Therefore, the
  tax report won't show the moves and taxes that occurred in the period.

After this commit:
- Introduced a method for updating the accounts on the payment method lines of
  the bank journal in the account module, as we need the same functionalities in
  l10n_in as well.
- For Moroccan localization, from now on, we are setting the outstanding accounts
  automatically on the bank journals.
- The payment accounts are applied by default during CoA loading and whenever
  payment method lines are recomputed, ensuring accounts remain consistent.

Task-6041119