### PR TITLE
[FIX] account : correct tax on line & currency write

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3026,9 +3026,6 @@ class AccountMove(models.Model):
             elif any(line not in base_lines for line, values in move_base_lines_values_before.items() if values['tax_ids']):
                 # Removed a base line affecting the taxes.
                 round_from_tax_lines = any_field_has_changed(move_tax_lines_values_before, tax_lines)
-            elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
-                # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
-                round_from_tax_lines = 'reapply_currency_rate'
             elif changed_lines := list(get_changed_lines(move_base_lines_values_before, base_lines)):
                 # A base line has been modified.
                 round_from_tax_lines = (
@@ -3055,6 +3052,9 @@ class AccountMove(models.Model):
                     and any(line[field] for line in changed_lines for field in ('amount_currency', 'balance'))
                 ):
                     continue
+            elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
+                # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
+                round_from_tax_lines = 'reapply_currency_rate'
             else:
                 continue
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4921,6 +4921,69 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {'balance': 851053.94},
         ])
 
+    def test_tax_on_line_and_currency_rate_change(self):
+        eur = self.setup_other_currency('EUR')
+        percent_tax = self.company_data['default_tax_sale']
+        percent_tax.amount = 10  # for easiness of calculation
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': eur.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'test line',
+                    'price_unit': 100,
+                    'tax_ids': [percent_tax.id]
+                }),
+            ],
+        })
+        invoice.write({
+            'invoice_currency_rate': 2,
+            'invoice_line_ids': [Command.update(invoice.invoice_line_ids.id, {'price_unit': 1000})]
+        })
+
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        # tax_base_amount = total(price_unit) / invoice_currency_rate
+        # balance = tax_base_amount * percent_tax.amount % * -1
+        self.assertRecordValues(tax_line, [
+            {
+                'tax_base_amount': 500,  # 1000 / 2
+                'balance': -50,  # 500 * 10% * -1
+                'tax_line_id': percent_tax.id,
+            }
+        ])
+
+        invoice.invoice_line_ids = [
+            Command.create({
+                'name': 'test line',
+                'price_unit': 20,
+                'tax_ids': [percent_tax.id]
+            })
+        ]
+        invoice.write({
+            'invoice_currency_rate': 3,
+            'invoice_line_ids': [Command.update(invoice.invoice_line_ids[0].id, {'price_unit': 10})]
+        })
+
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        self.assertRecordValues(tax_line, [
+            {
+                'tax_base_amount': 10,  # (20 + 10) / 3
+                'balance': -1,  # 10 * 10% * -1
+                'tax_line_id': percent_tax.id,
+            }
+        ])
+
+        invoice.invoice_currency_rate = 1
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        self.assertRecordValues(tax_line, [
+            {
+                'tax_base_amount': 30,  # (20 + 10) / 1
+                'balance': -3,  # 30 * 10% * -1
+                'tax_line_id': percent_tax.id,
+            }
+        ])
+
     def test_tax_recomputed_when_changing_base_lines(self):
         percent_tax = self.company_data['default_tax_sale']
 


### PR DESCRIPTION
# How to reproduce
- Install the l10n_hu_edi module
- Switch to a Hungarian company
- Enable a currency (e.g., EUR) and configure two different exchange rates on two different dates
- Create a new invoice with :
	- Delivery Date: One of the configured date
	- A line with a price unit and a tax
- Save the invoice
- Edit the invoice :
	- Delivery Date : The other configured date
	- Change the price unit of the line
- Save the invoice

# The problem
The taxed amount total is using the old price unit

# Cause
## TLDR
This commit (https://github.com/odoo/odoo/pull/225407) made it so we recompute the tax when the currency is changed with round globally. This recomputation is based on the old tax values, so it should not be done when editing the base lines in the form view. To prevent this, a condition checks that the invoice date was not changed (which should be the only way to change the currency rate from that view if I understand correctly).

Sadly, the l10n_hu_edi module changes this behavior and makes it so the currency rate is also recomputed when the delivery date changes

## Detailed analysis

In the write() method of an account_move, we try to determine `round_from_tax_lines`. Before, in the situation where a base line is modified, it was computed here :

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L3032-L3049

In our use case, `round_from_tax_lines` would then equal to `False`

But, this commit (https://github.com/odoo/odoo/pull/225407) added the following condition that made it so in our use case, `round_from_tax_line` is trucy :

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L3029-L3031

That value is then used right after in the computation of the tax line values :

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L3061

Since `round_from_tax_line` is trucy, we pass the tax_lines to the `_round_base_lines_tax_details()` function

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L1638

Which calls the `_round_tax_details_tax_amounts_from_tax_lines()` function. That function changes `base_lines["tax_details"]["tax_data"]` `tax_amount` and `tax_currency` based on the tax_lines `balance` and `amount_currency`

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_tax.py#L2143-L2144

Except, those tax_lines values are the values of the current tax_lines, not the updated one. So they use the `balance` and `amount_currency` values of before the write

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L1631-L1632

`base_lines["tax_details"]["tax_data"]` is later used to define `tax_rep_data`

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_tax.py#L2437-L2452

Which is then used to determine `base_lines_to_update`

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_tax.py#L3074-L3080

Nevertheless, this issue is quite niche because the condition to assign `round_from_tax_lines` checks that the invoice date has not changed, which would be the only way to edit the currency rate and the base lines at the same time

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/account/models/account_move.py#L3029

Except that the l10n_hu_edi module defines an override to recompute the currency rate when the delivery date changes

https://github.com/odoo/odoo/blob/262088c98673a342aa0ccdd70465e3be6bcb2439/addons/l10n_hu_edi/models/account_move.py#L128-L130

# Proposed solution
Since the tax recomputation is done using the values before the write, we never want to do it if the base lines have changed. Editing the condition of the commit that introduced the issue would not be enough because any module can ask for a currency rate recomputation for any reason.

Because of this, we should do the tax recomputation only if the base_lines have not changed.

opw-5800521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
