### PR TITLE
[PERF] purchase_mrp: cache cost share scan during bom explode

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -396,6 +396,7 @@ class MrpBom(models.Model):
             Quantity describes the number of times you need the BoM: so the quantity divided by the number created by the BoM
             and converted into its UoM
         """
+        self = self.with_context(bom_cost_share_cache=self.env.context.get('bom_cost_share_cache') or {})  # noqa: PLW0642
         product_ids = set()
         product_boms = {}
         def update_product_boms():

--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -42,10 +42,21 @@ class MrpBomLine(models.Model):
     def _get_cost_share(self):
         self.ensure_one()
         product = self.env.context.get('bom_variant_id', self.env['product.product'])
-        variant_bom_lines = self.bom_id.bom_line_ids.filtered(lambda bl: not bl._skip_bom_line(product) and not float_is_zero(bl.product_qty, precision_rounding=bl.product_uom_id.rounding))
-        if not float_is_zero(self.cost_share, precision_digits=2) or not len(variant_bom_lines) or not all(float_is_zero(bom_line.cost_share, precision_digits=2) for bom_line in variant_bom_lines):
+        cache = self.env.context.get('bom_cost_share_cache', {})
+        variant_cache_key = (self.bom_id.id, product.id)
+        if variant_cache_key not in cache:
+            variant_bom_lines = self.bom_id.bom_line_ids.filtered(
+                lambda bl: not bl._skip_bom_line(product)
+                and not float_is_zero(bl.product_qty, precision_rounding=bl.product_uom_id.rounding)
+            )
+            cache[variant_cache_key] = (
+                len(variant_bom_lines),
+                any(not float_is_zero(bom_line.cost_share, precision_digits=2) for bom_line in variant_bom_lines),
+            )
+        variant_bom_line_count, has_non_zero_cost_share = cache[variant_cache_key]
+        if not float_is_zero(self.cost_share, precision_digits=2) or not variant_bom_line_count or has_non_zero_cost_share:
             return self.cost_share / 100
-        return 1 / len(variant_bom_lines)
+        return 1 / variant_bom_line_count
 
     def _prepare_bom_done_values(self, quantity, product, original_quantity, boms_done):
         result = super()._prepare_bom_done_values(quantity, product, original_quantity, boms_done)


### PR DESCRIPTION
Before this commit, confirming a Sale Order that creates a Manufacturing Order for a product with a large BoM could take several minutes when `purchase_mrp` was installed.

The slowdown comes from `mrp.bom.line._get_cost_share()`, which is called for every line during a BoM explosion. When no explicit `cost_share` is set, the method recomputes the list of eligible BoM lines and checks whether any of them has a manual cost share.

That computation depends only on the BoM and the product variant, but it is recomputed for every exploded line during `mrp.bom.explode()`. This causes a full BoM scan to be repeated for every single line.

This commit introduces a contextual cache, initialized in `mrp.bom.explode()`, to store that metadata. We compute it once and reuse it for all lines of the same (BoM, variant) within the same explosion.

### Benchmark:

| BoM lines | Before PR | After PR |
| --- | ---: | ---: |
| 100 | 3.747s | 1.094s |
| 300 | 26.554s | 2.826s |
| 600 | 85.378s | 5.299s |
| 992 | 229.246s | 9.068s |

opw-6017626

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
