### PR TITLE
[IMP] website: improve clarity of editor labels and actions

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -315,6 +315,7 @@ export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
                     body: _t(
                         "Changing the color palette will reset all your color customizations, are you sure you want to proceed?"
                     ),
+                    confirmLabel: _t("Apply New Palette"),
                     confirm: () => resolve(true),
                     cancel: () => resolve(false),
                 });

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2840,7 +2840,7 @@
                 <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_restricted_editor" role="status">
                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                    <p>
-                     Note: To hide this page, uncheck it from the Customize tab in edit mode.
+                     Note: To hide this page, uncheck it from the Style tab in edit mode.
                    </p>
                 </div>
                 <h2>Installed Applications</h2>


### PR DESCRIPTION
This commit will update misleading and outdated UI labels across the
website editor to better reflect the current interface and user actions.

It replaces the obsolete "Customize" reference with "Style" on the
/website/info page, ensuring consistency with the renamed editor tab and
making instructions easier to follow when managing page visibility.

It also updates the palette confirmation button label from "Ok" to
"Apply New Palette", providing clearer intent about the action and its
impact on existing color customizations.

These changes reduce ambiguity in key interactions, align wording with
the current UI, and help users make more confident decisions without
needing additional context.

task-[6005106](https://www.odoo.com/odoo/project/974/tasks/6005106)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
