### PR TITLE
[FIX] stock: set delivery address by resupplying a warehouse from an other one

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1672,8 +1672,9 @@ Please change the quantity done or the rounding precision in your settings.""",
         return quantities
 
     def _get_partner_id(self):
+        self.ensure_one()
         if self.location_id == self.env.company.internal_transit_location_id:
-            return False
+            return self.location_dest_id.warehouse_id.partner_id.id
         return self.partner_id.id
 
     def _prepare_procurement_values(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -340,12 +340,13 @@ class StockRule(models.Model):
         move_dest_ids = values.get('move_dest_ids') and [(4, x.id) for x in values['move_dest_ids']] or []
 
         # when create chained moves for inter-warehouse transfers, set the warehouses as partners
-        if not partner and move_dest_ids:
+        if move_dest_ids:
             move_dest = values['move_dest_ids']
             if location_dest_id == company_id.internal_transit_location_id:
-                partners = move_dest.location_dest_id.warehouse_id.partner_id
-                if len(partners) == 1:
-                    partner = partners.id
+                if not partner:
+                    partners = move_dest.location_dest_id.warehouse_id.partner_id
+                    if len(partners) == 1:
+                        partner = partners.id
                 move_dest.partner_id = self.location_src_id.warehouse_id.partner_id or self.company_id.partner_id
 
         # If the quantity is negative the move should be considered as a refund

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -2,7 +2,7 @@
 
 from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
-from odoo.tests import Form
+from odoo.tests import tagged, Form
 from odoo.tests.common import new_test_user
 
 
@@ -950,3 +950,38 @@ class TestWarehouse(TestStockCommon):
         ]:
             res = self.env['stock.warehouse.orderpoint'].search([('qty_to_order', op, 0)])
             self.assertEqual(res, expected, "Error with operator %s" % op)
+
+
+@tagged('-at_install', 'post_install')
+class TestWarehousePostInstall(TestStockCommon):
+    def test_manual_resupply_from_wh_partner_propagation(self):
+        """
+        Check that the warehouse destination is set as delivery address
+        when a product is manually resupplied from an other warehouse.
+        """
+        warehouse_2 = self.env['stock.warehouse'].create({
+            'name': 'Warehouse 2',
+            'company_id': self.env.company.id,
+            'code': 'WHC2',
+            'resupply_wh_ids': [Command.set(self.warehouse_1.ids)],
+            'partner_id': self.partner.id,
+        })
+        self.product.route_ids = warehouse_2.resupply_route_ids
+        product_replenish = Form(self.env['product.replenish'].with_context(default_product_id=self.product.id))
+        product_replenish.warehouse_id = warehouse_2
+        product_replenish.save().launch_replenishment()
+        replenishment_pickings = self.env['stock.picking'].search([('origin', '=', 'Manual Replenishment'), ('product_id', '=', self.product.ids)]).sorted('id')
+        self.assertRecordValues(replenishment_pickings, [
+            {
+                'picking_type_id': self.warehouse_1.out_type_id.id,
+                'location_id': self.warehouse_1.lot_stock_id.id,
+                'location_dest_id': self.env.company.internal_transit_location_id.id,
+                'partner_id': warehouse_2.partner_id.id,
+            },
+            {
+                'picking_type_id': warehouse_2.in_type_id.id,
+                'location_id': self.env.company.internal_transit_location_id.id,
+                'location_dest_id': warehouse_2.lot_stock_id.id,
+                'partner_id': self.warehouse_1.partner_id.id,
+            },
+        ])


### PR DESCRIPTION
### Steps to reproduce:

- Ensure that sale_stock is installed
- In the settings enable Multi-Steps Routes
- Inventory > Configuration > Warehouse Management > Warehouses
- Create a second warehouse WH2 and enable: Resupply from WH1
- Create a physical product using the route: Resupply from WH1
- Click on the product form cog wheel icon > Replenish
- Replenish 1 unit to warehouses 2
#### > The delivery that was created from WH1 to the inter company transit location does not set the `partner_id` (delivery address) to the partner of warehouse 2.

### Cause of the issue:

Triggering the replenish will create a move chain relying on the `_run_pull` mechanich. In particular,
the receipt move will be created first from Inter-company transit to `WH2/Stock` without `partner_id`:
https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/stock/models/stock_move.py#L1709 https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/stock/models/stock_move.py#L1674-L1677 Then, during its confirmation, the delivery move from WH1/Stock to the intercompany transit location will be created based on the rule and, thanks to these lines:
https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/stock/models/stock_rule.py#L342-L349
The `partner_id` of WH2 will be set as the `partner_id` of the delivery. Since there is a single partner this will also set the partner of the `move_values` of the delivery move we are creating to this partner:
https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/stock/models/stock_rule.py#L355-L360 However, if `sale_stock` is installed that `move_value` is reset to the value provided by the procurement values just a few lines bellow: https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/stock/models/stock_rule.py#L381-L384 because the `partner_id` field is part of the field name returned by the `_get_custom_move_fields`:
https://github.com/odoo/odoo/blob/b9845f693af28e1d9fac773ae391b29f6831e982/addons/sale_stock/models/stock.py#L173-L176
Since the `partner_id` value provided by the procurement values was `False`, it resets the the `partner_id` creation value to `False`.

### Fix:

As the flow relies on the value provided here:
https://github.com/odoo/odoo/blob/c4f8eb2824bef7348e3f94031140450daa4df651/addons/stock/models/stock_rule.py#L342-L349 when `sale_stock` is not installed but relies on the value of the procurement provided here:
https://github.com/odoo/odoo/blob/c4f8eb2824bef7348e3f94031140450daa4df651/addons/stock/models/stock_move.py#L1709 https://github.com/odoo/odoo/blob/c4f8eb2824bef7348e3f94031140450daa4df651/addons/stock/models/stock_move.py#L1674-L1677
if `sale_stock` is installed, it is necessary that both provide the same value to keep coherence in the flow. However, since the partner is will be expected to be set also via the procurement values, it is necessary to adapt the condition to which we will set a partner on the reception of the inter-company-transit:
https://github.com/odoo/odoo/blob/c4f8eb2824bef7348e3f94031140450daa4df651/addons/stock/models/stock_rule.py#L349 Which is the reason why we moved this line should be triggered only if no partner was set by the procurement values.

opw-6034309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
