### PR TITLE
[FIX] hr_work_entry: Make work entry type required in public holidays

### DIFF
--- a/addons/hr_work_entry/views/resource_calendar_views.xml
+++ b/addons/hr_work_entry/views/resource_calendar_views.xml
@@ -50,7 +50,7 @@
         <field name="inherit_id" ref="resource.resource_calendar_leave_tree"/>
         <field name="arch" type="xml">
             <field name="date_to" position="after">
-                <field name="work_entry_type_id"/>
+                <field name="work_entry_type_id" required="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
All worked days lines in payslips should be linked to a work entry type. If we create a public holiday without linking it to a work entry type, it won't be possible to generate a payslip. Making the field required fixed the issue.

task-6044274

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
