### PR TITLE
[FIX] website_sale: enable hover effect for bento product design

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -248,7 +248,7 @@
 
             <BuilderRow
                 label.translate="Hover Effect"
-                t-if="anyThumb || anyCard || catalogThumb || catalogChips || listCondensed || (catalogPanel and this.isActiveItem('o_has_description_opt'))"
+                t-if="anyThumb || anyCard || catalogThumb || catalogChips || listCondensed || (catalogBento and this.isActiveItem('o_has_description_opt'))"
                 >
                 <BuilderSelect>
                     <BuilderSelectItem
@@ -281,7 +281,7 @@
                         Border-Primary
                     </BuilderSelectItem>
                     <BuilderSelectItem
-                        t-if="catalogPanel"
+                        t-if="catalogBento"
                         classAction="'o_wsale_products_opt_hover_show_description'">
                         Show description
                     </BuilderSelectItem>


### PR DESCRIPTION
During the introduction of the Bento product design in commit [1], a specific hover effect to show and hide the description was implemented. However, due to an incorrect reference to the 'catalog' variable, this feature was not available in the editor.

This commit updates the variable to the correct one, enabling the feature in the editor.

[1]: https://github.com/odoo/odoo/commit/1739b954fa34bc62223d892f2cdacbccebd5f8a2

task-6051497

| Current | This branch |
|--------|--------|
| <img width="1792" height="836" alt="Capture d’écran 2026-03-19 à 14 29 16" src="https://github.com/user-attachments/assets/7a900d47-73b4-4c35-b51e-8ff847361f0b" /> | <img width="1785" height="901" alt="Capture d’écran 2026-03-19 à 14 16 30" src="https://github.com/user-attachments/assets/eb5312bd-04dd-4acb-a44b-fc500b89ddda" /> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
