### PR TITLE
[IMP] mail,*: open avatar link on partner mention

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -783,7 +783,7 @@ class DiscussChannel(models.Model):
         if self.channel_type == "livechat":
             if member.is_self:
                 return self.env._("joined the conversation")
-            return self.env._("invited %s to the conversation", member._get_html_link(for_persona=True))
+            return self.env._("invited %s to the conversation", member._get_member_html_link())
         return super()._get_member_join_notification(member)
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -207,7 +207,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         "markup",
                         (
                             '<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="'
-                            f'{self.partner_employee.id}">@Ernest Employee</a> to the conversation</div>'
+                            f'{self.partner_employee.id}" class="o_mail_redirect">@Ernest Employee</a> to the conversation</div>'
                         ),
                     ],
                     # thread not renamed yet at this step

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -22,7 +22,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         channel._add_members(users=john)
         self.assertEqual(
             channel.message_ids[-1].body,
-            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{john.partner_id.id}">@ELOPERADOR</a> to the conversation</div>',
+            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{john.partner_id.id}" class="o_mail_redirect">@ELOPERADOR</a> to the conversation</div>',
         )
 
     def test_user_livechat_username_reactions(self):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -724,7 +724,7 @@ class DiscussChannel(models.Model):
     def _get_member_join_notification(self, member):
         if member.is_self:
             return self.env._("joined the channel")
-        return self.env._("invited %s to the channel", member._get_html_link(for_persona=True))
+        return self.env._("invited %s to the channel", member._get_member_html_link())
 
     def invite_by_email(self, emails):
         """
@@ -1630,7 +1630,7 @@ class DiscussChannel(models.Model):
         else:
             if members := self.channel_member_ids.filtered(lambda m: not m.is_self):
                 member_names = html_escape(format_list(self.env, [f"%(member_{member.id})s" for member in members])) % {
-                    f"member_{member.id}": member._get_html_link(for_persona=True)
+                    f"member_{member.id}": member._get_member_html_link()
                     for member in members
                 }
                 msg = _(
@@ -1666,7 +1666,7 @@ class DiscussChannel(models.Model):
             else:
                 list_params.append(_("you"))
             member_names = html_escape(format_list(self.env, list_params)) % {
-                f"member_{member.id}": member._get_html_link(for_persona=True)
+                f"member_{member.id}": member._get_member_html_link()
                 for member in members
             }
             msg = _(

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -696,9 +696,9 @@ class DiscussChannelMember(models.Model):
     def _get_html_link_title(self):
         return self.partner_id.name if self.partner_id else self.guest_id.name
 
-    def _get_html_link(self, *args, for_persona=False, **kwargs):
-        if not for_persona:
-            return self._get_html_link(*args, **kwargs)
+    def _get_member_html_link(self, *args, **kwargs):
         if self.partner_id:
-            return self.partner_id._get_html_link(title=f"@{self._get_html_link_title()}")
+            return self.partner_id._get_html_link(
+                title=f"@{self._get_html_link_title()}", extra_classes="o_mail_redirect"
+            )
         return Markup("<strong>%s</strong>") % self.guest_id.name

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -873,18 +873,20 @@ class Base(models.AbstractModel):
     # TOOLS
     # ------------------------------------------------------------
 
-    def _get_html_link(self, title=None):
+    def _get_html_link(self, title=None, extra_classes=None):
         """Generate the record html reference for chatter use.
 
         :param str title: optional reference title, the record display_name
             is used if not provided. The title/display_name will be escaped.
+        :param str extra_classes: optional additional CSS classes to add to the link
         :returns: generated html reference,
             in the format <a href data-oe-model="..." data-oe-id="...">title</a>
         :rtype: str
         """
         self.ensure_one()
-        return Markup("<a href=# data-oe-model='%s' data-oe-id='%s'>%s</a>") % (
-            self._name, self.id, title or self.display_name)
+        classes = f" class={extra_classes}" if extra_classes else ""
+        return Markup("<a href=# data-oe-model='%s' data-oe-id='%s'%s>%s</a>") % (
+            self._name, self.id, classes, title or self.display_name)
 
     @api.model
     def _get_backend_root_menu_ids(self):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -100,7 +100,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         "author_guest_id": False,
                                         "body": [
                                             "markup",
-                                            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
+                                            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}" class="o_mail_redirect">@Test Partner</a> to the channel</div>',
                                         ],
                                         "create_date": fields.Datetime.to_string(
                                             message.create_date,
@@ -910,8 +910,8 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "body":
                             "<span class='o_mail_notification'>"
                             "You are in a private conversation with "
-                            f"<a href=# data-oe-model='res.partner' data-oe-id='{test_user.partner_id.id}'>@Mario</a> "
-                            f"and <a href=# data-oe-model='res.partner' data-oe-id='{self.partner_employee_nomail.id}'>@&lt;strong&gt;Evita Employee NoEmail&lt;/strong&gt;</a>."
+                            f"<a href=# data-oe-model='res.partner' data-oe-id='{test_user.partner_id.id}' class=o_mail_redirect>@Mario</a> "
+                            f"and <a href=# data-oe-model='res.partner' data-oe-id='{self.partner_employee_nomail.id}' class=o_mail_redirect>@&lt;strong&gt;Evita Employee NoEmail&lt;/strong&gt;</a>."
                             "<br><br><b>@username</b> to mention someone"
                             "<br><b>@role</b> to notify multiple people"
                             "<br><b>#channel</b> to link a channel"

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -128,7 +128,7 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
             ("I will transfer you to a human", operator, False),
             (
                 'invited <a href="#" data-oe-model="res.partner" data-oe-id="'
-                f'{operator_member.partner_id.id}">@El Deboulonnator</a> to the conversation',
+                f'{operator_member.partner_id.id}" class="o_mail_redirect">@El Deboulonnator</a> to the conversation',
                 self.chatbot_script.operator_partner_id,
                 False,
             ),


### PR DESCRIPTION
Currently, if the mention is a partner without the "o_mail_redirect" class, clicking on it does not open the partner avatar popover.

This commit fixes this by adding the "o_mail_redirect" class to partner mentions that do not have it.

task-5978136


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
