### PR TITLE
[FIX] stock_account: compute correct cogs when partially consigned

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -514,13 +514,106 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
             # pylint: disable=bad-whitespace
             {'account_id': self.account_income.id,     'debit': 0,     'credit': 12},
             {'account_id': self.account_receivable.id,  'debit': 12,    'credit': 0},
-            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
-            {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 5},
+            {'account_id': self.account_expense.id,     'debit': 5,    'credit': 0},
         ])
         self.assertRecordValues(invoice02.line_ids, [
             # pylint: disable=bad-whitespace
             {'account_id': self.account_income.id,     'debit': 0,     'credit': 12},
             {'account_id': self.account_receivable.id,  'debit': 12,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 5},
+            {'account_id': self.account_expense.id,     'debit': 5,    'credit': 0},
+        ])
+
+    def test_avco_partially_owned_invoice_post_delivery(self):
+        """
+        Avco product with cost of 10. Sale order 2@12. One of the delivered
+        products was owned by an external partner. Invoice all quantities at once.
+        Make sure the cogs is only for the non consigned product.
+        """
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
+
+        self.env['stock.quant']._update_available_quantity(self.product_avco_auto, self.stock_location, 1, owner_id=self.partner_b)
+        self.env['stock.quant']._update_available_quantity(self.product_avco_auto, self.stock_location, 1)
+
+        # Create and confirm a sale order for 2@12
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
+        # Deliver both products (there should be two SML)
+        sale_order.picking_ids.move_line_ids.write({'quantity': 1, 'picked': True})
+        sale_order.picking_ids.button_validate()
+
+        # Invoice
+        invoice01 = sale_order._create_invoices()
+        invoice01.action_post()
+
+        # COGS should ignore the owned product
+        self.assertRecordValues(invoice01.line_ids, [
+            # pylint: disable=bad-whitespace
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 24},
+            {'account_id': self.account_receivable.id,  'debit': 24,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
+            {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
+        ])
+
+    def test_std_price_partially_owned_invoice_post_delivery(self):
+        """
+        Standard price product with price of 10. Sale order 2@12. One of the delivered
+        products was owned by an external partner. Invoice all quantities at once.
+        Make sure the cogs is only for the non consigned product.
+        """
+        self.product_standard_auto.invoice_policy = 'delivery'
+        self.product_standard_auto.standard_price = 10
+
+        self.env['stock.quant']._update_available_quantity(self.product_standard_auto, self.stock_location, 1, owner_id=self.partner_b)
+        self.env['stock.quant']._update_available_quantity(self.product_standard_auto, self.stock_location, 1)
+
+        # Create and confirm a sale order for 2@12
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
+        # Deliver both products (there should be two SML)
+        sale_order.picking_ids.move_line_ids.write({'quantity': 1, 'picked': True})
+        sale_order.picking_ids.button_validate()
+
+        # Invoice
+        invoice01 = sale_order._create_invoices()
+        invoice01.action_post()
+
+        # COGS should ignore the owned product
+        self.assertRecordValues(invoice01.line_ids, [
+            # pylint: disable=bad-whitespace
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 24},
+            {'account_id': self.account_receivable.id,  'debit': 24,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
+            {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
+        ])
+
+    def test_fifo_partially_owned_invoice_post_delivery(self):
+        """
+        Fifo product with cost of 10. Sale order 2@12. One of the delivered
+        products was owned by an external partner. Invoice all quantities at once.
+        Make sure the cogs is only for the non consigned product.
+        """
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
+
+        self.env['stock.quant']._update_available_quantity(self.product_fifo_auto, self.stock_location, 1, owner_id=self.partner_b)
+        self.env['stock.quant']._update_available_quantity(self.product_fifo_auto, self.stock_location, 1)
+
+        # Create and confirm a sale order for 2@12
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
+        # Deliver both products (there should be two SML)
+        sale_order.picking_ids.move_line_ids.write({'quantity': 1, 'picked': True})
+        sale_order.picking_ids.button_validate()
+
+        # Invoice
+        invoice01 = sale_order._create_invoices()
+        invoice01.action_post()
+
+        # COGS should ignore the owned product
+        self.assertRecordValues(invoice01.line_ids, [
+            # pylint: disable=bad-whitespace
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 24},
+            {'account_id': self.account_receivable.id,  'debit': 24,    'credit': 0},
             {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
             {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
         ])

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -251,8 +251,13 @@ class StockMove(models.Model):
         total_qty = sum(m._get_valued_qty() for m in self)
         if not total_qty:
             return 0
-        return sum(self.mapped('value')) / total_qty if self.product_id.cost_method == 'fifo' or \
-            (self.product_id.lot_valuated and self.product_id.cost_method == 'average') else self.product_id.standard_price
+        valued_consigned_qty = self._get_valued_consigned_qty()
+        total_qty += valued_consigned_qty
+        if self.product_id.cost_method == 'fifo' or valued_consigned_qty or\
+            (self.product_id.lot_valuated and self.product_id.cost_method == 'average'):
+            return sum(self.mapped('value')) / total_qty
+        else:
+            return self.product_id.standard_price
 
     @api.model
     def _get_valued_types(self):
@@ -641,3 +646,6 @@ class StockMove(models.Model):
         if valued_type == 'out':
             return self.location_dest_id and self.location_dest_id.usage == 'supplier'
         return bool(self.picking_id.return_picking_id)
+
+    def _get_valued_consigned_qty(self):
+        return sum(self.move_line_ids.filtered(lambda l: l._is_consigned_valued_line()).mapped('quantity_product_uom'))

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -64,3 +64,11 @@ class StockMoveLine(models.Model):
                     move._set_value(correction_quantity=delta)
         if moves_to_update := self.env['stock.move'].browse(move_to_update_ids):
             moves_to_update._set_value()
+
+    def _is_consigned_valued_line(self):
+        """ return true if the move line would have been considered in the _get_valued_qty() method except for
+        the _should_exclude_for_valuation criteria (.i.e the line would have been valued if it wasn't consigned)
+        """
+        return self.picked and self._should_exclude_for_valuation() and\
+            (self.move_id._is_in() and not self.location_id._should_be_valued() and self.location_dest_id._should_be_valued()
+            or self.move_id._is_out() and self.location_id._should_be_valued() and not self.location_dest_id._should_be_valued())


### PR DESCRIPTION
**Problem:**
cogs don't adapt to partially consigned quantities

**Steps to reproduce:**
- enable 'consignment' setting
- create a tracked product with perpetual category
(bug happens with avco, fifo and standard price category)
- set a cost of 10 
- add a quantity of 1 without owner and a quantity of 
1 with an owner
- create a sale order for a quantity of 2 of your produce
- confirm, validate picking and confirm invoice

**Current behavior:**
the cogs is 20 

**Expected behavior:**
the cogs should be 10 because the consigned 
quantity shouldn't be taken into account in the cogs

**Cause of the issue:**
to compute the cogs line amount, we multiply the quantity 
of the line (2 in our case) by the price unit of the cogs.
To compute the price_unit we call _get_cogs_value()
https://github.com/odoo/odoo/blob/0dbc1c01c6b48d0a765391d5b6ab03b555440aef/addons/stock_account/models/account_move.py#L122-L123 
In our case the price_unit (so the 'price per cogs unit') should 
be 5 because we have 2 units, 1 valued at 10 and 1 valued 
at 0 (the consigned one).
But the value returned by _get_cogs_value() is 10.

The reason for this is that _get_cogs_value uses the return 
value of _get_cogs_price_unit() because the delivery is validated.
https://github.com/odoo/odoo/blob/0dbc1c01c6b48d0a765391d5b6ab03b555440aef/addons/stock_account/models/account_move_line.py#L67-L68

Inside get_cogs_price_unit, we use _get_valued_qty() to 
sum the valued quantity of each move. 
https://github.com/odoo/odoo/blob/0dbc1c01c6b48d0a765391d5b6ab03b555440aef/addons/stock_account/models/stock_move.py#L251
But inside get_valued_qty() for our second move, when 
calling get_out_move_lines(), no lines will be returned 
because should_exclude_for_valuation() will return True 
as the owner of the line is not the user.
So total qty will be 1.
https://github.com/odoo/odoo/blob/0dbc1c01c6b48d0a765391d5b6ab03b555440aef/addons/stock_account/models/stock_move.py#L529

If the product is fifo, we return the total value of the moves (10) 
divided by total quantity (1). 
If the product is standard or avco we return the standard price. 
In both cases the return value is 10.
But in both cases it should be 5.
https://github.com/odoo/odoo/blob/0dbc1c01c6b48d0a765391d5b6ab03b555440aef/addons/stock_account/models/stock_move.py#L251-L255

**fix**
The first thing to change is to not use the standard price when 
some quantities are consigned. 
The other thing is to add the quantities that would have been 
used if they weren't consigned because in this case we need them 
in the computation. 
Indeed these quantities are included in the invoice line quantity. 
At the end we are multiplying the unit price by the invoice line quantity
which includes consigned quantity, so we need to take them into 
account also when computing the price per cogs quantity.

opw-6030161