### PR TITLE
[IMP] account_peppol: only enable Peppol sending if company is registered

### DIFF
--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -18,7 +18,8 @@ class AccountMoveSend(models.AbstractModel):
     def _get_default_sending_method(self, move) -> str:
         # EXTENDS 'account'
         preferred_method = move.commercial_partner_id.with_company(move.company_id).invoice_sending_method
-        if not preferred_method and self._is_applicable_to_move('peppol', move):
+        company_registered_on_peppol = move.company_id.account_peppol_proxy_state not in ('not_registered', 'in_verification')
+        if company_registered_on_peppol and not preferred_method and self._is_applicable_to_move('peppol', move):
             return 'peppol'
         return super()._get_default_sending_method(move)
 


### PR DESCRIPTION
Previously, the send wizard would automatically enable the send "by Peppol" option whenever Peppol was available for the company's country.

This behavior was misleading, as it didn't check whether the company was actually registered on Peppol.

This commit ensures the option is only enabled for companies that are registered on Peppol.

task-6044073

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
