### PR TITLE
[FIX] l10n_ca: adjust tooltip for PST Number

### DIFF
--- a/addons/l10n_ca/models/res_partner.py
+++ b/addons/l10n_ca/models/res_partner.py
@@ -4,4 +4,4 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    l10n_ca_pst = fields.Char(string='PST number', help='Canadian Provincial Tax Identification Number')
+    l10n_ca_pst = fields.Char(string='PST number', help='Canadian Provincial Tax Identification Number (PST) or Québec Sales Tax (QST)')


### PR DESCRIPTION
Currently, the `l10n_ca_pst` field label and help message implies that it is only for the PST number; however, in Quebec the proper name for such a value is the Quebec Sales Tax or (QST) registration number. As such, by updating the help message we clarify to the users that both PST and QST should be placed here.

task-5866356