### PR TITLE
[REM] tests, base: remove SingleTransactionCase

### DIFF
--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -10,7 +10,7 @@ import odoo
 from odoo.exceptions import UserError
 from odoo.modules.registry import Registry
 from odoo.tests import tagged, common
-from odoo.tests.common import BaseCase, SingleTransactionCase
+from odoo.tests.common import BaseCase, TransactionCase
 from odoo.tools.misc import mute_logger
 
 ADMIN_USER_ID = common.ADMIN_USER_ID
@@ -283,7 +283,7 @@ class TestIrSequenceInit(common.TransactionCase):
 
 
 @tagged('at_install', '-post_install')
-class TestIrSequenceDateRangeStandard(SingleTransactionCase):
+class TestIrSequenceDateRangeStandard(TransactionCase):
     """ A few tests for a 'Standard' (i.e. PostgreSQL) sequence. """
 
     def test_ir_sequence_date_range_1_create(self):
@@ -294,8 +294,6 @@ class TestIrSequenceDateRangeStandard(SingleTransactionCase):
             'use_date_range': True,
         })
         self.assertTrue(seq)
-
-    def test_ir_sequence_date_range_2_change_dates(self):
         """ Draw numbers to create a first subsequence then change its date range. Then, try to draw a new number adn check a new subsequence was correctly created. """
         year = date.today().year - 1
         january = lambda d: date(year, 1, d)
@@ -318,13 +316,12 @@ class TestIrSequenceDateRangeStandard(SingleTransactionCase):
         seq_date_range = self.env['ir.sequence.date_range'].search(domain)
         self.assertEqual(seq_date_range.date_to, january(17))
 
-    def test_ir_sequence_date_range_3_unlink(self):
         seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
         seq.unlink()
 
 
 @tagged('at_install', '-post_install')
-class TestIrSequenceDateRangeNoGap(SingleTransactionCase):
+class TestIrSequenceDateRangeNoGap(TransactionCase):
     """ Copy of the previous tests for a 'No gap' sequence. """
 
     def test_ir_sequence_date_range_1_create_no_gap(self):
@@ -337,7 +334,6 @@ class TestIrSequenceDateRangeNoGap(SingleTransactionCase):
         })
         self.assertTrue(seq)
 
-    def test_ir_sequence_date_range_2_change_dates(self):
         """ Draw numbers to create a first subsequence then change its date range. Then, try to draw a new number adn check a new subsequence was correctly created. """
         year = date.today().year - 1
         january = lambda d: date(year, 1, d)
@@ -360,13 +356,12 @@ class TestIrSequenceDateRangeNoGap(SingleTransactionCase):
         seq_date_range = self.env['ir.sequence.date_range'].search(domain)
         self.assertEqual(seq_date_range.date_to, january(17))
 
-    def test_ir_sequence_date_range_3_unlink(self):
         seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range_2')])
         seq.unlink()
 
 
 @tagged('at_install', '-post_install')
-class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
+class TestIrSequenceDateRangeChangeImplementation(TransactionCase):
     """ Create sequence objects and change their ``implementation`` field. """
 
     def test_ir_sequence_date_range_1_create(self):
@@ -386,7 +381,6 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
         })
         self.assertTrue(seq)
 
-    def test_ir_sequence_date_range_2_use(self):
         """ Make some use of the sequences to create some subsequences """
         year = date.today().year - 1
         january = lambda d: date(year, 1, d)
@@ -407,14 +401,12 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
             n = seq16.next_by_code('test_sequence_date_range_4')
             self.assertEqual(n, str(i))
 
-    def test_ir_sequence_date_range_3_write(self):
         """swap the implementation method on both"""
         domain = [('code', 'in', ['test_sequence_date_range_3', 'test_sequence_date_range_4'])]
         seqs = self.env['ir.sequence'].search(domain)
         seqs.write({'implementation': 'standard'})
         seqs.write({'implementation': 'no_gap'})
 
-    def test_ir_sequence_date_range_4_unlink(self):
         domain = [('code', 'in', ['test_sequence_date_range_3', 'test_sequence_date_range_4'])]
         seqs = self.env['ir.sequence'].search(domain)
         seqs.unlink()

--- a/odoo/addons/test_tests/tests/test_cases.py
+++ b/odoo/addons/test_tests/tests/test_cases.py
@@ -5,47 +5,11 @@ import requests
 import threading
 
 from odoo.http import route, Controller, request
-from odoo.tests.common import HttpCase, tagged, ChromeBrowser, TEST_CURSOR_COOKIE_NAME, Like, SingleTransactionCase, TransactionCase
+from odoo.tests.common import HttpCase, tagged, ChromeBrowser, TEST_CURSOR_COOKIE_NAME, Like, TransactionCase
 from odoo.tools import config
 from unittest.mock import patch
 
 _logger = logging.getLogger(__name__)
-
-
-@tagged('at_install', '-post_install')
-class TestSingleTransactionCase(SingleTransactionCase):
-    """
-    Check the whole-class transaction behavior of SingleTransactionCase.
-    """
-
-    def test_00(self):
-        """ Create a partner. """
-        self.env['res.partner'].create({'name': 'test_per_class_teardown_partner'})
-        partners = self.env['res.partner'].search([('name', '=', 'test_per_class_teardown_partner')])
-        self.assertEqual(1, len(partners), "Test partner not found.")
-
-    def test_01(self):
-        """ Find the created partner. """
-        partners = self.env['res.partner'].search([('name', '=', 'test_per_class_teardown_partner')])
-        self.assertEqual(1, len(partners), "Test partner not found.")
-
-    def test_20a(self):
-        """ Create a partner with a XML ID """
-        pid, _ = self.env['res.partner'].name_create('Mr Blue')
-        self.env['ir.model.data'].create({'name': 'test_partner_blue',
-                                          'module': 'base',
-                                          'model': 'res.partner',
-                                          'res_id': pid})
-
-    def test_20b(self):
-        """ Resolve xml id with ref() and browse_ref() """
-        xid = 'base.test_partner_blue'
-        partner = self.env.ref(xid)
-        pid = self.ref(xid)
-        self.assertTrue(pid, "ref() should resolve xid to database ID")
-        self.assertEqual(pid, partner.id, "ref() is not consistent with env.ref()")
-        partner2 = self.browse_ref(xid)
-        self.assertEqual(partner, partner2, "browse_ref() should resolve xid to browse records")
 
 
 @tagged('at_install', '-post_install')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1282,34 +1282,6 @@ class TransactionCase(BaseCase):
             yield
 
 
-class SingleTransactionCase(BaseCase):
-    """ TestCase in which all test methods are run in the same transaction,
-    the transaction is started with the first test method and rolled back at
-    the end of the last.
-    """
-    @classmethod
-    def __init_subclass__(cls):
-        super().__init_subclass__()
-        if issubclass(cls, TransactionCase):
-            _logger.warning("%s inherits from both TransactionCase and SingleTransactionCase")
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.registry = Registry(get_db_name())
-        cls.addClassCleanup(cls.registry.reset_changes)
-        cls.addClassCleanup(cls.registry.clear_all_caches)
-
-        cls.cr = cls.registry.cursor()
-        cls.addClassCleanup(typing.cast('Cursor', cls.cr).close)
-
-        cls.env = api.Environment(cls.cr, api.SUPERUSER_ID, {})
-
-    def setUp(self):
-        super(SingleTransactionCase, self).setUp()
-        self.env.flush_all()
-
-
 class ChromeBrowserException(Exception):
     pass
 


### PR DESCRIPTION
This test case is only used for sequences and a tests that uses SingleTransactionCase can easily be converted to use TransactionCase, either by having a single test method or subtests.

By design,
- a SingleTransactionCase test_method would most likely fail if a previous one failed.

- a SingleTransactionCase test_method will most likely fail if we disable one of them..

For those reasons the SingleTransactionCase is mostly useless and we don't want to maintain it anymore.

