### PR TITLE
[FIX] base: lower _file_read OSError log level from INFO to DEBUG

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -151,7 +151,7 @@ class IrAttachment(models.Model):
             with open(full_path, 'rb') as f:
                 return f.read(size)
         except OSError:
-            _logger.info("_read_file reading %s", full_path, exc_info=True)
+            _logger.debug("_read_file reading %s", full_path, exc_info=True)
         return b''
 
     @api.model


### PR DESCRIPTION
## Problem

When a filestore file is missing, `_file_read` handles the `OSError` gracefully and returns `b''`. However, it logs at `INFO` with `exc_info=True`, printing a full `FileNotFoundError` traceback that looks like an unhandled error.

This is especially misleading on Odoo.sh when creating development branches: the `force-demo` phase systematically triggers this path because the new branch's filestore may not contain all files referenced by copied DB records (e.g. partner images). Hundreds of `FileNotFoundError` tracebacks appear in build logs at `INFO` level even though every one is silently recovered.

Closes #247488

## Fix

Lower the log level from `INFO` to `DEBUG`. The traceback remains available when debugging filestore issues, without polluting production and CI logs.

```python
# Before
_logger.info("_read_file reading %s", full_path, exc_info=True)

# After
_logger.debug("_read_file reading %s", full_path, exc_info=True)
```
