### PR TITLE
[FIX] html_editor: remove scrollToSelection and use native scrolling

### DIFF
--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -1,3 +1,4 @@
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "../plugin";
 
 export class InputPlugin extends Plugin {
@@ -16,6 +17,9 @@ export class InputPlugin extends Plugin {
         }
         this.dependencies.history.stageSelection();
         this.dispatchTo("beforeinput_handlers", ev);
+        if (selection?.anchorNode) {
+            closestElement(selection.anchorNode)?.scrollIntoView({ block: "nearest" });
+        }
     }
 
     onInput(ev) {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -22,7 +22,6 @@ import {
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
-import { closestScrollableY } from "@web/core/utils/scrolling";
 
 /**
  * @typedef { Object } EditorSelection
@@ -111,41 +110,6 @@ function getUnselectedEdgeNodes(selection) {
 }
 
 /**
- * Scrolls the view to a specific node's position in the document
- * @param {Selection} selection - The current document selection
- * @returns {void}
- */
-function scrollToSelection(selection) {
-    const range = selection.getRangeAt(0);
-    const container = closestScrollableY(range.startContainer.parentElement);
-    if (!container) {
-        // If the container is not scrollable we don't scroll
-        return;
-    }
-    let rect = range.getBoundingClientRect();
-    // If the range is invisible (0 width & height),
-    // We call `getBoundingClientRect` on closest element.
-    if (rect.width === 0 && rect.height === 0 && selection.isCollapsed) {
-        rect = closestElement(selection.anchorNode).getBoundingClientRect();
-    }
-
-    const containerRect = container.getBoundingClientRect();
-    const offsetTop = rect.top - containerRect.top + container.scrollTop;
-    const offsetBottom = rect.bottom - containerRect.top + container.scrollTop;
-
-    if (rect.bottom > containerRect.top && rect.top < containerRect.bottom) {
-        // If selection is partially visible, no need to scroll.
-        return;
-    }
-    // Simulate the "nearest" behavior by scrolling to the closest top/bottom edge
-    if (rect.top < containerRect.top) {
-        container.scrollTo({ top: offsetTop, behavior: "instant" });
-    } else if (rect.bottom > containerRect.bottom) {
-        container.scrollTo({ top: offsetBottom - container.clientHeight, behavior: "instant" });
-    }
-}
-
-/**
  * @typedef { Object } SelectionShared
  * @property { SelectionPlugin['extractContent'] } extractContent
  * @property { SelectionPlugin['focusEditable'] } focusEditable
@@ -201,13 +165,7 @@ export class SelectionPlugin extends Plugin {
 
     setup() {
         this.resetSelection();
-        this.addDomListener(this.document, "selectionchange", () => {
-            this.updateActiveSelection();
-            const selection = this.document.getSelection();
-            if (this.isSelectionInEditable(selection)) {
-                scrollToSelection(selection);
-            }
-        });
+        this.addDomListener(this.document, "selectionchange", this.updateActiveSelection);
         this.addDomListener(this.editable, "mousedown", (ev) => {
             if (ev.detail === 2) {
                 this.correctDoubleClick = true;

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,14 +1,8 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { isInViewPort, press, queryFirst, queryOne } from "@odoo/hoot-dom";
+import { press, queryFirst, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
-import {
-    defineModels,
-    fields,
-    models,
-    mountView,
-    patchWithCleanup,
-} from "@web/../tests/web_test_helpers";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
@@ -1583,65 +1577,6 @@ describe("selection setters", () => {
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 2, ef, 2]);
         });
     });
-});
-
-test.tags("desktop");
-test("should not autoscroll if selection is partially visible in viewport", async () => {
-    class Test extends models.Model {
-        name = fields.Char();
-        txt = fields.Html();
-        _records = [{ id: 1, name: "Test", txt: "<p>This is some text</p>".repeat(50) }];
-    }
-
-    defineModels([Test]);
-    await mountView({
-        type: "form",
-        resId: 1,
-        resModel: "test",
-        arch: `
-            <form>
-                <field name="name"/>
-                <field name="txt" widget="html"/>
-            </form>`,
-    });
-
-    const scrollableElement = queryOne(".o_content");
-    const editable = queryOne(".odoo-editor-editable");
-    const lastParagraph = editable.lastElementChild;
-    const fifthLastParagraph = editable.children[45];
-
-    // Select the last five paragraphs in backward.
-    setSelection({
-        anchorNode: lastParagraph,
-        anchorOffset: 1,
-        focusNode: fifthLastParagraph,
-        focusOffset: 0,
-    });
-    await animationFrame();
-
-    // Both ends of the selection are initially visible in the viewport.
-    expect(isInViewPort(fifthLastParagraph)).toBe(true);
-    expect(isInViewPort(lastParagraph)).toBe(true);
-
-    // Scroll above so that last paragraph becomes invisible in viewport.
-    scrollableElement.scrollTop -= 70;
-    await animationFrame();
-    expect(isInViewPort(lastParagraph)).toBe(false);
-    expect(isInViewPort(fifthLastParagraph)).toBe(true);
-
-    const scrollTop = scrollableElement.scrollTop;
-    // Extend the selection to include one more paragraph above.
-    setSelection({
-        anchorNode: lastParagraph,
-        anchorOffset: 1,
-        focusNode: fifthLastParagraph.previousElementSibling,
-        focusOffset: 0,
-    });
-    await animationFrame();
-
-    // Ensure that extending selection did not trigger any auto-scrolling.
-    expect(scrollableElement.scrollTop).toBe(scrollTop);
-    expect(isInViewPort(lastParagraph)).toBe(false);
 });
 
 describe("Preserve selection", () => {


### PR DESCRIPTION
Before this commit: we have a scrollToSelection in selection_plugin to make sure the editable scrolls when pressing "Enter" many times and out of view.

After the commit: the cause of not automatically scrolling is that we prevent the default behavior of insert a line break or a paragraph. To trigger the scrolling behavior, we call scrollIntoView on the new selection's anchor node's element now. We pass the parameter "nearest" like the scrollToSelection intend to.

It reverts the commits below:

- https://github.com/odoo/odoo/commit/0655190e4b826e03c7def39f992ff0878eaa1334
- https://github.com/odoo/odoo/commit/def59b082071bc21b548855297691fa60c7bbe9b
- https://github.com/odoo/odoo/pull/204506/changes/a6b1ff47f94b7f3f75184ebbda8d7818ede71cf8
- https://github.com/odoo/odoo/commit/21cba77761fe1561f44f365949ebc6af4d4b0a48

task-6026990


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
