### PR TITLE
[FIX] html_editor:prevent second flow on Media Dialog double-click

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -92,6 +92,7 @@ export class ImageSelector extends FileSelector {
         this.MIN_ROW_HEIGHT = 128;
 
         this.fileMimetypes = IMAGE_MIMETYPES.join(",");
+        this.isProcessingClick = false;
     }
 
     get canLoadMore() {
@@ -300,10 +301,19 @@ export class ImageSelector extends FileSelector {
     }
 
     async onClickAttachment(attachment) {
+        if (this.isProcessingClick) {
+            return;
+        }
+        this.isProcessingClick = true;
         this.selectAttachment(attachment);
         if (!this.props.multiSelect) {
             await this.props.save();
         }
+        // The use of requestAnimationFrame is not ideal but we do it as a
+        // temporary fix as the media dialog will be refactored
+        requestAnimationFrame(() => {
+            this.isProcessingClick = false;
+        });
     }
 
     async onClickMedia(media) {

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { click, press, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { click, dblclick, press, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
-import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import { makeMockEnv, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { delay } from "@web/core/utils/concurrency";
+import { ImageSelector } from "@html_editor/main/media/media_dialog/image_selector";
 
 test("Can replace an image", async () => {
     onRpc("ir.attachment", "search_read", () => [
@@ -250,4 +251,34 @@ test("Image cropper disappear on backspace", async () => {
     press("backspace");
     await waitForNone(".o_we_crop_widget", { timeout: 1500 });
     expect("img.o_we_cropper_img").toHaveCount(0);
+});
+
+test("double-click on image in Media Dialog executes onClickAttachment only once", async () => {
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+
+    let executionCount = 0;
+    patchWithCleanup(ImageSelector.prototype, {
+        selectAttachment(attachment) {
+            executionCount++;
+            return super.selectAttachment(attachment);
+        },
+    });
+
+    const env = await makeMockEnv();
+    await setupEditor(`<p><img class="img-fluid" src="/web/static/img/logo.png"></p>`, { env });
+    await click("img");
+    await waitFor(".o-we-toolbar");
+    await click("button[name='replace_image']");
+    await animationFrame();
+    await dblclick(".o_existing_attachment_cell");
+    expect(executionCount).toBe(1);
 });

--- a/addons/website/static/src/components/media_dialog/media_dialog.js
+++ b/addons/website/static/src/components/media_dialog/media_dialog.js
@@ -4,7 +4,7 @@ import { MediaDialog, TABS } from "@html_editor/main/media/media_dialog/media_di
 patch(MediaDialog.prototype, {
     extraClassesToAdd() {
         const classes = super.extraClassesToAdd();
-        const closestDivEl = this.props.node?.parentElement.closest("div");
+        const closestDivEl = this.props.node?.closest("div");
         if (
             this.state.activeTab == TABS.IMAGES.id &&
             closestDivEl?.matches(".s_social_media, .s_share")


### PR DESCRIPTION

Before this commit:
When double-clicking an image in the Media Dialog, the onClickAttachment
method was executed twice, causing the media flow to be processed
multiple times.

After this commit:
The issue is fixed using a boolean flag: isProcessingClick. Initially,
the flag is set to false. When the first click starts, it is updated to
true. If another click occurs during the same flow
(e.g during a double click), isProcessingClick is already true, so the
function immediately returns and prevents the action from being executed
multiple times.

task-6033320