### PR TITLE
[IMP] account_edi_ubl_cii: Add parameter to disable PDF auto-generation

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -25,6 +25,7 @@ Pro rules and show the errors.
     'data': [
         'data/cii_22_templates.xml',
         'data/ubl_20_templates.xml',
+        'data/ir_config_parameter_data.xml',
         'data/ubl_21_templates.xml',
         'views/account_move_views.xml',
         'views/res_partner_views.xml',

--- a/addons/account_edi_ubl_cii/data/ir_config_parameter_data.xml
+++ b/addons/account_edi_ubl_cii/data/ir_config_parameter_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record model="ir.config_parameter" id="disable_pdf_in_xml">
+            <field name="key">account_edi_ubl_cii.disable_pdf_in_xml</field>
+            <field name="value">False</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2,7 +2,7 @@ import io
 import logging
 
 from odoo import _, models
-from odoo.tools import frozendict, html2plaintext, pdf
+from odoo.tools import frozendict, html2plaintext, pdf, str2bool
 from odoo.addons.account_edi_ubl_cii.models.account_edi_common import (
     FloatFmt,
     GST_COUNTRY_CODES,
@@ -18,9 +18,15 @@ class AccountEdiUBL(models.AbstractModel):
 
     def _import_attachments(self, invoice, tree):
         """ EXTENDS 'account_edi_common': ATTEMPTS to create a PDF attachment when the XML file doesn't provide one."""
-
+        IrConfigParam = self.env['ir.config_parameter'].sudo()
+        disable_pdf_in_xml = str2bool(IrConfigParam.get_param("account_edi_ubl_cii.disable_pdf_in_xml", 'False'))
         additional_docs = super()._import_attachments(invoice, tree)
-        if additional_docs or invoice.message_main_attachment_id or not invoice.is_purchase_document():
+        if (
+            additional_docs or
+            invoice.message_main_attachment_id or
+            not invoice.is_purchase_document() or
+            disable_pdf_in_xml
+        ):
             return additional_docs
         try:
             invoices_by_odoo_xmlid = 'account_edi_ubl_cii.action_report_account_invoices_generated_by_odoo'

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_auto_generate_pdf.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_auto_generate_pdf.py
@@ -12,13 +12,32 @@ class TestUblImportBis3InvoiceBEAutoGeneratePDF(TestUblImportBis3InvoiceBE):
             _filename, file_content = self._import_file_content('test_import_invoice_auto_generate_pdf', 'pdf')
             return file_content
 
-        # Import the document that doesn't contain an embedded PDF
-        with patch.object(self.env.registry['ir.actions.report'], '_run_wkhtmltopdf', _run_wkhtmltopdf):
-            bill = self._import_invoice_as_attachment_on(
-                test_name='test_import_invoice_auto_generate_pdf',
-                journal=self.company_data["default_journal_purchase"].with_context(force_report_rendering=True),
+        def _set_pdf_param(value):
+            self.env['ir.config_parameter'].sudo().set_param(
+                'account_edi_ubl_cii.disable_pdf_in_xml',
+                value
             )
+            self.env['ir.config_parameter'].flush_model()
 
-        self.assertTrue(bill.ubl_cii_xml_id)  # Original XML
-        self.assertEqual(len(bill.attachment_ids), 1)  # Generated PDF
-        self.assertTrue(bill.attachment_ids.mimetype, 'pdf')
+        def _import_and_assert(should_generate_pdf):
+            # Import the document that doesn't contain an embedded PDF
+            with patch.object(self.env.registry['ir.actions.report'], '_run_wkhtmltopdf', _run_wkhtmltopdf):
+                bill = self._import_invoice_as_attachment_on(
+                    test_name='test_import_invoice_auto_generate_pdf',
+                    journal=self.company_data["default_journal_purchase"].with_context(force_report_rendering=True),
+                )
+
+            self.assertTrue(bill.ubl_cii_xml_id)  # Original XML
+            self.assertEqual(len(bill.attachment_ids), int(should_generate_pdf))  # Generated PDF
+            if should_generate_pdf:
+                self.assertTrue(bill.attachment_ids.mimetype, 'pdf')
+
+        # Default behaviour -> Creates PDF
+        _import_and_assert(True)
+
+        # Unabled conf -> No PDF
+        _set_pdf_param('True')
+        _import_and_assert(False)
+
+        # Return default behaviour
+        _set_pdf_param('False')


### PR DESCRIPTION
Commit 7bc35c4 introduced automatic PDF generation for imported XML invoices that don't include an embedded PDF file. However, this behavior was mandatory and couldn't be disabled.

This commit adds a new configuration parameter to allow users disable this behaviour.

Task-6050566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
