### PR TITLE
[FIX] html_editor: hide video command when videos are disabled

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -45,7 +45,7 @@
                                 <field name="activity_user_id" widget="many2one_avatar_user"
                                        required="not plan_id"/>
                             </group>
-                            <field name="note" class="oe-bordered-editor" placeholder="Log a note..."/>
+                            <field name="note" class="oe-bordered-editor" placeholder="Log a note..." widget="html_mail"/>
                         </group>
                         <div role="alert" class="alert alert-danger mb8" invisible="not has_error">
                             <field name="error"/>


### PR DESCRIPTION
---
When in the chatter, we can create an activity. If we add
an attachment to the notes of this activity and save it, the
overview of the attachment won't show in the chatter.

1. Open an app that gives you access to the chatter, for
 instance, an invoice in Accounting.
2. Click on Activity. Click on Log a Note... and on the
button Upload a file. Upload an attachment and save.

The overview of the file (blue box with the name of the
attachment) should appear.

The overview doesn't appear

Since 19.0, we want to replace static rendering with
embedded components everywhere for rendering attachments, but
this creates issues for the rendering of the overview in the
chatter. Therefore, after internal discussion, we agreed
to keep rendering overviews statically.

Backport of: https://github.com/odoo-dev/odoo/commit/4a2412b93bcac9e71826f7c0101243cdb882ddf6

opw-6035026

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
