### PR TITLE
[FIX] account_peppol: prevent duplicate documents

### DIFF
--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -248,7 +248,7 @@ class AccountMoveSend(models.TransientModel):
                         for attachment in attachments_linked
                     ] + base_attachments
 
-                    new_message = invoice.with_context(no_new_invoice=True).message_post(
+                    new_message = invoice.with_context(no_new_invoice=True, no_document=True).message_post(
                         body=attachments_linked_message,
                         attachments=attachments_embedded,
                     )


### PR DESCRIPTION
When sending an invoice via Peppol, the PDF and XML attachments are logged in the chatter. This automatically triggers a synchronization with the Documents app. However, the Peppol sending flow also includes a dedicated document linking step later in the process.

This caused the same attachments to be registered as documents twice.

This commit skips the document synchronization during the initial chatter logging step. The attachments will now only be synchronized once during the dedicated linking phase.

Note: ec6e559 prevented duplicate attachments in the chatter with some cleanup code, but this cleanup code runs after the document has already been created and does not remove the document, resulting in duplicate documents, which this commit fixes.

Task-6030468
