### PR TITLE
[IMP] account_edi_ubl_cii: inverse addresses on generated PDF for received XML invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -3158,7 +3158,10 @@ class AccountEdiUBL(models.AbstractModel):
             return additional_docs
         try:
             invoices_by_odoo_xmlid = 'account_edi_ubl_cii.action_report_account_invoices_generated_by_odoo'
-            report_xmlid = invoices_by_odoo_xmlid if self.env.ref(invoices_by_odoo_xmlid, raise_if_not_found=False) else 'account.account_invoices'
+            if not self.env.ref(invoices_by_odoo_xmlid, raise_if_not_found=False):
+                _logger.warning("Missing template while generating substitute PDF attachment for invoice %s", invoice.id)
+                return additional_docs
+            report_xmlid = invoices_by_odoo_xmlid
 
             pdf_raw, pdf_extension = self.env['ir.actions.report'] \
                         ._render_qweb_pdf(report_xmlid, res_ids=[invoice.id])

--- a/addons/account_edi_ubl_cii/report/account_edi_ubl_cii_report_templates.xml
+++ b/addons/account_edi_ubl_cii/report/account_edi_ubl_cii_report_templates.xml
@@ -11,17 +11,45 @@
 
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//t[@t-call='web.external_layout']" position="attributes">
-            <attribute name="t-call">account_edi_ubl_cii.external_layout_with_context</attribute>
+            <attribute name="t-call">web.internal_layout</attribute>
+        </xpath>
+
+        <xpath expr="//div[hasclass('row')]" position="replace">
+            <t t-set="partner_issuer" t-value="o.partner_id"/>
+            <t t-set="partner_receiver" t-value="o.company_id.partner_id"/>
+            <!-- Partner Information (Issuer) -->
+            <div class="row">
+                <div class="col-6" name="issuer_address">
+                    <span class="text-muted">FROM</span>
+                    <address t-field="partner_issuer.self" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                    <div t-if="partner_issuer.vat" id="issuer_partner_vat_address">
+                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                        <t t-else="">Tax ID</t>: <span t-field="partner_issuer.vat"/>
+                    </div>
+                </div>
+            </div>
+            <!-- Company Information (Receiver) -->
+            <div class="row">
+                <div class="col-6"/>
+                <div class="offset-col-6 col-6" name="receiver_address">
+                    <span class="text-muted">TO</span>
+                    <address class="mb-0" t-field="partner_receiver.self" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                    <div t-if="partner_receiver.vat" id="company_vat_address">
+                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                        <t t-else="">Tax ID</t>: <span t-field="partner_receiver.vat"/>
+                    </div>
+                </div>
+            </div>
+            <h2>
+                <t t-if="o.ref" t-out="o.ref"/>
+                <t t-else="">Vendor Bill</t>
+            </h2>
+            <hr/>
         </xpath>
     </template>
 
-    <template id="external_layout_with_context" inherit_id="web.external_layout" primary="True">
-        <xpath expr="//t[@t-if='company.external_report_layout_id']" position="replace">
-            <t t-set="chosen_layout" t-value="env.context.get('force_report_layout')"/>
-            <t t-if="chosen_layout" t-call="{{ chosen_layout }}">
-                <t t-out="0"/>
-            </t>
-        </xpath>
+    <template id="external_layout_with_context" inherit_id="web.internal_layout" primary="True">
+    <!-- # TODO REMOVE IN MASTER -->
     </template>
 
     <record id="action_report_account_invoices_generated_by_odoo" model="ir.actions.report">


### PR DESCRIPTION

When an invoice is received through Peppol, it may not contain an embed PDF.
If no, we create one. However, due to several complaints, this commit
exchange the place of the issuer and receiver addresses and information.

Company information were rendered in the header of the document through
the external_layout. Switching to the internal layer avoid doing so.

opw-5980655

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
