### PR TITLE
[FIX] account: correct rounding precision of total amount price

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -95,7 +95,7 @@ class ProductTemplate(models.Model):
 
     def _construct_tax_string(self, price):
         currency = self.currency_id
-        res = self.taxes_id._filter_taxes_by_company(self.env.company).compute_all(
+        res = self.taxes_id._filter_taxes_by_company(self.env.company).with_context(round_base=False).compute_all(
             price, product=self, partner=self.env['res.partner']
         )
         joined = []

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -1219,3 +1219,14 @@ class TestTax(TestTaxCommon):
             ],
             res
         )
+
+    def test_product_correct_rounding_tax_string(self):
+        """To verify that the tax string computation correctly rounds the price to the expected precision"""
+
+        self.env['decimal.precision'].search([('name', '=', 'Product Price')]).write({'digits': 7})
+        product = self.env['product.template'].create({
+            'name': 'Test Product',
+            'list_price': 19.8347107,
+            'taxes_id': [Command.set([self.tax_21_percent.id])],
+        })
+        self.assertEqual(product.tax_string.replace('\xa0', ' '), '(= $ 24.00 Incl. Taxes)')


### PR DESCRIPTION
### Issue before this commit:
When setting a product price intended to result in a clean tax-included amount (e.g., 24€ with a 21% tax), the computed “price including taxes” displayed in the UI was slightly off due to rounding issues. Instead of returning exactly 24.00, the system would display values such as 23.99 or 24.01.

### Steps to reproduce the issue:
1. Download l10n_be and switch to the BE company
2. Create a new product and be sure the tax is setted on 21%
3. Try to insert a price =24/1.21
4. The computed price Incl. taxes inside the brackets is never 24.0 but or 23.99 or 24.01

### Cause of the issue:
When the base_round was not setted to False the calculation was taking t he currency precision to round the number from the start of the calculations even if the number of digits setted was higher. This way the rounding will be computed only at the end of the calculations instead of being already setted from the start.

### Reason to introduce the fix:
Be able to represent all the numbers as the final price for one product.

opw-6024520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
