### PR TITLE
[FIX] website: activate the default alignment view on the header change

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
@@ -1,28 +1,17 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { onWillStart } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+
 export class HeaderNavigationOption extends BaseOptionComponent {
     static id = "header_navigation_option";
     static template = "website.HeaderNavigationOption";
-    static dependencies = ["customizeWebsite"];
+    static dependencies = ["customizeWebsite", "headerOption"];
 
     setup() {
         super.setup();
 
-        this.keys = [
-            "website.template_header_default",
-            "website.template_header_hamburger",
-            "website.template_header_boxed",
-            "website.template_header_stretch",
-            "website.template_header_vertical",
-            "website.template_header_search",
-            "website.template_header_sales_one",
-            "website.template_header_sales_two",
-            "website.template_header_sales_three",
-            "website.template_header_sales_four",
-            "website.template_header_sidebar",
-        ];
-
+        this.headerTemplates = this.dependencies.headerOption.getHeaderTemplates();
+        this.headerTemplateIds = this.headerTemplates.map((template) => template.props.views[0]);
         this.currentActiveViews = {};
         onWillStart(async () => {
             this.currentActiveViews = await this.getCurrentActiveViews();
@@ -38,14 +27,37 @@ export class HeaderNavigationOption extends BaseOptionComponent {
         return false;
     }
     async getCurrentActiveViews() {
-        const actionParams = { views: this.keys };
+        const actionParams = { views: this.headerTemplateIds };
         await this.dependencies.customizeWebsite.loadConfigKey(actionParams);
         const currentActiveViews = {};
-        for (const key of this.keys) {
+        for (const key of this.headerTemplateIds) {
             const isActive = this.dependencies.customizeWebsite.getConfigKey(key);
             currentActiveViews[key] = isActive;
         }
         return currentActiveViews;
+    }
+
+    getAlignmentViews(direction) {
+        if (!direction || direction === "left") {
+            return [];
+        }
+        const views = [];
+        // We find the active template, and make corresponding alignment views
+        const activeTemplate = this.headerTemplates.find(
+            (template) => this.currentActiveViews[template.props.views[0]]
+        );
+        if (activeTemplate) {
+            const templateId = activeTemplate.props.views[0];
+            const templateAlignment = activeTemplate.props.defaultAlignment;
+            // If not alignment is set, then the default alignment is "desktop left"
+            if (!templateAlignment || "desktop" in templateAlignment) {
+                views.push(templateId + `_align_${direction}`);
+            }
+            if (templateAlignment && "mobile" in templateAlignment) {
+                views.push(templateId + `_mobile_align_${direction}`);
+            }
+        }
+        return views;
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
@@ -6,37 +6,6 @@
         <span class="options-container-label ps-2 py-2">Navigation</span>
     </div>
 
-    <t t-set="align_left_views" t-value="[
-    ]"/>
-
-    <t t-set="align_center_views" t-value="[
-        'website.template_header_hamburger_mobile_align_center',
-        'website.template_header_default_align_center',
-        'website.template_header_boxed_align_center',
-        'website.template_header_stretch_align_center',
-        'website.template_header_search_align_center',
-        'website.template_header_sales_one_align_center',
-        'website.template_header_sales_two_align_center',
-        'website.template_header_sales_three_align_center',
-        'website.template_header_sales_four_align_center',
-        'website.template_header_sidebar_align_center',
-        'website.template_header_vertical_align_center',
-    ]"/>
-
-    <t t-set="align_right_views" t-value="[
-        'website.template_header_hamburger_mobile_align_right',
-        'website.template_header_default_align_right',
-        'website.template_header_boxed_align_right',
-        'website.template_header_stretch_align_right',
-        'website.template_header_search_align_right',
-        'website.template_header_sales_one_align_right',
-        'website.template_header_sales_two_align_right',
-        'website.template_header_sales_three_align_right',
-        'website.template_header_sales_four_align_right',
-        'website.template_header_sidebar_align_right',
-        'website.template_header_vertical_align_right',
-    ]"/>
-
     <BuilderRow label.translate="Desktop Menu" tooltip.translate="Change the burger button position/menu items alignment">
         <!-- Reason why we enable this option for those templates only:
             website.template_header_hamburger => Hamburger Icon Position
@@ -60,19 +29,19 @@
         </BuilderButtonGroup>
 
         <BuilderSelect action="'websiteConfig'">
-            <BuilderSelectItem ltrRtlMapping="'align'" actionParam="{ views: align_left_views }">
+            <BuilderSelectItem ltrRtlMapping="'align'" actionParam="{ views: this.getAlignmentViews('left') }">
                 <div title="Align Left">
                     <i class="fa fa-align-left fa-fw" role="img" aria-hidden="true"/>
                     <span class="visually-hidden">Align Left</span>
                 </div>
             </BuilderSelectItem>
-            <BuilderSelectItem actionParam="{ views: align_center_views }">
+            <BuilderSelectItem actionParam="{ views: this.getAlignmentViews('center') }">
                 <div title="Center">
                     <i class="fa fa-align-center fa-fw" role="img" aria-hidden="true"/>
                     <span class="visually-hidden">Center</span>
                 </div>
             </BuilderSelectItem>
-            <BuilderSelectItem ltrRtlMapping="'align'" actionParam="{ views: align_right_views }">
+            <BuilderSelectItem ltrRtlMapping="'align'" actionParam="{ views: this.getAlignmentViews('right') }">
                 <div title="Align Right">
                     <i class="fa fa-align-right fa-fw" role="img" aria-hidden="true"/>
                     <span class="visually-hidden">Align Right</span>

--- a/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
@@ -3,6 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { HeaderTemplateChoice } from "./header_template_option";
 import { HeaderTopOptions } from "./header_top_options";
+import { WebsiteConfigAction } from "../../customize_website_plugin";
 
 /** @typedef {import("@odoo/owl").Component} Component */
 
@@ -25,6 +26,7 @@ export class HeaderOptionPlugin extends Plugin {
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
+        builder_actions: { HeaderTemplateConfigAction },
         builder_header_middle_buttons: [
             {
                 Component: HeaderTopOptions,
@@ -48,14 +50,29 @@ export class HeaderOptionPlugin extends Plugin {
                         name: "hamburger",
                         title: _t("Hamburger Menu"),
                         extraViews: ["website.no_autohide_menu"],
+                        defaultAlignment: {
+                            mobile: "left",
+                        },
                     },
                     { name: "boxed", title: _t("Rounded Box Menu") },
                     { name: "stretch", title: _t("Stretch Menu") },
-                    { name: "vertical", title: _t("Vertical") },
+                    {
+                        name: "vertical",
+                        title: _t("Vertical"),
+                        defaultAlignment: {
+                            desktop: "center",
+                        },
+                    },
                     { name: "search", title: _t("Menu with Search Bar") },
                     { name: "sales_one", title: _t("Menu - Sales 1") },
                     { name: "sales_two", title: _t("Menu - Sales 2") },
-                    { name: "sales_three", title: _t("Menu - Sales 3") },
+                    {
+                        name: "sales_three",
+                        title: _t("Menu - Sales 3"),
+                        defaultAlignment: {
+                            desktop: "right",
+                        },
+                    },
                     { name: "sales_four", title: _t("Menu - Sales 4") },
                     {
                         name: "sidebar",
@@ -75,6 +92,7 @@ export class HeaderOptionPlugin extends Plugin {
                             title: info.title,
                             varName: info.name,
                             views: [view, ...(info.extraViews || [])],
+                            defaultAlignment: info.defaultAlignment,
                         },
                     };
                 }),
@@ -90,6 +108,43 @@ export class HeaderOptionPlugin extends Plugin {
     getHeaderTemplates() {
         return this.headerTemplates;
     }
+}
+
+export class HeaderTemplateConfigAction extends WebsiteConfigAction {
+    static id = "headerTemplateConfig";
+
+    async apply(applySpec) {
+        const template = applySpec.params.views[0];
+        const alignmentViews = getAlignmentViews(template, applySpec.params.defaultAlignment);
+        applySpec.params.views.push(...alignmentViews);
+        await super.apply(applySpec);
+        return;
+    }
+}
+
+/**
+ * Returns the alignment view keys to enable/disable for the given header
+ * template. "left" is the default so it has no dedicated view;
+ * only "center" and "right" are toggled. "!" prefix means disable.
+ *
+ * @param {string} template - Fully-qualified header template view key
+ * @param {object} [alignment]
+ * @returns {string[]} View keys to activate or deactivate
+ */
+function getAlignmentViews(template, alignment) {
+    const views = [];
+    // If not alignment is set, then the default alignment is "desktop left"
+    for (const direction of ["center", "right"]) {
+        if (!alignment || "desktop" in alignment) {
+            const view = template + `_align_${direction}`;
+            views.push(alignment?.desktop === direction ? view : "!" + view);
+        }
+        if (alignment && "mobile" in alignment) {
+            const view = template + `_mobile_align_${direction}`;
+            views.push(alignment.mobile === direction ? view : "!" + view);
+        }
+    }
+    return views;
 }
 
 registry.category("website-plugins").add(HeaderOptionPlugin.id, HeaderOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.js
@@ -27,5 +27,6 @@ export class HeaderTemplateChoice extends BaseOptionComponent {
         imgSrc: String,
         id: String,
         menuShadowClass: String,
+        defaultAlignment: { type: Object, optional: true },
     };
 }

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="website.HeaderTemplateOption">
         <BuilderRow label.translate="Template">
-            <BuilderSelect action="'reloadComposite'">
+            <BuilderSelect>
                 <t t-foreach="this.headerTemplates" t-as="template" t-key="template.key">
                     <t t-component="template.Component" t-props="template.props"/>
                 </t>
@@ -161,20 +161,17 @@
         <BuilderSelectItem
             id="this.props.id"
             title="this.props.title"
-            actionParam="[
-                {
-                    action: 'websiteConfig',
-                    actionParam: {
-                        views: this.props.views,
-                        vars: {
-                            'header-template': this.props.varName,
-                            'menu-shadow-class': this.props.menuShadowClass,
-                            'menu-box-shadow-style': null,
-                        },
-                        checkVars: false,
-                    },
-                }
-            ]">
+            action="'headerTemplateConfig'"
+            actionParam="{
+                views: this.props.views,
+                vars: {
+                    'header-template': this.props.varName,
+                    'menu-shadow-class': this.props.menuShadowClass,
+                    'menu-box-shadow-style': null,
+                },
+                checkVars: false,
+                defaultAlignment: this.props.defaultAlignment,
+            }">
             <Image attrs="{ style: 'width: calc(100% - 0.5rem);' }" src="this.props.imgSrc"/>
         </BuilderSelectItem>
     </t>


### PR DESCRIPTION
This commit fixes the wrong alignment of 'Vertical' and 'Menu - Sale 3'
header templates.

Steps to reproduce the issue:
- Go to the website and start editing
- Click on the header
- Change the header template to Vertical or Menu Sale 3
=> Menu is aligned on the left, instead of being centered (or being
on the right, if you chose Menu Sale 3).

When we change a desktop menu alignment, it activates corresponding
views for every header, so if we change it to "Right" and then change
the template, the alignment will be "Right". However, headers should
have a default alignment, which should be activated once we switch to
that template.

This commit introduces a new builder action for changing headers, which
activates the necessary alignment view, and deactivates the others.

task-5900220