### PR TITLE
[IMP] mail: enhance print layout in discuss

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_patch.xml
+++ b/addons/im_livechat/static/src/core/common/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="showVisitorDisconnected" class="o-livechat-VisitorDisconnected bg-secondary py-1 px-3 fw-bold smaller shadow-sm border border-secondary" t-out="disconnectedText"/>
+            <div t-if="showVisitorDisconnected" class="o-livechat-VisitorDisconnected bg-secondary py-1 px-3 fw-bold smaller shadow-sm border border-secondary d-print-none" t-out="disconnectedText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -182,6 +182,9 @@ For more specific needs, you may also assign custom-defined actions
             "mail/static/src/utils/common/format.js",
             "mail/static/src/utils/common/html.js",
         ],
+        "web.assets_web_print": [
+            "mail/static/src/scss/discuss_print.scss",
+        ],
         'mail.assets_discuss_public_test_tours': [
             'web/static/lib/hoot-dom/**/*',
             'web_tour/static/src/js/**/*',

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -8,7 +8,7 @@
     <t t-set="normal" t-value="props.mode === 'normal'"/>
     <t t-set="extended" t-value="props.mode === 'extended'"/>
     <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex o-rounded-bubble'"/>
-    <div t-ref="root">
+    <div class="d-print-none" t-ref="root">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0 position-relative"
                 t-att-class="{
                     'pb-2': extended and !props.composer.message,

--- a/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar-resizablePanelContainer h-100 d-flex">
+        <div class="o-mail-DiscussSidebar-resizablePanelContainer h-100 d-flex d-print-none">
             <ResizablePanel handleSide="'end'" initialWidth="store.discuss.isSidebarCompact ? store.discuss.COMPACT_SIDEBAR_WIDTH : store.discuss.INSPECTOR_WIDTH" minWidth="60" onResize.bind="onResize">
-                <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-dark o-border-opacity-15 z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+                <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-dark o-border-opacity-15 z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
                     <DiscussSearch class="{
                         'position-sticky top-0 z-2 o-mail-discussSidebarBgColor': true,
                         'pt-2 o-pb-0_5 o-mb-0_5': !store.inPublicPage and store.discuss.isSidebarCompact,

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -45,7 +45,7 @@
                     </div>
                     <div t-if="showsChatLocalDateTime" class="text-muted smaller ms-1" t-out="state.correspondentLocalDateTimeFormatted"/>
                 </div>
-                <div class="pe-3">
+                <div class="pe-3 d-print-none">
                     <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group.slice().reverse()]" inline="true" odooControlPanelSwitchStyle="true"/>
                 </div>
                 <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
@@ -65,7 +65,7 @@
                             <Composer t-if="(thread.model !== 'mail.box' and !thread.channel?.composerHidden) or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                             <span t-if="thread.channel?.composerHidden" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.channel?.composerHiddenText"/>
                         </div>
-                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-dark o-border-opacity-15 flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
+                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-dark o-border-opacity-15 flex-shrink-0 d-print-none" t-att-class="{ 'w-100': ui.isSmall }">
                             <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>

--- a/addons/mail/static/src/scss/discuss_print.scss
+++ b/addons/mail/static/src/scss/discuss_print.scss
@@ -1,0 +1,10 @@
+@media print {
+    .o_action_manager:has(.o-mail-Discuss) {
+        width: 100%;
+        height: 100%;
+
+        & .o-mail-Discuss div {
+            overflow: visible !important;
+        }
+    }
+}


### PR DESCRIPTION
Before this commit, using the brower's print feature without
knowledge installed would show a blank page.

This occurs because knowledge print assets add an overflow
visible rules to a bunch of DOM elements.

This commit fixes the issue by doing something similar for
the discuss app.

Additionally, the print discuss layout has several issues:
- The sidebar is hidden but still takes space.
- The composer is displayed and takes up space,
even though only the conversation content matters.
- Thread actions are shown in the discuss header.
- Visitor offline banner is shown.

This PR fixes these issues.

task-6008968


| | |
|--|--|
|Before|<img width="611" height="385" alt="image" src="https://github.com/user-attachments/assets/d8060268-ed04-45f2-b152-04c7c50a03c2" />|
|After|<img width="624" height="407" alt="image" src="https://github.com/user-attachments/assets/41fa26ee-e25d-4495-8d22-088782d9e8e1" />|

