### PR TITLE
[FIX] web: prevent FileUploader from taking extra space

### DIFF
--- a/addons/web/static/src/views/fields/file_handler.xml
+++ b/addons/web/static/src/views/fields/file_handler.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FileUploader">
-        <div t-on-click.stop="">
+        <div class="d-contents" t-on-click.stop="">
             <t t-if="state.isUploading and props.showUploadingText">Uploading...</t>
             <span t-else="" t-on-click.prevent="onSelectFileButtonClick" style="display:contents">
                 <t t-slot="toggler"/>


### PR DESCRIPTION
This PR completes the changes introduced in: https://github.com/odoo/odoo/commit/2cbb735f5eecb7c31db8245b8d598d7193992a05

### Issue:
A `<div>` was added to prevent click propagation in the FileUploader, but it introduced unintended extra spacing in several parts of the UI

### Cause:
The added `<div>` affected the layout by taking up space where it should not

### Fix:
A specific class is added to neutralize the layout impact of this element while preserving the click propagation behavior

### Steps to reproduce:
- Install `hr'
- Create a new Employee
- Go in Private Information > Work Permit
- Upload a file
Before the fix, the edition's buttons are in another line

opw-5918379