### PR TITLE
[FIX] account : correct tax on line & currency change

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3026,9 +3026,6 @@ class AccountMove(models.Model):
             elif any(line not in base_lines for line, values in move_base_lines_values_before.items() if values['tax_ids']):
                 # Removed a base line affecting the taxes.
                 round_from_tax_lines = any_field_has_changed(move_tax_lines_values_before, tax_lines)
-            elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
-                # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
-                round_from_tax_lines = 'reapply_currency_rate'
             elif changed_lines := list(get_changed_lines(move_base_lines_values_before, base_lines)):
                 # A base line has been modified.
                 round_from_tax_lines = (
@@ -3055,6 +3052,9 @@ class AccountMove(models.Model):
                     and any(line[field] for line in changed_lines for field in ('amount_currency', 'balance'))
                 ):
                     continue
+            elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
+                # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
+                round_from_tax_lines = 'reapply_currency_rate'
             else:
                 continue
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4920,6 +4920,60 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {'balance': 851053.94},
         ])
 
+    def test_tax_on_line_and_currency_rate_change(self):
+        eur = self.setup_other_currency('EUR')
+        percent_tax = self.company_data['default_tax_sale']
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': eur.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'test line',
+                    'price_unit': 10,
+                    'tax_ids': [percent_tax.id]
+                }),
+            ],
+        })
+        invoice.write({
+            'invoice_currency_rate': 1.1,
+            'invoice_line_ids': [Command.update(invoice.line_ids[0].id, {
+                'price_unit': 400_000
+            })]
+        })
+
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        self.assertRecordValues(tax_line, [
+            {
+                'balance': -54_545.45,
+                'tax_base_amount': 363_636.36,
+                'tax_line_id': percent_tax.id,
+            }
+        ])
+
+        invoice.invoice_line_ids = [
+            Command.create({
+                'name': 'test line',
+                'price_unit': 20,
+                'tax_ids': [percent_tax.id]
+            })
+        ]
+        invoice.write({
+            'invoice_currency_rate': 1.2,
+            'invoice_line_ids': [Command.update(invoice.line_ids[0].id, {
+                'price_unit': 10
+            })]
+        })
+
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        self.assertRecordValues(tax_line, [
+            {
+                'balance': -3.75,
+                'tax_base_amount': 25.0,
+                'tax_line_id': percent_tax.id,
+            }
+        ])
+
     def test_tax_recomputed_when_changing_base_lines(self):
         percent_tax = self.company_data['default_tax_sale']
 


### PR DESCRIPTION
# How to reproduce
- Install the l10n_hu_edi module
- Switch to a Hungarian company
- Enable a currency (e.g., EUR) and configure two different exchange rates on two different dates
- Create a new invoice with :
	- Delivery Date: One of the configured date
	- A line with a price unit and a tax
- Save the invoice
- Edit the invoice :
	- Delivery Date : The other configured date
	- Change the price unit of the line
- Save the invoice

# The problem
The taxed amount total is using the old price unit

# Why
This commit (https://github.com/odoo/odoo/pull/225407) added a condition on the write of an account_move that made it so the tax amount is recomputed when the currency_rate is changed :

```py
elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
    # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
    round_from_tax_lines = 'reapply_currency_rate'
```

However, this recomputation is done using the old values for the invoice_lines and so it does not take into account the the newly changed price_unit

opw-5800521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
