### PR TITLE
[FIX] stock: test_context_from_warehouse_filter tour

### DIFF
--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -24,7 +24,6 @@ registry.category("web_tour.tours").add("test_stock_route_diagram_report", {
 });
 
 registry.category("web_tour.tours").add("test_context_from_warehouse_filter", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         // Add "foo" to the warehouse context key
         {
@@ -39,10 +38,16 @@ registry.category("web_tour.tours").add("test_context_from_warehouse_filter", {
             trigger: ".o-dropdown-item:contains(Warehouse):contains(foo)",
             run: "click",
         },
+        {
+            trigger: "body:not(:has(.o_popover))",
+        },
         // Add warehouse A's id to the warehouse context key
         {
             trigger: ".o_searchview_input",
             run: "click",
+        },
+        {
+            trigger: "body:has(.o_popover)",
         },
         {
             trigger: ".o_searchview_input",


### PR DESCRIPTION
Remove 'undeterministicTour_doNotCopy' and fix timing issues in the 'test_context_from_warehouse_filter' tour. Added triggers to wait for the search popover to close before clicking the search bar again, and to wait for it to open before typing.