### PR TITLE
[FIX] portal_rating : fix rating stars positionning

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/composer_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/composer_patch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.Composer" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o-mail-Composer-coreMain')]" position="before">
+        <xpath expr="//div[hasclass('o-mail-Composer-coreHeader')]" position="inside">
             <div t-if="env.displayRating and !message" class="o-mail-Composer-starCard d-flex">
                 <div class="o-mail-Composer-stars enabled" t-on-mouseleave="onMouseLeaveStar">
                     <t t-set="index" t-value="0" />


### PR DESCRIPTION
# How to reproduce
- Go to the eCommerce page of any product
- In Edit mode, in the Customize tab, enable reviews
- Scroll down and click on the "+" button next to reviews

# The problem
The star rating element is squished / hidden behind other elements of the review

# Why
The star rating element is added to the mail composer element as follows :

```xml
<t t-inherit="mail.Composer" t-inherit-mode="extension">
        <xpath expr="//div[hasclass('o-mail-Composer-coreMain')]" position="before">
            <div t-if="env.displayRating and !message" class="o-mail-Composer-starCard d-flex">
```

The composer element has the display: grid attribute with different grid-areas defined :

```scss
.o-mail-Composer {
    grid-template-areas:
        "sidebar-header core-header"
        "sidebar-main core-main"
        "sidebar-footer core-footer";
    grid-template-columns: auto 1fr;
    grid-template-rows: auto 1fr auto;
```

But, o-mail-Composer-starCard does not define any grid-area, so the star rating element fills the grid in the first space available that is not already taken. That space used to be core-header, which worked totally fine, but this commit (https://github.com/odoo/odoo/commit/451c2c9) made it so the composer element always has a div in the core-header area. This made it so there was no available space for the star rating element (since core-header was taken) and so it defaulted to a position in the center of the composer.

Since there is now always a div element in the core-header area, this fix change the xpath of the star-rating so that it is put inside of that div.

opw-6046551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
