### PR TITLE
[FIX] *: remove use of short in format_datetime and format_time

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -57,7 +57,7 @@
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.env.lang) or ''">4</t>
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='MMMM y', lang_code=object.env.lang) or ''">May 2021</t>
                     <t t-if="not object.event_id.allday">
-                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, time_format='short', lang_code=object.env.lang) or ''">11:00 AM</t>
+                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, lang_code=object.env.lang) or ''">11:00 AM</t>
                         <t t-if="object.mail_tz">
                             <span style="font-size: 11px; font-weight: normal;">
                                 (<t t-out="object.mail_tz or ''">Europe/Brussels</t>)
@@ -187,7 +187,7 @@
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.env.lang) or ''">4</t>
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='MMMM y', lang_code=object.env.lang) or ''">May 2021</t>
                     <t t-if="not object.event_id.allday">
-                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, time_format='short', lang_code=object.env.lang) or ''">11:00 AM</t>
+                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, lang_code=object.env.lang) or ''">11:00 AM</t>
                         <t t-if="object.mail_tz">
                             <span style="font-size: 11px; font-weight: normal;">
                                 (<t t-out="object.mail_tz or ''">Europe/Brussels</t>)
@@ -294,7 +294,7 @@
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.env.lang) or ''">4</t>
                     <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='MMMM y', lang_code=object.env.lang) or ''">May 2021</t>
                     <t t-if="not object.event_id.allday">
-                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, time_format='short', lang_code=object.env.lang) or ''">11:00 AM</t>
+                        <t t-out="format_time(time=object.event_id.start, tz=object.mail_tz, lang_code=object.env.lang) or ''">11:00 AM</t>
                         <t t-if="object.mail_tz">
                             <span style="font-size: 11px; font-weight: normal;">
                                 (<t t-out="object.mail_tz or ''">Europe/Brussels</t>)
@@ -394,7 +394,7 @@
                     <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='d', lang_code=object.env.lang)">4</t>
                     <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='MMMM y', lang_code=object.env.lang)">May 2021</t>
                     <t t-if="not object.allday">
-                        <t t-out="format_time(time=object.start, tz=mail_tz, time_format='short', lang_code=object.env.lang)">11:00 AM</t>
+                        <t t-out="format_time(time=object.start, tz=mail_tz, lang_code=object.env.lang)">11:00 AM</t>
                         <t t-if="mail_tz">
                             <span style="font-size: 11px; font-weight: normal;">
                                 (<t t-out="mail_tz or ''">Europe/Brussels</t>)
@@ -491,7 +491,7 @@
                     <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='d', lang_code=object.env.lang)">4</t>
                     <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='MMMM y', lang_code=object.env.lang)">May 2021</t>
                     <t t-if="not object.allday">
-                        <t t-out="format_time(time=object.start, tz=mail_tz, time_format='short', lang_code=object.env.lang)">11:00 AM</t>
+                        <t t-out="format_time(time=object.start, tz=mail_tz, lang_code=object.env.lang)">11:00 AM</t>
                         <t t-if="mail_tz">
                             <span style="font-size: 11px; font-weight: normal;">
                                 (<t t-out="mail_tz or ''">Europe/Brussels</t>)

--- a/addons/event_sms/data/sms_data.xml
+++ b/addons/event_sms/data/sms_data.xml
@@ -11,7 +11,7 @@
         <field name="name">Event: Reminder</field>
         <field name="model_id" ref="event.model_event_registration"/>
         <field name="body">Ready for "{{ object.event_id.name }}" {{ object.event_date_range }}?
-{{ 'It starts at %s' % format_time(time=object.event_begin_date, tz=object.event_id.date_tz, time_format='short', lang_code=object.partner_id.lang) + (', at %s' % object.event_id.address_inline if object.event_id.address_inline else '') + '.\nSee you there!' if object.event_id.address_inline or 'website_published' not in object.event_id._fields else 'Join us on %s/event/%i!' % (object.get_base_url(), object.event_id.id) }}</field>
+{{ 'It starts at %s' % format_time(time=object.event_begin_date, tz=object.event_id.date_tz, lang_code=object.partner_id.lang) + (', at %s' % object.event_id.address_inline if object.event_id.address_inline else '') + '.\nSee you there!' if object.event_id.address_inline or 'website_published' not in object.event_id._fields else 'Join us on %s/event/%i!' % (object.get_base_url(), object.event_id.id) }}</field>
     </record>
 
 </data></odoo>

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -889,7 +889,7 @@ class HrEmployee(models.Model):
                 last_activity_datetime = last_presence.replace(tzinfo=UTC).astimezone(timezone(tz)).replace(tzinfo=None)
                 employee.last_activity = last_activity_datetime.date()
                 if employee.last_activity == fields.Date.today():
-                    employee.last_activity_time = format_time(self.env, last_presence, time_format='short')
+                    employee.last_activity_time = format_time(self.env, last_presence)
                 else:
                     employee.last_activity_time = False
             else:

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -99,7 +99,7 @@ class HrEmployeePublic(models.Model):
                 last_activity_datetime = last_presence.replace(tzinfo=UTC).astimezone(timezone(tz)).replace(tzinfo=None)
                 employee.last_activity = last_activity_datetime.date()
                 if employee.last_activity == fields.Date.today():
-                    employee.last_activity_time = format_time(self.env, last_presence, time_format='short')
+                    employee.last_activity_time = format_time(self.env, last_presence)
                 else:
                     employee.last_activity_time = False
             else:

--- a/addons/point_of_sale/data/mail_template_data.xml
+++ b/addons/point_of_sale/data/mail_template_data.xml
@@ -26,7 +26,7 @@
                     <div>Thank you for purchasing from <t t-out="store_name">Store name</t>!</div>
                     <div>Attached, you will find your receipt for the purchase of <span><t
                             t-out="format_datetime(dt=object.date_order, tz=tz, dt_format=&quot;EEEE d MMMM&quot;,
-                         lang_code=lg) or ''">date</t> <t t-out="format_time(time=object.date_order, tz=tz, time_format='short',
+                         lang_code=lg) or ''">date</t> <t t-out="format_time(time=object.date_order, tz=tz,
                          lang_code=lg)">time</t>.</span>
                     </div>
                     <br/>

--- a/addons/pos_self_order/data/mail_template_data.xml
+++ b/addons/pos_self_order/data/mail_template_data.xml
@@ -22,7 +22,7 @@
                         <t t-else="">Hello,</t>
                     </div>
                     <br/>
-                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time">It will be ready at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span></div>
+                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time">It will be ready at <t t-out="format_time(time=object.preset_time, tz=tz, lang_code=lg)">12:00 pm</t></span></div>
                     <br/>
                     <div>Thank you,</div>
                     <br/>
@@ -62,7 +62,7 @@
                         <t t-else="">Hello,</t>
                     </div>
                     <br/>
-                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time or client.street">It will be ready</span> <span t-if="object.preset_time">at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span> <span t-if="client.street">at <t t-out="street">street</t>, <t t-out="state">state</t>, <t t-out="client.zip or ''">zip</t>, <t t-out="city">city</t>, <t t-out="country">country</t></span></div>
+                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time or client.street">It will be ready</span> <span t-if="object.preset_time">at <t t-out="format_time(time=object.preset_time, tz=tz, lang_code=lg)">12:00 pm</t></span> <span t-if="client.street">at <t t-out="street">street</t>, <t t-out="state">state</t>, <t t-out="client.zip or ''">zip</t>, <t t-out="city">city</t>, <t t-out="country">country</t></span></div>
                     <br/>
                     <div>Thank you,</div>
                     <br/>


### PR DESCRIPTION
modules: calendar, event_sms, hr, point_of_sale, pos_self_order

From this [commit], the methods `format_datetime` and `format_time` no longer handle `short` because the fields `short_time_format` and `short_date_format` are no longer available in 19.0.

[commit]: https://github.com/odoo/odoo/commit/062b14097033afc19252cf3b8bb1fc541f8c868d#diff-61162ac65633a1c7b054fc83ce1813f1a7984e3169ff36021713ef441f62a208

opw-6030342
---