### PR TITLE
[17.0][FIX] stock method _find_or_create_global_route with user lang

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -389,7 +389,8 @@ class Warehouse(models.Model):
         data_route = route = self.env.ref(xml_id, raise_if_not_found=False)
         company = self.company_id[:1] or self.env.company
         if not route or (route.sudo().company_id and route.sudo().company_id != company):
-            route = self.env['stock.route'].with_context(active_test=False).search([
+            # search route with user lang as `route_name` is translated
+            route = self.env['stock.route'].with_context(lang=self.env.user.lang, active_test=False).search([
                 ('name', 'like', route_name), ('company_id', 'in', [False, company.id])
             ], order='company_id', limit=1)
         if not route:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
if the method `_find_or_create_global_route` is invoked during a migration process, it will fail as the term `route_name` is translated, but the call is made clearing it

Current behavior before PR:
a migration process failed for an external module: `stock_mts_mto_rule`

Desired behavior after PR is merged:
the migration process succeeds



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
