### PR TITLE
[16.0][FIX] l10n_ch: filter characters for QR codes

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+from itertools import chain
 from stdnum.util import clean
 
 from odoo import api, fields, models, _
@@ -13,6 +14,9 @@ from odoo.tools.misc import mod10r
 
 ISR_SUBSCRIPTION_CODE = {'CHF': '01', 'EUR': '03'}
 CLEARING = "09000"
+# Swiss Payment Standards - Swiss Implementation Guidelines for the QR-bill - version 2.3
+UNICODE_ALLOWED = {chr(ucode) for ucode in
+                   chain(range(0x20, 0x80), range(0xA0, 0x180), range(0x218, 0x21C), [0x20AC])}
 _re_postal = re.compile('^[0-9]{2}-[0-9]{1,6}-[0-9]$')
 
 
@@ -237,9 +241,20 @@ class ResPartnerBank(models.Model):
             return self._pretty_postal_num(iban[-9:])
         return None
 
+    def _l10n_ch_filter_text(self, value):
+        value = ' '.join((value or '').split())
+        if value.isprintable() and value.isascii() or {*value} < UNICODE_ALLOWED:
+            return value  # shortcut for performance
+        forbidden = {*value} - UNICODE_ALLOWED
+        for char in forbidden:
+            value = value.replace(char, '')
+        return value.strip()
+
     def _l10n_ch_get_qr_vals(self, amount, currency, debtor_partner, free_communication, structured_communication):
+        filter_text = self._l10n_ch_filter_text
         comment = ""
         if free_communication:
+            free_communication = filter_text(free_communication)
             comment = (free_communication[:137] + '...') if len(free_communication) > 140 else free_communication
 
         cred_street, cred_street_number, cred_zip, cred_city = self._get_partner_address_lines(self.partner_id)
@@ -262,6 +277,8 @@ class ResPartnerBank(models.Model):
             reference = structured_communication.replace(' ', '')
 
         currency = currency or self.currency_id or self.company_id.currency_id
+        cred_name = filter_text(self.acc_holder_name or self.partner_id.name)
+        debt_name = filter_text(debtor_partner.commercial_partner_id.name)
 
         return [
             'SPC',                                                # QR Type
@@ -269,7 +286,7 @@ class ResPartnerBank(models.Model):
             '1',                                                  # Coding Type
             acc_number,                                           # IBAN / QR-IBAN
             'S',                                                  # Creditor Address Type
-            (self.acc_holder_name or self.partner_id.name)[:70],  # Creditor Name
+            cred_name[:70],                                       # Creditor Name
             cred_street,                                          # Creditor Street Name
             cred_street_number,                                   # Creditor Building Number
             cred_zip,                                             # Creditor Postal Code
@@ -285,7 +302,7 @@ class ResPartnerBank(models.Model):
             '{:.2f}'.format(amount),                              # Amount
             currency.name,                                        # Currency
             'S',                                                  # Ultimate Debtor Address Type
-            debtor_partner.commercial_partner_id.name[:70],       # Ultimate Debtor Name
+            debt_name[:70],                                       # Ultimate Debtor Name
             debt_street,                                          # Ultimate Debtor Street Name
             debt_street_number,                                   # Ultimate Debtor Building Number
             debt_zip,                                             # Ultimate Debtor Postal Code
@@ -320,23 +337,24 @@ class ResPartnerBank(models.Model):
         """ Retrieves the partner's address fields, truncated to respect the line specs.
         :returns: tuple(street, street_number, zip, city)
         """
-        street_1_split = street_split(partner.street or '')
+        filter_text = self._l10n_ch_filter_text
+        street_1_split = street_split(filter_text(partner.street))
         street_name = street_1_split['street_name']
         building_number = f"{street_1_split['street_number']} {street_1_split['street_number2']}".strip()
 
         if building_number:
-            concatenated_building_number = f"{building_number} {partner.street2 or ''}".strip()
+            concatenated_building_number = f"{building_number} {filter_text(partner.street2)}".strip()
             if len(concatenated_building_number) <= 16:
                 building_number = concatenated_building_number
         else:
             # Try to complete the address with street2
-            street_2_split = street_split(partner.street2 or '')
+            street_2_split = street_split(filter_text(partner.street2))
 
             building_number = f"{street_2_split['street_number']} {street_2_split['street_number2']}".strip()
             if building_number:
                 street_name = f"{street_name} {street_2_split['street_name']}".strip()
             else:
-                building_number = (partner.street2 or '').strip()
+                building_number = filter_text(partner.street2)
 
         return street_name[:70], building_number[:16], partner.zip[:16], partner.city[:35]
 

--- a/addons/l10n_ch/tests/test_swissqr.py
+++ b/addons/l10n_ch/tests/test_swissqr.py
@@ -3,6 +3,7 @@
 import time
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_ch.models.res_bank import UNICODE_ALLOWED
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tools.misc import mod10r
@@ -64,6 +65,7 @@ class TestSwissQR(AccountTestInvoicingCommon):
                     'partner_id': self.customer.id,
                     'currency_id': self.env.ref(currency_to_use).id,
                     'date': time.strftime('%Y') + '-12-22',
+                    'ref': 'ABC \u202F421',
                     'invoice_line_ids': [
                         (
                             0,
@@ -110,17 +112,16 @@ class TestSwissQR(AccountTestInvoicingCommon):
         if ref_type == 'QRR':
             self.assertTrue(invoice.payment_reference)
             struct_ref = invoice.payment_reference
-            unstr_msg = invoice.ref or invoice.name or ''
         else:
             struct_ref = ''
-            unstr_msg = invoice.payment_reference or invoice.ref or invoice.name or ''
-        unstr_msg = unstr_msg or invoice.number
+        # Check that invalid characters are removed from Unstructured message 'invoice.ref'
+        unstr_msg = 'ABC 421'
 
-        payload = (
+        expected_payload = (
             "SPC\n"
             "0200\n"
             "1\n"
-            "{iban}\n"
+            f"{invoice.partner_bank_id.sanitized_acc_number}\n"  # IBAN
             "S\n"
             "company_1_data\n"
             "Route de Berne\n"
@@ -138,15 +139,10 @@ class TestSwissQR(AccountTestInvoicingCommon):
             "1000\n"
             "Lausanne\n"
             "CH\n"
-            "{ref_type}\n"
-            "{struct_ref}\n"
-            "{unstr_msg}\n"
+            f"{ref_type}\n"
+            f"{struct_ref}\n"
+            f"{unstr_msg}\n"
             "EPD"
-        ).format(
-            iban=invoice.partner_bank_id.sanitized_acc_number,
-            ref_type=ref_type,
-            struct_ref=struct_ref or '',
-            unstr_msg=unstr_msg,
         )
 
         expected_params = {
@@ -156,11 +152,11 @@ class TestSwissQR(AccountTestInvoicingCommon):
             'height': 256,
             'quiet': 1,
             'mask': 'ch_cross',
-            'value': payload,
+            'value': expected_payload,
         }
 
         params = invoice.partner_bank_id._get_qr_code_generation_params(
-            'ch_qr', 42.0, invoice.currency_id, invoice.partner_id, unstr_msg, struct_ref
+            'ch_qr', 42.0, invoice.currency_id, invoice.partner_id, invoice.ref, struct_ref
         )
 
         self.assertEqual(params, expected_params)
@@ -224,3 +220,33 @@ class TestSwissQR(AccountTestInvoicingCommon):
         payment_transaction._set_pending()
 
         self.assertEqual(order.reference, mod10r(order.reference[:-1]))
+
+    def test_swiss_allowed_unicode(self):
+        # Test Unicode range U+0000 to U+20FF
+
+        # Any space char is replaced with ' ':
+        #  - Printable '\u00A0' - NO-BREAK SPACE
+        #  - ASCII '\x09\x0a\x0b\x0c\x0d\x1c\x1d\x1e\x1f' (not printable)
+        #  - Non-ASCII '\u0085\u202F...' (not printable)
+        space_chars = {
+            *'\x09\x0a\x0b\x0c\x0d\x1c\x1d\x1e\x1f\u0085\u00A0'
+            '\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F'
+        }
+
+        # All Printable codepoints in range U+0020 - U+017F are allowed
+        # plus U+00AD {SOFT HYPHEN} and U+0218, U+0219, U+021A, U+021B, U+20AC
+        str_allowed = ''.join(UNICODE_ALLOWED - {'\u00A0'})  # NO-BREAK SPACE is replaced by SPACE
+
+        # Not allowed chars
+        str_rejected = ''.join({chr(ucode) for ucode in range(0x2100)} - UNICODE_ALLOWED - space_chars)
+
+        filter_text = self.env['res.partner.bank']._l10n_ch_filter_text
+
+        self.assertEqual(filter_text('\t   Aaa    \n  Bb   '), 'Aaa Bb')
+        self.assertEqual(filter_text(str_allowed), str_allowed)
+        self.assertEqual(filter_text(str_rejected), '')
+        self.assertEqual(filter_text(None), '')
+        self.assertEqual(filter_text(False), '')
+        self.assertEqual(filter_text('-'.join(space_chars)), ' '.join('-' * (len(space_chars) - 1)))
+        self.assertEqual(filter_text('@  \u202f88\nline 2  '), '@ 88 line 2')
+        self.assertEqual(len(str_allowed) + len(str_rejected) + len(space_chars), 0x2100)

--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -55,3 +55,4 @@ Sarah Jallon sarah.jallon@camptocamp.com https://github.com/sarsurgithub
 Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/ricardoalso
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
 Luca Policastro luca.policastro@camptocamp.com https://github.com/Luca-Policastro
+Florent Xicluna florent.xicluna@camptocamp.com https://github.com/florentx


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

QR code is rejected by the bank, when it contains an invalid character `U+202F`.

**Current behavior before PR:**

Unauthorized Unicode characters are encoded in the QR-Bill, and it is rejected on the receiving part.

**Desired behavior after PR is merged:**

Any Unicode codepoint which is not in the subset of 324 allowed codepoints has to be filtered out.

> spec of QR-bill allows only a subset of characters, a precise list of 324 Unicode codepoints (section 4.1.1, page 30 of the Swiss Implementation Guidelines for the QR-bill)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
