### PR TITLE
[IMP] mail:  send push notification when a user is invited to a channel

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -702,6 +702,30 @@ class DiscussChannel(models.Model):
             if new_members:
                 stores[channel].add(channel, ["member_count"])
                 stores[channel].add(new_members, "_store_member_fields")
+                if channel.channel_type == "channel":
+                    devices, private_key, public_key = channel._web_push_get_partners_parameters(new_members.partner_id.ids)
+                    if devices:
+                        icon = f"/web/image/discuss.channel/{channel.id}/avatar_128"
+                        languages = set(devices.partner_id.mapped("lang"))
+                        payload_by_lang = {}
+                        for lang in languages:
+                            channel_lang = channel.with_context(lang=lang)
+                            payload_by_lang[lang] = {
+                                "title": channel_lang.display_name,
+                                "options": {
+                                    "body": channel_lang.env._(
+                                        "%(user)s has invited you to this channel",
+                                        user=channel_lang.env.user.partner_id.display_name,
+                                    ),
+                                    "data": {
+                                        "action": "mail.action_discuss",
+                                        "model": "discuss.channel",
+                                        "res_id": channel.id,
+                                    },
+                                    "icon": icon,
+                                },
+                            }
+                        channel._web_push_send_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
             if existing_members and (bus_channel := current_user or current_guest):
                 # If the current user invited these members but they are already present, notify the current user about their existence as well.
                 # In particular this fixes issues where the current user is not aware of its own member in the following case:

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -705,6 +705,31 @@ class DiscussChannel(models.Model):
             if new_members:
                 stores[channel].add(channel, ["member_count"])
                 stores[channel].add(new_members, "_store_member_fields")
+                if channel.channel_type == "channel":
+                    devices, private_key, public_key = channel._web_push_get_partners_parameters(new_members.partner_id.ids)
+                    if devices:
+                        icon = f"/web/image/discuss.channel/{channel.id}/avatar_128"
+                        languages = [partner.lang for partner in devices.partner_id]
+                        payload_by_lang = {}
+                        for lang in languages:
+                            env_lang = channel.with_context(lang=lang).env
+                            payload_by_lang[lang] = {
+                                "title": channel.with_env(env_lang).display_name,
+                                "options": {
+                                    "body": env_lang._(
+                                        "%s invited you to join this channel",
+                                        self.env.user.partner_id.with_env(env_lang).display_name,
+                                    ),
+                                    "data": {
+                                        "action": "mail.action_discuss",
+                                        "model": "discuss.channel",
+                                        "res_id": channel.id,
+                                    },
+                                    "icon": icon,
+                                    "tag": f"channel_invite_{channel.id}",
+                                },
+                            }
+                        channel._web_push_send_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
             if existing_members and (bus_channel := current_user or current_guest):
                 # If the current user invited these members but they are already present, notify the current user about their existence as well.
                 # In particular this fixes issues where the current user is not aware of its own member in the following case:

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -1,7 +1,6 @@
 import { proxy } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 export class DiscussCorePublicWeb {
@@ -13,28 +12,10 @@ export class DiscussCorePublicWeb {
         this.env = env;
         this.store = services["mail.store"];
         this.busService = services.bus_service;
-        this.notificationService = services.notification;
         this.busService.subscribe("discuss.channel/joined", async (payload) => {
-            const {
-                store_data,
-                channel_id,
-                invite_to_rtc_call,
-                invited_by_user_id: invitedByUserId,
-            } = payload;
+            const { store_data, channel_id } = payload;
             this.store.insert(store_data);
             await this.store.fetchChannel(channel_id);
-            const channel = this.store["discuss.channel"].get(channel_id);
-            if (
-                channel &&
-                invitedByUserId &&
-                invitedByUserId !== this.store.self_user?.id &&
-                !invite_to_rtc_call
-            ) {
-                this.notificationService.add(
-                    _t("You have been invited to #%s", channel.displayName),
-                    { type: "info" }
-                );
-            }
         });
         browser.navigator.serviceWorker?.addEventListener(
             "message",
@@ -68,7 +49,7 @@ export class DiscussCorePublicWeb {
 }
 
 export const discussCorePublicWeb = {
-    dependencies: ["bus_service", "discuss.rtc", "mail.store", "notification"],
+    dependencies: ["bus_service", "discuss.rtc", "mail.store"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -181,7 +181,6 @@ test("unnamed group chat should display correct name just after being invited", 
         })
     );
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Jane and Mitchell Admin')");
-    await contains(".o_notification:text('You have been invited to #Jane and Mitchell Admin')");
 });
 
 test("invite user to self chat opens DM chat with user", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1993,9 +1993,6 @@ test("Channel is added to discuss after invitation", async () => {
         })
     );
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')");
-    await contains(
-        ".o_notification:has(.o_notification_bar.bg-info):text('You have been invited to #General')"
-    );
 });
 
 test("select another mailbox", async () => {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -1154,3 +1154,42 @@ class TestChannelInternals(MailCommon, HttpCase):
         actual_member_ids = [m.partner_id.id if m.partner_id else m.guest_id.id for m in channel.channel_member_ids]
         expected_member_ids = [self.partner_employee.id, self.guest.id, self.env.user.partner_id.id]
         self.assertCountEqual(actual_member_ids, expected_member_ids)
+
+    def test_channel_add_members_push_notification(self):
+        invited_user = mail_new_test_user(self.env, login="invitee_push_lang", groups="base.group_user")
+        invited_user.partner_id.lang = False
+        channel = self.env["discuss.channel"].create({"name": "Push Invite", "channel_type": "channel"})
+        push_device = self._setup_push_devices_for_partners(invited_user.partner_id)
+        self.authenticate(self.user_employee.login, self.user_employee.login)
+        with self.mock_push_to_end_point():
+            self.make_jsonrpc_request(
+                "/mail/store",
+                {
+                    "fetch_params": [
+                        [
+                            "/discuss/channel/add_members",
+                            {
+                                "channel_id": channel.id,
+                                "user_ids": invited_user.ids,
+                                "post_joined_message": False,
+                            },
+                        ],
+                    ],
+                },
+            )
+        self.assertPushNotification(
+            endpoint=push_device.endpoint,
+            title=channel.name,
+            body=self.env._(
+                "%(user)s has invited you to this channel",
+                user=self.user_employee.partner_id.display_name,
+            ),
+            options={
+                "icon": f"/web/image/discuss.channel/{channel.id}/avatar_128",
+                "data": {
+                    "action": "mail.action_discuss",
+                    "model": "discuss.channel",
+                    "res_id": channel.id,
+                },
+            },
+        )


### PR DESCRIPTION
Previously, when a user was invited to a channel, they were notified by a toast notification. Since toast notifications are transient, users could easily miss the invitation and remain unaware of the channel.

This PR adds a push notification when a user is invited to a channel, making the invitation more visible and ensuring users are properly informed when they are added to a conversation.

task-5422164




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
