### PR TITLE
[IMP] data_recycle: add warning when switching to automated

### DIFF
--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -80,6 +80,17 @@ class Data_RecycleModel(models.Model):
             if model.recycle_action == 'archive' and 'active' not in self.env[model.res_model_name]:
                 raise UserError(_("This model doesn't manage archived records. Only deletion is possible."))
 
+    @api.onchange('recycle_mode')
+    def _onchange_recycle_mode(self):
+        if self.recycle_mode == 'automatic':
+            return {
+                'warning': {
+                    'title': "Automatic Mode",
+                    'message': "When enabling automatic mode your rules will run periodically without manual validation. "
+                               "Please note that these changes are permanent and cannot be reversed."
+                }
+            }
+
     @api.depends('res_model_id')
     def _compute_domain(self):
         self.domain = '[]'


### PR DESCRIPTION
Setting the recycling  model to automated mode can trigger irreversible operations, but no warning is currently shown to users, unlike the manual recycling action.

This commit adds a warning popup when selecting "Automated" mode to inform users about the potential impact.

task-5933180

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
