### PR TITLE
[FIX] l10n: serialization expects bytes

### DIFF
--- a/addons/l10n_sa_edi/models/certificate.py
+++ b/addons/l10n_sa_edi/models/certificate.py
@@ -158,7 +158,7 @@ class CertificateCertificate(models.Model):
         for ext in x509_extensions:
             builder = builder.add_extension(ext[0], critical=ext[1])
 
-        private_key = serialization.load_pem_private_key(journal.company_id.l10n_sa_private_key_id.pem_key, password=None)
+        private_key = serialization.load_pem_private_key(journal.company_id.l10n_sa_private_key_id.pem_key.content, password=None)
         request = builder.sign(private_key, hashes.SHA256())
 
         return request.public_bytes(serialization.Encoding.PEM)


### PR DESCRIPTION
To use the serialization module, we need to pass bytes.

runbot-241772



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
