### PR TITLE
[IMP] runbot: log ormcache stats at the end of tests

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1629,6 +1629,8 @@ def preload_registries(dbnames):
                                 sql_db.sql_counter - t0_sql)
 
                     registry._assertion_report.log_stats()
+                    if os.environ.get('ODOO_RUNBOT'):
+                        log_ormcache_stats(signal.SIGUSR1)
                 if registry._assertion_report and not registry._assertion_report.wasSuccessful():
                     rc += 1
         except Exception:


### PR DESCRIPTION
Having the cache stats at the end in the logs will help to follow the cache that are the most used and also the heaviest to populate in order to improve test time in the future. 


Example script to combine all stats of a build:

```python
import sys
import requests
import re

url = sys.argv[1]
r = requests.get(url)
urls = []
for line in r.text.splitlines():
    match = re.search(r'href="([^"]+/logs/start_post_install_tests.txt)"', line)
    if match:
        urls.append(match.group(1))

gen_time_per_method = {}
cache_keys_freq = {}
for url in urls:
    r = requests.get(url)
    for line in r.text.splitlines():
        # collect line looking like  default,      0,  1230,   594,     0,        0.225,     67.4%,        16.3%,     687,  ResCompany.__accessible_branches
        match = re.search(r'^\s*(\w+),\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+),\s*([\d.]+),\s*([\d.]+)%,\s*([\d.]+)%,\s*(\d+),\s*(.+)$', line)
        if match:
            cache_name, entry, hit, miss, err, gen_time, hit_ratio, txhitratio, txcall, method = match.groups()
            method = method.strip()
            gen_time_per_method[method] = gen_time_per_method.get(method, 0) + float(gen_time)
        if line.startswith("cache miss ") and " " in line:
            _, _, method, key = line.split(' ', 3)
            cache_keys_freq.setdefault(method, {}).setdefault(key, 0)
            cache_keys_freq[method][key] += 1

sorted_gen_time_per_method = sorted(gen_time_per_method.items(), key=lambda x: x[1], reverse=True)
for method, gen_time in sorted_gen_time_per_method[:50]:
    print(f'{method}: {gen_time:.2f} seconds')

if cache_keys_freq:
  print("most frequent cache keys")
  for method, keys in cache_keys_freq.items():
      print(f'{method}:')
      sorted_keys = sorted(keys.items(), key=lambda x: x[1], reverse=True)
      for key, freq in sorted_keys[:30]:
          if freq > 20:
              print(f'  {key}: {freq} hits')

```
(The cache_keys_freq part is not part of the pr)
            
This will output something like


```
IrAsset._get_asset_paths: 1384.36 seconds
IrQweb._generate_asset_links_cache: 1269.25 seconds
IrHttp.routing_map: 860.19 seconds
IrRule._compute_domain: 715.28 seconds
ResGroups._get_group_definitions: 385.82 seconds
IrQweb._generate_code_cached: 360.97 seconds
IrModelFields._get_fields_cached: 352.91 seconds
ResUsers._get_group_ids: 340.20 seconds
IrModelAccess._get_allowed_models: 327.01 seconds
IrDefault._get_model_defaults: 165.79 seconds
ResGroups._get_view_group_hierarchy: 160.54 seconds
Base._get_view_cache: 159.36 seconds
IrQweb._generate_code_cached_memo: 132.85 seconds
IrAsset._topological_sort: 104.62 seconds
IrUiMenu.load_menus: 102.36 seconds
IrModelData._xmlid_lookup: 83.85 seconds
ResUsers.context_get: 79.27 seconds
MailMessageSubtype._get_auto_subscription_subtypes: 65.73 seconds
CachedModel._cached_data: 46.80 seconds
IrHttp._get_web_translations_hash: 43.05 seconds
IrUiView._get_cached_template_info: 39.26 seconds
MailThread._track_get_fields: 35.41 seconds
IrConfig_Parameter._get: 32.90 seconds
ResUsers._get_company_ids: 28.45 seconds
ResGroups._get_lock_timeouts: 26.61 seconds
IrUiMenu._visible_menu_ids: 24.29 seconds
IrModelFields._get_ids: 17.90 seconds
IrModelAccess._get_access_groups: 17.64 seconds
HrRuleParameter._get_parameter_from_code: 16.21 seconds
IrDefault._get_field_column_fallbacks: 13.07 seconds
MailMessageSubtype._default_subtypes: 11.98 seconds
ResUsers._check_uid_passwd: 10.33 seconds
Website._get_current_website_id: 9.34 seconds
ResLang._get_frontend: 8.91 seconds
PropertiesBaseDefinition._get_definition_id_for_property_field: 7.05 seconds
ResLang._get_active_by: 7.03 seconds
IrModel._get_id: 6.26 seconds
IrActionsActions._get_bindings: 6.15 seconds
DecimalPrecision.precision_get: 5.37 seconds
AccountAnalyticPlan.__get_all_plans: 5.26 seconds
IrModuleModule._installed: 4.91 seconds
IrActionsAct_Window._existing: 4.08 seconds
IrModuleModule._get_imported_module_names: 3.77 seconds
Website._cached_data: 3.63 seconds
AIAgent._get_available_menus: 3.33 seconds
IrModuleModule._get_id: 3.26 seconds
ResUsers._compute_session_token: 2.80 seconds
ProductTemplate._get_first_possible_variant_id: 2.01 seconds
ProductTemplate._default_uom_id: 1.87 seconds
ResCompany.__accessible_branches: 1.85 seconds
```

