### PR TITLE
[IMP] orm: fix cache pollution for x2m fields 

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -114,7 +114,6 @@ class AccountAccount(models.Model):
         context={'append_fields': ['type_tax_use', 'company_id']})
     note = fields.Text('Internal Notes', tracking=True)
     company_ids = fields.Many2many('res.company', string='Companies', required=True, readonly=False,
-        depends_context=('uid',),  # To avoid cache pollution between sudo / non-sudo uses of the field
         default=lambda self: self.env.company)
     code_mapping_ids = fields.One2many(comodel_name='account.code.mapping', inverse_name='account_id')
     # Ensure `code_mapping_ids` is written before `company_ids` so we don't trigger the `_ensure_code_is_unique`

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=526):  # crm 500 / com 500 / ent 526
+        with self.assertQueryCount(user_sales_manager=527):  # crm 500 / com 500 / ent 527
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -210,10 +210,10 @@ class ChatbotScriptStep(models.Model):
     def _find_first_user_free_input(self, discuss_channel):
         """Find the first message from the visitor responding to a free_input step."""
         chatbot_partner = self.chatbot_script_id.operator_partner_id
-        for answer in discuss_channel.chatbot_message_ids.sorted("id"):
+        for answer in discuss_channel.sudo().chatbot_message_ids.sorted("id"):
             if answer.script_step_id.step_type not in ("free_input_single", "free_input_multi"):
                 continue
-            message = answer.mail_message_id
+            message = answer.mail_message_id.with_env(self.env)
             if message.has_access('read') and message.author_id != chatbot_partner:
                 return message.with_prefetch()
         return self.env["mail.message"]

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -772,12 +772,11 @@ class DiscussChannel(models.Model):
             to fill, like : {'question_email': 'email_from', 'question_phone': 'mobile'}
         """
         values = {}
-        filtered_message_ids = self.chatbot_message_ids.filtered(
-            # sudo: chatbot.script.step - getting the type of the current step
-            lambda m: m.script_step_id.sudo().step_type in step_type_to_field
-        )
-        for message_id in filtered_message_ids:
-            field_name = step_type_to_field[message_id.script_step_id.step_type]
+        for message_id in self.sudo().chatbot_message_ids:
+            step_type = message_id.script_step_id.step_type
+            if step_type not in step_type_to_field:
+                continue
+            field_name = step_type_to_field[step_type]
             if not values.get(field_name):
                 values[field_name] = html2plaintext(message_id.user_raw_answer or '')
 

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -132,7 +132,7 @@ class MailMail(models.Model):
         and the number of attachments we do not have access to.
         """
         for mail_sudo, mail in zip(self.sudo(), self):
-            mail.unrestricted_attachment_ids = mail_sudo.attachment_ids.sudo(False)._filtered_access('read')
+            mail.unrestricted_attachment_ids = mail.sudo(False).attachment_ids
             mail.restricted_attachment_count = len(mail_sudo.attachment_ids) - len(mail.unrestricted_attachment_ids)
 
     def _inverse_unrestricted_attachment_ids(self):

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -500,10 +500,9 @@ class TestDiscussChannelAccess(MailCommon):
         elif channel_key == "group_failing":
             channel.group_public_id = self.env.ref("base.group_system")
         if sub_channel:
-            channel.sudo()._create_sub_channel()
-            channel = channel.sub_channel_ids[0]
+            channel = channel.sudo()._create_sub_channel()
             if membership == "member":
-                channel.sudo()._add_members(users=user, guests=guest)
+                channel._add_members(users=user, guests=guest)
         return channel.id
 
     def _execute_action_channel(self, user_key, channel_key, membership, operation, result, for_sub_channel):

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -152,12 +152,13 @@ class TestMailComposerForm(TestMailComposer):
         partner_classic = self.partner_classic.with_env(self.env)
         test_record = self.test_record.with_env(self.env)
 
-        with self.assertRaises(AccessError):
-            _form = Form(self.env['mail.compose.message'].with_context({
-                'default_partner_ids': (self.partner_private + partner_classic).ids,
-                'default_model': test_record._name,
-                'default_res_ids': test_record.ids,
-            }))
+        form = Form(self.env['mail.compose.message'].with_context({
+            'default_partner_ids': (self.partner_private + partner_classic).ids,
+            'default_model': test_record._name,
+            'default_res_ids': test_record.ids,
+        }))
+        msg = form.save()
+        self.assertEqual(partner_classic, msg.sudo().partner_ids, 'partner_private must not be saved')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('employee')

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -55,6 +55,7 @@ class StockWarehouse(models.Model):
                     ('action', '=', 'manufacture'), ('warehouse_id', '=', warehouse.id)]).route_id
             if not manufacture_route:
                 continue
+            manufacture_route = manufacture_route.sudo()
             if warehouse.manufacture_to_resupply:
                 manufacture_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
@@ -64,7 +65,7 @@ class StockWarehouse(models.Model):
         manufacture_route = self._find_or_create_global_route('mrp.route_warehouse0_manufacture', _('Manufacture'))
         for warehouse in self:
             if warehouse.manufacture_to_resupply:
-                manufacture_route.warehouse_ids = [Command.link(warehouse.id)]
+                manufacture_route.sudo().warehouse_ids = [Command.link(warehouse.id)]
         return super()._create_or_update_route()
 
     def get_rules_dict(self):

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -171,7 +171,7 @@ class PosConfig(models.Model):
         help="This field depicts the maximum difference allowed between the ending balance and the theoretical cash when "
              "closing a session, for non-POS managers. If this maximum is reached, the user will have an error message at "
              "the closing of his session saying that he needs to contact his manager.")
-    payment_method_ids = fields.Many2many('pos.payment.method', string='Payment Methods', default=lambda self: self._default_payment_methods(), copy=False)
+    payment_method_ids = fields.Many2many('pos.payment.method', string='Payment Methods', bypass_search_access=True, default=lambda self: self._default_payment_methods(), copy=False)
     company_has_template = fields.Boolean(string="Company has chart of accounts", compute="_compute_company_has_template")
     current_user_id = fields.Many2one('res.users', string='Current Session Responsible', compute='_compute_current_session_user')
     other_devices = fields.Boolean(string="Other Devices", help="Connect devices to your PoS without an IoT Box.")

--- a/addons/point_of_sale/tests/test_generic_localization.py
+++ b/addons/point_of_sale/tests/test_generic_localization.py
@@ -12,12 +12,12 @@ class TestGenericLocalization(TestPointOfSaleHttpCommon):
         super().setUpClass()
         cls.partner_a.name = "AAAA Generic Partner"
         cls.partner_a.vat = "32345678"
-        cls.whiteboard_pen.write({
+        cls.whiteboard_pen.sudo().write({
             'standard_price': 10.0,
             'taxes_id': [Command.link(cls.tax_sale_a.id)]
         })
 
-        cls.wall_shelf.write({
+        cls.wall_shelf.sudo().write({
             'standard_price': 10.0,
             'taxes_id': [Command.link(cls.tax_sale_a.id)]
         })

--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -10,12 +10,15 @@ class PosConfig(models.Model):
 
     minimal_employee_ids = fields.Many2many(
         'hr.employee', 'pos_hr_minimal_employee_hr_employee', string="Employees with minimal access",
+        bypass_search_access=True,
         help='If left empty, all employees can log in to PoS')
     basic_employee_ids = fields.Many2many(
         'hr.employee', 'pos_hr_basic_employee_hr_employee', string="Employees with basic access",
+        bypass_search_access=True,
         help='If left empty, all employees can log in to PoS')
     advanced_employee_ids = fields.Many2many(
         'hr.employee', 'pos_hr_advanced_employee_hr_employee', string="Employees with manager access",
+        bypass_search_access=True,
         help='Employees linked to users with the PoS Manager role are automatically added to this list')
 
     def write(self, vals):

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -127,9 +127,10 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
         self.start_tour(self_route, "test_kiosk_cart_restore_and_cancel")
 
         kiosk_order = self.env['pos.order'].search(
-            [('config_id', '=', self.pos_config.id), ('state', '=', 'cancel')],
+            [('config_id', '=', self.pos_config.id)],
             order="id desc", limit=1
         )
+        self.assertEqual(kiosk_order.state, 'cancel')
 
         # Collect order lines in a dict by product name
         order_lines = {line.product_id.name: line for line in kiosk_order.lines}

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -89,6 +89,7 @@ class StockWarehouse(models.Model):
             if not buy_route:
                 buy_route = self.env['stock.rule'].search([
                     ('action', '=', 'buy'), ('warehouse_id', '=', warehouse.id)]).route_id
+            buy_route = buy_route.sudo()
             if warehouse.buy_to_resupply:
                 buy_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
@@ -98,7 +99,7 @@ class StockWarehouse(models.Model):
         purchase_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', _('Buy'))
         for warehouse in self:
             if warehouse.buy_to_resupply:
-                purchase_route.warehouse_ids = [Command.link(warehouse.id)]
+                purchase_route.sudo().warehouse_ids = [Command.link(warehouse.id)]
         return super()._create_or_update_route()
 
     def _generate_global_route_rules_values(self):

--- a/addons/sale_purchase/tests/test_access_rights.py
+++ b/addons/sale_purchase/tests/test_access_rights.py
@@ -63,5 +63,6 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
         purchase_orders.read()
 
         # try to access the PO lines from the SO, as sale person
+        self.assertFalse(sol_service_purchase.with_user(self.user_salesperson).purchase_line_ids)
         with self.assertRaises(AccessError):
-            sol_service_purchase.with_user(self.user_salesperson).purchase_line_ids.read()
+            sol_service_purchase.sudo().purchase_line_ids.with_user(self.user_salesperson).read()

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -821,7 +821,7 @@ class ProductTemplate(models.Model):
         default=lambda self: self.env['stock.route'].search_count([('product_selectable', '=', True)]))
     route_ids = fields.Many2many(
         'stock.route', 'stock_route_product', 'product_id', 'route_id', 'Routes',
-        domain=[('product_selectable', '=', True)], depends_context=['company', 'allowed_companies'],
+        domain=[('product_selectable', '=', True)],
         help="Depending on the modules installed, this will allow you to define the route of the product: whether it will be bought, manufactured, replenished on order, etc.")
     nbr_moves_in = fields.Integer(compute='_compute_nbr_moves', compute_sudo=False, help="Number of incoming stock moves in the past 12 months")
     nbr_moves_out = fields.Integer(compute='_compute_nbr_moves', compute_sudo=False, help="Number of outgoing stock moves in the past 12 months")

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2157,7 +2157,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             moves_to_push._push_apply()
 
         for move in moves_todo:
-            for move_dest in move.move_dest_ids:
+            for move_dest in move.sudo().move_dest_ids:
                 if not move_dest.location_id._child_of(move.location_dest_id) and not move.location_dest_id._child_of(move_dest.location_id):
                     move_dest._break_mto_link(move)
                     continue

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -1196,6 +1196,7 @@ class SurveySurvey(models.Model):
         return '/s/%s' % self.access_token[:6]
 
     def get_print_url(self):
+        self.check_access('read')  # avoid cache pollution
         return '/survey/print/%s' % self.access_token
 
     # ------------------------------------------------------------

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -133,7 +133,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - _compute_message_unread
     #       - fetch im_livechat_channel
     #   1: _get_last_messages
-    #   23: store add message:
+    #   24: store add message:
     #       - fetch mail_message
     #       - search mail_message (_compute_linked_message_ids)
     #       - fetch mail_message (_compute_linked_message_ids)
@@ -157,7 +157,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (author)
     #       - fetch user (author)
     #       - fetch discuss_call_history
-    _query_count_discuss_channels = 61
+    #       - select the current db snapshot
+    _query_count_discuss_channels = 62
 
     def setUp(self):
         super().setUp()

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -100,7 +100,8 @@ class TestMailMail(MailCommon):
             self.assertEqual(mail.restricted_attachment_count, 2)
             self.assertEqual(len(mail.unrestricted_attachment_ids), 3)
             self.assertEqual(mail.unrestricted_attachment_ids.mapped('name'), ['file 1', 'file 3', 'new file'])
-            self.assertEqual(len(mail.attachment_ids), 5)
+            self.assertEqual(len(mail.attachment_ids), 3)
+            self.assertEqual(len(mail.sudo().attachment_ids), 5)
 
             # Remove an attachment
             mail.write({
@@ -109,13 +110,13 @@ class TestMailMail(MailCommon):
             self.assertEqual(mail.restricted_attachment_count, 2)
             self.assertEqual(len(mail.unrestricted_attachment_ids), 2)
             self.assertEqual(mail.unrestricted_attachment_ids.mapped('name'), ['file 1', 'file 3'])
-            self.assertEqual(len(mail.attachment_ids), 4)
+            self.assertEqual(len(mail.sudo().attachment_ids), 4)
 
             # Reset command
             mail.invalidate_recordset()
             mail.write({'unrestricted_attachment_ids': [Command.clear()]})
             self.assertEqual(len(mail.unrestricted_attachment_ids), 0)
-            self.assertEqual(len(mail.attachment_ids), 2)
+            self.assertEqual(len(mail.sudo().attachment_ids), 2)
 
             # Read in SUDO
             mail.invalidate_recordset()

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -600,7 +600,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=52, employee=52):
+        with self.assertQueryCount(admin=54, employee=53):
             composer._action_send_mail()
 
         # notifications
@@ -1017,7 +1017,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_subject_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=4):  # tm: 4
+        with self.assertQueryCount(employee=5):  # tm: 5
             _recipients = records._message_get_suggested_subject_batch()
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')

--- a/addons/website_forum/tests/test_forum_controller.py
+++ b/addons/website_forum/tests/test_forum_controller.py
@@ -46,7 +46,7 @@ class TestForumController(TestForumCommon):
                 if user != self.user_public:
                     self.env.user.karma = self.minimum_karma_allowing_to_post
                     # Like a post on forum 2 and verify that forum 2 is now in "my other forum"
-                    employee_2_forum_2_post.favourite_ids += self.env.user
+                    employee_2_forum_2_post.sudo().favourite_ids += self.env.user
                     self.assertEqual(self._get_my_other_forums(self.forum_1), self.forum_2)
                     self.assertFalse(self._get_my_other_forums(self.forum_2))
                     # Check similarly with posting and also checking that we don't see forum of website 2
@@ -61,5 +61,5 @@ class TestForumController(TestForumCommon):
                 if user != self.user_public:
                     self.assertFalse(self._get_my_other_forums(self.forum_1_website_2))
                     self.assertEqual(self._get_my_other_forums(self.forum_2_website_2), self.forum_1_website_2)
-                    employee_2_website_2_forum_2_post.favourite_ids += self.env.user
+                    employee_2_website_2_forum_2_post.sudo().favourite_ids += self.env.user
                     self.assertEqual(self._get_my_other_forums(self.forum_1_website_2), self.forum_2_website_2)

--- a/odoo/addons/test_orm/models/test_access_rights.py
+++ b/odoo/addons/test_orm/models/test_access_rights.py
@@ -15,6 +15,7 @@ class Test_Access_RightSome_Obj(models.Model):
     )
     forbidden2 = fields.Integer(groups='test_orm.test_group')
     forbidden3 = fields.Integer(groups=fields.NO_ACCESS)
+    child_ids = fields.One2many('test_access_right.child', 'parent_id')
 
 
 class Test_Access_RightContainer(models.Model):

--- a/odoo/addons/test_orm/tests/test_ir_rules.py
+++ b/odoo/addons/test_orm/tests/test_ir_rules.py
@@ -86,7 +86,6 @@ class TestRules(TransactionCase):
 
         # check the container as the public user
         container_user = container_admin.with_user(self.env.ref('base.public_user'))
-        container_user.invalidate_model(['some_ids'])
         self.assertItemsEqual(container_user.some_ids.ids, [self.allowed.id])
 
         # this should fail
@@ -94,17 +93,37 @@ class TestRules(TransactionCase):
             container_user.write({'some_ids': [Command.set(ids)]})
 
         container_admin.write({'some_ids': [Command.set(ids)]})
-        container_user.invalidate_model(['some_ids'])
         self.assertItemsEqual(container_user.some_ids.ids, [self.allowed.id])
-        container_admin.invalidate_model(['some_ids'])
         self.assertItemsEqual(container_admin.some_ids.ids, ids)
 
-        # this removes all records
+        # this removes all accessible records
         container_user.write({'some_ids': [Command.clear()]})
-        container_user.invalidate_model(['some_ids'])
         self.assertItemsEqual(container_user.some_ids.ids, [])
-        container_admin.invalidate_model(['some_ids'])
-        self.assertItemsEqual(container_admin.some_ids.ids, [])
+        self.assertItemsEqual(container_admin.some_ids.ids, [self.forbidden.id])
+
+    def test_many2many_no_read_access(self):
+        # create container and remove model access
+        container_admin = self.env['test_access_right.container'].create({'some_ids': [Command.set([self.allowed.id])]})
+        self.env['ir.model.access'].search([('model_id', '=', self.env['ir.model']._get(container_admin.some_ids._name).id)]).unlink()
+
+        # user cannot see any records
+        container_user = container_admin.with_user(self.env.ref('base.public_user'))
+        corecords = container_user.some_ids
+        self.assertFalse(corecords)
+        self.assertFalse(corecords.has_access('read'))
+
+    def test_one2many_no_read_access(self):
+        # create container and remove model access
+        parent_admin = self.allowed
+        child_admin = self.env['test_access_right.child'].create({'parent_id': parent_admin.id})
+        self.env['ir.model.access'].search([('model_id', '=', self.env['ir.model']._get(child_admin._name).id)]).unlink()
+
+        # user cannot see any records
+        assert parent_admin.has_access('read')
+        parent_user = parent_admin.with_user(self.env.ref('base.public_user'))
+        corecords = parent_user.child_ids
+        self.assertFalse(corecords)
+        self.assertFalse(corecords.has_access('read'))
 
     def test_access_rule_performance(self):
         env = self.env(user=self.env.ref('base.public_user'))

--- a/odoo/addons/test_orm/tests/test_many2many.py
+++ b/odoo/addons/test_orm/tests/test_many2many.py
@@ -1,7 +1,6 @@
-from unittest.mock import patch
-
-from odoo.fields import Command, Domain
+from odoo.fields import Command
 from odoo.tests.common import TransactionCase, new_test_user, tagged
+
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class Many2manyCase(TransactionCase):
@@ -62,33 +61,23 @@ class Many2manyCase(TransactionCase):
             'res_model': self.ship._name,
             'res_id': self.ship.id,
         }).with_user(user)
+        self.env['ir.rule'].create({
+            'name': "No access",
+            'model_id': self.env['ir.model']._get(attachment._name).id,
+            'domain_force': [(0, '=', 1)],
+        })
         record = self.env['test_orm.attachment.host'].create({
             'm2m_attachment_ids': [Command.link(attachment.id)],
         }).with_user(user)
 
+        self.assertFalse(attachment.has_access('read'))
         self.assertFalse(record.env.su)
-
         field = record._fields['m2m_attachment_ids']
         self.assertTrue(field.bypass_search_access)
 
-        # check that attachments are searched with bypass_access, and filtered with _check_access()
-        Attachment = type(attachment)
-        with (
-            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as p_search,
-            patch.object(Attachment, '_access_domain', autospec=True, side_effect=Attachment._access_domain) as p_access,
-        ):
-            record.invalidate_model()
-            record.m2m_attachment_ids
-            p_search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=True)
-            p_access.assert_called_once_with(attachment, 'read')
+        # attachments are always searched in sudo and filtered on record access
+        self.assertEqual(record.m2m_attachment_ids, attachment)
 
-        # check that otherwise, attachments are searched without bypass_access
+        # check that otherwise, attachments are filtered
         self.patch(field, 'bypass_search_access', False)
-        with (
-            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as p_search,
-            patch.object(Attachment, '_access_domain', autospec=True, side_effect=Attachment._access_domain) as p_access,
-        ):
-            record.invalidate_model()
-            record.m2m_attachment_ids
-            p_search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=False)
-            p_access.assert_called_once_with(attachment.browse(), 'read')
+        self.assertEqual(record.m2m_attachment_ids, attachment.browse())

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -665,30 +665,26 @@ class _RelationalMulti(_Relational):
 
         raise ValueError("Wrong value for %s: %s" % (self, value))
 
-    def convert_to_record(self, value, record):
+    def convert_to_record(self, value, record: BaseModel):
         # use registry to avoid creating a recordset for the model
         prefetch_ids = Prefetch.relational(self, record)
-        Comodel = record.pool[self.comodel_name]
-        corecords = Comodel(record.env, value, prefetch_ids)
+        env = record.env
+        Comodel = env.registry[self.comodel_name]
+        corecords = Comodel(env, value, prefetch_ids)
+        if not env.su and corecords and not self.bypass_search_access:
+            corecords = corecords._filtered_access('read')
         if (
             Comodel._active_name
-            and self.context.get('active_test', record.env.context.get('active_test', True))
+            and self.context.get('active_test', env.context.get('active_test', True))
         ):
             corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
         return corecords
 
-    def convert_to_record_multi(self, values, records):
+    def convert_to_record_multi(self, values, records: BaseModel):
         # return the list of ids as a recordset without duplicates
-        prefetch_ids = Prefetch.relational(self, records)
-        Comodel = records.pool[self.comodel_name]
+        # same logic as convert_to_record (but references multiple source records)
         ids = tuple(unique(id_ for ids in values for id_ in ids))
-        corecords = Comodel(records.env, ids, prefetch_ids)
-        if (
-            Comodel._active_name
-            and self.context.get('active_test', records.env.context.get('active_test', True))
-        ):
-            corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
-        return corecords
+        return self.convert_to_record(ids, records)
 
     def convert_to_read(self, value, record, use_display_name=True):
         return value.ids
@@ -976,13 +972,15 @@ class One2many(_RelationalMulti):
 
         # optimization: fetch the inverse and active fields with search()
         domain = self.get_comodel_domain(records) & Domain(inverse, 'in', records.ids)
-        field_names = [inverse]
+        field_names = OrderedSet((inverse,))
         if comodel._active_name:
-            field_names.append(comodel._active_name)
-        try:
-            lines = comodel.search_fetch(domain, field_names)
-        except AccessError as e:
-            raise AccessError(records.env._("Failed to read field %s", self) + '\n' + str(e)) from e
+            # add the active field
+            field_names.add(comodel._active_name)
+        if not comodel.env.su:
+            # add fields for security rules
+            sec_domain = comodel._access_domain('read')
+            field_names.update(c.field_expr for c in sec_domain.optimize(comodel.sudo()).iter_conditions())
+        lines = comodel.sudo().search_fetch(domain, field_names)
 
         # group lines by inverse field (without prefetching other fields)
         get_id = (lambda rec: rec.id) if inverse_field.type == 'many2one' else int
@@ -1421,16 +1419,10 @@ class Many2many(_RelationalMulti):
         context.update(self.context)
         comodel = records.env[self.comodel_name].with_context(**context)
 
-        # bypass the access during search if method is overwriten to avoid
-        # possibly filtering all records of the comodel before joining
-        bypass_access = self.bypass_search_access and getattr(comodel, '_access_domain_heavy', False)
-
         # make the query for the lines
         domain = self.get_comodel_domain(records)
-        try:
-            query = comodel._search(domain, order=comodel._order, bypass_access=bypass_access)
-        except AccessError as e:
-            raise AccessError(records.env._("Failed to read field %s", self) + '\n' + str(e)) from e
+        # bypass_access set because of context management in ir.attachment
+        query = comodel.sudo()._search(domain, order=comodel._order, bypass_access=True)
 
         # join with many2many relation table
         sql_id1 = SQL.identifier(self.relation, self.column1)
@@ -1446,19 +1438,6 @@ class Many2many(_RelationalMulti):
         for id1, id2 in records.env.execute_query(query.select(sql_id1, sql_id2)):
             group[id1].append(id2)
             corecord_ids.add(id2)
-
-        # filter using record rules
-        if bypass_access and corecord_ids:
-            accessible_corecords = comodel.browse(corecord_ids)._filtered_access('read')
-            if len(accessible_corecords) < len(corecord_ids):
-                # some records are inaccessible, remove them from groups
-                corecord_ids = set(accessible_corecords._ids)
-                for id1, ids in group.items():
-                    group[id1] = [id_ for id_ in ids if id_ in corecord_ids]
-        elif corecord_ids and not comodel.env.su:
-            # query is already filtered, corecords are accessible
-            accessible_corecords = comodel.browse(corecord_ids)
-            comodel.env._add_to_access_cache(accessible_corecords)
 
         # store result in cache
         values = [tuple(group[id_]) for id_ in records._ids]
@@ -1489,28 +1468,39 @@ class Many2many(_RelationalMulti):
                 self.read(records.browse(missing_ids))
 
         # determine new relation {x: ys}
-        old_relation = {record.id: set(record[self.name]._ids) for record in records}
+        old_relation = {record.id: set(record[self.name]._ids) for record in records.sudo()}
         new_relation = {x: set(ys) for x, ys in old_relation.items()}
+        inaccessible_coids = set() if model.env.su else set(records.sudo()[self.name]._ids) - set(records[self.name]._ids)
+        added_ids = set()
 
         # operations on new relation
         def relation_add(xs, y):
+            added_ids.add(y)
             for x in xs:
                 new_relation[x].add(y)
 
         def relation_remove(xs, y):
+            if y in inaccessible_coids:
+                return
             for x in xs:
                 new_relation[x].discard(y)
 
         def relation_set(xs, ys):
-            for x in xs:
-                new_relation[x] = set(ys)
+            added_ids.update(ys)
+            if inaccessible_coids:
+                for x in xs:
+                    new_relation[x] = set(ys) | (new_relation[x] & inaccessible_coids)
+            else:
+                for x in xs:
+                    new_relation[x] = set(ys)
 
         def relation_delete(ys):
+            ys = set(ys) - inaccessible_coids
             # the pairs (x, y) have been cascade-deleted from relation
             for ys1 in old_relation.values():
-                ys1 -= ys
+                ys1.difference_update(ys)
             for ys1 in new_relation.values():
-                ys1 -= ys
+                ys1.difference_update(ys)
 
         for recs, commands in records_commands_list:
             to_create = []  # line vals to create
@@ -1550,11 +1540,7 @@ class Many2many(_RelationalMulti):
         # disabled on the comodel
         if not model.env.su:
             try:
-                comodel.browse(
-                    co_id
-                    for rec_id, new_co_ids in new_relation.items()
-                    for co_id in new_co_ids - old_relation[rec_id]
-                ).check_access('read')
+                comodel.browse(added_ids).check_access('read')
             except AccessError as e:
                 raise AccessError(model.env._("Failed to write field %s", self) + "\n" + str(e))
 

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -672,7 +672,27 @@ class _RelationalMulti(_Relational):
         Comodel = env.registry[self.comodel_name]
         corecords = Comodel(env, value, prefetch_ids)
         if not env.su and corecords and not self.bypass_search_access:
-            corecords = corecords._filtered_access('read')
+            # For performance, this slightly modified version of
+            # `_filtered_access` does not recheck permissions for records marked
+            # as inaccessible. Without this, we would recheck record access on
+            # each `convert_to_record` call if one of them in inaccessible.
+            read_access = env._access_cache[Comodel._name]
+            if all(map(read_access.get, corecords._ids)):
+                pass  # all records are accessible
+            elif all(map(read_access.__contains__, corecords._origin)):
+                # we have a value for all origins in access
+                # consider inaccessible records as inaccessible
+                if not corecords.browse().has_access('read'):
+                    return corecords.browse()
+                if corecords._origin:
+                    def accessible(rec):
+                        origin = rec._origin
+                        # no origin: new id without origin
+                        return not origin or read_access[origin.id]
+                    corecords = corecords.filtered(accessible)
+            else:
+                # default behaviour
+                corecords = corecords._filtered_access('read')
         if (
             Comodel._active_name
             and self.context.get('active_test', env.context.get('active_test', True))


### PR DESCRIPTION
The values in cache are put in sudo and filtered when converting to records. This way, no matter who reads the field first, the cache contains all ids of corecords which we can filter as we convert from cache to recordset.

In other words, `record.tag_ids` returns accessible tags to the current user linked to the record. However, if we had code
`record.sudo().tag_ids` that returned all records, `record.tag_ids` would return the same records afterwards directly from cache. Now we filter only accessible corecords before returning them.
