### PR TITLE
[FIX] l10n_it_stock_ddt: display DDT information in dropship

### DIFF
--- a/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
+++ b/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
@@ -15,7 +15,7 @@
                 <attribute name="invisible">l10n_it_show_print_ddt_button or picking_type_code == 'outgoing' and country_code == 'IT'</attribute>
             </xpath>
             <group name='carrier_data' position="after">
-                <group string="DDT Information" invisible="country_code != 'IT' or picking_type_code != 'outgoing'">
+                <group string="DDT Information" invisible="country_code != 'IT' or picking_type_code not in ('outgoing', 'dropship')">
                     <field name="country_code" invisible="1"/>
                     <field name="l10n_it_ddt_number"/>
                     <field name="l10n_it_transport_reason"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a company with country = Italy and select it
- Install the module “l10n_it_stock_ddt”
- Activate “Dropshipping” in the inventory settings
- Create a delivery → the group "DDT Information" is visible
- Create a dropship → the group "DDT Information" is not visible

Problem:
The DDT information should also be visible for dropship operations. The compute used for “l10n_it_show_print_ddt_button” correctly takes dropship operations into account, but it cannot be reused to control the visibility of the DDT Information group because this compute is True only when the picking state is done and locked:

https://github.com/odoo/odoo/blob/e6d4ab62e950c8b88ac54fecbf2682cba846c7c3/addons/l10n_it_stock_ddt/models/stock_picking.py#L34-L35

opw-5190251
