### PR TITLE
[FIX] mail: call menu 'volume-up' icon is misaligned

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -8,25 +8,18 @@
 
     &.o-isOdooCommunity {
         height: $o-navbar-height - 20px !important; // same button height as in enterprise.
-        overflow: hidden;
         color: $o-action !important;
     }
 }
 
 .o-discuss-CallMenu-animationContainer {
-    top: 4px;
-    left: 6px;
+    top: 8px;
+    left: 8px;
+    padding: 1px 2px;
 }
 
-.o-discuss-CallMenu-animation {
-    --flash-low-opacity: .35;
-    animation: flash 2.5s;
-    animation-direction: alternate;
-    animation-iteration-count: 2;
-
-    &.o-isOdooCommunity {
-        transform: translateY(10px);
-    }
+.o-discuss-CallMenu-dropdownMore.o-isOdooCommunity {
+    background: inherit !important;
 }
 
 .o-discuss-CallMenu-dropdownMore, .o-discuss-CallMenu-channelInfo {

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -5,8 +5,8 @@
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
             <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow px-0 rounded-2" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center btn-group rounded-2" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
-                    <small class="o-discuss-CallMenu-animationContainer d-flex position-absolute o-xsmaller bg-inherit o-p-0_5 rounded-circle m-n2 z-2">
-                        <i class="fa fa-volume-up o-discuss-inCallIconColor bg-inherit rounded-circle o-discuss-CallMenu-animation" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
+                    <small class="o-discuss-CallMenu-animationContainer d-flex position-absolute o-xsmaller bg-inherit rounded-circle m-n2 z-2">
+                        <i class="fa fa-volume-up o-discuss-inCallIconColor bg-inherit rounded-circle o-discuss-CallMenu-animation"/>
                     </small>
                     <div class="o-discuss-CallMenu-channelInfo text-truncate btn btn-group-item border-0 m-0 p-0 d-flex align-items-center gap-1 o-ps-1_5 pe-1 rounded-2 rounded-end-0 align-self-stretch bg-inherit opacity-75 opacity-100-hover" role="button" title="Open Conversation">
                         <span class="position-relative small bg-inherit">
@@ -16,7 +16,7 @@
                     </div>
                     <span class="o-rounded-bubble h-100 py-2 border-end border-dark border-opacity-25"/>
                     <Dropdown state="dropdownState">
-                        <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item border-0 m-0 pe-1 o-ps-0_5 rounded-2 rounded-start-0 opacity-100-hover text-body" t-att-class="{ 'opacity-75 bg-transparent': !dropdownState.isOpen and !lastSelfAction?.tags.includes('WARNING_BADGE'), 'opacity-100': dropdownState.isOpen or lastSelfAction?.tags.includes('WARNING_BADGE') }" title="Select Actions">
+                        <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item border-0 m-0 pe-1 o-ps-0_5 rounded-2 rounded-start-0 opacity-100-hover text-body" t-att-class="{ 'o-isOdooCommunity': !isEnterprise, 'opacity-75 bg-transparent': !dropdownState.isOpen and !lastSelfAction?.tags.includes('WARNING_BADGE'), 'opacity-100': dropdownState.isOpen or lastSelfAction?.tags.includes('WARNING_BADGE') }" title="Select Actions">
                             <i class="fa fa-fw o-fs-small" t-attf-class="{{ icon }}" t-att-class="lastSelfActionAttClass"/>
                             <i class="oi oi-chevron-down o-xxsmaller opacity-75" t-att-class="{ 'mt-2': lastSelfAction?.tags.includes('WARNING_BADGE') }"/>
                             <span t-if="lastSelfAction?.tags.includes('WARNING_BADGE')" class="o-discuss-CallMenu-warningBadge fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center o-discuss-warningBadge position-absolute bg-warning" style="aspect-ratio: 1; font-size: 0.6rem;">


### PR DESCRIPTION
When in a discuss call, the call menu shows the conversation avatar with the 'volume-up' icon. This volume-up icon is to show the conversation has an active call. While all conversations have active call and this looks unnecessary in the call menu, this is shown there to look the same as in the discuss app sidebar where this is used to quickly see conversations with an ongoing call.

Before this commit, the alignment of this 'volume-up' icon was off in the call menu. This commit fixes it to have a more natural position: more overlap on avatar, like in discuss sidebar, which looks best and also make more room for button outline.

This commit also removes the 'volume-up' animation, to match with discuss sidebar look that has no animation.

Before / After

<img width="1228" height="389" alt="Screenshot 2026-03-19 at 18 38 56" src="https://github.com/user-attachments/assets/b0380f15-01eb-4232-be9d-2c5b83d5ccdd" />

<img width="1230" height="393" alt="Screenshot 2026-03-19 at 18 36 16" src="https://github.com/user-attachments/assets/8cefecfe-d87c-428e-90a9-dc2949a49008" />
