### PR TITLE
[FIX] l10n_sa_pos: clamp POS invoice_date to Riyadh time

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -443,8 +443,11 @@ class AccountEdiFormat(models.Model):
             errors.append(_set_missing_partner_fields(supplier_missing_info, _("Supplier")))
         if customer_missing_info:
             errors.append(_set_missing_partner_fields(customer_missing_info, _("Customer")))
-        if invoice.invoice_date > fields.Date.context_today(self.with_context(tz='Asia/Riyadh')):
-            errors.append(_("- Please set the Invoice Date to be either less than or equal to today as per the Asia/Riyadh time zone, since ZATCA does not allow future-dated invoicing."))
+        if invoice.l10n_sa_confirmation_datetime:
+            issue_date = self._l10n_sa_get_zatca_datetime(invoice.l10n_sa_confirmation_datetime).date()
+            today_sa = fields.Date.context_today(self.with_context(tz='Asia/Riyadh'))
+            if issue_date > today_sa:
+                errors.append(_("- Please set the Invoice Date to be either less than or equal to today as per the Asia/Riyadh time zone, since ZATCA does not allow future-dated invoicing."))
         if invoice.move_type in ('in_refund', 'out_refund') and not invoice._l10n_sa_check_refund_reason():
             errors.append(
                 _("- Please, make sure either the Reversed Entry or the Reversal Reason are specified when confirming a Credit/Debit note"))

--- a/addons/l10n_sa_pos/tests/__init__.py
+++ b/addons/l10n_sa_pos/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pos_invoice

--- a/addons/l10n_sa_pos/tests/test_pos_invoice.py
+++ b/addons/l10n_sa_pos/tests/test_pos_invoice.py
@@ -1,0 +1,44 @@
+from datetime import date, datetime
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestPosOrderSaInvoiceDate(TestPoSCommon):
+
+    @freeze_time('2026-03-16 20:30:00')
+    def test_pos_invoice_date_uses_riyadh_not_user_tz(self):
+        """
+        Dubai user creates order at Mar 17 00:30 AM (UTC+4) = Mar 16 20:30 UTC.
+        Generic _prepare_invoice_vals sets invoice_date = Mar 17 (Dubai tz).
+        Only for POS systems (SA), override must use Riyadh date = Mar 16 instead.
+        """
+        self.company.account_fiscal_country_id = self.env.ref('base.sa')
+        self.config = self.basic_config
+        self.open_new_session()
+        order = self.env['pos.order'].create({
+            'company_id': self.company.id,
+            'session_id': self.pos_session.id,
+            'partner_id': self.customer.id,
+            'date_order': datetime(2026, 3, 16, 20, 30, 0),  # Dubai time in UTC
+            'lines': [Command.create({
+                'product_id': self.create_product('Test Product', self.categ_basic, 10.0).id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 1,
+                'price_subtotal': 10,
+                'price_subtotal_incl': 10,
+            })],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+        })
+        order.with_context(
+            generate_pdf=False, skip_edi_auto_post=True
+        )._generate_pos_order_invoice()
+        self.assertEqual(order.account_move.invoice_date, date(2026, 3, 16))


### PR DESCRIPTION
Before:
- POS orders created by users in timezones ahead of Riyadh (e.g. Dubai, UTC+4) produced an `invoice_date` based on the user's local date, which could be a day ahead of Riyadh.
- This caused `_get_normalized_l10n_sa_confirmation_datetime` to raise a UserError blocking POS invoice creation.

After:
- Overrides `_prepare_invoice_vals` on pos.order to convert date_order (UTC) to Asia/Riyadh and clamp to today's Riyadh date before passing to ZATCA validation.
- This override applies only during POS invoice generation, where date_order is the source of truth instead of a manually set invoice_date.

Impact:
- Fixes UserError on POS invoice creation for SA companies with staff operating in timezones ahead of Riyadh.

taskID-6043167