### PR TITLE
[IMP] stock: show date in 'Moves Analysis' report

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -30,9 +30,8 @@
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
                 <list string="Moves" create="0" editable="bottom" default_order="date desc" duplicate="0">
-                    <field name="date" groups="base.group_no_one"
-                           decoration-danger="(state not in ('cancel','done')) and date > current_date"
-                            readonly="1"/>
+                    <field name="date" optional="show" readonly="1"
+                        decoration-danger="(state not in ('cancel','done')) and date > current_date"/>
                     <field name="reference"/>
                     <field name="picking_type_id" column_invisible="True" readonly="1"/>
                     <field name="location_usage" column_invisible="True" readonly="1"/>


### PR DESCRIPTION
The date of the move is a basic and important information. 
Show it on the 'Moves Analysis' report list view, previously was only displayed in debug mode.

task-5380628
