### PR TITLE
[FIX] stock: prevent quantity update on validated pickings

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -305,7 +305,7 @@
                                     <field name="product_uom_qty" string="Demand" readonly="not is_initial_demand_editable"/>
                                     <field name="forecast_expected_date" column_invisible="True"/>
                                     <field name="product_qty" readonly="1" column_invisible="True"/>
-                                    <field name="quantity" string="Quantity" readonly="not is_quantity_done_editable" column_invisible="parent.state=='draft'" decoration-danger="product_uom_qty and quantity > product_uom_qty and parent.state not in ['done', 'cancel']"/>
+                                    <field name="quantity" string="Quantity" readonly="not is_quantity_done_editable or state in ['done']" column_invisible="parent.state=='draft'" decoration-danger="product_uom_qty and quantity > product_uom_qty and parent.state not in ['done', 'cancel']"/>
                                     <field name="product_uom" readonly="state != 'draft' and not additional" options="{'no_open': True, 'no_create': True}" widget="many2one_uom" groups="uom.group_uom"/>
                                     <field name="picked" optional="hide" column_invisible="parent.state=='draft'"/>
                                     <field name="lot_ids" widget="many2many_tags"


### PR DESCRIPTION
Currently, an error occurs when creating a return for a delivery order whose quantity has been manually set to zero after validation.

**Steps to reproduce:**
- Install `stock_account` module.
- Create and validate a delivery order.
- Unlock the order and set the product quantity to 0.
- Create a return order and validate it.

**Error:**
`ZeroDivisionError - float division by zero`

**Cause:**
The system allows quantities to be modified even after the picking is validated, leading to inconsistent data during return computations.

**Fix:**
This commit makes the quantity field read-only once the picking is in the done state to prevent invalid updates.

sentry-7345265575