### PR TITLE
[FIX] sale: prevent discount line under optional section to be editable

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1793,4 +1793,8 @@ class SaleOrderLine(models.Model):
     # For `sale_management`, to control optional products on portal
     def _can_be_edited_on_portal(self):
         self.ensure_one()
-        return self.order_id._can_be_edited_on_portal() and not self.combo_item_id
+        return (
+            self.order_id._can_be_edited_on_portal()
+            and not self.combo_item_id
+            and self.product_id != self.company_id.sale_discount_product_id
+        )

--- a/addons/sale/tests/test_sale_sections.py
+++ b/addons/sale/tests/test_sale_sections.py
@@ -189,3 +189,30 @@ class TestSaleSections(SaleCommon):
             self.sections_sale_order.order_line[7]._get_section_totals('price_subtotal'),
             sum(self.sections_sale_order.order_line[8:].mapped('price_subtotal')),
         )
+
+    def test_optional_section_discount_line_not_editable_on_portal(self):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "order_line": [
+                Command.create({
+                    "name": "Optional Section",
+                    "display_type": "line_section",
+                    "is_optional": True,
+                }),
+                Command.create({"product_id": self.product.id, "price_unit": 200}),
+            ],
+        })
+        wizard = self.env["sale.order.discount"].create({
+            "sale_order_id": so.id,
+            "discount_type": "so_discount",
+            "discount_percentage": 0.1,
+        })
+        wizard.action_apply_discount()
+        self.assertTrue(
+            so.order_line[1]._can_be_edited_on_portal(),
+            "Optional section line should be editable on portal",
+        )
+        self.assertFalse(
+            so.order_line[2]._can_be_edited_on_portal(),
+            "Discount line on optional section should not be editable on portal",
+        )


### PR DESCRIPTION
Issue:
---
Due to this issue global discount line can be edited by customer.

#### Steps to reproduce:
1- Create a SO with SOLs and add a optional section.
2- Add a global discount under optional section.
3- Preview the SO.

The quantity of discount can be edited.

Cause and Fix:
---
In `_can_be_edited_on_portal` we are not excluding the global discount line from being editable.

We could fix that by excluding line with company discount product
from being editable.

opw-6045297