### PR TITLE
[IMP] web: prioritize "contains" for char, text, and html fields

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -22,7 +22,7 @@ export function getDomainDisplayedOperators(fieldDef) {
         case "char":
         case "text":
         case "html":
-            return ["=", "!=", "ilike", "not ilike", "starts with", "set", "not set"];
+            return ["ilike", "not ilike", "=", "!=", "starts with", "set", "not set"];
         case "date":
         case "datetime":
             return ["in range", "=", "<", ">", "set", "not set"];

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -273,7 +273,7 @@ test("building a domain with an invalid operator", async () => {
     await makeDomainSelector({
         domain: `[("foo", "!!!!=!!!!", "abc")]`,
         update(domain) {
-            expect(domain).toBe(`[("foo", "=", "abc")]`);
+            expect(domain).toBe(`[("foo", "ilike", "abc")]`);
         },
     });
 
@@ -287,15 +287,15 @@ test("building a domain with an invalid operator", async () => {
     expect(getCurrentPath()).toBe("Foo");
     expect(".o_model_field_selector_warning").toHaveCount(0);
     expect(getOperatorOptions()).toEqual([
-        label("="),
-        label("!="),
         label("ilike"),
         label("not ilike"),
+        label("="),
+        label("!="),
         label("starts with"),
         label("set"),
         label("not set"),
     ]);
-    expect(getCurrentOperator()).toBe(label("="));
+    expect(getCurrentOperator()).toBe(label("ilike"));
     expect(getCurrentValue()).toBe("abc");
 });
 
@@ -349,6 +349,43 @@ test("building a domain with a m2o without following the relation", async () => 
 
     await contains(`${SELECTORS.valueEditor} input`).edit("pad");
     expect.verifySteps([`[("product_id", "ilike", "pad")]`]);
+});
+
+test("Char/Text/Html fields have operator suggestions in their usage frequency order", async () => {
+    Partner._fields.dummy_text = fields.Text({ string: "Dummy text" });
+    Partner._fields.dummy_html = fields.Html({ string: "Dummy html" });
+
+    const expectedOperators = [
+        label("ilike"),
+        label("not ilike"),
+        label("="),
+        label("!="),
+        label("starts with"),
+        label("set"),
+        label("not set"),
+    ];
+
+    const toTest = [
+        { name: "Display name", expectedDomain: `[("display_name", "ilike", "")]` },
+        { name: "Dummy text", expectedDomain: `[("dummy_text", "ilike", "")]` },
+        { name: "Dummy html", expectedDomain: `[("dummy_html", "ilike", "")]` },
+    ];
+
+    await makeDomainSelector({
+        isDebugMode: true,
+    });
+    await addNewRule();
+    for (const { name, expectedDomain } of toTest) {
+        await openModelFieldSelectorPopover();
+        await contains(
+            `.o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains(${name})`
+        ).click();
+        expect(getCurrentPath()).toBe(name);
+        expect(getCurrentOperator()).toBe(label("ilike"));
+        expect(getOperatorOptions()).toEqual(expectedOperators);
+        expect(getCurrentValue()).toBe("");
+        expect(SELECTORS.debugArea).toHaveValue(expectedDomain);
+    }
 });
 
 test("editing a domain with `parent` key", async () => {
@@ -1044,12 +1081,12 @@ test("support properties", async () => {
         },
         {
             name: "xphone_prop_3",
-            domain: `[("properties.xphone_prop_3", "=", "")]`,
+            domain: `[("properties.xphone_prop_3", "ilike", "")]`,
             options: [
-                label("="),
-                label("!="),
                 label("ilike"),
                 label("not ilike"),
+                label("="),
+                label("!="),
                 label("starts with"),
                 label("set"),
                 label("not set"),
@@ -1214,7 +1251,7 @@ test("updating path should also update operator if invalid", async () => {
     await makeDomainSelector({
         domain: `[("id", "<", 0)]`,
         update: (domain) => {
-            expect(domain).toBe(`[("foo", "=", "")]`);
+            expect(domain).toBe(`[("foo", "ilike", "")]`);
         },
     });
 

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -357,7 +357,7 @@ test("check condition by default when creating a new rule", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Country ID", label("="), ""] },
+        { level: 1, value: ["Country ID", label("ilike"), ""] },
     ]);
 });
 
@@ -404,7 +404,7 @@ test("no field of type properties in model field selector", async () => {
     ]);
     expect(isNotSupportedPath()).toBe(true);
     await clearNotSupported();
-    expect.verifySteps([`foo == ""`]);
+    expect.verifySteps([`"".lower() in (foo or "").lower()`]);
 
     await openModelFieldSelectorPopover();
     expect(queryAllTexts(".o_model_field_selector_popover_item_name")).toEqual(["Bar", "Foo"]);
@@ -423,9 +423,9 @@ test("no special fields in fields", async () => {
     await addNewRule();
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Foo", label("="), ""] },
+        { level: 1, value: ["Foo", label("ilike"), ""] },
     ]);
-    expect.verifySteps([`foo == ""`]);
+    expect.verifySteps([`"".lower() in (foo or "").lower()`]);
 });
 
 test("between operator", async () => {
@@ -716,10 +716,10 @@ test("expression for char field support 'contains'", async () => {
 
     await makeExpressionEditor({ expression: "name", update });
     expect(getOperatorOptions()).toEqual([
-        label("="),
-        label("!="),
         label("ilike"),
         label("not ilike"),
+        label("="),
+        label("!="),
         label("set"),
         label("not set"),
     ]);
@@ -743,10 +743,10 @@ test("expression for char field support 'contains'", async () => {
     await selectOperator("not ilike");
 
     expect(getOperatorOptions()).toEqual([
-        label("="),
-        label("!="),
         label("ilike"),
         label("not ilike"),
+        label("="),
+        label("!="),
         label("set"),
         label("not set"),
     ]);


### PR DESCRIPTION
In the domain selector, **Char, Text,** and **HTML** fields currently list their operators in this order: =, !=, ilike, not ilike, starts with, set, not set. However, **"contains" (ilike)** and **"does not contain" (not ilike)** are by far the most natural and frequently used operators when filtering on text-based fields. Reordering the list to surface these operators first improves discoverability.

Enterprise: https://github.com/odoo/enterprise/pull/111120

task-6023007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
