### PR TITLE
[FIX] survey: fix question error alert

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -374,9 +374,13 @@
             <t t-if="question.question_type == 'scale'" t-call="survey.question_scale"/>
             <t t-if="question.question_type == 'multiple_choice'" t-call="survey.question_multiple_choice"/>
             <t t-if="question.question_type == 'matrix'" t-call="survey.question_matrix"/>
+            <!-- Display the error message if the question is considered post submit (needs to be reviewed to get an answer) and
+            it's the post-submit flow or it's the pre-submit flow and the question was effectively skipped. -->
+            <t t-set="display_error_msg" t-value="is_post_submit_question and
+                (answer.survey_first_submitted or (answer_lines and all(answer_lines.mapped('skipped'))))"/>
             <div t-attf-class="o_survey_question_error d-flex align-items-center justify-content-between overflow-hidden
-                 border-0 py-0 px-3 alert alert-danger mt-2 #{'slide_in' if is_post_submit_question else ''}" role="alert">
-                <span t-if="is_post_submit_question" t-out="question.constr_error_msg or default_constr_error_msg"/>
+                 border-0 py-0 px-3 alert alert-danger mt-2 #{'slide_in' if display_error_msg else ''}" role="alert">
+                <span t-if="display_error_msg" t-out="question.constr_error_msg or default_constr_error_msg"/>
             </div>
         </div>
     </template>


### PR DESCRIPTION
Purpose
=======
Fix the "This question requires an answer" alert which is displayed under the question even if it's the first time the user sees it.

Specification
=============
Following odoo/odoo#215237 conditional questions can now be displayed in the post-submit flow. The purpose was to give the user the chance to see and answer the conditional questions that are triggered by a mandatory question that was skipped.

However the condition to display this error alert was only relying on the fact that the question was considered post-submit or not. But now that the post-submit questions also includes the conditional questions that are waiting for answer, this condition is not enough anymore.

Making the condition more precise to be sure that the error is displayed only if the questions is considered post-submit AND it's already the post-submit flow or it's the pre-submit flow and the question was effectively skipped by the user.

Task-6048598


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
