### PR TITLE
[FIX] website: avoid crash on preview iframe unload

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -652,7 +652,9 @@ export class WebsiteBuilderClientAction extends Component {
             fallBackDoc.documentElement.replaceWith(websiteDoc.documentElement.cloneNode(true));
             const currentScrollEl = getScrollingElement(websiteDoc);
             const scrollElement = getScrollingElement(fallBackDoc);
-            scrollElement.scrollTop = currentScrollEl.scrollTop;
+            if (currentScrollEl && scrollElement) {
+                scrollElement.scrollTop = currentScrollEl.scrollTop;
+            }
             this.cleanIframeFallback();
         }
     }

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -129,6 +129,35 @@ test("elements within iframe can't be clicked while the builder is being set up"
     expect.verifySteps(["button clicked"]);
 });
 
+test("onPageUnload does not crash when scrolling elements are unavailable", async () => {
+    let websiteBuilder;
+    patchWithCleanup(WebsiteBuilderClientAction.prototype, {
+        setup() {
+            websiteBuilder = this;
+            super.setup();
+        },
+        get testMode() {
+            return false;
+        },
+        cleanIframeFallback() {},
+    });
+
+    await setupWebsiteBuilder(`<h1>Homepage</h1>`, { openEditor: false });
+
+    const websiteDoc = websiteBuilder.websiteContent.el.contentDocument;
+    const fallbackDoc = websiteBuilder.iframefallback.el.contentDocument;
+    Object.defineProperty(websiteDoc, "scrollingElement", {
+        value: null,
+        configurable: true,
+    });
+    Object.defineProperty(fallbackDoc, "scrollingElement", {
+        value: null,
+        configurable: true,
+    });
+
+    expect(() => websiteBuilder.onPageUnload()).not.toThrow();
+});
+
 describe.tags("desktop");
 describe("BuilderMany2One: exit editor when previewing", () => {
     beforeEach(async () => {


### PR DESCRIPTION
When the website preview unloads, it copies the current document into the fallback iframe and restores its scroll position.

At that point, one of the two documents can already be partially torn down, so `getScrollingElement(...)` may return `null`. The code then dereferenced `.scrollTop` unconditionally, which crashes `WebsiteBuilderClientAction.onPageUnload()` and leaves the generic fallback page visible.

This commit only restores the scroll position when both scrolling elements are available, so the preview degrades gracefully instead of crashing.

opw-6037573

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
