### PR TITLE
[IMP] survey: rename "Allow Roaming" to "Free Navigation"

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -122,7 +122,8 @@
                                            invisible="questions_layout == 'one_page' or survey_type == 'live_session'"/>
                                     <field name="questions_selection" widget="radio"
                                            invisible="survey_type == 'live_session'"/>
-                                    <field name="users_can_go_back" string="Allow Roaming"
+                                    <field name="users_can_go_back" string="Free Navigation"
+                                           help="If checked, users can navigate back and forth between questions."
                                            invisible="questions_layout == 'one_page' or survey_type == 'live_session'"/>
                                 </group>
                                 <group string="Participants" name="participants">


### PR DESCRIPTION
The "Allow Roaming" label on the users_can_go_back field was confusing and didn't clearly convey its purpose. Renaming it to "Free Navigation" makes the feature more intuitive for users.

Also added a help tooltip to clarify that when enabled, users can navigate back and forth between questions.

Task-5864998
