### PR TITLE
[IMP] l10n_in_hr_holidays: align sandwich policy fields

### DIFF
--- a/addons/l10n_in_hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_work_entry_type_views.xml
@@ -14,8 +14,8 @@
                     string="Limited to Optional Holidays" invisible="country_code and country_code != 'IN'"/>
             </xpath>
             <xpath expr="//group[@name='configuration']//field[@name='support_document']" position="after">
-                <div class="row" invisible="country_code and country_code != 'IN'">
-                    <field name="l10n_in_is_sandwich_leave"/>
+                <div class="d-flex" invisible="country_code and country_code != 'IN'">
+                    <field style="width: fit-content;" name="l10n_in_is_sandwich_leave"/>
                     <field name="l10n_in_sandwich_policy" class="w-75" invisible="not l10n_in_is_sandwich_leave"/>
                 </div>
                 <field name="l10n_in_is_limited_to_optional_days" class="mb-2" nolabel="1"


### PR DESCRIPTION
Fix the vertical misalignment between the configuration labels and fields when the sandwich policy selection is toggled. By grouping the boolean and selection field into a flex container, the layout remains consistent without shifting the left-hand labels.

Task: 6050912
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
