### PR TITLE
[FIX] html_editor: remove gradient when applying solid text color

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -585,10 +585,7 @@ export class ColorPlugin extends Plugin {
         if (oldClassName !== newClassName) {
             element.setAttribute("class", newClassName);
         }
-        if (color.startsWith("text") || color.startsWith("bg-")) {
-            element.style[mode] = "";
-            element.classList.add(color);
-        } else if (isColorGradient(color)) {
+        if (isColorGradient(color)) {
             element.style[mode] = "";
             parts.gradient = color;
             if (mode === "color") {
@@ -606,9 +603,14 @@ export class ColorPlugin extends Plugin {
             if (hasGradientStyle && !backgroundImagePartsToCss(parts)) {
                 element.style["background-image"] = "";
             }
-            // Change camelCase to kebab-case.
-            mode = mode.replace("backgroundColor", "background-color");
-            this.delegateTo("apply_style", element, mode, color);
+            if (color.startsWith("text") || color.startsWith("bg-")) {
+                element.style[mode] = "";
+                element.classList.add(color);
+            } else {
+                // Change camelCase to kebab-case.
+                mode = mode.replace("backgroundColor", "background-color");
+                this.delegateTo("apply_style", element, mode, color);
+            }
         }
         this.fixColorCombination(element, color);
     }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -543,12 +543,20 @@ test("should apply gradient text color on selected text", async () => {
             '<div style="background-image:none"><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ab<strong>cd</strong>ef]</font></p></div>',
     });
 });
-test("should remove text gradient and apply new text color if gradient is fully selected", async () => {
+test("should remove text gradient and apply new text color if gradient is fully selected (1)", async () => {
     await testEditor({
         contentBefore:
             '<p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient">[abcd]</font></p>',
         stepFunction: setColor("#ff0000", "color"),
         contentAfter: '<p><font style="color: rgb(255, 0, 0);">[abcd]</font></p>',
+    });
+});
+test("should remove text gradient and apply new text color if gradient is fully selected (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient">[abcd]</font></p>',
+        stepFunction: setColor("text-o-color-1", "color"),
+        contentAfter: '<p><font class="text-o-color-1">[abcd]</font></p>',
     });
 });
 test("should remove background gradient and apply new background color if gradient is fully selected", async () => {


### PR DESCRIPTION
Steps to reproduce:
- Go to a To-do note
- Select a word
- Apply a gradient as the text color
- Re-open the color picker
- From the Solid tab, select the primary color (o-color-1)

Description of the issue:
- The gradient is not removed and ends up being displayed as a background color

Cause:
- In the `colorElement` method, the gradient is removed when applying a text color via inline styles. However, when applying a color via class (e.g., text-*), the gradient is not properly cleared. Only the text-gradient class is replaced, while the gradient style remains, causing it to appear as a background color.

Solution:
Ensure the gradient is removed in both cases:
- when applying a color via class and when applying a color via inline styles in `colorElement`.

task-6045533
