### PR TITLE
[FIX] hr_work_entry: prevent duplicate work entry type code

### DIFF
--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -38,7 +38,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
         cls.work_entry_type_hour_day = cls.env['hr.work.entry.type'].create({
             'name': 'Paid Time Off hours',
-            'code': 'Paid Time Off hours',
+            'code': 'Paid Time Off hours Test',
             'count_as': 'absence',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',

--- a/addons/hr_holidays/tests/test_hr_leave_report.py
+++ b/addons/hr_holidays/tests/test_hr_leave_report.py
@@ -8,7 +8,7 @@ class TestHrLeaveReport(TestHrHolidaysCommon):
         super().setUpClass()
         cls.overtime_work_entry_type = cls.env['hr.work.entry.type'].create({
             'name': 'Overtime Type',
-            'code': 'OVERTIME',
+            'code': 'overtime_test',
             'requires_allocation': True,
             'leave_validation_type': 'no_validation',
             'request_unit': 'hour',

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -50,12 +50,46 @@ class HrWorkEntryType(models.Model):
 
     @api.constrains('code', 'country_id')
     def _check_code_unicity(self):
-        similar_work_entry_types_by_code = self.search([
+        """
+        There should be maximum one work entry type per code, per country.
+        """
+        # check if self does not already contain duplicates
+        grouped_duplicates = self.grouped(lambda wt: (wt.code, wt.country_id))
+        for code, country_id in grouped_duplicates:
+            if len(grouped_duplicates[code, country_id]) > 1:
+                raise UserError(self.env._(
+                    'You cannot create more than one work entry type of code "%(code)s" for the same country (%(country)s)',
+                    code=code, country=(country_id.name if country_id else self.env._("All")),
+                ))
+
+        related_we_types = self.search([
             ('code', 'in', self.mapped('code')),
             ('country_id', 'in', self.country_id.ids + [False]),
-        ]).grouped('code')
-        for code, similar_work_entry_types in similar_work_entry_types_by_code.items():
-            if len(similar_work_entry_types) == 1:
-                continue
-            if len(similar_work_entry_types) > 2 or (similar_work_entry_types.country_id and len(similar_work_entry_types.country_id.code) != 2):
-                UserError(_("The same code cannot be associated to multiple work entry types for the same company (%s)", code))
+            ('id', 'not in', self.ids),
+        ]).grouped(lambda wt: (wt.code, wt.country_id))
+
+        for we_type in self:
+            if not related_we_types.get((we_type.code, we_type.country_id)):
+                continue  # no duplicate work entry type
+            # we're not supposed to have more than one duplicate
+            duplicate = related_we_types[we_type.code, we_type.country_id][:1]
+            if we_type.country_id:
+                raise UserError(self.env._(
+                    """
+Cannot insert "%(insert_name)s":
+Work entry type "%(name)s" of code "%(code)s" already exists for country "%(country)s".
+                    """,
+                    insert_name=we_type.name,
+                    name=duplicate.name,
+                    code=duplicate.code,
+                    country=duplicate.country_id.name,
+                ))
+            raise UserError(self.env._(
+                    """
+Cannot insert "%(insert_name)s":
+Work entry type "%(name)s" of code "%(code)s", with no country assigned, already exists.
+                    """,
+                insert_name=we_type.name,
+                name=duplicate.name,
+                code=duplicate.code,
+            ))

--- a/addons/hr_work_entry/tests/__init__.py
+++ b/addons/hr_work_entry/tests/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_work_entry
+from . import test_work_entry_type
 from . import test_work_entry_type_data

--- a/addons/hr_work_entry/tests/test_work_entry_type.py
+++ b/addons/hr_work_entry/tests/test_work_entry_type.py
@@ -1,0 +1,121 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWorkEntryType(TransactionCase):
+
+    def test_duplicate_work_entry_type_same_country(self):
+        country_be = self.env.ref('base.be')
+        self.env['hr.work.entry.type'].create({
+            'code': 'test123',
+            'name': "Test we type",
+            'country_id': country_be.id,
+
+        })
+        with self.assertRaises(
+            UserError,
+            msg="It should not be possible to create two work entry types with the same code in the same country",
+        ):
+            self.env['hr.work.entry.type'].create({
+                'code': 'test123',
+                'name': "Test we type",
+                'country_id': country_be.id,
+            })
+
+        with self.assertRaises(
+            UserError,
+            msg="It should not be possible to create two work entry types at the same time with the same code in the same country",
+        ):
+            self.env['hr.work.entry.type'].create([
+                {
+                    'code': 'test456',
+                    'name': "Test we type",
+                    'country_id': country_be.id,
+                },
+                {
+                    'code': 'test456',
+                    'name': "Test we type",
+                    'country_id': country_be.id,
+                },
+            ])
+
+    def test_duplicate_work_entry_type_all_countries(self):
+        self.env['hr.work.entry.type'].create({
+            'code': 'test123',
+            'name': "Test we type",
+            'country_id': False,
+
+        })
+        with self.assertRaises(
+            UserError,
+            msg="It should not be possible to create two work entry types with the same code for all countries",
+        ):
+            self.env['hr.work.entry.type'].create({
+                'code': 'test123',
+                'name': "Test we type",
+                'country_id': False,
+            })
+
+        with self.assertRaises(
+            UserError,
+            msg="It should not be possible to create two work entry types at the same time with the same code for all countries",
+        ):
+            self.env['hr.work.entry.type'].create([
+                {
+                    'code': 'test456',
+                    'name': "Test we type",
+                    'country_id': False,
+                },
+                {
+                    'code': 'test456',
+                    'name': "Test we type",
+                    'country_id': False,
+                },
+            ])
+
+    def test_unique_work_entry_types(self):
+        """
+        No error should be raised if the work entry codes are unique per country_id
+        """
+        country_be = self.env.ref('base.be')
+        country_us = self.env.ref('base.us')
+
+        # creating them one by one. `self` should contain one record only
+        self.env['hr.work.entry.type'].create({
+            'code': 'test123',
+            'name': "Test we type",
+            'country_id': country_be.id,
+
+        })
+        self.env['hr.work.entry.type'].create({
+            'code': 'test123',
+            'name': "Test we type",
+            'country_id': country_us.id,
+        })
+        self.env['hr.work.entry.type'].create({
+            'code': 'test123',
+            'name': "Test we type",
+            'country_id': False
+        })
+
+        # creating them in batch. `self` should have multiple records at once
+        self.env['hr.work.entry.type'].create([
+            {
+                'code': 'test456',
+                'name': "Test we type",
+                'country_id': False,
+            },
+            {
+                'code': 'test456',
+                'name': "Test we type",
+                'country_id': country_us.id,
+            },
+            {
+                'code': 'test456',
+                'name': "Test we type",
+                'country_id': country_be.id,
+            },
+        ])

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -495,7 +495,7 @@ class TestSandwichLeave(TransactionCase):
         """
         other_work_entry_type = self.env['hr.work.entry.type'].create({
             'name': 'Test Leave Type',
-            'code': 'Test Leave Type',
+            'code': 'Test Other Leave Type',
             'request_unit': 'day',
             'unit_of_measure': 'day',
             'requires_allocation': False,


### PR DESCRIPTION
It was previously possible to create two work entry types with the same code in the same country. It was due to a missing `raise` before the `UserError`.

The condition to raise the exception was not correct either. So it has been changed to prevent having two work entry type codes covering the same country.

task-6037156
