### PR TITLE
[FIX] l10n_in_sale: Fix Wrong Fiscal for SEZ Partner in Sale Order

### DIFF
--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -22,6 +22,7 @@ class SaleOrder(models.Model):
 
     @api.depends('partner_id', 'partner_shipping_id', 'l10n_in_gst_treatment')
     def _compute_fiscal_position_id(self):
+        sez_foreign_state = self.env.ref("l10n_in.state_in_oc", raise_if_not_found=False)
 
         def _get_fiscal_state(order, foreign_state):
             """
@@ -38,7 +39,7 @@ class SaleOrder(models.Model):
                 return False
             elif order.l10n_in_gst_treatment == 'special_economic_zone':
                 # Special Economic Zone
-                return foreign_state
+                return sez_foreign_state or foreign_state
 
             # Computing Place of Supply for particular order
             partner = (

--- a/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
+++ b/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
@@ -79,7 +79,7 @@ class TestSaleFiscal(L10nInTestInvoicingCommon):
 
             self.assertEqual(
                 sale_order.fiscal_position_id,
-                template.ref('fiscal_position_in_export_sez_in')
+                template.ref('fiscal_position_in_sez')
             )
 
         # Sub-test: Manual Partner Fiscal Check


### PR DESCRIPTION
Before this commit:
When creating a sale order, if the GST Treatment of partner is SEZ, then the Fiscal position is set as Export instead of SEZ.

Reason:
The default `foreign_state` obtained currently is searched on base of state whose country is not India, so any random state is fetched. But in the fiscal position of SEZ, we want "Foreign State", so while selecting fiscal position from `_get_fiscal_position` method, the Export fiscal gets higher ranking and gets selected.

This commit fixes this issue by returning the correct Foreign State if fiscal position is set to SEZ.

task-5958903

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
