### PR TITLE
[FIX] survey: restore `o_form_sheet` layout

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -50,7 +50,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="background_image" widget="image" class="oe_avatar" filename="background_image_filename"/>
                     <field name="allowed_survey_types" invisible="True"/>
-                     <field name="survey_type" widget="badges_selection" nolabel="1"
+                    <field name="survey_type" widget="badges_selection" nolabel="1" class="w-auto mb-3"
                         options="{
                             'allowed_selection_field': 'allowed_survey_types',
                             'icon_mapping': {


### PR DESCRIPTION
This commit fixes the layout of Survey's `o_form_sheet`, to show the survey type selector and the title on the same level as the image.

task-6049001

| Before | After |
|--------|--------|
|  <img width="1146" height="357" alt="Screenshot 2026-03-18 at 16 50 57" src="https://github.com/user-attachments/assets/75c39555-12a3-4922-b292-93f30e7efa60" /> | <img width="1141" height="302" alt="Screenshot 2026-03-18 at 16 55 13" src="https://github.com/user-attachments/assets/b13480f9-72c2-412c-a3a5-8f753cbe1ab6" /> | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
