### PR TITLE
[FIX] l10n_nl_reports: use negative sign for 1d in tax report

### DIFF
--- a/addons/l10n_nl/data/account_tax_report_data.xml
+++ b/addons/l10n_nl/data/account_tax_report_data.xml
@@ -95,12 +95,12 @@
                             <record id="tax_report_rub_1d_tag" model="account.report.expression">
                                 <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">1d (omzet)</field>
+                                <field name="formula">-1d (omzet)</field>
                             </record>
                             <record id="tax_report_rub_btw_1d_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">1d (BTW)</field>
+                                <field name="formula">-1d (BTW)</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
It is be better to change the sign, because it is under supplies and the other report lines in that section also have a negative sign.

In other words, anyone who would have configured the tax, would
 have used the negative tag to configure it right before. Now that
the sign on the tags is gone, we need to put it correctly on the report line.

opw-5874677

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
