### PR TITLE
[IMP] web: optimize command palette for mobile devices

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -7,16 +7,10 @@ import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { scrollTo } from "@web/core/utils/scrolling";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { debounce } from "@web/core/utils/timing";
-import { isMacOS, isMobileOS } from "@web/core/browser/feature_detection";
+import { isMacOS, hasTouch } from "@web/core/browser/feature_detection";
 import { highlightText } from "@web/core/utils/html";
 
-import {
-    Component,
-    onWillStart,
-    onWillDestroy,
-    EventBus,
-    markRaw,
-} from "@odoo/owl";
+import { Component, onWillStart, onWillDestroy, EventBus, markRaw } from "@odoo/owl";
 
 const DEFAULT_PLACEHOLDER = _t("Search...");
 const DEFAULT_EMPTY_MESSAGE = _t("No result found");
@@ -380,7 +374,7 @@ export class CommandPalette extends Component {
     get isMacOS() {
         return isMacOS();
     }
-    get isMobileOS() {
-        return isMobileOS();
+    get hasTouch() {
+        return hasTouch();
     }
 }

--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -1,14 +1,17 @@
 .o_command_palette {
     $-app-icon-size: 1.8rem;
-    top: 120px;
-    position: absolute;
-
+    @include media-breakpoint-up(md) {
+        top: 120px;
+        position: absolute;
+    }
     > .modal-body {
         padding: 0;
     }
 
     &_listbox {
-        max-height: 50vh;
+        @include media-breakpoint-up(md) {
+            max-height: 50vh;
+        }
 
         .o_command {
             &.focused {

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
   <t t-name="web.CommandPalette">
-    <Dialog header="false" footer="false" size="'md'" withBodyPadding="false" contentClass="'o_command_palette'">
-      <div t-custom-ref="root">
-        <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom">
-          <span t-if="this.state.namespace !== 'default'" class="o_namespace d-flex align-items-center me-1 fs-4 text-muted opacity-75" t-out="this.state.namespace"/>
+    <Dialog header="false" size="this.env.isSmall ? 'lg' : 'md'" footer="false" withBodyPadding="false" contentClass="'o_command_palette'">
+      <div t-custom-ref="root" class="d-flex flex-column h-100">
+        <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom flex-shrink-0">
+          <span t-if="state.namespace !== 'default'" class="o_namespace d-flex align-items-center me-1 fs-4 text-muted opacity-75" t-out="state.namespace"/>
           <input class="form-control border-0 p-0" type="text" data-allow-hotkeys="true" t-att-value="this.state.searchValue" t-custom-ref="autofocus" t-att-placeholder="this.state.placeholder" t-on-input="this.onSearchInput" t-on-keydown="this.onKeyDown"
               role="combobox"
               t-attf-aria-activedescendant="o_command_{{this.state.commands.length ? this.state.commands.indexOf(this.state.selectedCommand) : 'empty'}}"
@@ -19,7 +19,7 @@
           </div>
         </div>
 
-        <div t-custom-ref="listbox" role="listbox" class="o_command_palette_listbox position-relative overflow-auto">
+        <div t-custom-ref="listbox" role="listbox" class="o_command_palette_listbox position-relative overflow-auto flex-grow-1">
           <div t-if="!this.state.commands.length" id="o_command_empty" role="option" aria-selected="true" class="o_command_palette_listbox_empty px-4 py-3 fst-italic" t-out="this.state.emptyMessage"/>
           <t t-if="!this.isFuzzySearch" t-foreach="this.commandsByCategory" t-as="category" t-key="category.keyId">
             <div class="o_command_category px-0">
@@ -29,7 +29,7 @@
                 <div t-attf-id="o_command_{{commandIndex}}" class="o_command"
                   role="option"
                   t-att-aria-selected="this.state.selectedCommand === command ? 'true' : 'false'"
-                  t-att-class="{ focused: this.state.selectedCommand === command }"
+                  t-att-class="{ focused: !this.hasTouch and this.state.selectedCommand === command }"
                   t-on-click="(event) => this.onCommandClicked(event, commandIndex)"
                   t-on-mouseenter="() => this.onCommandMouseEnter(commandIndex)"
                   t-on-close="() => this.props.closeMe()">
@@ -39,7 +39,7 @@
                         <span class="o_command_name text-ellipsis" t-att-title="command.name" t-out="command.text"/>
                       </t>
                       <t t-set-slot="focusMessage">
-                          <small t-if="!this.isMobileOS and command.href and this.state.selectedCommand === command" class="o_command_focus text-muted"><kbd><t t-if="this.isMacOS">CMD</t><t t-else="">CTRL</t></kbd>+<kbd>⏎</kbd><span class="ms-1">new tab</span></small>
+                          <small t-if="!this.hasTouch and command.href and this.state.selectedCommand === command" class="o_command_focus text-muted"><kbd><t t-if="this.isMacOS">CMD</t><t t-else="">CTRL</t></kbd>+<kbd>⏎</kbd><span class="ms-1">new tab</span></small>
                       </t>
                     </t>
                   </a>
@@ -51,7 +51,7 @@
           </t>
         </div>
 
-        <div t-if="this.state.FooterComponent" class="o_command_palette_footer mt-2 px-4 py-2 border-top rounded-bottom bg-100 text-muted">
+        <div t-if="this.state.FooterComponent" class="o_command_palette_footer mt-2 px-4 py-2 border-top rounded-bottom bg-100 text-muted flex-shrink-0">
           <t t-component="this.state.FooterComponent" switchNamespace="(namespace) => this.debounceSearch(namespace.concat(this.state.searchValue))"/>
         </div>
       </div>

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -1,7 +1,7 @@
 import { useChildSubEnv, useExternalListener, useState } from "@web/owl2/utils";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { useActiveElement } from "../ui/ui_service";
-import { useForwardRefToParent } from "@web/core/utils/hooks";
+import { useBackButton, useForwardRefToParent } from "@web/core/utils/hooks";
 import { Component, onWillDestroy } from "@odoo/owl";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { makeDraggableHook } from "../utils/draggable_hook_builder_owl";
@@ -117,6 +117,7 @@ export class Dialog extends Component {
             }
         });
         this.bodyTabIndex = hasTouch() ? "0" : undefined;
+        useBackButton(() => this.dismiss());
     }
 
     get size() {

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -14,6 +14,7 @@ import {
 } from "@odoo/hoot-dom";
 import {
     contains,
+    getMockEnv,
     getService,
     mountWithCleanup,
     patchWithCleanup,
@@ -239,6 +240,7 @@ test("custom placeholder", async () => {
     expect(".o_command_palette_search input").toHaveAttribute("placeholder", "@ placeholder");
 });
 
+test.tags("desktop");
 test("add a footer", async () => {
     await mountWithCleanup(MainComponentsContainer);
     const config = {
@@ -567,12 +569,20 @@ test("command palette keeps the same top position when its content changes", asy
     await animationFrame();
     expect(".o_command_palette").toHaveCount(1);
     expect(".o_command").toHaveCount(4);
-    expect(".o_command_palette").toHaveRect({ top: 120 });
+    if (getMockEnv().isSmall) {
+        expect(".o_command_palette").toHaveRect({ top: 0 });
+    } else {
+        expect(".o_command_palette").toHaveRect({ top: 120 });
+    }
     await click(".o_command_palette_search input");
     await edit("z");
     await runAllTimers();
     expect(".o_command").toHaveCount(0);
-    expect(".o_command_palette").toHaveRect({ top: 120 });
+    if (getMockEnv().isSmall) {
+        expect(".o_command_palette").toHaveRect({ top: 0 });
+    } else {
+        expect(".o_command_palette").toHaveRect({ top: 120 });
+    }
 });
 
 test("open the command palette with a namespace already in the searchbar", async () => {
@@ -886,8 +896,8 @@ test("click on command", async () => {
     expect(".o_command_palette").toHaveCount(1);
     expect(".o_command").toHaveCount(2);
     expect(queryAllTexts(".o_command")).toEqual(["Command1", "Command2"]);
-    expect(".o_command.focused").toHaveText(commands[0].name);
-    await contains(".o_command.focused").click();
+    expect(".o_command:first").toHaveText(commands[0].name);
+    await contains(".o_command:first").click();
     expect.verifySteps(["C1"]);
 });
 
@@ -922,7 +932,7 @@ test("press enter on command", async () => {
     expect(".o_command_palette").toHaveCount(1);
     expect(".o_command").toHaveCount(2);
     expect(queryAllTexts(".o_command")).toEqual(["Command1", "Command2"]);
-    expect(".o_command.focused").toHaveText(commands[0].name);
+    expect(".o_command:first").toHaveText(commands[0].name);
     await press("arrowdown");
     await animationFrame();
     await press("enter");
@@ -931,6 +941,7 @@ test("press enter on command", async () => {
     expect.verifySteps(["C2"]);
 });
 
+test.tags("desktop");
 test("keyboard navigation scroll", async () => {
     await mountWithCleanup(MainComponentsContainer);
     const commands = [
@@ -1119,7 +1130,7 @@ test("multi level command", async () => {
     await runAllTimers();
     expect(".o_command").toHaveCount(1);
     expect(queryAllTexts(".o_command")).toEqual(["Command1"]);
-    expect(".o_command.focused").toHaveText(commands[0].name);
+    expect(".o_command:first").toHaveText(commands[0].name);
     await press("enter");
     await animationFrame();
     expect(".o_command").toHaveCount(1);
@@ -1152,6 +1163,7 @@ test("command palette dialog can be rendered and closed on outside click", async
     expect(".o_command_palette").toHaveCount(0);
 });
 
+test.tags("desktop");
 test("navigate in the command palette with the arrows", async () => {
     expect.assertions(6);
 

--- a/addons/web/static/tests/core/dialog.test.js
+++ b/addons/web/static/tests/core/dialog.test.js
@@ -1,4 +1,4 @@
-import { destroy, expect, mockTouch, test } from "@odoo/hoot";
+import { destroy, expect, mockTouch, mockUserAgent, test } from "@odoo/hoot";
 import { keyDown, keyUp, press, queryAllTexts, queryOne, resize } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Component, onMounted, useState, xml } from "@odoo/owl";
@@ -434,4 +434,27 @@ test("dialog's position is reset on resize", async () => {
         left: "0px",
         top: "0px",
     });
+});
+
+test.tags("mobile");
+test("back button closes dialog in mobile", async () => {
+    mockUserAgent("android");
+    class Parent extends Component {
+        static components = { Dialog };
+        static template = xml`
+            <Dialog title="'Wow(l) Effect'">
+                Hello!
+            </Dialog>
+        `;
+        static props = ["*"];
+    }
+    await makeDialogMockEnv({
+        dialogData: {
+            dismiss: () => expect.step("dismiss"),
+        },
+    });
+    await mountWithCleanup(Parent);
+    expect(".o_dialog").toHaveCount(1);
+    history.back();
+    expect.verifySteps(["dismiss"]);
 });


### PR DESCRIPTION
Building upon https://github.com/odoo/odoo/pull/229643, first commit improves the mobile user experience by intercepting the device's back button.

Instead of triggering a browser-level back navigation, pressing the back button will now cleanly close the currently active dialog. This is especially useful for the command palette after second commit. 

Second commit introduces several styling adjustments to ensure the command palette provides a native-feeling experience on mobile devices:

* **Full-Screen Modal:** On small screens, the palette now expands to take up the entire viewport.
* **Flexbox Layout:** The internal structure has been adapted using flexbox to ensure the full-screen display renders correctly.
* **Touch-Friendly UI:** Keyboard-specific information (like shortcuts) has been removed on touch devices.

task-5966849