### PR TITLE
[IMP] website_sale: display tax-included prices for combo products

### DIFF
--- a/addons/sale/controllers/combo_configurator.py
+++ b/addons/sale/controllers/combo_configurator.py
@@ -50,13 +50,15 @@ class SaleComboConfiguratorController(Controller):
         date = datetime.fromisoformat(date)
         selected_combo_item_dict = {item["id"]: item for item in selected_combo_items or []}
 
+        price, pricelist_rule_id = product_template._get_configurator_display_price(
+            product_template, quantity, date, currency, pricelist, **kwargs
+        )
+
         return {
             "product_tmpl_id": product_tmpl_id,
             "display_name": product_template.display_name,
             "quantity": quantity,
-            "price": product_template._get_configurator_display_price(
-                product_template, quantity, date, currency, pricelist, **kwargs
-            )[0],
+            "price": price,
             "combos": [
                 {
                     "id": combo.id,
@@ -70,6 +72,7 @@ class SaleComboConfiguratorController(Controller):
                             currency,
                             pricelist,
                             quantity=quantity,
+                            pricelist_rule_id=pricelist_rule_id,
                             **kwargs,
                         )
                         for combo_item in combo.combo_item_ids

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -4,6 +4,7 @@ from odoo.http import request, route
 from odoo.tools.image import image_data_uri
 
 from odoo.addons.sale.controllers.combo_configurator import SaleComboConfiguratorController
+from odoo.addons.website.models import ir_http
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
@@ -45,4 +46,36 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
             combo_item_image := combo_item.product_id.image_256
         ):
             data["product"]["image_src"] = image_data_uri(combo_item_image)
+
+        if not data["extra_price"]:
+            return data
+
+        if pricelist:
+            rule_id = pricelist._get_product_price_rule(combo_item.product_id, 1.0, date=date)[1]
+            if rule_id:
+                rule = request.env["product.pricelist.item"].sudo().browse(rule_id)
+                discount_percentage = 0.0
+                if rule.compute_price == "percentage":
+                    discount_percentage = rule.percent_price
+                elif rule.compute_price == "formula":
+                    discount_percentage = rule.price_discount
+
+                if discount_percentage > 0:
+                    data["extra_price"] -= data["extra_price"] * (discount_percentage / 100.0)
+
+        website = ir_http.get_request_website()
+        if website and website.show_line_subtotals_tax_selection == "tax_included":
+            taxes = combo_item.product_id.taxes_id._filter_taxes_by_company(request.env.company)
+            if hasattr(request, "fiscal_position") and request.fiscal_position:
+                taxes = request.fiscal_position.map_tax(taxes)
+            if taxes:
+                tax_res = taxes.compute_all(
+                    data["extra_price"],
+                    currency,
+                    1,
+                    combo_item.product_id,
+                    request.env.user.partner_id,
+                )
+                data["extra_price"] = tax_res["total_included"]
+
         return data

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -45,4 +45,33 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
             combo_item_image := combo_item.product_id.image_256
         ):
             data["product"]["image_src"] = image_data_uri(combo_item_image)
+
+        if not data["extra_price"]:
+            return data
+
+        pricelist_rule_id = kwargs.get("pricelist_rule_id")
+        if pricelist and pricelist_rule_id:
+            rule = self.env["product.pricelist.item"].sudo().browse(pricelist_rule_id)
+            discount_percentage = 0.0
+            if rule.compute_price == "percentage":
+                discount_percentage = rule.percent_price
+            elif rule.compute_price == "formula":
+                discount_percentage = rule.price_discount
+
+            data["extra_price"] -= data["extra_price"] * (discount_percentage / 100.0)
+
+        website = self.env.website
+        if website and website.show_line_subtotals_tax_selection == "tax_included":
+            item_taxes = combo_item.product_id.taxes_id._filter_taxes_by_company(self.env.company)
+            taxes = request.fiscal_position.map_tax(item_taxes)
+            if taxes:
+                tax_res = taxes.compute_all(
+                    data["extra_price"],
+                    currency,
+                    1,
+                    combo_item.product_id,
+                    self.env.user.partner_id,
+                )
+                data["extra_price"] = tax_res["total_included"]
+
         return data

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -657,6 +657,7 @@ class ProductTemplate(models.Model):
                     product_taxes=product_taxes,
                     taxes=taxes,
                     website=website,
+                    fiscal_position=fiscal_position_sudo,
                 ),
             }
             pricelist_item_sudo = (
@@ -674,6 +675,7 @@ class ProductTemplate(models.Model):
                         product_taxes=product_taxes,
                         taxes=taxes,
                         website=website,
+                        fiscal_position=fiscal_position_sudo,
                     )
 
             if not base_price and comparison_prices_enabled and template.compare_list_price:
@@ -817,16 +819,6 @@ class ProductTemplate(models.Model):
                 product, combination_info
             )
 
-        if (
-            self.type == "combo"
-            and website.show_line_subtotals_tax_selection == "tax_included"
-            and not all(
-                tax.price_include
-                for tax in self.sudo().combo_ids.combo_item_ids.product_id.taxes_id
-            )
-        ):
-            combination_info["tax_disclaimer"] = self.env._("Taxes calculated at checkout.")
-
         return combination_info
 
     def _get_additional_combination_info(
@@ -885,7 +877,7 @@ class ProductTemplate(models.Model):
         # Apply taxes
         product_taxes = product_or_template.sudo().taxes_id._filter_taxes_by_company()
         taxes = self.env["account.tax"]
-        if product_taxes:
+        if product_taxes or product_or_template.type == "combo":
             taxes = fiscal_position.map_tax(product_taxes)
             # We do not apply taxes on the compare_list_price value because it's meant to be
             # a strict value displayed as is.
@@ -896,6 +888,7 @@ class ProductTemplate(models.Model):
                     product_taxes=product_taxes,
                     taxes=taxes,
                     website=website,
+                    fiscal_position=fiscal_position,
                 )
         is_zero_price = currency.is_zero(combination_info["price"])
         prevent_sale = website._prevent_product_sale(product_or_template, is_zero_price)
@@ -970,8 +963,7 @@ class ProductTemplate(models.Model):
             stock_notification_email = ""
             if not website.is_public_user():
                 has_stock_notification = product_sudo._has_stock_notification(
-                    self.env.user.partner_id,
-                    website,
+                    self.env.user.partner_id, website
                 )
             elif request:
                 has_stock_notification = product_sudo.id in request.session.get(
@@ -1031,6 +1023,92 @@ class ProductTemplate(models.Model):
 
         return attr_images
 
+    def _get_combo_item_tax_included_price(self, combo_item, currency, fiscal_position):
+        """Return a combo item's tax-included price, used to compare items.
+
+        :param product.combo.item combo_item: The combo item to price.
+        :param res.currency currency: The currency to use to compute the price.
+        :param account.fiscal.position fiscal_position: The fiscal position to map the taxes with.
+        :rtype: float
+        :return: The combo item's tax-included price.
+        """
+        price = combo_item.lst_price + combo_item.extra_price
+        item_taxes = combo_item.product_id.sudo().taxes_id._filter_taxes_by_company()
+        if not item_taxes:
+            return price
+        mapped_taxes = fiscal_position.map_tax(item_taxes)
+        base = combo_item.product_id._get_tax_included_unit_price_from_price(
+            price, item_taxes, product_taxes_after_fp=mapped_taxes
+        )
+        return mapped_taxes.compute_all(base, currency, 1, partner=self.env.user.partner_id)[
+            "total_included"
+        ]
+
+    def _apply_taxes_of_cheapest_combo_choices(
+        self,
+        price,
+        currency,
+        *,
+        product_or_template=None,
+        product_taxes=None,
+        taxes=None,
+        fiscal_position=None,
+        include_extra_price=True,
+    ):
+        base_price = self.env["product.product"]._get_tax_included_unit_price_from_price(
+            price, product_taxes, product_taxes_after_fp=taxes
+        )
+        combos = product_or_template.sudo().combo_ids
+        combo_base_prices = {
+            combo: combo.currency_id._convert(
+                combo.base_price, currency, self.env.company, fields.Date.context_today(self)
+            )
+            for combo in combos
+        }
+        total_combo_base_price = sum(combo_base_prices.values())
+        combo_prices = {
+            combo: currency.round(base * base_price / (total_combo_base_price or 1))
+            for combo, base in combo_base_prices.items()
+        }
+        combo_price_delta = base_price - sum(combo_prices.values())
+        if combo_price_delta and combos:
+            combo_prices[combos[-1]] += combo_price_delta
+
+        # Heuristic: Pick the cheapest combo item of each choice
+        assumed_combo_items = combos.mapped(
+            lambda c: (
+                min(
+                    c.combo_item_ids,
+                    key=lambda item: self._get_combo_item_tax_included_price(
+                        item, currency, fiscal_position
+                    ),
+                )
+                if c.combo_item_ids
+                else self.env["product.combo.item"]
+            )
+        )
+
+        bases_by_tax = {}
+        for item in assumed_combo_items:
+            if not item:
+                continue
+            prorated_base = combo_prices[item.combo_id]
+            if include_extra_price:
+                prorated_base += item.extra_price
+            item_taxes = item.product_id.sudo().taxes_id._filter_taxes_by_company()
+            mapped_taxes = fiscal_position.map_tax(item_taxes)
+            bases_by_tax[mapped_taxes] = bases_by_tax.get(mapped_taxes, 0.0) + prorated_base
+
+        approx_price = 0.0
+        for tax, base in bases_by_tax.items():
+            if tax:
+                approx_price += tax.compute_all(
+                    base, currency, 1, partner=self.env.user.partner_id
+                )["total_included"]
+            else:
+                approx_price += base
+        return approx_price
+
     def _apply_taxes_to_price(
         self,
         price,
@@ -1041,8 +1119,28 @@ class ProductTemplate(models.Model):
         taxes=None,
         tax_display=None,
         website=None,
+        fiscal_position=None,
+        include_combo_extra_price=True,
     ):
         product = product or self.env["product.product"]
+        if not tax_display:
+            show_tax = (website or self.env.website).show_line_subtotals_tax_selection
+            tax_display = "total_excluded" if show_tax == "tax_excluded" else "total_included"
+        if fiscal_position is None:
+            fiscal_position = (
+                request.fiscal_position if request else self.env["account.fiscal.position"]
+            )
+
+        if self.type == "combo" and tax_display == "total_included":
+            return self._apply_taxes_of_cheapest_combo_choices(
+                price,
+                currency,
+                product_or_template=product or self,
+                product_taxes=product_taxes,
+                taxes=taxes,
+                fiscal_position=fiscal_position,
+                include_extra_price=include_combo_extra_price,
+            )
 
         if product_taxes is None:
             product_taxes = self.sudo().taxes_id._filter_taxes_by_company()
@@ -1052,7 +1150,7 @@ class ProductTemplate(models.Model):
             return price
 
         if taxes is None:
-            taxes = request.fiscal_position.map_tax(product_taxes)
+            taxes = fiscal_position.map_tax(product_taxes)
 
         price = product._get_tax_included_unit_price_from_price(
             price, product_taxes, product_taxes_after_fp=taxes
@@ -1062,10 +1160,6 @@ class ProductTemplate(models.Model):
         tax_details = taxes.compute_all(
             price, currency, 1, product or self, self.env.user.partner_id
         )
-
-        if not tax_display:
-            show_tax = (website or self.env.website).show_line_subtotals_tax_selection
-            tax_display = "total_excluded" if show_tax == "tax_excluded" else "total_included"
 
         return tax_details[tax_display]
 
@@ -1445,7 +1539,9 @@ class ProductTemplate(models.Model):
         )
 
         if website := self.env.website:
-            price = product_or_template._apply_taxes_to_price(price, currency, website=website)
+            price = product_or_template._apply_taxes_to_price(
+                price, currency, website=website, include_combo_extra_price=False
+            )
 
         return price, pricelist_rule_id
 

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from werkzeug import urls
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import float_is_zero, is_html_empty
@@ -517,16 +517,6 @@ class ProductTemplate(models.Model):
                 product, combination_info
             )
 
-        if (
-            product_or_template.type == "combo"
-            and website.show_line_subtotals_tax_selection == "tax_included"
-            and not all(
-                tax.price_include
-                for tax in product_or_template.sudo().combo_ids.combo_item_ids.product_id.taxes_id
-            )
-        ):
-            combination_info["tax_disclaimer"] = _("Taxes calculated at checkout.")
-
         return combination_info
 
     def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
@@ -593,7 +583,7 @@ class ProductTemplate(models.Model):
             self.env.company
         )
         taxes = self.env["account.tax"]
-        if product_taxes:
+        if product_taxes or product_or_template.type == "combo":
             taxes = request.fiscal_position.map_tax(product_taxes)
             # We do not apply taxes on the compare_list_price value because it's meant to be
             # a strict value displayed as is.
@@ -684,16 +674,61 @@ class ProductTemplate(models.Model):
         self, price, currency, product_taxes, taxes, product_or_template, website=None
     ):
         website = website or self.env["website"].get_current_website()
-        price = self.env["product.product"]._get_tax_included_unit_price_from_price(
+        base_price = self.env["product.product"]._get_tax_included_unit_price_from_price(
             price, product_taxes, product_taxes_after_fp=taxes
         )
         show_tax = website.show_line_subtotals_tax_selection
         tax_display = "total_excluded" if show_tax == "tax_excluded" else "total_included"
 
-        # The list_price is always the price of one.
-        return taxes.compute_all(price, currency, 1, product_or_template, self.env.user.partner_id)[
-            tax_display
-        ]
+        if product_or_template.type == "combo" and tax_display == "total_included":
+            combos = product_or_template.sudo().combo_ids
+
+            combo_base_prices = {
+                combo: combo.currency_id._convert(
+                    combo.base_price, currency, self.env.company, fields.Date.context_today(self)
+                )
+                for combo in combos
+            }
+            total_combo_base_price = sum(combo_base_prices.values())
+            combo_prices = {
+                combo: currency.round(base * base_price / (total_combo_base_price or 1))
+                for combo, base in combo_base_prices.items()
+            }
+            combo_price_delta = base_price - sum(combo_prices.values())
+            if combo_price_delta and combos:
+                combo_prices[combos[-1]] += combo_price_delta
+
+            # Heuristic: Pick the cheapest combo item of each choice
+            assumed_combo_items = combos.mapped(
+                lambda c: (
+                    min(
+                        c.combo_item_ids,
+                        key=lambda item: item.product_id.lst_price + item.extra_price,
+                    )
+                    if c.combo_item_ids
+                    else self.env["product.combo.item"]
+                )
+            )
+
+            approx_price = 0.0
+            for item in assumed_combo_items:
+                if not item:
+                    continue
+
+                prorated_base = combo_prices[item.combo_id] + item.extra_price
+
+                item_taxes = item.product_id.taxes_id._filter_taxes_by_company(self.env.company)
+                if item_taxes:
+                    approx_price += item_taxes.compute_all(
+                        prorated_base, currency, 1, item.product_id, self.env.user.partner_id
+                    )[tax_display]
+                else:
+                    approx_price += prorated_base
+            return approx_price
+
+        return taxes.compute_all(
+            base_price, currency, 1, product_or_template, self.env.user.partner_id
+        )[tax_display]
 
     def create_product_variant(self, product_template_attribute_value_ids):
         """Create if necessary and possible and return the id of the product
@@ -922,8 +957,18 @@ class ProductTemplate(models.Model):
             "image_url": {"name": "image_url", "type": "html"},
             "description": {"name": "description_ecommerce", "type": "text", "html": True, "match": True},
             "tags": {"name": "product_tag_ids", "type": "tags", "match": True},
-            "attribute_value_ids": {"name": "attribute_value_ids", "type": "tags", "match": True, "force_show": True},
-            "description_sale": {"name": "description_sale", "type": "text", "html": True, "match": True},
+            "attribute_value_ids": {
+                "name": "attribute_value_ids",
+                "type": "tags",
+                "match": True,
+                "force_show": True,
+            },
+            "description_sale": {
+                "name": "description_sale",
+                "type": "text",
+                "html": True,
+                "match": True,
+            },
         }
         return {
             "model": "product.template",

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -55,8 +55,30 @@ class SaleOrderLine(models.Model):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = "total_excluded" if show_tax == "tax_excluded" else "total_included"
         is_combo = self.product_type == "combo"
-        unit_price = self._get_display_price_ignore_combo() if is_combo else self.price_unit
 
+        if is_combo and tax_display == "total_included":
+            combo_items = self.order_id.order_line.filtered(
+                lambda line: line.linked_line_id == self and line.combo_item_id
+            )
+            if combo_items:
+                bases_by_tax = {}
+                for item in combo_items:
+                    original_price = item._get_combo_item_display_price()
+                    bases_by_tax[item.tax_ids] = (
+                        bases_by_tax.get(item.tax_ids, 0.0) + original_price
+                    )
+
+                total_tax_included_price = 0.0
+                for tax_ids, base in bases_by_tax.items():
+                    if tax_ids:
+                        total_tax_included_price += tax_ids.compute_all(
+                            base, self.currency_id, partner=self.order_partner_id
+                        )["total_included"]
+                    else:
+                        total_tax_included_price += base
+                return total_tax_included_price
+
+        unit_price = self._get_display_price_ignore_combo() if is_combo else self.price_unit
         return self.tax_ids.compute_all(
             unit_price, self.currency_id, 1, self.product_id, self.order_partner_id
         )[tax_display]
@@ -102,6 +124,23 @@ class SaleOrderLine(models.Model):
             if self.order_id.website_id.show_line_subtotals_tax_selection == "tax_excluded"
             else "price_total"
         )
+        if price_type == "price_total" and self.product_type == "combo":
+            lines = self._get_lines_with_price()
+            bases_by_tax = {}
+            for line in lines:
+                bases_by_tax[line.tax_ids] = (
+                    bases_by_tax.get(line.tax_ids, 0.0) + line.price_subtotal
+                )
+
+            total_tax_included_price = 0.0
+            for tax_ids, base in bases_by_tax.items():
+                if tax_ids:
+                    total_tax_included_price += tax_ids.compute_all(
+                        base, self.currency_id, partner=self.order_partner_id
+                    )["total_included"]
+                else:
+                    total_tax_included_price += base
+            return total_tax_included_price
         return sum(self._get_lines_with_price().mapped(price_type))
 
     def _check_validity(self):

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -56,8 +56,21 @@ class SaleOrderLine(models.Model):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = "total_excluded" if show_tax == "tax_excluded" else "total_included"
         is_combo = self.product_type == "combo"
-        unit_price = self._get_display_price_ignore_combo() if is_combo else self.price_unit
 
+        if is_combo and tax_display == "total_included":
+            combo_items = self.order_id.order_line.filtered(
+                lambda line: line.linked_line_id == self and line.combo_item_id
+            )
+            if combo_items:
+                total_tax_included_price = 0.0
+                for item in combo_items:
+                    original_price = item._get_combo_item_display_price()
+                    total_tax_included_price += item.tax_ids.compute_all(
+                        original_price, self.currency_id, 1, item.product_id, self.order_partner_id
+                    )[tax_display]
+                return total_tax_included_price
+
+        unit_price = self._get_display_price_ignore_combo() if is_combo else self.price_unit
         return self.tax_ids.compute_all(
             unit_price, self.currency_id, 1, self.product_id, self.order_partner_id
         )[tax_display]

--- a/addons/website_sale/static/tests/tours/combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/combo_configurator.js
@@ -18,10 +18,6 @@ registry
             ...productConfiguratorTourUtils.saveConfigurator(),
             comboConfiguratorTourUtils.selectComboItem("Product B2"),
             comboConfiguratorTourUtils.assertFooterButtonsEnabled(),
-            {
-                content: "Check that the tax disclaimer gets displayed",
-                trigger: '.js_product small:contains(Taxes calculated at checkout.)',
-            },
             // Assert that the cart's content is correct.
             {
                 content: "Proceed to checkout",
@@ -54,7 +50,7 @@ registry
             ...wsTourUtils.assertCartContains({ productName: "2 x Product B2" }),
             {
                 content: "Verify the combo product's price",
-                trigger: 'h6[name=website_sale_cart_line_price]:contains(71.31)',
+                trigger: 'h6[name=website_sale_cart_line_price]:contains(71.30)',
             },
         ],
     });

--- a/addons/website_sale/static/tests/tours/combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/combo_configurator.js
@@ -18,10 +18,6 @@ registry
             ...productConfiguratorTourUtils.saveConfigurator(),
             comboConfiguratorTourUtils.selectComboItem("Product B2"),
             comboConfiguratorTourUtils.assertFooterButtonsEnabled(),
-            {
-                content: "Check that the tax disclaimer gets displayed",
-                trigger: '.js_product small:contains(Taxes calculated at checkout.)',
-            },
             // Assert that the cart's content is correct.
             {
                 content: "Proceed to checkout",

--- a/addons/website_sale/tests/test_combo_configurator.py
+++ b/addons/website_sale/tests/test_combo_configurator.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
@@ -108,3 +110,33 @@ class TestWebsiteSaleComboConfigurator(HttpCase, WebsiteSaleCommon):
         self.start_tour(
             combo_product.website_url, "website_sale.combo_configurator_single_configurable_item"
         )
+
+    def test_combo_item_tax_included_extra_price(self):
+        """Test that combo item extra prices in the website sale configurator include taxes when the
+        website is configured to display tax-inclusive prices.
+        """
+        self.website.show_line_subtotals_tax_selection = "tax_included"
+        tax_10 = self.env["account.tax"].create({"name": "Tax 10%", "amount": 10.0})
+
+        product = self._create_product(
+            name="Product", list_price=0.0, taxes_id=[Command.link(tax_10.id)]
+        )
+        combo = self.env["product.combo"].create({
+            "name": "Combo choice",
+            "combo_item_ids": [Command.create({"product_id": product.id, "extra_price": 10.0})],
+        })
+        combo_product = self._create_product(
+            name="Combo product", list_price=50.0, type="combo", combo_ids=[Command.link(combo.id)]
+        )
+
+        result = self.make_jsonrpc_request(
+            "/website_sale/combo_configurator/get_data",
+            {
+                "product_tmpl_id": combo_product.product_tmpl_id.id,
+                "quantity": 1,
+                "date": datetime(2026, 1, 1).isoformat(),
+            },
+        )
+
+        combo_item_data = result["combos"][0]["combo_items"][0]
+        self.assertAlmostEqual(combo_item_data["extra_price"], 11.0)

--- a/addons/website_sale/tests/test_product_template.py
+++ b/addons/website_sale/tests/test_product_template.py
@@ -205,3 +205,46 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
         self.assertEqual(product_template.base_unit_count, 0.0001)
         self.assertEqual(product.base_unit_price, 10000.0)
         self.assertEqual(product_template.base_unit_price, 10000.0)
+
+    def test_combo_display_price_heuristic(self):
+        """
+        Test that tax-inclusive combo price is estimated by picking cheapest item of each combo
+        choice.
+        """
+        self.website.show_line_subtotals_tax_selection = "tax_included"
+        tax_10 = self.env["account.tax"].create({"name": "Tax 10%", "amount": 10.0})
+
+        product_a1 = self._create_product(list_price=20.0, taxes_id=[Command.link(tax_10.id)])
+        product_a2 = self._create_product(list_price=30.0, taxes_id=[Command.link(tax_10.id)])
+        product_b1 = self._create_product(list_price=90.0)
+        product_b2 = self._create_product(list_price=80.0)
+
+        combo_a = self.env["product.combo"].create({
+            "name": "Combo choice A",
+            "combo_item_ids": [
+                Command.create({"product_id": product_a1.id}),
+                Command.create({"product_id": product_a2.id}),
+            ],
+        })
+        combo_b = self.env["product.combo"].create({
+            "name": "Combo choice B",
+            "combo_item_ids": [
+                Command.create({"product_id": product_b1.id}),
+                Command.create({"product_id": product_b2.id}),
+            ],
+        })
+        combo_tmpl = self._create_product(
+            name="Combo product",
+            list_price=95.0,
+            type="combo",
+            combo_ids=[Command.link(combo_a.id), Command.link(combo_b.id)],
+        ).product_tmpl_id
+
+        with self.mock_request():
+            price = combo_tmpl._apply_taxes_to_price(95.0, self.currency, website=self.website)
+
+        # combo_a.base_price=20, combo_b.base_price=80; total=100
+        # combo_a's price is 20/100*95=19; cheapest item (product_a1) has 10% tax → 20.90
+        # combo_b's price is' 80/100*95=76; cheapest item (product_b2) has 15% default tax → 87.40
+        # Total: 20.90 + 87.40 = 108.30
+        self.assertAlmostEqual(price, 108.30)


### PR DESCRIPTION
Previously, in eCommerce, combo product prices were shown tax-excluded independently of the tax settings of the website. Because combo taxes depend on the specific components chosen, the final tax amount was unknown until checkout. Additionally, component upcharges (extra prices) did not reflect active pricelist discounts or included taxes, and the cart's strikethrough (original) price failed to account for component-level taxes.

This commit introduces several improvements to ensure accurate price transparency across the entire buying flow:
- Product Page: Introduces a heuristic to estimate the baseline tax-included price upfront. It precisely mimics backend prorating logic while assuming the user selects the cheapest available item for each combo choice. The "Taxes calculated at checkout" disclaimer is removed.
- Combo Configurator: Option upcharges (`extra_price`) now correctly evaluate against active pricelist discounts (percentage/formula rules) and display as tax-included on the UI.
- Shopping Cart: The original/strikethrough price for discounted combos now accurately computes the tax-included sum of the actual selected child components, rather than falling back to the taxless parent line.

task-5956777