### PR TITLE
[FIX] mass_mailing: remove duplicate snippet template and handle vxml bump

### DIFF
--- a/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_mail_block_footer_social" name="Social + Footer">
-    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-name="Footer Center" data-vxml="001">
+    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-name="Footer Center" data-vxml="002">
         <div class="container">
             <div class="row">
                 <div class="col-md-12 col-12">
@@ -25,7 +25,7 @@
 </template>
 
 <template id="s_mail_block_footer_social_left" name="Social + Footer">
-    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16 pb16" data-name="Footer Left" data-vxml="001">
+    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16 pb16" data-name="Footer Left" data-vxml="002">
         <div class="container">
             <div class="row">
                 <div class="col-md-6 col-12">
@@ -44,7 +44,7 @@
 </template>
 
 <template id="s_mail_block_footer_one_liner" name="Social + Footer + Separator">
-    <section class="s_footer_one_liner o_mail_block_footer o_mail_snippet_general pt16 pb16" data-name="One Liner">
+    <section class="s_footer_one_liner o_mail_block_footer o_mail_snippet_general pt16 pb16" data-name="One Liner" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-12 col-12">

--- a/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
@@ -200,21 +200,6 @@
     </section>
 </template>
 
-<template id="s_mail_block_header_name_and_inline_menu" name="Company Name and Menu">
-    <section class="o_mail_snippet_general pt32 pb32" data-vxml="001">
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="col-md-6 col-12">
-                    <h1><span class="h2-fs" t-out="company_id.partner_id.name"/></h1>
-                </div>
-                <div class="col-md-6 col-12">
-                    <p class="m-0" style="text-align: center;"><a href="#" class="btn btn-link">News</a><a href="#" class="btn btn-link">Shop</a><a href="#" class="btn btn-link">Contact Us</a></p>
-                </div>
-            </div>
-        </div>
-    </section>
-</template>
-
 <template id="s_mail_block_header_name_and_button" name="Company Name and Log In Button">
     <section class="o_mail_snippet_general pt32 pb32" data-vxml="001">
         <div class="container">

--- a/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
@@ -263,7 +263,7 @@
 </template>
 
 <template id="s_blockquote" name="Blockquote">
-    <section class="s_mail_blockquote s_blockquote o_mail_snippet_general pt16 pb16">
+    <section class="s_mail_blockquote s_blockquote o_mail_snippet_general pt16 pb16" data-vxml="001">
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-12 col-12">


### PR DESCRIPTION
Issue
=============
- vxml was not bumped in [commit] for updated snippets.
- A duplicate snippet template was introduced.

Fix
=============
Remove the duplicated snippet template and add missing vxml bumps so the editor can detect outdated blocks and suggest replacements correctly.

[commit]: https://github.com/odoo/odoo/commit/81e43a8dd70ffa2746740f7bd5904007e76d2260

task-5959046