### PR TITLE
[FIX] account: error when deleting parent account

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -134,7 +134,7 @@ class AccountAccount(models.Model):
         comodel_name='account.account',
         string="Parent Account",
         domain="['!', ('id', 'child_of', id)]",
-        ondelete='set null',
+        ondelete='restrict',
         context={'active_test': False},
         check_company=True,
     )


### PR DESCRIPTION
Before this commit, deleting an account that is set as a parent to some other accounts caused some problems (e.g., the indentation on the CoA is not changed accordingly, and the profit and loss report becomes in error).

This commit fixes this issue by restricting the user from deleting an account that is set as a parent to other accounts.

task-6042719


