### PR TITLE
[FIX] pos_online_payment: prevent traceback when closing qr popup

### DIFF
--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -135,7 +135,7 @@ patch(OrderPaymentValidation.prototype, {
                         {
                             onClose: () => {
                                 onlinePaymentLine.onlinePaymentResolver(false);
-                                this.currentOrder.onlinePaymentData = {};
+                                this.order.onlinePaymentData = {};
                             },
                         }
                     );

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -12,6 +12,10 @@ registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
             ProductScreen.addOrderline("Letter Tray", "10"),
             ProductScreen.selectedOrderlineHas("Letter Tray", "10"),
             ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.validateButtonIsHighlighted(),
+            PaymentScreen.clickValidate(),
+            Dialog.cancel(),
             PaymentScreen.totalIs("48.0"),
             PaymentScreen.emptyPaymentlines("48.0"),
 


### PR DESCRIPTION
Steps to reproduce:
-----------
- Setup Online Payment.
1. Open POS.
2. Make an order.
3. Choose Online Payment.
4. Close the QR popup.

Issue:
--------
Traceback occurs when closing the online payment QR popup.

Cause:
-------
`onClose()` used `this.currentOrder`, which is undefined.

Fix:
---------
Replaced `this.currentOrder` with `this.order` to safely reset `onlinePaymentData`.

Task-6053434