### PR TITLE
[FIX] account_edi_ubl_cii: restricted access user cannot import bill

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -356,7 +356,11 @@ class AccountEdiCommon(models.AbstractModel):
             self._correct_invoice_tax_amount(tree, invoice)
 
         # Set XML as ubl_cii_xml_file (XML used to import)
-        file_data['attachment'].res_field = 'ubl_cii_xml_file'
+        file_data['attachment'].write({
+            'res_field': 'ubl_cii_xml_file',
+            'res_model': invoice._name,
+            'res_id': invoice.id,
+        })
 
         # === Import the embedded documents in the xml if some are found ===
         attachments = self.env['ir.attachment']


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: restricted access user cannot import bill

To reproduce:
- create a user that has readonly access in Accounting
- try to import a XML in vendor bills -> should traceback

This commit modifies the `res_field` assignation by setting both `res_model` and `res_id` at the same time