### PR TITLE
[IMP] core: in threaded mode, log the thread ids

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -117,7 +117,9 @@ PID_COLORS = (
     GREEN, BLUE, MAGENTA, CYAN,
     HI_RED, HI_GREEN, HI_YELLOW, HI_BLUE, HI_MAGENTA, HI_CYAN, HI_WHITE,
 )
-
+if os.environ.get('ODOO_PY_COLORS_NOPID'):
+    TRUE_COLOR_PATTERN = f"\033[%dm%s{RESET_SEQ}"
+    PID_COLORS = [0]
 
 class PerfFilter(logging.Filter):
 
@@ -172,10 +174,7 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         fg_color, bg_color = LEVEL_COLOR_MAPPING.get(record.levelno, (GREEN, DEFAULT))
         record.levelname = COLOR_PATTERN % (30 + fg_color, 40 + bg_color, record.levelname)
-        if tools.config['workers']:
-            record.process = TRUE_COLOR_PATTERN % (PID_COLORS[record.process % len(PID_COLORS)], record.process)
-        else:
-            record.process = TRUE_COLOR_PATTERN % (PID_COLORS[record.thread % len(PID_COLORS)], record.process)
+        record.process = TRUE_COLOR_PATTERN % (PID_COLORS[record.thread_native % len(PID_COLORS)], record.thread_native)
         return super().format(record)
 
 
@@ -183,6 +182,7 @@ class LogRecord(logging.LogRecord):
     def __init__(self, name, level, pathname, lineno, msg, args, exc_info, func=None, sinfo=None, **kwargs):
         super().__init__(name, level, pathname, lineno, msg, args, exc_info, func=func, sinfo=sinfo, **kwargs)
         self.perf_info = ""
+        self.thread_native = threading.get_native_id()
         self.dbname = getattr(threading.current_thread(), 'dbname', '?')
 
 


### PR DESCRIPTION
When running tests, the value displayed is the process id but the color is based on the thread id, so you get a bunch of random colors for the exact same value.

Update this on multiple axis:

- Log the native thread id instead of the PID, in worker mode on linux this is the same thing, because the pid is also the main thread's tid. The main divergence is that ancillary threads used in worker mode will now be visible. This also should not hinder sending signals (on linux anyway) as python always dispatches signals on the main thread (and linux calls signal handlers on arbitrary threads).
- Allow disabling pid / tid colors, when running a lot of tests it makes the log extremely noisy and hides log levels, while having very little value (because there's basically one thread per request so every line but the main process / thread is in a different color).
