### PR TITLE
[IMP] website: enable to translate static page url

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -152,17 +152,18 @@ class IrHttp(models.AbstractModel):
         except (NotFound, AccessError, MissingError):
             # The build method returns a quoted URL so convert in this case for consistency.
             path = werkzeug.urls.url_quote_plus(url, safe='/')
+        path_without_url_code = path
         if force_default_lang or lang != request.env['ir.http']._get_default_lang():
             path = f'/{lang.url_code}{path if path != "/" else ""}'
 
         if canonical_domain:
             # canonical URLs should not have qs
-            return tools.urls.urljoin(canonical_domain, path)
+            return {'location': tools.urls.urljoin(canonical_domain, path), 'loc_without_lang': path_without_url_code, 'lang': lang}
 
-        return path + sep + qs
+        return {'location': path + sep + qs, 'loc_without_lang': path_without_url_code, 'lang': lang}
 
     @classmethod
-    def _url_lang(cls, path_or_uri: str, lang_code: str | None = None) -> str:
+    def _url_lang(cls, path_or_uri: str, lang_code: str | None = None) -> dict:
         ''' Given a relative URL, make it absolute and add the required lang or
             remove useless lang.
             Nothing will be done for absolute or invalid URL.
@@ -181,6 +182,7 @@ class IrHttp(models.AbstractModel):
             # e.g. Invalid IPv6 URL, `urllib.parse.urlparse('http://]')`
             url = False
         # relative URL with either a path or a force_lang
+        loc_without_lang = ''
         if url and not url.netloc and not url.scheme and (url.path or force_lang):
             location = werkzeug.urls.url_join(request.httprequest.path, location)
             lang_url_codes = [info.url_code for info in Lang._get_frontend().values()]
@@ -192,21 +194,27 @@ class IrHttp(models.AbstractModel):
                 ps = loc.split('/')
                 default_lg = request.env['ir.http']._get_default_lang()
                 if ps[1] in lang_url_codes:
+                    ps_without_url_code = [''] if len(ps) <= 2 else ps[2:]
+                    loc_without_lang = '/'.join(ps_without_url_code)
                     # Replace the language only if we explicitly provide a language to url_for
                     if force_lang:
                         ps[1] = lang_url_code
                     # Remove the default language unless it's explicitly provided
                     elif ps[1] == default_lg.url_code:
                         ps.pop(1)
+                        lang_code = default_lg.code
                 # Insert the context language or the provided language
                 elif lang_url_code != default_lg.url_code or force_lang:
+                    loc_without_lang = '/'.join(ps)
                     ps.insert(1, lang_url_code)
                     # Remove the last empty string to avoid trailing / after joining
                     if not ps[-1]:
                         ps.pop(-1)
+                else:
+                    loc_without_lang = '/'.join(ps)
 
                 location = '/'.join(ps) + sep + qs
-        return location
+        return {'location': location, 'loc_without_lang': loc_without_lang, 'lang_code': lang_code}
 
     @classmethod
     def _url_for(cls, url_from: str, lang_code: str | None = None) -> str:
@@ -217,7 +225,7 @@ class IrHttp(models.AbstractModel):
             :param lang_code: Must be the lang `code`. It could also be something
                               else, such as `'[lang]'` (used for url_return).
         '''
-        return cls._url_lang(url_from, lang_code=lang_code)
+        return cls._url_lang(url_from, lang_code=lang_code)['location']
 
     @classmethod
     def _is_multilang_url(cls, local_url: str, lang_url_codes: list[str] | None = None) -> bool:

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -79,7 +79,7 @@
             </button>
             <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
                 <t t-foreach="frontend_languages.values()" t-as="lg">
-                    <a class="dropdown-item" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, force_default_lang=True)"
+                    <a class="dropdown-item" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, force_default_lang=True)['location']"
                     t-attf-class="dropdown-item js_change_lang #{active_lang == lg and 'active'}"
                     t-att-data-url_code="lg.url_code" t-att-title="lg.name.split('/').pop()"
                     role="menuitem">

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -582,7 +582,6 @@
         </record>
         <record id="menu_home" model="website.menu">
             <field name="name">Home</field>
-            <field name="url">/</field>
             <field name="page_id" ref="website.homepage_page"/>
             <field name="parent_id" ref="website.main_menu"/>
             <field name="sequence" type="int">10</field>

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -79,6 +79,51 @@ class IrHttp(models.AbstractModel):
         return adapter.build(endpoint, kw) + (qs and '?%s' % qs or '')
 
     @classmethod
+    def _translate_url_page(cls, url: str, loc_without_lang: str, lang_code: str) -> str:
+        """ Returns the given URL adapted for the given lang, meaning that the
+        page part of it will be translated.
+
+        :param url: The url that has to be adapted.
+        :param loc_without_lang: The lang code that is potentially in the url.
+        :param lang_code: The lang in which the url has to be found.
+        """
+        if hasattr(request, 'website'):
+            search_page = request.env['website.page']._get_page_from_url(loc_without_lang, request.website.id, False)
+            if search_page:
+                # Replace the url of the page by the translated url
+                url_page_translated = search_page.with_context(lang=lang_code).sudo().url
+                url = url.replace(loc_without_lang, url_page_translated)
+        return url
+
+    @classmethod
+    def _url_lang(cls, path_or_uri: str, lang_code: str | None = None) -> dict:
+        ''' Given a relative URL, make it absolute, add the required lang or
+            remove useless lang and translate the page part of the url if any.
+            Nothing will be done for absolute or invalid URL.
+            If there is only one language installed, the lang will not be
+            handled unless forced with `lang` parameter.
+
+            :param lang_code: Must be the lang `code`. It could also be
+            something else, such as `'[lang]'` (used for url_return).
+        '''
+        url_lang = super()._url_lang(path_or_uri, lang_code)
+        location, loc_without_lang, lang_code = url_lang['location'], url_lang['loc_without_lang'], url_lang['lang_code']
+        if loc_without_lang:
+            location = cls._translate_url_page(location, loc_without_lang, lang_code)
+        return {'location': location, 'loc_without_lang': loc_without_lang, 'lang_code': lang_code}
+
+    @classmethod
+    def _url_localized(cls,
+                       url: str | None = None,
+                       lang_code: str | None = None,
+                       canonical_domain: str | tuple[str, str, str, str, str] | None = None,
+                       prefetch_langs: bool = False, force_default_lang: bool = False) -> str:
+        url_localized = super()._url_localized(url, lang_code, canonical_domain, prefetch_langs, force_default_lang)
+        location, loc_without_lang, lang = url_localized['location'], url_localized['loc_without_lang'], url_localized['lang']
+        location = cls._translate_url_page(location, loc_without_lang, lang.code)
+        return {'location': location, 'loc_without_lang': loc_without_lang, 'lang': lang}
+
+    @classmethod
     def _url_for(cls, url_from: str, lang_code: str | None = None) -> str:
         ''' Return the url with the rewriting applied.
             Nothing will be done for absolute URL, invalid URL, or short URL from 1 char.

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -549,28 +549,42 @@ class IrModuleModule(models.Model):
         if not default_menu:
             return res
 
-        lang_value_list = [SQL("%(lang)s, o_menu.name->>%(lang)s", lang=lang) for lang in langs if lang != 'en_US']
-        update_jsonb_list = [SQL('jsonb_build_object(%s)', SQL(', ').join(items)) for items in split_every(50, lang_value_list)]
-        update_jsonb = SQL(' || ').join(update_jsonb_list)
-        o_menu_name = SQL('menu.name || %s' if overwrite else '%s || menu.name', update_jsonb)
-        self.env.cr.execute(SQL(
-            """
-            UPDATE website_menu menu
-               SET name = %(o_menu_name)s
-              FROM website_menu o_menu
-             INNER JOIN website_menu s_menu
-                ON o_menu.name->>'en_US' = s_menu.name->>'en_US' AND o_menu.url = s_menu.url
-             INNER JOIN website_menu root_menu
-                ON s_menu.parent_id = root_menu.id AND root_menu.parent_id IS NULL
-             WHERE o_menu.website_id IS NULL AND o_menu.parent_id = %(default_menu_id)s
-               AND s_menu.website_id IS NOT NULL
-               AND menu.id = s_menu.id
-            """,
-            o_menu_name=o_menu_name,
-            default_menu_id=default_menu.id
-        ))
+        default_menus = self.env['website.menu'].search([
+            ('website_id', '=', False),
+            ('parent_id', '=', default_menu.id)
+        ])
 
-        return res
+        site_menus = self.env['website.menu'].search([
+            ('website_id', '!=', False),
+            ('parent_id', '!=', False),
+            ('parent_id.parent_id', '=', None)
+        ])
+        for o_menu in default_menus:
+            for menu in site_menus:
+                if menu.url == o_menu.url and o_menu.with_context(lang='en_US').name == menu.with_context(lang='en_US').name:
+
+                    lang_value_list = [
+                        SQL("%(lang)s, %(value)s", lang=lang, value=o_menu.with_context(lang=lang).name)
+                        for lang in langs if lang != 'en_US'
+                    ]
+
+                    update_jsonb_list = [
+                        SQL('jsonb_build_object(%s)', SQL(', ').join(items))
+                        for items in split_every(50, lang_value_list)
+                    ]
+                    update_jsonb = SQL(' || ').join(update_jsonb_list)
+
+                    o_menu_name = SQL('menu.name || %s' if overwrite else '%s || menu.name', update_jsonb)
+
+                    self.env.cr.execute(SQL(
+                        """
+                        UPDATE website_menu menu
+                        SET name = %(o_menu_name)s
+                        WHERE id = %(menu_id)s
+                        """,
+                        o_menu_name=o_menu_name,
+                        menu_id=menu.id
+                    ))
 
     # ----------------------------------------------------------------
     # New page templates

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -127,6 +127,7 @@ class IrQweb(models.AbstractModel):
 
         atts = super()._post_processing_att(tagName, atts)
 
+
         website = ir_http.get_request_website()
         if not website and self.env.context.get('website_id'):
             website = self.env['website'].browse(self.env.context['website_id'])

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1895,7 +1895,7 @@ class Website(models.CachedModel):
             url = '/'
         return self.env['ir.http']._url_localized(
             url=url, lang_code=request.lang.code, canonical_domain=self.get_base_url()
-        )
+        )['location']
 
     def _is_canonical_url(self):
         """Returns whether the current request URL is canonical."""

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1270,7 +1270,6 @@ class Website(models.CachedModel):
             if not menu:
                 default_menu_values = {
                     'name': name,
-                    'url': page_url,
                     'parent_id': website.menu_id.id,
                     'page_id': page.id,
                     'website_id': website.id,

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -6,7 +6,7 @@ import werkzeug.urls
 from werkzeug.urls import url_parse
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools.translate import html_translate
@@ -39,7 +39,8 @@ class WebsiteMenu(models.Model):
                 menu.mega_menu_classes = False
 
     name = fields.Char('Menu', required=True, translate=True)
-    url = fields.Char("Url", compute="_compute_url", store=True, required=True, readonly=False, default="#", copy=True)
+    url = fields.Char("Url", compute="_compute_url", inverse="_inverse_url", search="_search_url")
+    url_defined_by_user = fields.Char('Url defined by user')
     page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade', index='btree_not_null')
     controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')
@@ -68,13 +69,64 @@ class WebsiteMenu(models.Model):
                 menu_name += f' [{menu.website_id.name}]'
             menu.display_name = menu_name
 
-    @api.depends("page_id", "is_mega_menu", "child_id")
+    @api.depends("page_id", "page_id.url", "is_mega_menu", "child_id", "url_defined_by_user")
     def _compute_url(self):
         for menu in self:
             if menu.is_mega_menu or menu.child_id:
                 menu.url = "#"
             else:
-                menu.url = (menu.page_id.url if menu.page_id else menu.url) or "#"
+                menu.url = (menu.page_id.sudo().url if menu.page_id else menu.url_defined_by_user) or "#"
+
+    def _inverse_url(self):
+        for menu in self:
+            # search for a page that has the url and adapt url_defined_by_user
+            # and page_id correctly.
+            # Check if the url matches a website.page (to set the m2o relation),
+            # except if the menu url contains '#', we then unset the page_id
+            if '#' in menu.url:
+                # Multiple case possible
+                # 1. `#` => menu container (dropdown, ..)
+                # 2. `#top` or `#bottom` => special anchors valid for any page
+                # 3. `#anchor` => anchor on current page
+                # 4. `/url#something` => valid internal URL
+                # 5. https://google.com#smth => valid external URL
+                if menu.page_id:
+                    menu.page_id = None
+                if request and menu.url.startswith('#') and len(menu.url) > 1 and \
+                        menu.url not in ['#top', '#bottom']:
+                    # Working on case 2.: prefix anchor with referer URL
+                    referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
+                    menu.url = referer_url + menu.url
+                menu.url_defined_by_user = menu.url
+            else:
+                domain = menu.website_id.website_domain() & (
+                    Domain("url", "=", menu["url"])
+                    | Domain("url", "=", "/" + menu["url"])
+                )
+                page = self.env["website.page"].search(domain, limit=1)
+                if page:
+                    menu.page_id = page.id
+                    menu.url_defined_by_user = ''
+                else:
+                    if menu.page_id:
+                        try:
+                            # a page shouldn't have the same url as a controller
+                            self.env['ir.http']._match(menu.url)
+                            menu.page_id = None
+                            menu.url_defined_by_user = menu.url
+                        except werkzeug.exceptions.NotFound:
+                            menu.page_id.write({'url': menu.url})
+                    else:
+                        menu.url_defined_by_user = menu.url
+
+    def _search_url(self, operator, value):
+        return (Domain('page_id', '!=', False) & Domain('page_id.url', operator, value)) | Domain('url_defined_by_user', operator, value)
+
+    @api.constrains('url')
+    def _check_url_is_set(self):
+        for menu in self:
+            if not menu.url:
+                raise ValidationError(_("Menu %(menu)s needs a url", menu=menu))
 
     @api.constrains("parent_id", "child_id", "is_mega_menu", "mega_menu_content")
     def _validate_parent_menu(self):
@@ -152,8 +204,8 @@ class WebsiteMenu(models.Model):
         return menus
 
     def write(self, vals):
-        if any(self._ids):
-            self.env.registry.clear_cache('templates')
+        # if any(self._ids):
+        #     self.env.registry.clear_cache('templates')
         res = super().write(vals)
         if 'group_ids' in vals and not self.env.context.get("adding_designer_group_to_menu"):
             self.filtered("group_ids").with_context(
@@ -307,41 +359,6 @@ class WebsiteMenu(models.Model):
                 replace_id(mid, new_menu.id)
         for menu in data['data']:
             menu_id = self.browse(menu['id'])
-            # Check if the url match a website.page (to set the m2o relation),
-            # except if the menu url contains '#', we then unset the page_id
-            if '#' in menu['url']:
-                # Multiple case possible
-                # 1. `#` => menu container (dropdown, ..)
-                # 2. `#top` or `#bottom` => special anchors valid for any page
-                # 3. `#anchor` => anchor on current page
-                # 4. `/url#something` => valid internal URL
-                # 5. https://google.com#smth => valid external URL
-                if menu_id.page_id:
-                    menu_id.page_id = None
-                if request and menu['url'].startswith('#') and len(menu['url']) > 1 and \
-                        menu['url'] not in ['#top', '#bottom']:
-                    # Working on case 2.: prefix anchor with referer URL
-                    referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
-                    menu['url'] = referer_url + menu['url']
-            else:
-                domain = self.env["website"].browse(website_id).website_domain() & (
-                    Domain("url", "=", menu["url"])
-                    | Domain("url", "=", "/" + menu["url"])
-                )
-                page = self.env["website.page"].search(domain, limit=1)
-                if page:
-                    menu['page_id'] = page.id
-                    menu['url'] = page.url
-                    if isinstance(menu.get('parent_id'), str):
-                        # Avoid failure if parent_id is sent as a string from a customization.
-                        menu['parent_id'] = int(menu['parent_id'])
-                elif menu_id.page_id:
-                    try:
-                        # a page shouldn't have the same url as a controller
-                        self.env['ir.http']._match(menu['url'])
-                        menu_id.page_id = None
-                    except werkzeug.exceptions.NotFound:
-                        menu_id.page_id.write({'url': menu['url']})
             menu_id.write(menu)
 
         return True

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import time
+import werkzeug.exceptions
 from collections import Counter
 
 from odoo import api, fields, models, tools
@@ -37,7 +38,7 @@ class WebsitePage(models.Model):
     # for how long a cache entry is considered valid (in seconds)
     _CACHE_DURATION = 3600
 
-    url = fields.Char('Page URL', required=True)
+    url = fields.Char('Page URL', required=True, translate=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, index=True, ondelete="cascade")
 
     view_write_uid = fields.Many2one('res.users', "Last Content Update by",
@@ -72,8 +73,9 @@ class WebsitePage(models.Model):
 
     def _compute_is_homepage(self):
         website = self.env['website'].get_current_website()
+        website_default_lang = website.default_lang_id.code
         for page in self:
-            page.is_homepage = page.url == (website.homepage_url or page.website_id == website and '/')
+            page.is_homepage = page.with_context(lang=website_default_lang).url == (website.homepage_url or page.website_id == website and '/')
 
     def _compute_visible(self):
         for page in self:
@@ -154,7 +156,7 @@ class WebsitePage(models.Model):
             menu = self.env['website.menu'].search([('page_id', '=', page_id)], limit=1)
             if menu:
                 # If the page being cloned has a menu, clone it too
-                menu.copy({'url': new_page.url, 'name': new_page.name, 'page_id': new_page.id})
+                menu.copy({'name': new_page.name, 'page_id': new_page.id})
 
         return new_page.url
 
@@ -174,6 +176,41 @@ class WebsitePage(models.Model):
             self.env.registry.clear_cache('templates')
         return super().unlink()
 
+    def _handle_url_update(self, page, website_id, url, lang):
+        """ Handles a url update. More specifically, it slugifies it and makes
+        sure that the url is unique, handles redirection update, updates page
+        menus and website homepage url if needed.
+        :param page: The page whose url is updated.
+        :param website_id: The id of the website linked to the page.
+        :param url: The new url.
+        :param lang: The lang for which the url has to be updated.
+        """
+        # Slugify the translated url
+        url = '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
+        page = page.with_context(lang=lang)
+        if page.url != url:
+            # Make sure that the slugified url is unique
+            url = self.env['website'].with_context(website_id=website_id, lang=lang).get_unique_path(url)
+            self.env.registry.clear_cache('templates')
+            # Handle the synchronization of website's homepage URL if the lang
+            # is the default website language.
+            website = self.env['website'].get_current_website().with_context(lang=lang)
+            website_default_lang = website.default_lang_id.code
+            if lang == website_default_lang:
+                page_url_normalized = {'homepage_url': page.url}
+                website._handle_homepage_url(page_url_normalized)
+                if website.homepage_url == page_url_normalized['homepage_url']:
+                    website.homepage_url = url
+        return url
+
+    def _update_field_translations(self, field_name, translations, digest=None, source_lang=''):
+        self.ensure_one()
+        if field_name == 'url':
+            for lang, url in translations.items():
+                website_id = self.website_id.id if self.website_id else False
+                translations[lang] = self._handle_url_update(self, website_id, url, lang)
+        return super()._update_field_translations(field_name, translations, digest=digest, source_lang=source_lang)
+
     def write(self, vals):
         for page in self:
             website_id = False
@@ -183,17 +220,7 @@ class WebsitePage(models.Model):
             # If URL has been edited, slug it
             if 'url' in vals:
                 url = vals['url'] or ''
-                url = '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
-                if page.url != url:
-                    url = self.env['website'].with_context(website_id=website_id).get_unique_path(url)
-                    page.menu_ids.write({'url': url})
-                    # Sync website's homepage URL
-                    website = self.env['website'].get_current_website()
-                    page_url_normalized = {'homepage_url': page.url}
-                    website._handle_homepage_url(page_url_normalized)
-                    if website.homepage_url == page_url_normalized['homepage_url']:
-                        website.homepage_url = url
-                vals['url'] = url
+                vals['url'] = self._handle_url_update(page, website_id, url, self.env.user.lang)
 
             # If name has changed, check for key uniqueness
             if 'name' in vals and page.name != vals['name']:
@@ -460,20 +487,50 @@ class WebsitePage(models.Model):
 
     @tools.conditional(
         'xml' not in tools.config['dev_mode'],
-        tools.ormcache('(request.httprequest.path, self.env.context.get("website_id"))', cache='templates.cached_values'),
+        tools.ormcache('(request.httprequest.path, self.env.context.get("website_id"), request.env.lang)', cache='templates.cached_values'),
     )
     @api.model
     def _get_page_info(self, request) -> dict | None:
         req_page = request.httprequest.path
 
+        def _search_page(comparator='='):
+            page_domain = Domain('url', comparator, req_page) & request.website.website_domain()
+            search_page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+            if search_page:
+                return search_page
+            else:
+                # Search if the page domain can be found thanks to a translation
+                # of language installed on the website.
+                self.env.cr.execute("""
+                    SELECT id
+                    FROM website_page p
+                    WHERE (
+                        p.website_id = %(website_id)s OR p.website_id IS NULL
+                    )
+                    AND EXISTS (
+                        SELECT 1
+                        FROM jsonb_each_text(p.url) AS t(lang, value)
+                        WHERE (
+                            (%(case_sensitive)s AND value = %(req)s)
+                            OR
+                            (NOT %(case_sensitive)s AND lower(value) = lower(%(req)s))
+                        )
+                    )
+                    ORDER BY p.website_id;;
+                """, params={'req': req_page, 'website_id': request.website.id, 'case_sensitive': comparator == '='})
+                res = self.env.cr.fetchall()
+                search_page = len(res) and self.browse(res[0])
+                if search_page:
+                    redirect = request.redirect_query(search_page.sudo().with_context(lang=request.env.lang).url, request.httprequest.args)
+                    redirect.set_cookie('frontend_lang', request.env.lang)
+                    werkzeug.exceptions.abort(redirect)
+
         # specific page first
-        page_domain = Domain('url', '=', req_page) & request.website.website_domain()
-        page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+        page = _search_page()
 
         # case insensitive search
         if not page:
-            page_domain = Domain('url', '=ilike', req_page) & request.website.website_domain()
-            page = self.sudo().search_fetch(page_domain, order='website_id asc', limit=1)
+            page = _search_page('=ilike')
 
         if page:
             return {

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -501,25 +501,7 @@ class WebsitePage(models.Model):
             else:
                 # Search if the page domain can be found thanks to a translation
                 # of language installed on the website.
-                self.env.cr.execute("""
-                    SELECT id
-                    FROM website_page p
-                    WHERE (
-                        p.website_id = %(website_id)s OR p.website_id IS NULL
-                    )
-                    AND EXISTS (
-                        SELECT 1
-                        FROM jsonb_each_text(p.url) AS t(lang, value)
-                        WHERE (
-                            (%(case_sensitive)s AND value = %(req)s)
-                            OR
-                            (NOT %(case_sensitive)s AND lower(value) = lower(%(req)s))
-                        )
-                    )
-                    ORDER BY p.website_id;;
-                """, params={'req': req_page, 'website_id': request.website.id, 'case_sensitive': comparator == '='})
-                res = self.env.cr.fetchall()
-                search_page = len(res) and self.browse(res[0])
+                search_page = self._get_page_from_url(req_page, request.website.id, comparator == '=')
                 if search_page:
                     redirect = request.redirect_query(search_page.sudo().with_context(lang=request.env.lang).url, request.httprequest.args)
                     redirect.set_cookie('frontend_lang', request.env.lang)
@@ -539,3 +521,26 @@ class WebsitePage(models.Model):
                 'view_id': page.view_id.id,
                 'group_ids': page.group_ids.ids,
             }
+
+    def _get_page_from_url(self, url, website_id, case_sensitive):
+        if not isinstance(url, str):
+            return False
+        self.env.cr.execute("""
+            SELECT id
+            FROM website_page p
+            WHERE (
+                p.website_id = %(website_id)s OR p.website_id IS NULL
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jsonb_each_text(p.url) AS t(lang, url_translated)
+                WHERE (
+                    (%(case_sensitive)s AND url_translated = %(url)s)
+                    OR
+                    (NOT %(case_sensitive)s AND lower(url_translated) = lower(%(url)s))
+                )
+            )
+            ORDER BY p.website_id;;
+        """, params={'url': url, 'website_id': website_id, 'case_sensitive': case_sensitive})
+        res = self.env.cr.fetchall()
+        return len(res) and self.browse(res[0])

--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -116,11 +116,15 @@ class WebsitePagePropertiesBase(models.TransientModel):
     def _inverse_is_homepage(self):
         self.ensure_one()
         url = self.url
+        self._update_homepage(url)
+
+    def _update_homepage(self, url):
         if self.is_homepage:
             if url and url != '/':
                 self.website_id.homepage_url = url
         else:
             self.website_id.homepage_url = False
+
 
     @api.depends('target_model_id')
     def _compute_can_publish(self):
@@ -224,9 +228,17 @@ class WebsitePageProperties(models.TransientModel):
         accessed route's url.
         """
         for record in self:
-            url = record.url
+            website_default_lang = record.website_id.default_lang_id.code
+            # The following line makes it buggy when the website default langage is not english
+            url = record.with_context(lang=website_default_lang).url
             current_homepage_url = record.website_id.homepage_url or '/'
             record.is_homepage = url == current_homepage_url
+
+    def _inverse_is_homepage(self):
+        self.ensure_one()
+        website_default_lang = self.website_id.default_lang_id.code
+        url = self.with_context(lang=website_default_lang).url
+        self._update_homepage(url)
 
     @api.depends('parent_id')
     def _compute_has_parent_page(self):

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -7,13 +7,14 @@ import { _t } from "@web/core/l10n/translation";
 import { debounce } from "@web/core/utils/timing";
 import { Component } from "@odoo/owl";
 import { charField, CharField } from "@web/views/fields/char/char_field";
+import { TranslationButton } from "@web/views/fields/translation_button";
 
 /**
  * Displays website page dependencies and URL redirect options when the page URL
  * is updated.
  */
 class PageUrlField extends UrlField {
-    static components = { ...UrlField.components, PageDependencies };
+    static components = { ...UrlField.components, PageDependencies, TranslationButton };
     static template = "website.PageUrlField";
     static defaultProps = {
         ...UrlField.defaultProps,
@@ -66,6 +67,9 @@ class PageUrlField extends UrlField {
         // and thus doesn't accept an empty string.
         this.props.record.data[this.props.name] = `/${value.trim()}`;
         return value;
+    }
+    get isTranslatable() {
+        return this.props.record.fields[this.props.name].translate;
     }
 }
 

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -9,6 +9,14 @@
             t-esc="this.serverUrl.length > slicingLength ? this.serverUrl.slice(0, (slicingLength / 2) - 1) + '..' + this.serverUrl.slice((-slicingLength / 2) + 1) : this.serverUrl"
         />
     </xpath>
+    <xpath expr="//InputBox" position="after">
+        <t t-if="isTranslatable">
+            <TranslationButton
+                fieldName="props.name"
+                record="props.record"
+            />
+        </t>
+    </xpath>
 </t>
 
 <t t-name="website.FieldImageRadio">

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -1,0 +1,85 @@
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+const translateUrl = function (newUrl) {
+    return [
+        {
+            content: "Click on the 'Site' button",
+            trigger: "button:contains('Site')",
+            run: "click",
+        },
+        {
+            content: "Click on the 'Properties' button",
+            trigger: "a:contains('Properties')",
+            run: "click",
+        },
+        {
+            content: "Click on the input url",
+            trigger: "[name=url] input.o_input",
+            run: "click",
+        },
+        {
+            content: "Click on the translate button",
+            trigger: "button.o_field_translate:contains('EN')",
+            run: "click",
+        },
+        {
+            content: "Change the french translation of the contactus page url",
+            trigger: `div.row:contains('French') input[type='text']`,
+            run: `edit ${newUrl}`,
+        },
+        {
+            content: "Click on 'Save' in the translate modal",
+            trigger: ".modal-content:contains('Translate: url') footer button:contains('Save')",
+            run: "click",
+        },
+        {
+            content: "Click on the 'Save' of the Page Properties",
+            trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
+            run: "click",
+        },
+        {
+            content: "Wait for the load operation to finish",
+            trigger: "body.o_web_client:not(.modal-open)",
+        },
+        {
+            trigger: ":iframe .s_website_form",
+        },
+    ];
+};
+
+registerWebsitePreviewTour("translate_url_exists_in_other_language", {}, () => [
+    ...translateUrl("/page-en"),
+]);
+
+registerWebsitePreviewTour("translate_url_exists_in_same_language", {}, () => [
+    ...translateUrl("/page-fr"),
+]);
+
+registerWebsitePreviewTour("update_homepage_url", {}, () => [...translateUrl("/contactus-fr")]);
+
+registerWebsitePreviewTour("set_homepage_property_of_a_page", {}, () => [
+    {
+        content: "Click on the 'Site' button",
+        trigger: "button:contains('Site')",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Properties' button",
+        trigger: "a:contains('Properties')",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Is Homepage' button",
+        trigger: "#is_homepage_0",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Save' of the Page Properties",
+        trigger: ".modal-content:contains('Page Properties') footer button:contains('Save')",
+        run: "click",
+    },
+    {
+        content: "Wait for the load operation to finish",
+        trigger: "body.o_web_client:not(.modal-open)",
+    },
+]);

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -170,3 +170,98 @@ class TestControllerRedirect(TestLangUrlCommon):
         # website.page
         assertUrlRedirect('/fr/page_1/', '/fr/page_1', "Check for website.page with language in URL.")
         assertUrlRedirect('/fr/page_1/?a=b', '/fr/page_1?a=b', "Check for website.page with language in URL + URL params.")
+
+@tagged('-at_install', 'post_install')
+class TestTranslateUrl(TestLangUrl):
+    def setUp(self):
+        super().setUp()
+        self.base = self.base_url()
+        view_test_translate_url = self.env['ir.ui.view'].create({
+            'name': 'NewPage',
+            'type': 'qweb',
+            'arch': '<div>NewPage</div>',
+            'key': 'test.view_test_translate_url',
+        })
+        self.name_page_en = '/page-en'
+        self.page = self.env['website.page'].create({
+            'view_id': view_test_translate_url.id,
+            'url': self.name_page_en,
+            'is_published': True,
+            'website_id': self.website.id,
+        })
+        self.name_page_fr = '/page-fr'
+        self.page.with_context(lang='fr_FR').url = self.name_page_fr
+
+    def test_access_translated_url(self):
+        # Trying to access the french url of a page (without the lang in the
+        # url) if the website language is in english should redirect to the
+        # english url of this page.
+        r = self.url_open(self.name_page_fr)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + self.name_page_en)
+
+        # Trying to access the french url of a page (with the lang in the url)
+        # should change the website language to french and access the french url
+        # of the page.
+        r = self.url_open('/fr' + self.name_page_fr)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + self.name_page_fr)
+
+        # Trying to access the english url of a page (without the lang in the
+        # url) if the website language is in french should redirect to the
+        # french url of this page.
+        r = self.url_open(self.name_page_en)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + self.name_page_fr)
+
+    def test_access_translated_homepage(self):
+        # From the homepage, changing the language of the website should
+        # redirect to the french url of the specific homepage (as it is the
+        # first menu).
+        name_homepage_url_fr = '/accueil'
+        homepage_domain = [('url', '=', '/')] + self.website.website_domain()
+        homepage_specific = self.env['website.page'].search(homepage_domain, order='website_id asc', limit=1)
+        homepage_specific.with_context(lang='fr_FR').url = name_homepage_url_fr
+        r = self.url_open('/fr', timeout=800)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr' + name_homepage_url_fr)
+
+    def test_translate_url_exists_in_other_language(self):
+        # It should be possible to translate the url of a page with a url that
+        # exists in another language.
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'translate_url_exists_in_other_language', login='admin')
+        r = self.url_open('/fr/page-en')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr/page-en')
+
+    def test_translate_url_exists_in_current_language(self):
+        # It should not be possible to have two url that are the same in the
+        # same language
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'translate_url_exists_in_same_language', login='admin')
+        r = self.url_open('/fr/page-fr-1')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, self.base + '/fr/page-fr-1')
+
+    def test_update_url_impact_homepage_url(self):
+        # If a page url is the website homepage url, updating this url through
+        # the "translate" modal should also update the homepage url if the
+        # translation is done in the website default language.
+        self.website.homepage_url = '/contactus'
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'update_homepage_url', login='admin')
+        self.assertEqual(self.website.homepage_url, '/contactus-fr')
+
+    def test_new_homepage_impact_homepage_url_translations(self):
+        # Using a page as the default website page should update the website
+        # homepage url.
+        page = self.env['website.page'].search([('url', '=', '/contactus')])
+        page_name_fr = '/contactus-fr'
+        page.with_context(lang='fr_FR').url = page_name_fr
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
+        self.assertEqual(self.website.homepage_url, page_name_fr)
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
+        self.assertEqual(self.website.homepage_url, False)

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -265,3 +265,52 @@ class TestTranslateUrl(TestLangUrl):
         self.assertEqual(self.website.homepage_url, page_name_fr)
         self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'set_homepage_property_of_a_page', login='admin')
         self.assertEqual(self.website.homepage_url, False)
+
+    def test_automatic_link_on_page_translation(self):
+        # If a url is translated, the links to this url that are present on a
+        # page should automatically be translated when changing the website
+        # language.
+        view_with_anchor = self.env['ir.ui.view'].create({
+            'name': 'new_page_with_anchor',
+            'type': 'qweb',
+            'arch': f'<a id="foo" href="{self.name_page_en}">Link to page</a>',
+            'key': 'test.test_translate_url_links',
+        })
+        page_with_anchor_url_en = '/page-link-en'
+        page_with_anchor = self.env['website.page'].create({
+            'name': 'page-link',
+            'view_id': view_with_anchor.id,
+            'url': page_with_anchor_url_en,
+            'website_id': self.website.id,
+        })
+        page_with_anchor_url_fr = '/page-link-fr'
+        page_with_anchor.with_context(lang='fr_FR').url = page_with_anchor_url_fr
+        default_website = self.env.ref('website.default_website')
+        self.page_specific_menu = self.env['website.menu'].create({
+            'name': 'page-link',
+            'page_id': page_with_anchor.id,
+            'website_id': self.website.id,
+            'parent_id': default_website.menu_id.id,
+        })
+        with MockRequest(self.env, website=self.website, context={'lang': 'fr_FR'}):
+            self.authenticate('admin', 'admin')
+            r = self.url_open('/fr')
+            # Check that the url in the menu is correct
+            self.assertIn(f'href="/fr{page_with_anchor_url_fr}"', r.text)
+            self.assertNotIn(f'href="{page_with_anchor_url_en}"', r.text)
+            r = self.url_open(f'/fr{page_with_anchor_url_fr}', r.text)
+            # Check that the url in the view is correct
+            self.assertIn(f'href="/fr{self.name_page_fr}"', r.text)
+            self.assertNotIn(f'href="{self.name_page_en}"', r.text)
+
+    def test_translate_url_page_in_lang_selector(self):
+        name_page_en = '/page-specific-en'
+        name_page_fr = '/page-specific-fr'
+        page_info = self.website.new_page(
+            name=name_page_en,
+        )
+        self.env['website.page'].browse(page_info['page_id']).with_context(lang='fr_FR').url = name_page_fr
+        r = self.url_open('/fr' + name_page_fr)
+        self.assertNotIn(f'href="{name_page_fr}"', r.text)
+        self.assertIn(f'href="/fr{name_page_fr}"', r.text)
+        self.assertIn(f'href="{name_page_en}"', r.text)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -165,9 +165,9 @@
         <!-- no hreflang on non-canonical pages or if no alternate language -->
         <t t-if="request.is_frontend_multilang and website._is_canonical_url() and len(frontend_languages) &gt; 1">
             <t t-foreach="frontend_languages.values()" t-as="lg">
-        <link rel="alternate" t-att-hreflang="lg.hreflang" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, canonical_domain=canonical_domain)"/>
+        <link rel="alternate" t-att-hreflang="lg.hreflang" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, canonical_domain=canonical_domain)['location']"/>
             </t>
-        <link rel="alternate" hreflang="x-default" t-att-href="url_localized(lang_code=website.default_lang_id.code, canonical_domain=canonical_domain)"/>
+        <link rel="alternate" hreflang="x-default" t-att-href="url_localized(lang_code=website.default_lang_id.code, canonical_domain=canonical_domain)['location']"/>
         </t>
         <link rel="canonical" t-att-href="website._get_canonical_url()"/>
         <!-- TODO: Once we have style in DB, add this preconnect only if a

--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -161,7 +161,7 @@ class ProductFeed(models.Model):
             "title": website_homepage.website_meta_title or self.website_id.name,
             "link": urls.urljoin(
                 self.website_id.get_base_url(),
-                self.env["ir.http"]._url_lang(homepage_url, lang_code=self.lang_id.code),
+                self.env["ir.http"]._url_lang(homepage_url, lang_code=self.lang_id.code)['location'],
             ),
             "description": website_homepage.website_meta_description or self.website_id,
             "items": self._prepare_gmc_items(),
@@ -188,7 +188,7 @@ class ProductFeed(models.Model):
                 query["pricelist"] = self.pricelist_id.id
                 url_ = parsed_url._replace(query=url_encode(query)).to_url()
             return urls.urljoin(
-                base_url, self.env["ir.http"]._url_lang(url_, lang_code=self.lang_id.code)
+                base_url, self.env["ir.http"]._url_lang(url_, lang_code=self.lang_id.code)['location']
             )
 
         return {

--- a/addons/website_sale/models/website_menu.py
+++ b/addons/website_sale/models/website_menu.py
@@ -8,8 +8,7 @@ class WebsiteMenu(models.Model):
 
     def _compute_visible(self):
         """Hide '/shop' menus to the public user if only logged-in users can access it."""
-        shop_menus = self.filtered(lambda m: m.url[:5] == "/shop")
+        super()._compute_visible()
+        shop_menus = self.filtered(lambda m: m.is_visible and m.url[:5] == "/shop")
         for menu in shop_menus:
             menu.is_visible = menu.website_id.has_ecommerce_access()
-
-        return super(WebsiteMenu, self - shop_menus)._compute_visible()


### PR DESCRIPTION
The goal of this commit is to add the possibility to translate page url. Here is an example to illustrate the case: A website page has the url `/page-en`. If the user adds "French (BE)" as a language on its website, he can now translate the `page-en` website url into `page-fr`. If the language of the website and its default language is English, the url of the page will be `/page-en` but if the language of the website is French, the url of the page will be `/fr_BE/page-fr`. If the language of the website is in English and the user is searching for `/page-fr`, the system detects that the requested page exists but redirects the user to the English version of the page as the language of the website is in English. However, if the user is searching for `/fr_BE/page-fr`, it will be redirected to the French version of the page and the language of the website will switch to French whatever the original language of the website was.

When a user translates a url, it is slugified and made unique. The related menus url are then updated. Concerning the website homepage url, if it is a page url, it has to be the one of the default website language. When a user modifies a page url, the website homepage url is updated if the modification of the url is done in the website default language and if the original url was the default website url.

task-3355343

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
