### PR TITLE
[FIX] web: resolve conflicting translations by module context

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -44,12 +44,19 @@ export const localizationService = {
             multi_lang: multiLang,
         } = await response.json();
 
-        // FIXME We flatten the result of the python route.
-        // Eventually, we want a new python route to return directly the good result.
+        // The first module to define a term owns the plain key.
+        // When a later module defines the same term differently, a scoped key
+        // ("module\x04term") is stored for that module so _t() can pick the
+        // right translation via this.templateName in the OWL CodeGenerator.
+        // Scoped keys are only created on actual conflicts, saving memory.
         const terms = {};
         for (const addon of Object.keys(modules)) {
             for (const message of modules[addon].messages) {
-                terms[message.id] = message.string;
+                if (!(message.id in terms)) {
+                    terms[message.id] = message.string;
+                } else {
+                    terms[`${addon}\x04${message.id}`] = message.string;
+                }
             }
         }
 

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -11,6 +11,21 @@ export const translationIsReady = new Deferred();
 
 const Markup = markup().constructor;
 
+function _translate(term, moduleName, ...values) {
+    if (translatedTerms[translationLoaded]) {
+        let translation = translatedTerms[term] ?? term;
+        if (moduleName) {
+            const scopedKey = `${moduleName}\x04${term}`;
+            if (scopedKey in translatedTerms) {
+                translation = translatedTerms[scopedKey];
+            }
+        }
+        return values.length === 0 ? translation : _safeSprintf(translation, ...values);
+    } else {
+        return new LazyTranslatedString(term, values);
+    }
+}
+
 /**
  * Translates a term, or returns the term as it is if no translation can be
  * found.
@@ -34,15 +49,25 @@ const Markup = markup().constructor;
  * @returns {string|Markup|LazyTranslatedString}
  */
 export function _t(term, ...values) {
-    if (translatedTerms[translationLoaded]) {
-        const translation = translatedTerms[term] ?? term;
-        if (values.length === 0) {
-            return translation;
-        }
-        return _safeSprintf(translation, ...values);
-    } else {
-        return new LazyTranslatedString(term, values);
-    }
+    // When OWL calls translateFn it does so as `this.translateFn(term, ctx)`,
+    // binding `this` to the CodeGenerator which carries `templateName`
+    return _translate(term, this?.templateName?.split(".")[0], ...values);
+}
+
+/**
+ * Creates a module-specific translation function. Called automatically by the
+ * transpiler when a file imports `_t` from this module; should not be needed
+ * in hand-written code.
+ *
+ * @param {string} moduleName
+ * @returns {typeof _t}
+ */
+export function createModuleT(moduleName) {
+    return function _t(term, ...values) {
+        // If called as OWL's translateFn, this.templateName takes precedence
+        // so that template translations resolve to the template's own module.
+        return _translate(term, this?.templateName?.split(".")[0] || moduleName, ...values);
+    };
 }
 
 class LazyTranslatedString extends String {

--- a/addons/web/static/src/module_loader.js
+++ b/addons/web/static/src/module_loader.js
@@ -216,8 +216,15 @@
 
         /** @type {OdooModuleLoader["startModule"]} */
         startModule(name) {
+            const addon = name.match(/^@([^/]+)\//)?.[1];
             /** @type {(dependency: string) => OdooModule} */
-            const require = (dependency) => this.modules.get(dependency);
+            const require = (dependency) => {
+                const mod = this.modules.get(dependency);
+                if (dependency === "@web/core/l10n/translation" && mod?.createModuleT && addon) {
+                    return Object.assign(Object.create(mod), { _t: mod.createModuleT(addon) });
+                }
+                return mod;
+            };
             this.jobs.delete(name);
             const factory = this.factories.get(name);
             /** @type {OdooModule | null} */

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -8,7 +8,7 @@ import {
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
-import { _t, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
+import { _t, createModuleT, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
 import { session } from "@web/session";
 
 import { Component, markup, xml } from "@odoo/owl";
@@ -154,6 +154,39 @@ test("_t fills the format specifiers in lazy translated terms with its extra arg
         "Due in %s days": "Échéance dans %s jours",
     });
     expect(translatedStr.toString()).toBe("Échéance dans 513 jours");
+});
+
+describe("createModuleT", () => {
+    test("resolves to module-specific translation when two modules define the same term differently", () => {
+        // Simulate what localization_service does: first module (web_editor) owns
+        // the plain key; second module (pos_restaurant) gets a scoped key.
+        patchTranslations({
+            Table: "Tabla",
+            "pos_restaurant\x04Table": "Mesa",
+        });
+        const tWebEditor = createModuleT("web_editor");
+        const tPosRestaurant = createModuleT("pos_restaurant");
+        expect(tWebEditor("Table")).toBe("Tabla");
+        expect(tPosRestaurant("Table")).toBe("Mesa");
+    });
+
+    test("falls back to plain key when no scoped key exists for the module", () => {
+        patchTranslations({ Table: "Tabla" });
+        const tUnknownModule = createModuleT("some_other_module");
+        expect(tUnknownModule("Table")).toBe("Tabla");
+    });
+
+    test("templateName takes precedence over module name when used as OWL translateFn", () => {
+        patchTranslations({
+            Table: "Tabla",
+            "pos_restaurant\x04Table": "Mesa",
+        });
+        // Simulate OWL calling translateFn with `this` bound to a CodeGenerator
+        // whose templateName belongs to pos_restaurant.
+        const tWebEditor = createModuleT("web_editor");
+        const result = tWebEditor.call({ templateName: "pos_restaurant.TicketScreen" }, "Table");
+        expect(result).toBe("Mesa");
+    });
 });
 
 describe("_t with markups", () => {


### PR DESCRIPTION
When multiple addons provide different translations for the same term (e.g. "Table" → "Mesa" in pos_restaurant vs "Tabla" in web_editor), the last-loaded module would silently overwrite the others.

Fix by storing scoped keys ("addon\x04term") in translatedTerms for any module that conflicts with a previously loaded one. The module loader now intercepts require("@web/core/l10n/translation") and returns a module-bound _t via createModuleT(addon), so every JS import of _t resolves translations against the importing addon's scope — including calls inside method bodies, not just at module init time. OWL templates continue to resolve via this.templateName in the CodeGenerator, which takes precedence inside createModuleT.

opw-5970092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
