### PR TITLE
[FIX] mail, *: archived channels

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -214,7 +214,7 @@ class LivechatController(http.Controller):
     @http.route("/im_livechat/feedback", type="json", auth="public")
     @add_guest_to_context
     def feedback(self, channel_id, rate, reason=None, **kwargs):
-        if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
+        if channel := request.env["discuss.channel"]._find_channels(channel_id):
             # limit the creation : only ONE rating per session
             values = {
                 'rating': rate,
@@ -247,14 +247,14 @@ class LivechatController(http.Controller):
     @http.route("/im_livechat/history", type="json", auth="public")
     @add_guest_to_context
     def history_pages(self, pid, channel_id, page_history=None):
-        if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
+        if channel := request.env["discuss.channel"]._find_channels(channel_id):
             if pid in channel.sudo().channel_member_ids.partner_id.ids:
                 request.env["res.partner"].browse(pid)._bus_send_history_message(channel, page_history)
 
     @http.route("/im_livechat/email_livechat_transcript", type="json", auth="public")
     @add_guest_to_context
     def email_livechat_transcript(self, channel_id, email):
-        if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
+        if channel := request.env["discuss.channel"]._find_channels(channel_id):
             channel._email_livechat_transcript(email)
 
     @http.route("/im_livechat/visitor_leave_session", type="json", auth="public")

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -41,6 +41,9 @@
                         ('start_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
                         ('start_date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <separator/>
+                    <filter string="Active Sessions Only" name="active_only" domain="[('channel_id.active', '=', True)]"/>
+                    <filter string="Include Archived" name="include_archived" domain="['|', ('channel_id.active', '=', True), ('channel_id.active', '=', False)]"/>
+                    <separator/>
                     <filter name="filter_start_date" date="start_date"/>
                     <group expand="0" string="Group By...">
                         <filter name="group_by_session" string="Code" domain="[]" context="{'group_by':'technical_name'}"/>
@@ -58,7 +61,7 @@
             <field name="name">Session Statistics</field>
             <field name="res_model">im_livechat.report.channel</field>
             <field name="view_mode">graph,pivot</field>
-            <field name="context">{"search_default_last_week":1, "group_by": "start_date:day"}</field>
+            <field name="context">{"search_default_active_only":1, "group_by": "start_date:day"}</field>
             <field name="help">Livechat Support Channel Statistics allows you to easily check and analyse your company livechat session performance. Extract information about the missed sessions, the audience, the duration of a session, etc.</field>
         </record>
 
@@ -66,7 +69,7 @@
             <field name="name">Session Statistics</field>
             <field name="res_model">im_livechat.report.channel</field>
             <field name="view_mode">graph,pivot</field>
-            <field name="context">{"graph_measure": "time_to_answer", "search_default_last_week":1}</field>
+            <field name="context">{"graph_measure": "time_to_answer", "search_default_active_only":1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data yet!

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -10,7 +10,7 @@ import { patch } from "@web/core/utils/patch";
 
 threadActionsRegistry.add("restart", {
     condition(component) {
-        return component.chatbotService.canRestart;
+        return component.thread?.isActive && component.chatbotService.canRestart;
     },
     icon: "fa fa-fw fa-refresh",
     name: _t("Restart Conversation"),
@@ -29,6 +29,7 @@ patch(callSettingsAction, {
             return super.condition(...arguments);
         }
         return (
+            component.thread.isActive &&
             component.livechatService.state === SESSION_STATE.PERSISTED &&
             component.rtcService.state.channel?.eq(component.thread)
         );

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -69,6 +69,9 @@ patch(Thread.prototype, {
     get hasWelcomeMessage() {
         return this.channel_type === "livechat" && !this.chatbot && !this.requested_by_operator;
     },
+    get isActive() {
+        return super.isActive || this.isTransient;
+    },
     /** @returns {Promise<import("models").Message} */
     async post() {
         if (

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -118,7 +118,7 @@ async function feedback(request) {
     const RatingRating = this.env["rating.rating"];
 
     const { channel_id, rate, reason } = await parseRequestParams(request);
-    let [channel] = DiscussChannel.search_read([["id", "=", channel_id]]);
+    const [channel] = DiscussChannel._find_channels(channel_id);
     if (!channel) {
         return false;
     }
@@ -136,7 +136,6 @@ async function feedback(request) {
     } else {
         RatingRating.write([channel.rating_ids[0]], values);
     }
-    [channel] = DiscussChannel.search_read([["id", "=", channel_id]]);
     return channel.rating_ids[0];
 }
 

--- a/addons/mail/controllers/discuss/binary.py
+++ b/addons/mail/controllers/discuss/binary.py
@@ -18,7 +18,7 @@ class BinaryController(Binary):
     )
     @add_guest_to_context
     def discuss_channel_attachment(self, channel_id, attachment_id, download=None, **kwargs):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         domain = [
@@ -44,7 +44,7 @@ class BinaryController(Binary):
     )
     @add_guest_to_context
     def fetch_image(self, channel_id, attachment_id, width=0, height=0, **kwargs):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         domain = [

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -26,7 +26,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/members", methods=["POST"], type="json", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_members(self, channel_id, known_member_ids):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         return channel._load_more_members(known_member_ids)
@@ -41,7 +41,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/info", methods=["POST"], type="json", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_info(self, channel_id):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             return
         return Store(channel).get_result()
@@ -49,7 +49,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/messages", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
     def discuss_channel_messages(self, channel_id, search_term=None, before=None, after=None, limit=30, around=None):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         domain = [
@@ -72,7 +72,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/pinned_messages", methods=["POST"], type="json", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_pins(self, channel_id):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         messages = channel.pinned_message_ids.sorted(key="pinned_at", reverse=True)
@@ -120,7 +120,7 @@ class ChannelController(http.Controller):
         :param limit: maximum number of attachments to return
         :param before: id of the attachment from which to load older attachments
         """
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         domain = [
@@ -145,7 +145,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/join", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
     def discuss_channel_join(self, channel_id):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         channel._find_or_create_member_for_self()
@@ -165,7 +165,7 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
     def discuss_channel_sub_channel_fetch(self, parent_channel_id, search_term=None, before=None, limit=30):
-        channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(parent_channel_id)
         if not channel:
             raise NotFound()
         domain = [("parent_channel_id", "=", channel.id)]
@@ -173,5 +173,7 @@ class ChannelController(http.Controller):
             domain.append(("id", "<", before))
         if search_term:
             domain.append(("name", "ilike", search_term))
-        sub_channels = request.env["discuss.channel"].search(domain, order="id desc", limit=limit)
+        sub_channels = request.env["discuss.channel"]._find_channels(
+            domain=domain, order="id desc", limit=limit
+        )
         return Store(sub_channels).add(sub_channels._get_last_messages()).get_result()

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -53,7 +53,7 @@ class PublicPageController(http.Controller):
     @add_guest_to_context
     def discuss_channel(self, channel_id, *, highlight_message_id=None):
         # highlight_message_id is used JS side by parsing the query string
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        channel = request.env["discuss.channel"]._find_channels(channel_id)
         if not channel:
             raise NotFound()
         return self._response_discuss_public_template(Store(), channel)

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -216,10 +216,10 @@ class Channel(models.Model):
         current_partner, current_guest = self.env["res.partner"]._get_current_persona()
         if current_guest:
             # sudo: discuss.channel - sudo for performance, just checking existence
-            channels = current_guest.sudo().channel_ids
+            channels = current_guest.sudo().with_context(active_test=False).channel_ids
         elif current_partner:
             # sudo: discuss.channel - sudo for performance, just checking existence
-            channels = current_partner.sudo().channel_ids
+            channels = current_partner.sudo().with_context(active_test=False).channel_ids
         else:
             channels = self.env["discuss.channel"]
         return [('id', "in" if is_in else "not in", channels.ids)]
@@ -336,6 +336,22 @@ class Channel(models.Model):
         self._cr.execute('SELECT indexname FROM pg_indexes WHERE indexname = %s', ('discuss_channel_member_seen_message_id_idx',))
         if not self._cr.fetchone():
             self._cr.execute('CREATE INDEX discuss_channel_member_seen_message_id_idx ON discuss_channel_member (channel_id,partner_id,seen_message_id)')
+
+    # ------------------------------------------------------------
+    # ACTIONS
+    # ------------------------------------------------------------
+
+    def action_archive(self):
+        if to_archive := self.sub_channel_ids.filtered("active"):
+            to_archive.action_archive()
+        return super().action_archive()
+
+    def action_unarchive(self):
+        if to_unarchive := self.with_context(active_test=False).sub_channel_ids.filtered(
+            lambda sc: not sc.active
+        ):
+            to_unarchive.action_unarchive()
+        return super().action_unarchive()
 
     # ------------------------------------------------------------
     # MEMBERS MANAGEMENT
@@ -860,6 +876,25 @@ class Channel(models.Model):
             }
             self.message_post(body=notification, message_type="notification", subtype_xmlid="mail.mt_comment")
 
+    @api.model
+    def _find_channels(self, ids=None, domain=False, limit=None, order=None):
+        """
+        Get channels including archived ones.
+        :param ids: single ID or list of IDs
+        :param list domain: search domain
+        :param int limit: number of records to return
+        :param str order: sort string
+        :return: discuss.channel recordset
+        """
+        channel_domain = []
+        if ids:
+            channel_domain = [("id", "in", [ids] if isinstance(ids, int) else ids)]
+        if domain:
+            channel_domain = expression.AND([channel_domain, domain])
+        if not channel_domain:
+            return self.env["discuss.channel"]
+        return self.with_context(active_test=False).search(channel_domain, limit=limit, order=order)
+
     def _find_or_create_member_for_self(self):
         self.ensure_one()
         domain = [("channel_id", "=", self.id), ("is_self", "=", True)]
@@ -920,6 +955,7 @@ class Channel(models.Model):
         self.ensure_one()
         data = self._read_format(
             [
+                "active",
                 "allow_public_upload",
                 "channel_type",
                 "create_uid",

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -78,7 +78,7 @@ class IrWebsocket(models.AbstractModel):
         if guest:
             channels.append(guest)
         domain = ["|", ("is_member", "=", True), ("id", "in", discuss_channel_ids)]
-        all_user_channels = self.env["discuss.channel"].search(domain)
+        all_user_channels = self.env["discuss.channel"]._find_channels(domain=domain)
         member_specific_channels = [(c, "members") for c in all_user_channels if c.id not in discuss_channel_ids]
         channels.extend([*all_user_channels, *member_specific_channels])
         return super()._build_bus_channel_list(channels)

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -108,7 +108,7 @@
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer t-if="thread.isActive" composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -453,6 +453,7 @@ export class Message extends Record {
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canReplyTo(thread) {
         return (
+            thread?.isActive &&
             ["discuss.channel", "mail.box"].includes(thread.model) &&
             this.message_type !== "user_notification"
         );

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -73,6 +73,9 @@ export class UseSuggestion {
         this.state.items = undefined;
     }
     detect() {
+        if (this.thread && !this.thread.isActive) {
+            return;
+        }
         const { start, end } = this.composer.selection;
         const text = this.composer.text;
         if (start !== end) {

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -32,7 +32,7 @@ threadActionsRegistry
     .add("rename-thread", {
         condition(component) {
             return (
-                component.thread &&
+                component.thread?.isActive &&
                 component.props.chatWindow?.isOpen &&
                 (component.thread.is_editable || component.thread.channel_type === "chat")
             );

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -387,6 +387,10 @@ export class Thread extends Record {
         return attachments;
     }
 
+    get isActive() {
+        return this.model !== "discuss.channel";
+    }
+
     get isUnread() {
         return this.selfMember?.message_unread_counter > 0 || this.needactionMessages.length > 0;
     }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -10,7 +10,7 @@
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
-                        <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
+                        <FileUploader t-if="thread.isActive and !thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>
@@ -30,7 +30,7 @@
                         </div>
                         <AutoresizeInput
                             className="'o-mail-Discuss-threadName fw-bolder flex-shrink-1 text-dark py-0 fs-4'"
-                            enabled="thread.is_editable or thread.channel_type === 'chat'"
+                            enabled="thread.isActive and (thread.is_editable or thread.channel_type === 'chat')"
                             onValidate.bind="renameThread"
                             value="thread.displayName"
                         />
@@ -39,9 +39,9 @@
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                             <AutoresizeInput
                                 className="'o-mail-Discuss-threadDescription flex-shrink-1 text-muted small pt-1'"
-                                enabled="thread.is_editable"
+                                enabled="thread.isActive and thread.is_editable"
                                 onValidate.bind="updateThreadDescription"
-                                placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
+                                placeholder="thread.isActive and thread.is_editable ? autogrowDescriptionPlaceholder : ''"
                                 value="thread.description or ''"
                             />
                         </t>
@@ -94,7 +94,7 @@
                         <t t-if="thread">
                             <div class="o-mail-Discuss-threadContainer d-flex flex-column flex-grow-1">
                                 <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
-                                <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
+                                <Composer t-if="thread.isActive and (thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread))" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
                             </div>
                             <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer h-100 border-start border-secondary flex-shrink-0">
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -10,7 +10,9 @@ threadActionsRegistry
     .add("call", {
         condition(component) {
             return (
-                component.thread?.allowCalls && !component.thread?.eq(component.rtc.state.channel)
+                component.thread?.isActive &&
+                component.thread.allowCalls &&
+                !component.thread.eq(component.rtc.state.channel)
             );
         },
         icon: "fa fa-fw fa-phone",
@@ -29,7 +31,9 @@ threadActionsRegistry
     .add("camera-call", {
         condition(component) {
             return (
-                component.thread?.allowCalls && !component.thread?.eq(component.rtc.state.channel)
+                component.thread?.isActive &&
+                component.thread.allowCalls &&
+                !component.thread.eq(component.rtc.state.channel)
             );
         },
         icon: "fa fa-fw fa-video-camera",
@@ -52,7 +56,8 @@ threadActionsRegistry
         },
         condition(component) {
             return (
-                component.thread?.allowCalls &&
+                component.thread?.isActive &&
+                component.thread.allowCalls &&
                 (component.props.chatWindow?.isOpen || component.store.inPublicPage)
             );
         },

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.js
@@ -51,6 +51,7 @@ export class AttachmentPanel extends Component {
 
     get hasToggleAllowPublicUpload() {
         return (
+            this.props.thread.isActive &&
             this.props.thread.model !== "mail.box" &&
             this.props.thread.channel_type !== "chat" &&
             this.store.self.isInternalUser

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="250" icon="'fa fa-users'">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
+            <button t-if="props.thread.isActive" t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -14,6 +14,7 @@ threadActionsRegistry
         condition(component) {
             return (
                 component.thread?.model === "discuss.channel" &&
+                component.thread.isActive &&
                 component.store.self.type !== "guest" &&
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
@@ -78,6 +79,7 @@ threadActionsRegistry
         condition(component) {
             return (
                 component.thread?.model === "discuss.channel" &&
+                component.thread.isActive &&
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -12,6 +12,8 @@ const commandRegistry = registry.category("discuss.channel_commands");
 const threadPatch = {
     setup() {
         super.setup();
+        /** @type {Boolean} */
+        this.active;
         this.fetchChannelMutex = new Mutex();
         this.fetchChannelInfoDeferred = undefined;
         this.fetchChannelInfoState = "not_fetched";
@@ -51,6 +53,9 @@ const threadPatch = {
     },
     get hasMemberList() {
         return ["channel", "group"].includes(this.channel_type);
+    },
+    get isActive() {
+        return super.isActive || this.active;
     },
     async fetchChannelInfo() {
         return this.fetchChannelMutex.exec(async () => {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -294,6 +294,7 @@ export class DiscussSidebarCategories extends Component {
     filteredThreads(threads) {
         return threads.filter(
             (thread) =>
+                thread.isActive &&
                 thread.displayInSidebar &&
                 (thread.parent_channel_id ||
                     !this.state.quickSearchVal ||

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -32,8 +32,8 @@
         <t t-if="category.open">
             <DiscussSidebarChannel t-foreach="filteredThreads(category.threads)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />
+        <DiscussSidebarChannel t-elif="store.discuss.thread?.isActive and store.discuss.thread.in(category.threads)" thread="store.discuss.thread"/>
+        <DiscussSidebarChannel t-elif="store.discuss.thread?.isActive and store.discuss.thread.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">

--- a/addons/mail/static/src/discuss/core/public_web/message_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_actions.js
@@ -3,7 +3,8 @@ import { _t } from "@web/core/l10n/translation";
 
 messageActionsRegistry.add("create-or-view-thread", {
     condition: (component) =>
-        component.message.thread?.eq(component.props.thread) &&
+        component.message.thread?.isActive &&
+        component.message.thread.eq(component.props.thread) &&
         component.message.thread.hasSubChannelFeature &&
         component.store.self.isInternalUser,
     icon: "fa fa-comments-o",

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -14,7 +14,7 @@
                             <i t-if="!state.loading" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Sub Channels" title="Search Sub Channels"/>
                             <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
                         </button>
-                        <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
+                        <button t-if="props.thread.isActive and store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                     </div>
                 </div>
             </t>

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -168,7 +168,7 @@ test("load messages from opening chat window from messaging menu", async () => {
 
 test("chat window: basic rendering", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
@@ -194,6 +194,20 @@ test("chat window: basic rendering", async () => {
     await contains(".o-dropdown-item", { text: "Open in Discuss" });
     await contains(".o-dropdown-item", { text: "Notification Settings" });
     await contains(".o-dropdown-item", { text: "Call Settings" });
+    await click("[title='Open Actions Menu']");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(".o-mail-ChatWindow-command", { count: 3 });
+    await contains("[title='Open Actions Menu']");
+    await contains("[title='Fold']");
+    await contains("[title*='Close Chat Window']");
+    await click("[title='Open Actions Menu']");
+    await contains(".o-mail-ChatWindow-command", { count: 9 });
+    await contains(".o-dropdown-item", { text: "Attachments" });
+    await contains(".o-dropdown-item", { text: "Pinned Messages" });
+    await contains(".o-dropdown-item", { text: "Members" });
+    await contains(".o-dropdown-item", { text: "Threads" });
+    await contains(".o-dropdown-item", { text: "Search Messages" });
+    await contains(".o-dropdown-item", { text: "Open in Discuss" });
 });
 
 test.skip("Fold state of chat window is sync among browser tabs", async () => {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -56,6 +56,12 @@ test("basic rendering", async () => {
     await click("[title='More']");
     await contains("[title='Raise Hand']");
     await contains("[title='Enter Full Screen']");
+    await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
+    await contains("[title='Start a Call']");
+    await contains("[title='Start a Video Call']");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains("[title='Start a Call']", { count: 0 });
+    await contains("[title='Start a Video Call']", { count: 0 });
 });
 
 test("keep the `more` popover active when hovering it", async () => {

--- a/addons/mail/static/tests/discuss/core/attachment_panel.test.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel.test.js
@@ -69,7 +69,13 @@ test("Can toggle allow public upload", async () => {
         contains: ["label", { text: "File upload is disabled for external users" }],
     });
     await click(`${env1.selector} .o-mail-ActionPanel input[type='checkbox']`);
+    const uploadLabel = "File upload is enabled for external users";
     await contains(`${env2.selector} .o-mail-ActionPanel`, {
-        contains: ["label", { text: "File upload is enabled for external users" }],
+        contains: ["label", { text: uploadLabel }],
+    });
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(`${env2.selector} .o-mail-ActionPanel`, {
+        contains: ["label", { text: uploadLabel }],
+        count: 0,
     });
 });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -87,6 +87,9 @@ test("can change the thread name of #general", async () => {
     await assertSteps(["/web/dataset/call_kw/discuss.channel/channel_rename"]);
     await contains(".o-mail-DiscussSidebarChannel:contains(special)");
     await contains("input.o-mail-Discuss-threadName:value(special)");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(".o-mail-Composer-input", { count: 0 });
+    await contains("input.o-mail-Discuss-threadName:disabled");
 });
 
 test("can active change thread from messaging menu", async () => {
@@ -127,6 +130,8 @@ test("can change the thread description of #general", async () => {
     triggerHotkey("Enter");
     await assertSteps(["/web/dataset/call_kw/discuss.channel/channel_change_description"]);
     await contains("input.o-mail-Discuss-threadDescription:value(I want a burger today!)");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains("input.o-mail-Discuss-threadDescription:disabled");
 });
 
 test("Message following a notification should not be squashed", async () => {
@@ -580,7 +585,7 @@ test("sidebar: change active", async () => {
 
 test("sidebar: basic channel rendering", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
@@ -592,6 +597,8 @@ test("sidebar: basic channel rendering", async () => {
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Leave Channel']"
     );
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });
 
 test("channel become active", async () => {
@@ -694,7 +701,7 @@ test("default active id on mailbox", async () => {
 
 test("basic top bar rendering", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss();
     await contains("button:disabled", { text: "Mark all read" });
@@ -704,7 +711,11 @@ test("basic top bar rendering", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "Starred" });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-header button[title='Invite People']");
+    await contains(".o-mail-Discuss-header button[title='Notification Settings']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains("[title='Invite People']", { count: 0 });
+    await contains("[title='Notification Settings']", { count: 0 });
 });
 
 test("rendering of inbox message", async () => {
@@ -1541,7 +1552,10 @@ test("Thread avatar image is displayed in top bar of channels of type 'channel' 
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Discuss-header .o-mail-Discuss-threadAvatar");
+    await contains(".o-mail-Discuss-header .o-mail-Discuss-threadAvatar .fa-pencil");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(".o-mail-Discuss-threadAvatar");
+    await contains(".o-mail-Discuss-threadAvatar .fa-pencil", { count: 0 });
 });
 
 test("Partner IM status is displayed as thread icon in top bar of channels of type 'chat'", async () => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1968,3 +1968,30 @@ test("Copy Message Link", async () => {
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { text: url(`/mail/message/${messageId_2}`) });
 });
+
+test("Message actions change when channel is archived", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Test",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message .o-mail-Message-actions");
+    await contains("[title='Add a Reaction']");
+    await contains("[title='Reply']");
+    await contains("[title='Mark as Todo']");
+    await click("[title='Expand']");
+    await contains("[title='Pin']");
+    await contains("[title='Mark as Unread']");
+    await contains("[title='Create Thread']");
+    pyEnv["discuss.channel"].write([channelId], { active: false });
+    await contains(".o-mail-Message .o-mail-Message-actions");
+    await contains("[title='Expand']", { count: 0 });
+    await contains("[title='Add a Reaction']");
+    await contains("[title='Mark as Todo']");
+    await contains("[title='Pin']");
+    await contains("[title='Mark as Unread']");
+});

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -155,6 +155,8 @@ async function mail_attachment_delete(request) {
 registerRoute("/discuss/channel/attachments", load_attachments);
 /** @type {RouteCallback} */
 async function load_attachments(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
     /** @type {import("mock_models").IrAttachment} */
     const IrAttachment = this.env["ir.attachment"];
 
@@ -163,6 +165,10 @@ async function load_attachments(request) {
         limit = 30,
         older_attachment_id = null,
     } = await parseRequestParams(request);
+    const channel = DiscussChannel._find_channels(channel_id);
+    if (!channel.length) {
+        return;
+    }
     const attachmentIds = IrAttachment.filter(
         ({ id, res_id, res_model }) =>
             res_id === channel_id &&
@@ -284,7 +290,7 @@ async function discuss_channel_info(request) {
     const DiscussChannel = this.env["discuss.channel"];
 
     const { channel_id } = await parseRequestParams(request);
-    const channel = DiscussChannel.search([["id", "=", channel_id]]);
+    const channel = DiscussChannel._find_channels(channel_id);
     if (!channel.length) {
         return;
     }
@@ -298,12 +304,18 @@ async function discuss_channel_members(request) {
     const DiscussChannel = this.env["discuss.channel"];
 
     const { channel_id, known_member_ids } = await parseRequestParams(request);
-    return DiscussChannel._load_more_members([channel_id], known_member_ids);
+    const channel = DiscussChannel._find_channels(channel_id);
+    if (!channel.length) {
+        return;
+    }
+    return channel._load_more_members([channel_id], known_member_ids);
 }
 
 registerRoute("/discuss/channel/messages", discuss_channel_messages);
 /** @type {RouteCallback} */
 async function discuss_channel_messages(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
@@ -315,6 +327,10 @@ async function discuss_channel_messages(request) {
         limit = 30,
         search_term,
     } = await parseRequestParams(request);
+    const channel = DiscussChannel._find_channels(channel_id);
+    if (!channel.length) {
+        return;
+    }
     const domain = [
         ["res_id", "=", channel_id],
         ["model", "=", "discuss.channel"],
@@ -354,11 +370,17 @@ async function discuss_channel_sub_channel_fetch(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
     const { parent_channel_id, before, limit } = await parseRequestParams(request);
+    const channel = DiscussChannel._find_channels(parent_channel_id);
+    if (!channel.length) {
+        return;
+    }
     const domain = [["parent_channel_id", "=", parent_channel_id]];
     if (before) {
         domain.push(["id", "<", before]);
     }
-    const subChannels = DiscussChannel.search(domain, makeKwArgs({ limit, order: "id DESC" }));
+    const subChannels = DiscussChannel._find_channels(
+        makeKwArgs({ domain, limit, order: "id DESC" })
+    );
     const store = new mailDataHelpers.Store(subChannels);
     const lastMessageIds = [];
     for (const channel of subChannels) {
@@ -435,10 +457,16 @@ async function channel_ping(request) {}
 registerRoute("/discuss/channel/pinned_messages", discuss_channel_pins);
 /** @type {RouteCallback} */
 async function discuss_channel_pins(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
     const { channel_id } = await parseRequestParams(request);
+    const channel = DiscussChannel._find_channels(channel_id);
+    if (!channel.length) {
+        return;
+    }
     const messageIds = MailMessage.search([
         ["model", "=", "discuss.channel"],
         ["res_id", "=", channel_id],

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -234,6 +234,7 @@ export class DiscussChannel extends models.ServerModel {
         const [data] = this.read(
             ids,
             [
+                "active",
                 "allow_public_upload",
                 "avatarCacheKey", // mock server simplification
                 "channel_type",
@@ -1044,5 +1045,31 @@ export class DiscussChannel extends models.ServerModel {
             channel_member_ids: [Command.create({ guest_id: guestId })],
         });
         MailGuest._set_auth_cookie(guestId);
+    }
+
+    _find_channels() {
+        const { ids, domain, limit, order } = getKwArgs(
+            arguments,
+            "ids",
+            "domain",
+            "limit",
+            "order"
+        );
+        let channelDomain = domain || [];
+        if (ids) {
+            channelDomain = [["id", "in", ensureArray(ids)], ...channelDomain];
+        }
+        if (channelDomain.length === 0) {
+            return this.browse();
+        }
+        const resultIds = this.search(
+            channelDomain,
+            makeKwArgs({
+                context: { ...this.env.context, active_test: false },
+                limit,
+                order,
+            })
+        );
+        return this.browse(resultIds);
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_websocket.js
@@ -73,21 +73,24 @@ export class IrWebSocket extends busModels.IrWebSocket {
         channels = channels.filter(
             (c) => typeof c !== "string" || !c.startsWith("discuss.channel_")
         );
-        const allChannels = DiscussChannel.search_read([
+        const allChannels = DiscussChannel.search_read(
             [
-                "id",
-                "in",
-                DiscussChannelMember.search_read([
-                    "|",
-                    guest
-                        ? ["guest_id", "=", guest.id]
-                        : ["partner_id", "=", authenticatedPartner.id],
-                    ["channel_id", "in", discussChannelIds],
-                ]).map((member) =>
-                    isIterable(member.channel_id) ? member.channel_id[0] : member.channel_id
-                ),
+                [
+                    "id",
+                    "in",
+                    DiscussChannelMember.search_read([
+                        "|",
+                        guest
+                            ? ["guest_id", "=", guest.id]
+                            : ["partner_id", "=", authenticatedPartner.id],
+                        ["channel_id", "in", discussChannelIds],
+                    ]).map((member) =>
+                        isIterable(member.channel_id) ? member.channel_id[0] : member.channel_id
+                    ),
+                ],
             ],
-        ]);
+            makeKwArgs({ context: { active_test: false } })
+        );
         for (const channel of allChannels) {
             channels.push(channel);
             if (!discussChannelIds.includes(channel.id)) {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -893,3 +893,9 @@ class TestChannelInternals(MailCommon, HttpCase):
         actual_member_ids = [m.partner_id.id if m.partner_id else m.guest_id.id for m in channel.channel_member_ids]
         expected_member_ids = [self.partner_employee.id, self.guest.id, self.env.user.partner_id.id]
         self.assertCountEqual(actual_member_ids, expected_member_ids)
+
+    def test_archived_channel(self):
+        channel = self.env["discuss.channel"].create({"name": "test", "active": False})
+        self.authenticate(self.user_employee.login, self.user_employee.login)
+        res = self.make_jsonrpc_request("/discuss/channel/messages", {"channel_id": channel.id})
+        self.assertEqual(res, {"data": {}, "messages": []})

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -567,6 +567,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         last_interest_dt = fields.Datetime.to_string(channel.last_interest_dt)
         if channel == self.channel_general:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": self.group_user.full_name,
                 "anonymous_country": False,
@@ -599,6 +600,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_1:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -631,6 +633,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_2:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -663,6 +666,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_1:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": self.group_user.full_name,
                 "anonymous_country": False,
@@ -698,6 +702,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_2:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": self.group_user.full_name,
                 "anonymous_country": False,
@@ -730,6 +735,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_group_1:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -762,6 +768,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_1:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -794,6 +801,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_2:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -826,6 +834,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_3:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -858,6 +867,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_4:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": False,
@@ -890,6 +900,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": {
@@ -929,6 +940,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2:
             return {
+                "active": True,
                 "allow_public_upload": False,
                 "authorizedGroupFullName": False,
                 "anonymous_country": {

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -15,11 +15,13 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
         As we don't have a im_livechat.channel linked to it, we pre-emptively create a discuss.channel
         that will hold the conversation between the bot and the user testing the script. """
 
-        channels = request.env["discuss.channel"].search([
-            ["is_member", "=", True],
-            ["livechat_active", "=", True],
-            ["chatbot_current_step_id.chatbot_script_id", "=", chatbot_script.id],
-        ])
+        channels = request.env["discuss.channel"]._find_channels(
+            domain=[
+                ["is_member", "=", True],
+                ["livechat_active", "=", True],
+                ["chatbot_current_step_id.chatbot_script_id", "=", chatbot_script.id],
+            ]
+        )
         for channel in channels:
             channel._close_livechat_session()
 


### PR DESCRIPTION
Although we currently support archiving channels, we have not taken this into
account alongside other features. This could result in crashes when accessing
those channels for example when opening one. This change allows
`reading/passive` actions while preventing `active` ones on archived channels.

task-4715483
task-4764934
task-5420147