### PR TITLE
[IMP] l10n_ro_edi, l10n_ro_efactura_synchronize: allow to resend rejected invoices

### DIFF
--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -22,8 +22,8 @@ class AccountMove(models.Model):
                 - Validated: Sent & validated by the SPV
                 - Error: Sending error or validation error from the SPV""",
     )
-    l10n_ro_edi_attachment_id = fields.Many2one(comodel_name='ir.attachment')
-    l10n_ro_edi_index = fields.Char(string='E-Factura Index', readonly=True)
+    l10n_ro_edi_attachment_id = fields.Many2one(comodel_name='ir.attachment', copy=False)
+    l10n_ro_edi_index = fields.Char(string='E-Factura Index', readonly=True, copy=False)
 
     ################################################################################
     # Compute Methods
@@ -120,6 +120,7 @@ class AccountMove(models.Model):
         :param values: dictionary containing 'key_loading', 'key_signature', 'key_certificate', and 'attachment_raw'
         :return: ``l10n_ro_edi.document`` object """
         self.ensure_one()
+        self._l10n_ro_edi_get_sent_and_failed_documents().unlink()
         document = self.env['l10n_ro_edi.document'].sudo().create({
             'invoice_id': self.id,
             'state': 'invoice_validated',
@@ -140,6 +141,11 @@ class AccountMove(models.Model):
         """ Shorthand for getting all l10n_ro_edi.document in invoice_sending_failed state """
         self.ensure_one()
         return self.l10n_ro_edi_document_ids.filtered(lambda d: d.state == 'invoice_sending_failed')
+
+    def _l10n_ro_edi_get_sent_documents(self):
+        """ Shorthand for getting all l10n_ro_edi.document in invoice_sent state """
+        self.ensure_one()
+        return self.l10n_ro_edi_document_ids.filtered(lambda d: d.state == 'invoice_sent')
 
     def _l10n_ro_edi_get_sent_and_failed_documents(self):
         """ Shorthand for getting all l10n_ro_edi.document in ``invoice_sent`` and ``invoice_sending_failed`` state """
@@ -168,22 +174,22 @@ class AccountMove(models.Model):
 
          - Pre-check any errors from the invoice's pre_send check before sending
 
-            - if error -> delete all error documents, create a new error document
+            - if error -> create a new error document (previous documents are preserved for traceability)
             - else -> continue to the next step
 
          - Send to E-Factura, and based on the result:
 
-            - if error -> delete all error documents, create a new error document
-            - if success -> delete all error & sending documents, create a new sending document
+            - if error -> create a new error document (previous documents are preserved for traceability)
+            - if success -> delete any existing sent document, create a new sent document
 
         :param xml_data: string of the xml data to be sent
         """
         self.ensure_one()
         if errors := self._l10n_ro_edi_get_pre_send_errors(xml_data, True):
-            self._l10n_ro_edi_get_failed_documents().unlink()
             self._l10n_ro_edi_create_document_invoice_sending_failed({'error': '\n'.join(errors)})
             return
 
+        self.l10n_ro_edi_index = False
         self.env['res.company']._with_locked_records(self)
         result = self.env['l10n_ro_edi.document']\
                      .with_context(is_b2b=self.partner_id.commercial_partner_id.is_company)\
@@ -194,12 +200,11 @@ class AccountMove(models.Model):
         )
         result['attachment_raw'] = xml_data
         if 'error' in result:  # result == {'error': <str>, 'attachment_raw': <bytes>}
-            self._l10n_ro_edi_get_failed_documents().unlink()
             self._l10n_ro_edi_create_document_invoice_sending_failed(result)
             self.message_post(body=_("Error when trying to send the E-Factura to the SPV: %s",
                                      result['error']))
         else:  # result == {'key_loading': <str>, 'attachment_raw': <bytes>}; initial sending successful
-            self._l10n_ro_edi_get_sent_and_failed_documents().unlink()
+            self._l10n_ro_edi_get_sent_documents().unlink()
             self._l10n_ro_edi_create_document_invoice_sent(result)
             self.l10n_ro_edi_index = result['key_loading']
             self.message_post(body=_(
@@ -225,7 +230,7 @@ class AccountMove(models.Model):
 
         for invoice in invoices_to_fetch:
             if errors := invoice._l10n_ro_edi_get_pre_send_errors():
-                to_delete_documents |= invoice._l10n_ro_edi_get_failed_documents()
+                to_delete_documents |= invoice._l10n_ro_edi_get_sent_documents()
                 invoice._l10n_ro_edi_create_document_invoice_sending_failed({'error': '\n'.join(errors)})
                 continue
 
@@ -241,7 +246,7 @@ class AccountMove(models.Model):
             if result == {}:  # SPV is still processing the XML (no answer yet); do nothing
                 continue
             elif 'error' in result:  # Fetch error / SPV finished validating the XML and sends back a disapproval answer
-                to_delete_documents |= invoice._l10n_ro_edi_get_sent_and_failed_documents()
+                to_delete_documents |= invoice._l10n_ro_edi_get_sent_documents()
                 result['key_loading'] = invoice.l10n_ro_edi_index
                 result['attachment_raw'] = previous_raw
                 invoice._l10n_ro_edi_create_document_invoice_sending_failed(result)
@@ -255,7 +260,7 @@ class AccountMove(models.Model):
                     session=session,
                     status=result['state_status'],
                 )
-                to_delete_documents |= invoice._l10n_ro_edi_get_sent_and_failed_documents()
+                to_delete_documents |= invoice._l10n_ro_edi_get_sent_documents()
                 final_result['key_loading'] = invoice.l10n_ro_edi_index
                 if final_result.get('error'):
                     final_error_message = final_result['error'].replace('\t', '')

--- a/addons/l10n_ro_edi/tests/__init__.py
+++ b/addons/l10n_ro_edi/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import common
 from . import test_xml_ubl_ro
+from . import test_ro_edi

--- a/addons/l10n_ro_edi/tests/common.py
+++ b/addons/l10n_ro_edi/tests/common.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestROEdiCommon(AccountTestInvoicingCommon):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country("ro")
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_data["company"].write(
+            {
+                "state_id": cls.env.ref("base.RO_B").id,
+                "city": "SECTOR1",
+                "zip": "010101",
+                "vat": "RO1234567897",
+                "phone": "+40 123 456 789",
+                "street": "Strada Test, 3",
+                "l10n_ro_edi_access_token": "test_token",
+            }
+        )
+
+        cls.partner_ro = cls.env["res.partner"].create(
+            {
+                "name": "Romanian Test Partner",
+                "country_id": cls.env.ref("base.ro").id,
+                "state_id": cls.env.ref("base.RO_B").id,
+                "city": "SECTOR3",
+                "zip": "010101",
+                "vat": "RO1234567897",
+                "phone": "+40 123 456 780",
+                "street": "Strada Partner, 88",
+                "invoice_edi_format": "ciusro",
+            }
+        )
+
+        cls.tax_19 = cls.env["account.tax"].create(
+            {
+                "name": "tax_19",
+                "amount_type": "percent",
+                "amount": 19,
+                "type_tax_use": "sale",
+                "country_id": cls.env.ref("base.ro").id,
+            }
+        )
+
+    def create_invoice(self, move_type="out_invoice", **kwargs):
+        """Create and post a Romanian invoice ready for EDI sending."""
+        vals = {
+            "move_type": move_type,
+            "partner_id": self.partner_ro.id,
+            "invoice_line_ids": [
+                Command.create(
+                    {
+                        "name": "Test Product",
+                        "quantity": 1,
+                        "price_unit": 500.0,
+                        "tax_ids": [Command.set(self.tax_19.ids)],
+                    }
+                ),
+            ],
+        }
+        vals.update(kwargs)
+        invoice = self.env["account.move"].create(vals)
+        invoice.action_post()
+        return invoice
+
+    def send_invoice_with_mock(self, invoice, mock_return_value):
+        """Helper to send invoice mocking the SPV response."""
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_send_invoice",
+            return_value=mock_return_value,
+        ):
+            invoice._l10n_ro_edi_send_invoice(
+                xml_data=invoice.ubl_cii_xml_id.raw if invoice.ubl_cii_xml_id else b"<xml>test</xml>",
+            )
+
+    def fetch_status_with_mock(self, invoice, mock_return_value):
+        """Helper to fetch invoice status mocking the SPV response."""
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_fetch_status",
+            return_value=mock_return_value,
+        ):
+            invoice._l10n_ro_edi_fetch_invoice_sent_documents()

--- a/addons/l10n_ro_edi/tests/test_ro_edi.py
+++ b/addons/l10n_ro_edi/tests/test_ro_edi.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+
+from odoo.addons.l10n_ro_edi.tests.common import TestROEdiCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "-at_install", "post_install")
+class TestRoEdi(TestROEdiCommon):
+    def test_documents_only_deleted_on_validation(self):
+        """Test that historical documents are preserved on failure and only cleaned up when the invoice is validated.
+
+        Flow:
+        1. Send invoice → invoice_sent doc created
+        2. Fetch → SPV refuses → invoice_sent deleted, invoice_sending_failed created (1 doc)
+        3. Resend → upload fails → new invoice_sending_failed added (2 docs, no deletion)
+        4. Resend → upload succeeds → old invoice_sending_failed preserved, invoice_sent created (3 docs)
+        5. Fetch → SPV validates → all previous docs deleted, only invoice_validated remains (1 doc)
+        """
+        invoice = self.create_invoice()
+
+        # Step 1: First send succeeds, index 'AA' received
+        self.send_invoice_with_mock(invoice, {"key_loading": "AA"})
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_sent")
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+
+        # Step 2: SPV refuses via fetch → sent doc deleted, failed doc created
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_fetch_status",
+            return_value={"key_download": "DL_AA", "state_status": "nok"},
+        ), patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_download_answer",
+            return_value={
+                "attachment_raw": b"<xml>error</xml>",
+                "key_signature": None,
+                "key_certificate": None,
+                "error": "XML validation failed by SPV",
+            },
+        ):
+            invoice._l10n_ro_edi_fetch_invoice_sent_documents()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, False)
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, "invoice_sending_failed")
+
+        # Step 3: Resend fails → new failed doc added, old one preserved
+        invoice.button_draft()
+        invoice.action_post()
+        self.send_invoice_with_mock(invoice, {"error": "SPV unavailable"})
+
+        self.assertEqual(invoice.l10n_ro_edi_state, False)
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 2)
+        self.assertTrue(all(d.state == "invoice_sending_failed" for d in invoice.l10n_ro_edi_document_ids))
+
+        # Step 4: Resend succeeds → failed docs preserved, new sent doc added
+        self.send_invoice_with_mock(invoice, {"key_loading": "BB"})
+
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_sent")
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 3)
+        self.assertEqual(len(invoice._l10n_ro_edi_get_failed_documents()), 2)
+        self.assertEqual(len(invoice._l10n_ro_edi_get_sent_documents()), 1)
+
+        # Step 5: SPV validates → all old docs deleted, only invoice_validated remains
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_fetch_status",
+            return_value={"key_download": "DL_BB", "state_status": "ok"},
+        ), patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_download_answer",
+            return_value={
+                "attachment_raw": b"<xml>signature</xml>",
+                "key_signature": "KEY_SIG",
+                "key_certificate": "KEY_CERT",
+                "error": False,
+            },
+        ):
+            invoice._l10n_ro_edi_fetch_invoice_sent_documents()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_validated")
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, "invoice_validated")

--- a/addons/l10n_ro_efactura_synchronize/models/account_move.py
+++ b/addons/l10n_ro_efactura_synchronize/models/account_move.py
@@ -12,15 +12,6 @@ HOLDING_DAYS = 3  # Arbitrary
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    @api.depends('l10n_ro_edi_index')
-    def _compute_show_reset_to_draft_button(self):
-        # OVERRIDE to remove the reset to draft button for invoices with an SPV
-        # index, i.e. they have already been sent and should not be modified
-        super()._compute_show_reset_to_draft_button()
-        for move in self:
-            if move.l10n_ro_edi_index:
-                move.show_reset_to_draft_button = True
-
     @api.model
     def _l10n_ro_edi_fetch_invoices(self):
         """ Synchronize bills/invoices from SPV """
@@ -51,12 +42,11 @@ class AccountMove(models.Model):
 
         document_ids_to_delete = []
         for invoice in non_indexed_invoices:
-            # At that point, only one sent document should exist on an invoice
-            sent_document = invoice.l10n_ro_edi_document_ids
+            sent_document = invoice._l10n_ro_edi_get_sent_documents()
 
             if (fields.Datetime.now() - sent_document.create_date).days > HOLDING_DAYS:
                 # The last document sent to ANAF was live for longer than the holding period, refuse it
-                document_ids_to_delete += invoice.l10n_ro_edi_document_ids.ids
+                document_ids_to_delete += sent_document.ids
 
                 error_message = _(
                     "The invoice has probably been refused by the SPV. We were unable to recover the reason of the refusal because "
@@ -120,7 +110,7 @@ class AccountMove(models.Model):
                 invoice.l10n_ro_edi_index = message['id_solicitare']
 
             if 'error' in message['answer']:
-                document_ids_to_delete += invoice._l10n_ro_edi_get_sent_and_failed_documents().ids
+                document_ids_to_delete += invoice._l10n_ro_edi_get_sent_documents().ids
                 error_message = _(
                     "Error when trying to download the E-Factura data from the SPV: %s",
                     message['answer']['error'],
@@ -133,7 +123,7 @@ class AccountMove(models.Model):
             # be due to a resequencing of the invoice and/or re-sending of an invoice. In that case coupled with name
             # matching where none of the two invoices received an index, all signatures are added to the invoice; the
             # user will have to manually update/select the correct one.
-            document_ids_to_delete += invoice._l10n_ro_edi_get_sent_and_failed_documents().ids
+            document_ids_to_delete += invoice._l10n_ro_edi_get_sent_documents().ids
 
             invoice.message_post(body=_("This invoice has been accepted by the SPV."))
             invoice._l10n_ro_edi_create_document_invoice_validated({
@@ -169,7 +159,7 @@ class AccountMove(models.Model):
                 continue
 
             if 'error' in message['answer']:
-                document_ids_to_delete += invoice._l10n_ro_edi_get_sent_and_failed_documents().ids
+                document_ids_to_delete += invoice._l10n_ro_edi_get_sent_documents().ids
                 error_message = _(
                     "Error when trying to download the E-Factura data from the SPV: %s",
                     message['answer']['error']
@@ -177,7 +167,7 @@ class AccountMove(models.Model):
                 invoice._l10n_ro_edi_create_document_invoice_sending_failed({'error': error_message})
                 continue
 
-            document_ids_to_delete += invoice.l10n_ro_edi_document_ids.ids
+            document_ids_to_delete += invoice._l10n_ro_edi_get_sent_documents().ids
 
             error_message = message['answer']['invoice']['error'].replace('\t', '')
             invoice._l10n_ro_edi_create_document_invoice_sending_failed({'error': error_message})

--- a/addons/l10n_ro_efactura_synchronize/tests/__init__.py
+++ b/addons/l10n_ro_efactura_synchronize/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_xml_ubl_ro
+from . import test_ro_edi

--- a/addons/l10n_ro_efactura_synchronize/tests/test_ro_edi.py
+++ b/addons/l10n_ro_efactura_synchronize/tests/test_ro_edi.py
@@ -1,0 +1,130 @@
+from unittest.mock import patch
+
+from odoo.addons.l10n_ro_edi.tests.common import TestROEdiCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "-at_install", "post_install")
+class TestRoEdi(TestROEdiCommon):
+    def synchronize_with_mock(self, mock_return_value):
+        """Helper to run synchronize mocking the SPV response."""
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_synchronize_invoices",
+            return_value=mock_return_value,
+        ):
+            self.env["account.move"]._l10n_ro_edi_fetch_invoices()
+
+    def test_ciusro_synchronize_resent_invoice_after_refusal(self):
+        """ Test the full lifecycle when an invoice is sent, refused by the SPV, reset and resent
+            without receiving an index (simulating a server timeout), and synchronize returns 2 messages:
+            the original refusal ('AA') and the new acceptance ('BB').
+
+            Expected outcome:
+            - The acceptance 'BB' is matched by invoice name (since l10n_ro_edi_index is False after timeout)
+            - The refusal 'AA' is skipped (the invoice no longer has index 'AA' and state 'invoice_sent')
+            - The invoice ends up as validated with index 'BB'
+            - All old documents are cleaned up by _l10n_ro_edi_create_document_invoice_validated
+        """
+        # Step 1: Create invoice and simulate successful first send with index 'AA'
+        invoice = self.create_invoice()
+        invoice._l10n_ro_edi_create_document_invoice_sent({
+            "key_loading": "AA",
+            "attachment_raw": b"<xml>invoice</xml>",
+        })
+        invoice.l10n_ro_edi_index = "AA"
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_sent")
+
+        # Step 2: SPV refuses the invoice via individual fetch (status 'nok')
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_fetch_status",
+            return_value={"key_download": "DL_AA", "state_status": "nok"},
+        ), patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_download_answer",
+            return_value={
+                "attachment_raw": b"<xml>error</xml>",
+                "key_signature": None,
+                "key_certificate": None,
+                "error": "XML validation failed by SPV",
+            },
+        ):
+            invoice._l10n_ro_edi_fetch_invoice_sent_documents()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, False)
+        self.assertEqual(len(invoice._l10n_ro_edi_get_failed_documents()), 1)
+        self.assertEqual(invoice.l10n_ro_edi_index, "AA")  # index persists after refusal
+
+        # Step 3: Reset to draft and resend; timeout means no index is received from SPV
+        invoice.button_draft()
+        invoice.action_post()
+
+        with patch.object(
+            self.env.registry.get("l10n_ro_edi.document"),
+            "_request_ciusro_send_invoice",
+            return_value={"key_loading": False},
+        ):
+            invoice._l10n_ro_edi_send_invoice(b"<xml>invoice</xml>")
+
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_sent")
+        self.assertEqual(invoice.l10n_ro_edi_index, False)
+        # Historical failed doc is preserved alongside the new sent doc (traceability)
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 2)
+
+        # Step 4: Synchronize returns both messages: old refusal 'AA' + new acceptance 'BB'
+        # 'BB' is matched by invoice name since l10n_ro_edi_index is False
+        invoice_name = invoice.name
+        self.synchronize_with_mock({
+            "sent_invoices_accepted_messages": [
+                {
+                    "data_creare": "202503271639",
+                    "cif": self.env.company.vat,
+                    "id_solicitare": "BB",
+                    "tip": "FACTURA TRIMISA",
+                    "id": "MSG_BB",
+                    "answer": {
+                        "signature": {
+                            "attachment_raw": b"<xml>signature_bb</xml>",
+                            "key_signature": "KEY_SIG_BB",
+                            "key_certificate": "KEY_CERT_BB",
+                        },
+                        "invoice": {
+                            "name": invoice_name,
+                        },
+                    },
+                },
+            ],
+            "sent_invoices_refused_messages": [
+                {
+                    "data_creare": "202503271500",
+                    "cif": self.env.company.vat,
+                    "id_solicitare": "AA",
+                    "tip": "ERORI FACTURA",
+                    "id": "MSG_AA",
+                    "answer": {
+                        "signature": {
+                            "attachment_raw": b"<xml>error_signature_aa</xml>",
+                            "key_signature": "KEY_SIG_AA",
+                            "key_certificate": "KEY_CERT_AA",
+                        },
+                        "invoice": {
+                            "error": "XML validation failed by SPV",
+                            "attachment_raw": b"<xml>error_aa</xml>",
+                        },
+                    },
+                },
+            ],
+            "received_bills_messages": [],
+        })
+
+        invoice.invalidate_recordset()
+
+        # Acceptance 'BB' matched by name, index updated and invoice validated
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_validated")
+        self.assertEqual(invoice.l10n_ro_edi_index, "BB")
+        # _l10n_ro_edi_create_document_invoice_validated cleans up all old docs on success
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, "invoice_validated")
+        # Refusal 'AA' was skipped: invoice had index=False, not 'AA', when refused domain was evaluated
+        self.assertFalse(invoice.l10n_ro_edi_document_ids.filtered(lambda d: d.state == "invoice_sending_failed"))

--- a/addons/l10n_ro_efactura_synchronize/views/account_move_views.xml
+++ b/addons/l10n_ro_efactura_synchronize/views/account_move_views.xml
@@ -6,11 +6,6 @@
         <field name="priority">31</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='journal_div']" position="after">
-                <field name="l10n_ro_edi_index"
-                       invisible="not l10n_ro_edi_index or move_type in ('in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"/>
-            </xpath>
-
             <xpath expr="//button[@name='action_l10n_ro_edi_fetch_status']" position="attributes">
                 <attribute name="invisible">state != 'invoice_sending' or not key_loading</attribute>
             </xpath>


### PR DESCRIPTION
Allow users to re-send invoices that were rejected by the SPV. Previously, EDI documents were deleted and recreated on every interaction, losing history in the process. This commit updates existing EDI documents in place instead, preserving failed documents as history for traceability.

task-[5976612](https://www.odoo.com/odoo/project/967/tasks/5976612)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
