### PR TITLE
[FIX] web: handle long labels in model field selector

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector.scss
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.scss
@@ -19,6 +19,7 @@
             cursor: inherit;
             border: 1px solid darken($o-brand-lightsecondary, 10%);
             background: $o-brand-lightsecondary;
+            max-width: 100px;
         }
         > i {
             font-size: 10px;

--- a/addons/web/static/src/core/model_field_selector/model_field_selector.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.xml
@@ -8,7 +8,7 @@
                     <t t-if="!displayName_first">
                         <i class="oi oi-chevron-right m-1" role="img" aria-label="Followed by" data-tooltip="Followed by" />
                     </t>
-                    <span t-attf-class="o_model_field_selector_chain_part mb-1 #{props.readonly ? 'border-0 fw-bolder' : 'px-1'} text-nowrap">
+                    <span t-attf-class="o_model_field_selector_chain_part text-truncate d-inline-block align-middle mb-1 #{props.readonly ? 'border-0 fw-bolder' : 'px-1'}">
                         <t t-esc="displayName" />
                     </span>
                 </t>

--- a/addons/web/static/src/core/tree_editor/tree_editor.scss
+++ b/addons/web/static/src/core/tree_editor/tree_editor.scss
@@ -14,6 +14,11 @@
             }
         }
     }
+    .o_tree_editor_condition {
+        > .col-md-2 {
+            min-width: 100px;
+        }
+    }
     .o_record_selector .o-autocomplete,
     .o_multi_record_selector .o_record_autocomplete_with_caret {
         min-width: unset;


### PR DESCRIPTION
Before this commit:
---------------------------------
Long property names in the worksheet properties dropdown (ModelFieldSelector)
were overflowing and overlapping with the chatter, causing a poor user
experience and making it difficult to select and configure rules.

Steps to reproduce:
-------------------------
1. Install the quality_control_worksheet module.
2. Create a new Control Point.
3. Set the Type to Worksheet and select a Worksheet Template.
4. Open the selected Worksheet Template and add a property with a very long name.
5. Return to the Control Point, create a rule, select Worksheet Properties, and
   choose the property with the long name.
6. Observe that long labels overflow and overlap with the chatter, making
   selection difficult.

After this commit:
--------------------------------
This fix applies CSS to properly handle long text, preventing layout issues and
improving readability and usability, resulting in a smoother and more
user-friendly experience.

Before:

<img width="1916" height="789" alt="image" src="https://github.com/user-attachments/assets/ec585c21-bcce-4fed-a847-db42511f5f69" />

After:

<img width="1329" height="819" alt="image" src="https://github.com/user-attachments/assets/bb39e4bf-93b7-4885-80b2-ef75da8398f6" />

Enterprise PR: [110899](https://github.com/odoo/enterprise/pull/110899)
Task Id: 5955976