### PR TITLE
[PERF] mrp: limit the _bom_find() calls number

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -374,9 +374,14 @@ class MrpBom(models.Model):
         """
         product_ids = set()
         product_boms = {}
+        bom_per_product_per_type = self.env.context.get("bom_per_product_per_type", {})
         def update_product_boms():
             products = self.env['product.product'].browse(product_ids)
-            product_boms.update(self._bom_find(products, picking_type=picking_type or self.picking_type_id,
+            bom = bom_per_product_per_type.get((self.picking_type_id, self.company_id.id), None)
+            if bom:
+                product_boms.update(bom)
+            else:
+                product_boms.update(self._bom_find(products, picking_type=picking_type or self.picking_type_id,
                 company_id=self.company_id.id, bom_type='phantom'))
             # Set missing keys to default value
             for product in products:

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -232,8 +232,13 @@ class ProductProduct(models.Model):
         # pre-compute bom lines and identify missing kit components to prefetch
         bom_sub_lines_per_kit = {}
         prefetch_component_ids = set()
+        bom_per_type = {}
+        for bom in bom_kits.values():
+            if not bom_per_type.get((bom.picking_type_id, bom.company_id.id)):
+                bom_per_type[bom.picking_type_id, bom.company_id.id] = bom
+        bom_per_product_per_type = {k: v._bom_find(self, picking_type=k[0], company_id=k[1], bom_type='phantom') for k, v in bom_per_type.items()}
         for product in bom_kits:
-            __, bom_sub_lines = bom_kits[product].explode(product, 1)
+            __, bom_sub_lines = bom_kits[product].with_context(bom_per_product_per_type=bom_per_product_per_type).explode(product, 1)
             bom_sub_lines_per_kit[product] = bom_sub_lines
             for bom_line, __ in bom_sub_lines:
                 if bom_line.product_id.id not in qties:


### PR DESCRIPTION
When searching product based on the qty_available field, a lot of time is spent in explode() calls.

In the explode() method, we call _bom_find() for each bom involved. This method only depends on the picking_type_id and company_id of the bom.

Thus we could batch it and call the method once per tuple (picking_type_id, company_id).

Benchmark:

|No BoM | No product variants | Before | After |
|-------|------------|--------|-------|
|  1700  |       13000  |    80s |   40 s |

opw-6017527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
