### PR TITLE
[FIX] mail: handle background-image URLs in style attributes for massmailing

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -152,9 +152,9 @@ class MailRenderMixin(models.AbstractModel):
         html = re.sub(r"""(<[\w-]+(?=\s)[^>]*\sbackground=")(/[^/][^"]+)""", _sub_relative2absolute, html)
         html = re.sub(re.compile(
             r"""( # Group 1: element up to url in style
-                <[^>]+\bstyle=" # Element with a style attribute
-                [^"]+\burl\( # Style attribute contains "url(" style
-                (?:&\#34;|'|&quot;|&\#39;)?) # url style may start with (escaped) quote: capture it
+                <[^>]+\bstyle=['"] # Element with a style attribute
+                [^'"]+\burl\( # Style attribute contains "url(" style
+                (?:&\#34;|'|&quot;|&\#39;|")?) # url style may start with (escaped) quote: capture it
             ( # Group 2: url itself
                 /(?:[^'")]|(?!&\#34;)|(?!&\#39;))+ # stop at the first closing quote
         )""", re.VERBOSE), _sub_relative2absolute, html)

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -395,6 +395,7 @@ class TestMailRender(TestMailRenderCommon):
             '<div style="background-image:url(\'/web/path?a=a&b=b\');"/>',
             '<div style="background-image:url(&#34;/web/path?a=a&b=b&#34;);"/>',
             '<div background="/web/path?a=a&b=b"/>',
+            '<div style=\'background-image:url("/web/path?a=a&b=b");\'/>',
         ]
         base_url = self.env['mail.render.mixin'].get_base_url()
         rendered_local_links = [
@@ -406,6 +407,7 @@ class TestMailRender(TestMailRenderCommon):
             '<div style="background-image:url(\'%s/web/path?a=a&b=b\');"/>' % base_url,
             '<div style="background-image:url(&#34;%s/web/path?a=a&b=b&#34;);"/>' % base_url,
             '<div background="%s/web/path?a=a&b=b"/>' % base_url,
+            '<div style=\'background-image:url("%s/web/path?a=a&b=b");\'/>' % base_url,
         ]
         for source, expected in zip(local_links_template_bits, rendered_local_links):
             rendered = self.env['mail.render.mixin']._replace_local_links(source)


### PR DESCRIPTION
Problem:
Background images in mass mailings were sent with relative URLs,
resulting in broken images in email clients.

Cause:
When serializing, lxml will use single quotes for attribute values that
contain double quotes, and double quotes for attribute values that
contain single quotes or no quotes.

It automatically picks the attribute delimiter to produce valid HTML,
which explains why `style="...&quot;..."`` becomes `style='..."..."'`
after `tostring()`.

Solution:
Update the regex in `mail_render_mixin.py` to support both `"` and `'`
delimited `style` attributes, ensuring background-image URLs are
properly converted to absolute paths.

Steps to reproduce:
- Add any masonry snippet (with background image).
- Send the email.
- Observe the received email uses a relative image URL.

opw-5974203

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
