### PR TITLE
[FIX] mrp_*: enable showSeconds

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -104,7 +104,7 @@
                     <span t-out="l['name']"/>
                 </td>
                 <td class="text-end">
-                    <t t-if="l['type'] == 'operation'" t-out="l['quantity']" t-options="{'widget': 'float_time', 'unit': 'minutes'}"/>
+                    <t t-if="l['type'] == 'operation'" t-out="l['quantity']" t-options="{'widget': 'float_time', 'unit': 'minutes', 'show_seconds': True}"/>
                     <t t-else="" t-out="l['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
                 </td>
                 <td class="text-start" groups="uom.group_uom" t-out="l['uom']"/>

--- a/addons/mrp/report/mrp_report_mo_overview.xml
+++ b/addons/mrp/report/mrp_report_mo_overview.xml
@@ -148,7 +148,7 @@
             </td>
             <td t-if="data['show_replenishments']" class="text-center" t-out="line.get('formatted_state', '')"/>
             <td t-attf-class="text-end {{ data['get_color'](line.get('quantity_decorator')) }}">
-                <t t-if="line.get('model') == 'mrp.workorder'" t-out="line['quantity']" t-options="{'widget': 'float_time'}"/>
+                <t t-if="line.get('model') == 'mrp.workorder'" t-out="line['quantity']" t-options="{'widget': 'float_time', 'unit': 'minutes', 'show_seconds': True}"/>
                 <t t-else="" t-out="line['quantity']" t-options="{'widget': 'float', 'precision': line['uom_precision']}"/>
             </td>
             <td t-if="data['show_uom']" class="text-start" t-out="line['uom_name']"/>
@@ -209,7 +209,7 @@
                 </td>
                 <td t-if="data['show_replenishments']" class="text-center"/>
                 <td t-attf-class="text-end {{ data['get_color'](summary.get('quantity_decorator')) }}">
-                    <t t-out="summary['quantity']" t-options="{'widget': 'float_time'}"/>
+                    <t t-out="summary['quantity']" t-options="{'widget': 'float_time', 'unit': 'minutes', 'show_seconds': True}"/>
                 </td>
                 <td t-if="data['show_uom']" class="text-start" t-out="summary['uom_name']"/>
                 <td t-if="data['show_availabilities']" class="text-end"/>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -18,7 +18,7 @@
             </div>
         </td>
         <td class="text-end" name="quantity">
-            <t t-if="data.type == 'operation'" t-esc="formatFloatTime(data.quantity, {'unit': 'minutes'})"/>
+            <t t-if="data.type == 'operation'" t-esc="formatFloatTime(data.quantity, {'unit': 'minutes', 'showSeconds': true})"/>
             <t t-else="" t-esc="formatFloat(data.quantity, {'digits': [false, precision]})"/>
         </td>
          <td t-if="showUom" class="text-start" t-esc="data.uom_name"/>

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -13,7 +13,7 @@
             </span>
         </td>
         <td name="quantity" class="text-end">
-            <span t-if="props.type == 'operations'" t-esc="formatFloatTime(data.operations_time, {'unit': 'minutes'})"/>
+            <span t-if="props.type == 'operations'" t-esc="formatFloatTime(data.operations_time, {'unit': 'minutes', 'showSeconds': true})"/>
             <span t-elif="props.type == 'byproducts'" t-esc="formatFloat(data.byproducts_total, {'digits': [false, precision]})"/>
         </td>
         <td name="uom" t-if="showUom" class="text-start"/>

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
@@ -147,7 +147,7 @@ export class MoOverviewLine extends Component {
 
     get formattedQuantity() {
         if (this.data.model === "mrp.workorder" || !this.data.model) {
-            return this.formatFloatTime(this.data.quantity, { unit: this.data.state ? "minutes" : "hours" });
+            return this.formatFloatTime(this.data.quantity, { unit: this.data.state ? "minutes" : "hours", showSeconds: true });
         }
         return this.formatFloat(this.data.quantity);
     }

--- a/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
+++ b/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
@@ -87,7 +87,7 @@ export class MoOverviewOperationsBlock extends Component {
     get totalQuantity() {
         // Float for Hours when displaying done productions, FloatTime for Minutes otherwise.
         return this.props.summary?.done ?
-            formatFloatTime(this.props.summary.quantity, { unit: "hours" }) :
-            formatFloatTime(this.props.summary.quantity, { unit: "minutes" })
+            formatFloatTime(this.props.summary.quantity, { unit: "hours", showSeconds: true }) :
+            formatFloatTime(this.props.summary.quantity, { unit: "minutes", showSeconds: true })
     }
 }

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -74,8 +74,8 @@
                     <field name="reservation_state" optional="hide" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
                     <field name="uom_id" readonly="1" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" widget="many2one_uom" optional="show"/>
-                    <field name="duration_expected" invisible="duration_expected == 0" groups="mrp.group_mrp_routings" widget="float_time" options="{'unit': 'minutes'}" sum="Total expected duration" optional="hide"/>
-                    <field name="duration" invisible="duration == 0" groups="mrp.group_mrp_routings" widget="float_time" options="{'unit': 'minutes'}" sum="Total real duration" optional="hide"/>
+                    <field name="duration_expected" invisible="duration_expected == 0" groups="mrp.group_mrp_routings" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" sum="Total expected duration" optional="hide"/>
+                    <field name="duration" invisible="duration == 0" groups="mrp.group_mrp_routings" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" sum="Total real duration" optional="hide"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
                     <field name="state"
                            decoration-success="state in ('done', 'to_close')"

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -12,8 +12,8 @@
                     <field name="name"/>
                     <field name="bom_id" column_invisible="context.get('bom_id_invisible', False)"/>
                     <field name="workcenter_id"/>
-                    <field name="time_cycle" widget="float_time" options="{'unit': 'minutes'}" string="Duration"/>
-                    <field name="time_total" widget="float_time" options="{'unit': 'minutes'}" string="Total Duration" optional="hide"/>
+                    <field name="time_cycle" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" string="Duration"/>
+                    <field name="time_total" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" string="Total Duration" optional="hide"/>
                     <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                     <field name="possible_bom_product_template_attribute_value_ids" column_invisible="True"/>
                     <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
@@ -102,7 +102,7 @@
                                 <field name="time_mode" widget="radio" options="{'horizontal': true}"/>
                                 <label for="time_cycle_manual" string="Default Duration"/>
                                 <div>
-                                    <field name="time_cycle_manual" widget="float_time" options="{'unit': 'minutes'}" class="o_float_time" invisible="time_mode == 'auto' and workorder_count != 0"/>
+                                    <field name="time_cycle_manual" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" class="o_float_time" invisible="time_mode == 'auto' and workorder_count != 0"/>
                                     <span invisible="time_mode == 'manual'"> / last </span>
                                     <field name="time_mode_batch" class="oe_inline o_small_integer" invisible="time_mode == 'manual'"/>
                                     <span invisible="time_mode == 'manual'">work orders</span>
@@ -111,7 +111,7 @@
                                 <field name="show_time_total" invisible="1"/>
                                 <label for="time_total" string="Total Duration" invisible="not show_time_total"/>
                                 <div invisible="not show_time_total">
-                                    <field name="time_total" widget="float_time" options="{'unit': 'minutes'}" class="oe_inline"/>
+                                    <field name="time_total" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" class="oe_inline"/>
                                 </div>
                                 <field name="company_id" groups="base.group_multi_company" />
                             </group>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -328,11 +328,11 @@
                                         </div>
                                         <label for="time_start"/>
                                         <div>
-                                            <field name="time_start" widget="float_time" options="{'unit': 'minutes'}" class="oe_inline"/>
+                                            <field name="time_start" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" class="oe_inline"/>
                                         </div>
                                         <label for="time_stop"/>
                                         <div>
-                                            <field name="time_stop" widget="float_time" options="{'unit': 'minutes'}" class="oe_inline"/>
+                                            <field name="time_stop" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" class="oe_inline"/>
                                         </div>
                                     </group>
                                     <group string="Costing Information" name="costing">
@@ -351,8 +351,8 @@
                                         <field name="product_id" widget="stock.forced_placeholder" placeholder="All Products" decoration-it="not product_id"/>
                                         <field name="capacity"/>
                                         <field name="uom_id" groups="uom.group_uom" widget="many2one_uom" readonly="product_id != False"/>
-                                        <field name="time_start" widget="float_time" options="{'unit': 'minutes'}"/>
-                                        <field name="time_stop" widget="float_time" options="{'unit': 'minutes'}"/>
+                                        <field name="time_start" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
+                                        <field name="time_stop" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                                     </list>
                                 </field>
                             </page>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -77,7 +77,7 @@
                 <field name="qty_ready" optional="hide" groups="base.group_no_one"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
-                <field name="duration_expected" widget="float_time" options="{'unit': 'minutes'}" sum="expected duration" readonly="state in ['cancel', 'done']"/>
+                <field name="duration_expected" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" sum="expected duration" readonly="state in ['cancel', 'done']"/>
                 <field name="duration" widget="mrp_timer"
                   invisible="production_state == 'draft'"
                   readonly="is_user_working" sum="real duration"/>
@@ -207,7 +207,7 @@
                         </div>
                         <label for="duration_expected"/>
                         <div class="o_row">
-                            <field name="duration_expected" widget="float_time" options="{'unit': 'minutes'}" readonly="state in ['cancel', 'done']"/>
+                            <field name="duration_expected" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" readonly="state in ['cancel', 'done']"/>
                         </div>
                     </group>
                     <group>
@@ -219,7 +219,7 @@
                         <field name="time_ids" nolabel="1" context="{'default_workcenter_id': workcenter_id, 'default_workorder_id': id}">
                             <list editable="bottom">
                                 <field name="user_id"/>
-                                <field name="duration" widget="float_time" options="{'unit': 'minutes'}" readonly="id"/>
+                                <field name="duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" readonly="id"/>
                                 <field name="date_start"/>
                                 <field name="date_end"/>
                                 <field name="workcenter_id" column_invisible="True"/>
@@ -231,7 +231,7 @@
                                     <group>
                                         <field name="date_start"/>
                                         <field name="date_end"/>
-                                        <field name="duration" widget="float_time" options="{'unit': 'minutes'}"/>
+                                        <field name="duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                                         <field name="company_id" invisible="1"/>
                                     </group>
                                     <group>
@@ -245,7 +245,7 @@
                         </field>
                         <div>
                             <label for="duration" class="pe-2"/>
-                            <field name="duration" widget="float_time" options="{'unit': 'minutes'}" readonly="1"/>
+                            <field name="duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" readonly="1"/>
                         </div>
                 </page>
                 <page string="Components" name="components">
@@ -271,7 +271,7 @@
                             <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                             <field name="date_start" readonly="1"/>
                             <field name="date_finished" readonly="1"/>
-                            <field name="duration_expected" widget="float_time" options="{'unit': 'minutes'}" sum="expected duration" readonly="state in ['cancel', 'done']"/>
+                            <field name="duration_expected" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}" sum="expected duration" readonly="state in ['cancel', 'done']"/>
                             <field name="production_state" column_invisible="True"/>
                             <field name="state" widget="mo_view_list_dropdown"
                                 options="{'no_open': True, 'display': 'badge'}"
@@ -339,7 +339,7 @@
                 <field name="duration" type="measure" string="Duration"/>
                 <field name="duration_unit" type="measure"/>
                 <field name="cost" type="measure"/>
-                <field name="duration_expected" type="measure" string="Expected Duration" widget="float_time" options="{'unit': 'minutes'}"/>
+                <field name="duration_expected" type="measure" string="Expected Duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                 <field name="qty_reported_from_previous_wo" invisible="1"/>
                 <field name="costs_hour" invisible="1"/>
                 <field name="qty_production" invisible="1"/>
@@ -354,10 +354,10 @@
             <pivot string="Operations" sample="1">
                 <field name="date_start"/>
                 <field name="operation_id"/>
-                <field name="duration" type="measure" string="Duration" widget="float_time" options="{'unit': 'minutes'}"/>
-                <field name="duration_unit" type="measure" widget="float_time" options="{'unit': 'minutes'}"/>
+                <field name="duration" type="measure" string="Duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
+                <field name="duration_unit" type="measure" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                 <field name="cost" type="measure"/>
-                <field name="duration_expected" type="measure" string="Expected Duration" widget="float_time" options="{'unit': 'minutes'}"/>
+                <field name="duration_expected" type="measure" string="Expected Duration" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                 <field name="qty_reported_from_previous_wo" invisible="1"/>
                 <field name="costs_hour" invisible="1"/>
                 <field name="qty_production" invisible="1"/>
@@ -405,7 +405,7 @@
                         </div>
                         <footer>
                             <div class="o_kanban_workorder_remaining">
-                                <field name="remaining_time" class="mx-1" widget="float_time" options="{'unit': 'minutes'}"/>
+                                <field name="remaining_time" class="mx-1" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                             </div>
                             <div class="d-flex ms-auto">
                                 <field name="last_working_user_id" widget="many2one_avatar_user"/>


### PR DESCRIPTION
Previously, showSeconds was True by default. It has now been set to False by default so we need to enable it for MRP modules.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
