### PR TITLE
[IMP] stock_account: add reference to journal entries

### DIFF
--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -13,6 +13,18 @@ class TestMrpValuationStandard(TestBomPriceCommon):
             ('account_id', '=', self.account_production.id),
         ], order='date, id')
 
+    def test_mo_journal_entry_ref_matches_mo_name(self):
+        self.glass.categ_id = self.category_fifo_auto
+
+        self._make_in_move(self.glass, 1, 10)
+        mo = self._create_mo(self.bom_1, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+
+        account_moves = (mo.move_raw_ids + mo.move_finished_ids).account_move_id
+        self.assertTrue(account_moves, "Expected accounting entries to be created for the manufacturing order.")
+        self.assertEqual(set(account_moves.mapped('ref')), {mo.name})
+
     def test_fifo_fifo_1(self):
         self.glass.categ_id = self.category_fifo
         self.dining_table.categ_id = self.category_fifo

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -190,7 +190,14 @@ class StockMove(models.Model):
                 move_to_link.add(move.id)
         if not aml_vals_list:
             return self.env['account.move']
+
+        move_refs = list(set(self.mapped('reference')))
+        joined_refs = ", ".join(move_refs)
+        if len(joined_refs) > 43:
+            joined_refs = joined_refs[:40] + "..."
+
         account_move = self.env['account.move'].sudo().create({
+            'ref': joined_refs,
             'journal_id': self.company_id.account_stock_journal_id.id,
             'line_ids': [Command.create(aml_vals) for aml_vals in aml_vals_list],
             'date': self.env.context.get('force_period_date') or fields.Date.context_today(self),


### PR DESCRIPTION
To make auditing easier, this commit ensures that journal entries generated from stock movements include the source document reference. Currently, the 'ref' field on these account moves is often empty, forcing users to inspect individual lines to identify the origin.

- updates `_create_account_move` in `stock_move`.
- collects unique references from the stock moves using `mapped`.
- populates the `account.move` 'ref' field with a comma-separated list of these references.

task-5499000

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
