### PR TITLE
[FIX] base_vat: improve VIES error handling

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -219,9 +219,9 @@ class ResPartner(models.Model):
                 _logger.info('Calling VIES service to check VAT for validation: %s', partner.vies_vat_to_check)
                 vies_valid = check_vies(partner.vies_vat_to_check, timeout=10)
                 partner.vies_valid = vies_valid['valid']
-            except (OSError, InvalidComponent, zeep.exceptions.Error) as e:
+            except (OSError, InvalidComponent, zeep.exceptions.Error, Exception) as e:  # noqa: BLE001
                 if partner._origin.id:
-                    msg = ""
+                    msg = _("An error occurred while trying to validate the VAT number %s with the VIES service.", partner.vies_vat_to_check)
                     if isinstance(e, OSError):
                         msg = _("Connection with the VIES server failed. The VAT number %s could not be validated.", partner.vies_vat_to_check)
                     elif isinstance(e, InvalidComponent):
@@ -229,7 +229,7 @@ class ResPartner(models.Model):
                     elif isinstance(e, zeep.exceptions.Error):
                         msg = _('The request for VAT validation was not processed. VIES service has responded with the following error: %s', e.message)
                     partner._origin.message_post(body=msg)
-                _logger.warning("The VAT number %s failed VIES check.", partner.vies_vat_to_check)
+                _logger.warning("The VAT number %s failed VIES check. Error: %s", partner.vies_vat_to_check, e)
                 partner.vies_valid = False
 
     @api.model


### PR DESCRIPTION
When an error occurs during VAT validation with the VIES service, we currently try to catch specific exceptions to display a message in the contact chatter.

However, not all exceptions are handled, which can lead to a traceback instead of a user-friendly message. For example, `suds.WebFault` is not currently caught.

Step to reproduce:
- Ensure that in `new_get_soap_client`, you don't use the Zeep library, but instead use the `suds` library to create the client.
- On a contact, enter a VAT number and try to save.
- Due to the recurrent VIES server issues, you will likely get a `suds.WebFault` exception (MS_MAX_CONCURRENT_REQ) which is not currently caught, leading to a traceback.

This fix introduces a global exception catch to ensure robustness, while logging the error for debugging purposes. This also ensures compatibility if `new_get_soap_client` is modified to use a different library or client in the future.

opw-6007991