### PR TITLE
[FIX] pos_self_order: distribute parent price to extra combo lines

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -329,9 +329,27 @@ class PosOrder(models.Model):
             total_price = price_unit + price_extra + child.combo_item_id.extra_price
             child.price_unit = total_price
 
-        for child in child_line_extra:
+        extra_original_total = 0
+        if remaining_total and child_line_extra:
+            extra_original_total = sum(
+                line.combo_item_id.combo_id.base_price * line.qty
+                for line in child_line_extra
+            ) or 1
+
+        for index, child in enumerate(child_line_extra):
             combo_item = child.combo_item_id
             price_unit = currency.round(combo_item.combo_id.base_price)
+
+            if extra_original_total:
+                remaining_proportion = currency.round(
+                    combo_item.combo_id.base_price * parent_lst_price / extra_original_total
+                )
+                price_unit += remaining_proportion
+                remaining_total -= remaining_proportion * child.qty
+
+                if index == len(child_line_extra) - 1:
+                    price_unit += remaining_total / child.qty
+
             selected_attributes = child.attribute_value_ids
             price_extra = sum(attr.price_extra for attr in selected_attributes)
             total_price = price_unit + price_extra + child.combo_item_id.extra_price

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -68,6 +68,82 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
 
         self.start_tour(self_route, "self_combo_selector_category")
 
+    def test_combo_price_no_free_items(self):
+        """
+        Regression test: when all combo sub-combos have qty_free=0, remaining_total
+        (= parent list price) must be distributed proportionally to the extra lines,
+        not silently dropped.
+        """
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        # Sub-combo with qty_free=0 (no free items) and qty_max=1
+        no_free_combo = self.env['product.combo'].create({
+            'name': 'No Free Combo',
+            'qty_free': 0,
+            'qty_max': 1,
+            'combo_item_ids': [
+                Command.create({'product_id': self.cola.id, 'extra_price': 0}),
+                Command.create({'product_id': self.fanta.id, 'extra_price': 0}),
+            ],
+        })
+        combo_product = self.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'name': 'No Free Combo Product',
+            'type': 'combo',
+            'combo_ids': [Command.set([no_free_combo.id])],
+            'taxes_id': False,
+        })
+
+        cola_item = no_free_combo.combo_item_ids.filtered(
+            lambda i: i.product_id == self.cola
+        )
+
+        order = self.env['pos.order'].create({
+            'amount_total': 0,
+            'amount_paid': 0,
+            'amount_tax': 0,
+            'amount_return': 0,
+            'company_id': self.env.company.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [
+                Command.create({
+                    'product_id': combo_product.id,
+                    'qty': 1,
+                    'price_unit': combo_product.lst_price,
+                    'price_subtotal': combo_product.lst_price,
+                    'price_subtotal_incl': combo_product.lst_price,
+                    'tax_ids': False,
+                }),
+            ],
+        })
+
+        parent_line = order.lines
+        child_line = self.env['pos.order.line'].create({
+            'order_id': order.id,
+            'product_id': self.cola.id,
+            'qty': 1,
+            'price_unit': 0,
+            'price_subtotal': 0,
+            'price_subtotal_incl': 0,
+            'tax_ids': False,
+            'combo_parent_id': parent_line.id,
+            'combo_item_id': cola_item.id,
+        })
+
+        order.recompute_prices()
+
+        # base_price of the combo = min lst_price among items = min(cola.lst_price, fanta.lst_price) = 2.2
+        # With qty_free=0, remaining_total = parent lst_price = 10.0 must flow into the child
+        # price_unit should be: base_price + proportional_share_of_parent_price
+        # = base_price + round(base_price * 10 / (base_price * 1)) = base_price + 10.0
+        expected_price = no_free_combo.base_price + combo_product.lst_price
+        self.assertAlmostEqual(
+            child_line.price_unit, expected_price, places=2,
+            msg="When qty_free=0, remaining_total must be proportionally distributed to extra lines",
+        )
+
     def test_product_dont_display_all_variants(self):
         """
         Tests that when a variant is in a combo, clicking the variant


### PR DESCRIPTION
When all sub-combos have qty_free=0, no child lines were classified as free, leaving remaining_total (= parent list price) undistributed. Extra lines were priced at base_price only, silently dropping the parent combo price.

Fix by mirroring the JS computeComboItems logic: before processing extra lines, compute their proportional denominator and allocate remaining_total to each extra line as a share of parent_lst_price, with a per-unit rounding correction on the last line.

opw-6045562

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
