### PR TITLE
[FIX] l10n_it_edi: encode IAP XML response to base64

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -119,7 +119,7 @@ class AccountMoveSend(models.AbstractModel):
                 attachment_name = attachment['name']
             attachment_data = results.get(attachment_name, {})
             if attachment_data.get('signed') and (signed_data := attachment_data.get('signed_data')):
-                move.l10n_it_edi_attachment_file = signed_data.encode()
+                move.l10n_it_edi_attachment_file = base64.b64encode(signed_data.encode())
                 # Show that those moves couldn't be sent
             if 'error_message' in attachment_data:
                 moves_data[move]['error'] = {'error_title': attachment_data['error_message']}

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -187,11 +187,11 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
     def test_l10n_it_edi_send_success_with_signed_data_update_attachment(self):
         invoice = self.init_invoice(self.italian_partner_a)
         self.generate_l10n_it_edi_send_attachments(invoice)
-        signed_data_result = base64.b64encode(b'some signed data').decode()
+        signed_data_result = 'some signed data'
         success = {'id_transaction': "SDI ID 1", 'signed': True, 'signed_data': signed_data_result}
         with patch('odoo.addons.l10n_it_edi.models.account_move.AccountMove._l10n_it_edi_upload_single', return_value=success, autospec=True):
             self.env['account.move.send']._generate_and_send_invoices(invoice, sending_methods=['email'])
-            self.assertEqual(invoice.l10n_it_edi_attachment_file, signed_data_result.encode())
+            self.assertEqual(base64.b64decode(invoice.l10n_it_edi_attachment_file).decode(), signed_data_result)
 
     def test_l10n_it_edi_send_proxy_error(self):
         invoice = self.init_invoice(self.italian_partner_a)


### PR DESCRIPTION
When submitting invoices to the Italian Public Administration, we receive an updated XML response from IAP with the document including a signature. The response is a raw XML string, not base64.

Previously, we tried to encode it incorrectly, causing errors because `l10n_it_edi_attachment_file` direct assignment expects a base64 string.

This fix converts the raw XML received from IAP to base64 before assigning it to the `l10n_it_edi_attachment_file` field. It also updates the test to use a correct mock IAP response.