### PR TITLE
[IMP] stock_account: add reference to journal entries

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -190,7 +190,11 @@ class StockMove(models.Model):
                 move_to_link.add(move.id)
         if not aml_vals_list:
             return self.env['account.move']
+
+        move_refs = list(set(self.mapped('reference')))
+        
         account_move = self.env['account.move'].sudo().create({
+            'ref': ", ".join(move_refs),
             'journal_id': self.company_id.account_stock_journal_id.id,
             'line_ids': [Command.create(aml_vals) for aml_vals in aml_vals_list],
             'date': self.env.context.get('force_period_date') or fields.Date.context_today(self),


### PR DESCRIPTION
To make auditing easier, this commit ensures that journal entries
generated from stock movements include the source document reference.
Currently, the 'ref' field on these account moves is often empty,
forcing users to inspect individual lines to identify the origin.

- updates `_create_account_move` in `stock_move`.
  - collects unique references from the stock moves using `mapped`.
  - populates the `account.move` 'ref' field with a comma-separated
    list of these references.

task-5499000

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
