### PR TITLE
[IMP] stock: create quants relocation requests

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -491,6 +491,7 @@ class StockQuant(models.Model):
             'single_product': self.env.context.get("single_product", False)
         }
         return {
+            'name': 'Relocate',
             'res_model': 'stock.quant.relocate',
             'views': [[False, 'form']],
             'target': 'new',

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -459,6 +459,7 @@ class StockQuant(models.Model):
             'single_product': self.env.context.get("single_product", False)
         }
         return {
+            'name': 'Relocate',
             'res_model': 'stock.quant.relocate',
             'views': [[False, 'form']],
             'target': 'new',

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1418,6 +1418,63 @@ class TestStockQuant(TestStockCommon):
         )
         self.assertEqual(quant.inventory_quantity, 0)
 
+    def test_request_quant_relocation(self):
+        different_location = self.env['stock.location'].create({
+            'name': 'Different Location',
+            'usage': 'internal',
+            'location_id': self.stock_location.warehouse_id.view_location_id.id,
+        })
+        quant_1 = self.env['stock.quant'].create({
+            'location_id': self.stock_location.id,
+            'product_id': self.productA.id,
+            'quantity': 10,
+        })
+        quant_2 = self.env['stock.quant'].create({
+            'location_id': self.shelf_2.id,
+            'product_id': self.productA.id,
+            'quantity': 15,
+        })
+        quant_3 = self.env['stock.quant'].create({
+            'location_id': different_location.id,
+            'product_id': self.productA.id,
+            'quantity': 20,
+        })
+        package = self.env['stock.package'].create({'name': 'PACK001'})
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_1,
+            'message': "Product needs relocation",
+            'dest_location_id': self.stock_location.id,
+            'dest_package_id': package.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Product needs relocation')])
+        self.assertTrue(picking)
+        self.assertEqual(picking.move_ids.package_ids, wizard.dest_package_id)
+
+        # Multi-location quants relocation request with common internal parent
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_1 + quant_2,
+            'message': "Merged Transfer",
+            'dest_location_id': self.stock_location.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Merged Transfer')])
+        # Same products should be merged into the same move with a common parent
+        self.assertEqual(len(picking.move_ids), 1)
+        self.assertEqual(len(picking.move_line_ids), 2)
+        self.assertEqual(picking.location_id, self.stock_location)
+
+        # Multi-location quants relocation request with no common internal parent
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_2 + quant_3,
+            'message': "Different Transfers",
+            'dest_location_id': self.stock_location.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Different Transfers')])
+        self.assertEqual(len(picking), 2)
+        self.assertEqual(picking[0].location_id, different_location)
+
 
 class TestStockQuantRemovalStrategy(TestStockCommon):
 

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1418,6 +1418,60 @@ class TestStockQuant(TestStockCommon):
         )
         self.assertEqual(quant.inventory_quantity, 0)
 
+    def test_request_quant_relocation(self):
+        different_location = self.env['stock.location'].create({
+            'name': 'Different Location',
+            'usage': 'internal',
+            'location_id': self.stock_location.warehouse_id.view_location_id.id,
+        })
+        quant_1 = self.env['stock.quant'].create([{
+            'location_id': self.stock_location.id,
+            'product_id': self.productA.id,
+            'inventory_quantity': 10,
+        }])
+        quant_2 = self.env['stock.quant'].create([{
+            'location_id': self.shelf_2.id,
+            'product_id': self.productA.id,
+            'inventory_quantity': 15,
+        }])
+        quant_3 = self.env['stock.quant'].create([{
+            'location_id': different_location.id,
+            'product_id': self.productA.id,
+            'inventory_quantity': 20,
+        }])
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_1,
+            'message': "Product needs relocation",
+            'dest_location_id': self.stock_location.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Product needs relocation')])
+        self.assertTrue(picking)
+
+        # Multi-location quants relocation request with common internal parent
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_1 + quant_2,
+            'message': "Merged Transfer",
+            'dest_location_id': self.stock_location.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Merged Transfer')])
+        # Same products should be merged into the same move with a common parent
+        self.assertEqual(len(picking.move_ids), 1)
+        self.assertEqual(len(picking.move_ids.move_line_ids), 2)
+        self.assertEqual(picking.location_id, self.stock_location)
+
+        # Multi-location quants relocation request with no common internal parent
+        wizard = self.env['stock.quant.relocate'].create({
+            'quant_ids': quant_2 + quant_3,
+            'message': "Different Transfers",
+            'dest_location_id': self.stock_location.id,
+        })
+        wizard.action_request_quants_relocation()
+        picking = self.env['stock.picking'].search([('origin', '=', 'Relocation Request: Different Transfers')])
+        self.assertEqual(len(picking), 2)
+        self.assertEqual(picking[0].location_id, different_location)
+
 
 class TestStockQuantRemovalStrategy(TestStockCommon):
 

--- a/addons/stock/wizard/stock_quant_relocate.py
+++ b/addons/stock/wizard/stock_quant_relocate.py
@@ -3,7 +3,9 @@
 
 from ast import literal_eval
 
-from odoo import fields, models, api
+from odoo import fields, models, api, Command
+from odoo.exceptions import UserError
+from odoo.tools import groupby
 
 
 class StockQuantRelocate(models.TransientModel):
@@ -74,3 +76,106 @@ class StockQuantRelocate(models.TransientModel):
         elif self.env.context.get('single_product', False) and len(product_ids) == 1:
             return product_ids.action_open_quants()
         return self.quant_ids.with_context(always_show_loc=1).action_view_quants()
+
+    def action_request_quants_relocation(self):
+        self.ensure_one()
+        pickings = []
+        for warehouse in self.quant_ids.warehouse_id:
+            picking_type = (
+                warehouse.int_type_id
+                if warehouse.int_type_id.active
+                else self.env['stock.picking.type'].search(
+                    [
+                        ('code', '=', 'internal'),
+                        ('warehouse_id', '=', warehouse.id),
+                    ],
+                    limit=1,
+                )
+            )
+            if not picking_type:
+                raise UserError(self.env._('You need to create an internal operation type for your warehouse.'))
+
+            if len(self.quant_ids.location_id) > 1:
+                grouped_quants = groupby(self.quant_ids.filtered(lambda q: q.warehouse_id == warehouse),
+                                         key=lambda q: self._get_parent_location(q.location_id, warehouse.view_location_id))
+                for parent, quants in grouped_quants:
+                    if parent:
+                        location_id = parent.id if len(quants) > 1 else quants[0].location_id.id
+                        pickings.append(self._create_moves_and_picking(quants, location_id, picking_type))
+            else:
+                pickings.append(self._create_moves_and_picking(self.quant_ids, self.quant_ids.location_id.id, picking_type))
+
+        links, placeholders = self._generate_links_and_placeholders(pickings)
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': self.env._('The transfer request has been created') if pickings
+                    else self.env._('Only products assigned to a warehouse can be relocated'),
+                'message': placeholders,
+                'links': links,
+                'sticky': False,
+                'next': {'type': 'ir.actions.act_window_close'},
+            },
+        }
+
+    def _get_parent_location(self, location_id, view_location_id):
+        if view_location_id == location_id.location_id or location_id.location_id.usage == 'view':
+            return location_id
+        return self._get_parent_location(location_id.location_id, view_location_id)
+
+    def _create_moves_and_picking(self, quants, source_location, picking_type):
+        moves = []
+        grouped_quants = groupby(quants, key=lambda q: q.product_id)
+        for product, quants in grouped_quants:
+            move_vals = {
+                'product_id': product.id,
+                'product_uom_qty': quants[0].quantity,
+                'uom_id': quants[0].uom_id.id,
+                'location_id': quants[0].location_id.id,
+                'location_dest_id': self.dest_location_id.id or source_location,
+            }
+            if len(quants) > 1:
+                move_lines = []
+                quantity = 0
+                for quant in quants:
+                    move_lines.append(
+                            Command.create({
+                            'product_id': product.id,
+                            'quantity': quant.quantity,
+                            'uom_id': quant.uom_id.id,
+                            'location_id':  quant.location_id.id,
+                            'location_dest_id': self.dest_location_id.id or source_location,
+                            'company_id': quant.company_id.id,
+                        })
+                    )
+                    quantity += quant.quantity
+                move_vals['move_line_ids'] = move_lines
+                move_vals['product_uom_qty'] = quantity
+                move_vals['location_id'] = source_location
+            moves.append(Command.create(move_vals))
+
+        picking = self.env['stock.picking'].create({
+                    'picking_type_id': picking_type.id,
+                    'origin': f'Relocation Request{f': {self.message}' if self.message else ''}',
+                    'location_id': source_location,
+                    'location_dest_id': self.dest_location_id.id or source_location,
+                    'move_ids': moves,
+                })
+        picking.action_confirm()
+        # Link move_line_ids to the picking
+        picking.move_ids.move_line_ids.picking_id = picking
+        picking.move_line_ids.result_package_id = self.dest_package_id
+        return picking
+
+    def _generate_links_and_placeholders(self, pickings):
+        links = []
+        placeholders = "\n"
+        for picking in pickings:
+            links.append({
+                'label': picking.name,
+                'url': f'/odoo/action-stock.stock_picking_action_picking_type/{picking.id}'
+            })
+            placeholders += '%s '
+
+        return links, placeholders

--- a/addons/stock/wizard/stock_quant_relocate.py
+++ b/addons/stock/wizard/stock_quant_relocate.py
@@ -3,7 +3,9 @@
 
 from ast import literal_eval
 
-from odoo import fields, models, api
+from odoo import fields, models, api, Command
+from odoo.exceptions import UserError
+from odoo.tools import groupby
 
 
 class StockQuantRelocate(models.TransientModel):
@@ -74,3 +76,111 @@ class StockQuantRelocate(models.TransientModel):
         elif self.env.context.get('single_product', False) and len(product_ids) == 1:
             return product_ids.action_open_quants()
         return self.quant_ids.with_context(always_show_loc=1).action_view_quants()
+
+    def action_request_quants_relocation(self):
+        self.ensure_one()
+        pickings = []
+        for warehouse in self.quant_ids.warehouse_id:
+            picking_type = (
+                warehouse.int_type_id
+                if warehouse.int_type_id.active
+                else self.env['stock.picking.type'].search(
+                    [
+                        ('code', '=', 'internal'),
+                        ('warehouse_id', '=', warehouse.id),
+                    ],
+                    limit=1,
+                )
+            )
+            if not picking_type:
+                raise UserError(self.env._('You need to create an internal operation type for your warehouse.'))
+
+            if len(self.quant_ids.location_id) > 1:
+                grouped_quants = groupby(self.quant_ids.filtered(lambda q: q.warehouse_id == warehouse),
+                                         key=lambda q: self._get_parent_location(q.location_id, warehouse.view_location_id))
+                for parent, quants in grouped_quants:
+                    if parent:
+                        location_id = parent.id if len(quants) > 1 else quants[0].location_id.id
+                        pickings.append(self._create_moves_and_picking(quants, location_id, picking_type))
+            else:
+                pickings.append(self._create_moves_and_picking(self.quant_ids, self.quant_ids.location_id.id, picking_type))
+
+        links, placeholders = self._generate_links_and_placeholders(pickings)
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': self.env._('The transfer request has been created') if pickings
+                    else self.env._('Only products assigned to a warehouse can be relocated'),
+                'message': placeholders,
+                'links': links,
+                'sticky': False,
+                'next': {'type': 'ir.actions.act_window_close'},
+            },
+        }
+
+    def _get_parent_location(self, location_id, view_location_id):
+        if view_location_id == location_id.location_id or location_id.location_id.usage == 'view':
+            return location_id
+        return self._get_parent_location(location_id.location_id, view_location_id)
+
+    def _create_moves_and_picking(self, quants, source_location, picking_type):
+        moves = []
+        grouped_quants = groupby(quants, key=lambda q: q.product_id)
+        for product, quants in grouped_quants:
+            if len(quants) == 1:
+                moves.append(
+                    Command.create({
+                        'product_id': product.id,
+                        'product_uom_qty': quants[0].quantity,
+                        'uom_id': quants[0].uom_id.id,
+                        'location_id': quants[0].location_id.id,
+                        'location_dest_id': self.dest_location_id.id,
+                    }),
+                )
+            else:
+                move_lines = []
+                quantity = 0
+                for quant in quants:
+                    move_lines.append(
+                            Command.create({
+                            'product_id': product.id,
+                            'quantity': quant.quantity,
+                            'uom_id': quant.uom_id.id,
+                            'location_id':  quant.location_id.id,
+                            'location_dest_id': self.dest_location_id.id,
+                            'company_id': quant.company_id.id,
+                        })
+                    )
+                    quantity += quant.quantity
+                move = Command.create({
+                        'product_id': product.id,
+                        'product_uom_qty': quantity,
+                        'uom_id': quant.uom_id.id,
+                        'location_id':  source_location,
+                        'location_dest_id': self.dest_location_id.id,
+                        'move_line_ids': move_lines,
+                })
+                moves.append(move)
+
+        picking = self.env['stock.picking'].create({
+                    'picking_type_id': picking_type.id,
+                    'origin': f'Relocation Request{f': {self.message}' if self.message else ''}',
+                    'location_id': source_location,
+                    'location_dest_id': self.dest_location_id.id,
+                    'move_ids': moves,
+                })
+        picking.action_confirm()
+        return picking
+
+    def _generate_links_and_placeholders(self, pickings):
+        links = []
+        placeholders = "\n"
+        for picking in pickings:
+            links.append({
+                'label': picking.name,
+                'url': f'/odoo/action-stock.stock_picking_action_picking_type/{picking.id}'
+            })
+            placeholders += '%s '
+
+        return links, placeholders

--- a/addons/stock/wizard/stock_quant_relocate.xml
+++ b/addons/stock/wizard/stock_quant_relocate.xml
@@ -25,7 +25,8 @@
                     You may not assign them a package without moving them to a common location.
                 </div>
                 <footer>
-                    <button name="action_relocate_quants" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button name="action_relocate_quants" string="Done" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button name="action_request_quants_relocation" string="Request Relocation" type="object" class="btn-primary" data-hotkey="x"/>
                     <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>


### PR DESCRIPTION
In this commit, we allow users to request a quant
relocation if for example they need manager's
approval first, or the request is required to be
checked by more than one person before processing
to avoid errors.

Instead of it being done instantly it gives an
extra layer of security and facilitates
inventory tracking.

Multiple products can be added to one request
if they exist in the same location or have a
common parent internal location.

Multiple transfers will be created if there
is no common parent for every location, while
still merging the quants that have a common
parent internal location.

Products with no assigned warehouse will be
disregarded.

Note that the check for the common internal parent
stops at the first virtual location and won't
go further.

Task: 6005332





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
