### PR TITLE
[FIX] sale_{mrp,stock}: get correct picking and MO quantities on reconfirming SO

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -167,3 +167,8 @@ class SaleOrderLine(models.Model):
         elif bom and previous_product_uom_qty:
             return previous_product_uom_qty.get(self.id)
         return super()._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)
+
+    def _get_valid_moves_for_incoming_outgoing(self):
+        """Exclude production-linked moves before processing incoming and outgoing
+        sales order moves to ensure delivery quantities remain correct after SO reconfirmation."""
+        return super()._get_valid_moves_for_incoming_outgoing().filtered(lambda move: not move.production_id)

--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -23,3 +23,12 @@ class StockRule(models.Model):
                 if bom_line_id:
                     move_values['bom_line_id'] = bom_line_id
         return move_values
+
+    def _make_mo_get_domain(self, procurement, bom):
+        """Extend MO search domain to exclude cancelled moves when linked to a sale line,
+        ensuring correct quantities after order reconfirmation."""
+        domain = super()._make_mo_get_domain(procurement, bom)
+        sale_line_id = procurement.values.get('sale_line_id')
+        if sale_line_id:
+            domain += (('move_dest_ids.state', '!=', 'cancel'),)
+        return domain

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2795,3 +2795,35 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
             {'user_id': self.env.user.id, 'display_name': 'Exception'}
         ])
         self.assertRegex(production_2.activity_ids.note, fr"Exception\(s\) occurred on the sale order\(s\).*\n.*{sale_order_to_cancel.name}.*\n.*Manual actions may be needed")
+
+    def test_mto_delivery_quantity_on_SO_reconfirmation(self):
+        """
+        Test that the delivery quantity is correctly updated when a Sale Order
+        with an MTO product is cancelled, updated, and reconfirmed.
+        """
+        self.product_a.route_ids = self.env.ref('stock.route_warehouse0_mto').ids
+        self.env["mrp.bom"].create([{
+            "product_tmpl_id": self.product_a.product_tmpl_id.id,
+            "bom_line_ids": [Command.create({"product_id": self.product.id, "product_qty": 1})]},
+        ])
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "order_line": [Command.create({"product_id": self.product_a.id, "product_uom_qty": 1})],
+        })
+        so.action_confirm()
+        self.assertEqual(so.picking_ids.move_ids.product_uom_qty, 1)
+        so.action_cancel()
+        so.action_draft()
+        so.order_line.product_uom_qty = 2
+        so.action_confirm()
+        self.assertEqual(len(so.picking_ids), 2)
+        self.assertEqual(so.picking_ids[0].state, 'cancel')
+        new_picking = so.picking_ids[1]
+        self.assertEqual(new_picking.move_ids.product_uom_qty, 2)
+        # Test that a new manufacturing order created after reconfirming
+        self.assertEqual(len(so.mrp_production_ids), 2)
+        self.assertRecordValues(so.mrp_production_ids, [{'product_uom_qty': 1}, {'product_uom_qty': 2}])
+        so.order_line.product_uom_qty = 3
+        # After updating quantity values on picking and manufacturing order should be reflected correctly.
+        self.assertEqual(so.mrp_production_ids[1].product_uom_qty, 3)
+        self.assertRecordValues(new_picking.move_ids, [{'product_uom_qty': 2}, {'product_uom_qty': 1}])

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -319,6 +319,10 @@ class SaleOrderLine(models.Model):
             qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom_id, rounding_method='HALF-UP')
         return qty
 
+    def _get_valid_moves_for_incoming_outgoing(self):
+        """Overridable method that returns the valid moves for both incoming and outgoing processing."""
+        return self.move_ids.filtered(lambda m: m.state != 'cancel' and m.location_dest_usage != 'inventory' and self.product_id == m.product_id)
+
     def _get_outgoing_incoming_moves(self, strict=True):
         """ Return the outgoing and incoming moves of the sale order line.
             @param strict: If True, only consider the moves that are strictly delivered to the customer (old behavior).
@@ -328,7 +332,7 @@ class SaleOrderLine(models.Model):
         outgoing_moves_ids = set()
         incoming_moves_ids = set()
 
-        moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and r.location_dest_usage != 'inventory' and self.product_id == r.product_id)
+        moves = self._get_valid_moves_for_incoming_outgoing()
         if moves and not strict:
             # The first move created was the one created from the intial rule that started it all.
             sorted_moves = moves.sorted('id')


### PR DESCRIPTION
Currently when the user cancels the sale order and then reconfirms with different quantity, the delivery quanity is displayed incorrectly.

## Steps to replicate:
- Install Manufacturing and Sales
- Enable Multi-Step Routes in settings
- Routes > unarchive MTO route
- Create a Manufacturing Product with Bill of Materials and MTO route
- Create and confirm sale order with that product
- Cancel the SO > Set to Quotation > Set quantity 2 > Confirm
- Delivery > Go to newly created Delivery

## Observed Behavior:
The new delivery has demand quantity 3 even though sale order line asks for 2 of the product.

If you go to linked MO, it now has quantity 4.

And if you try to change the quantity from the SO after reconfirmation the quantities in the picking and MO get even worse.

## Root cause:
This issue occurs when a sale order is reconfirmed. During reconfirmation, `_action_launch_stock_rule` is triggered [1], which calls `_get_qty_procurement` [2] to compute quantity for procurement.

Inside `_get_qty_procurement`, `_get_outgoing_incoming_moves` is called. It processes two moves: manufacturing move and a delivery move. Since the delivery move is cancelled, it is filtered out, leaving only the manufacturing move, which is added to `incoming_move_ids` [3].

Later, the quantity from this incoming move is subtracted from qty (which is 0) [4], resulting in -1.
This value is then used to compute the new procurement quantity at [5]: 
```2 - (-1) = 3```

As a result, when `_run_pull` runs again, it creates a delivery order with quantity 3 instead of 2.
[1]-
https://github.com/odoo/odoo/blob/1ce06257f877711bd5de5487364909d72b476318/addons/sale_stock/models/sale_order.py#L213-L215 
[2]-
https://github.com/odoo/odoo/blob/1ce06257f877711bd5de5487364909d72b476318/addons/sale_stock/models/sale_order_line.py#L388 
[3]-
https://github.com/odoo/odoo/blob/1ce06257f877711bd5de5487364909d72b476318/addons/sale_stock/models/sale_order_line.py#L353-L358 
[4]-
https://github.com/odoo/odoo/blob/1ce06257f877711bd5de5487364909d72b476318/addons/sale_stock/models/sale_order_line.py#L310-L320 
[5]-
https://github.com/odoo/odoo/blob/cb9bd14395d78d0b23ef1796471554da6a279166/addons/sale_stock/models/sale_order_line.py#L397-L404

<h3>Why this only happens in 19.0: </h3> 
This happened because manufacturing moves weren’t originally linked to sale order lines.

After commit [commit](https://github.com/odoo/odoo/commit/2713876dbc70d3984e584a9037a2206dcda4e84a), sale order lines were included in procurement values when preparing the procurement which links the moves to the sale order lines when creating a MO.
(for the change see sale_stock > stock.py > _prepare_procurement_values)

As a result, manufacturing moves now appear in `_get_outgoing_incoming_moves`, causing the delivery quantity to be incorrect.


## Solution:
A possible solution is to exclude MO moves from the calculation of incoming and outgoing moves.

In sale orders, incoming quantities are typically related to returns/refunds, and there seem to be no scenario where that would need to trigger a MO, so excluding MO moves seems to be a safe approach.

This also prevents MO moves linked to canceled pickings from being counted as the first move created after triggering the MTO flow when the sales order is reconfirmed. This ensures that quantities are updated correctly if the product quantity on the sales order is changed after SO reconfirmation.

This fix keeps sale order lines linked to manufacturing orders and its moves and only excludes manufacturing moves from quantity calculations restoring the correct behavior from version 18.4 including creation of new MO when reconfirming the SO.

opw-5976500