### PR TITLE
[IMP] core: save chrome debug logs

### DIFF
--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -83,7 +83,7 @@ class TestChromeBrowser(HttpCase):
         super().setUp()
         screencasts_dir = config['screencasts'] or config['screenshots']
         with patch.dict(config.options, {'screencasts': screencasts_dir, 'screenshots': config['screenshots']}):
-            self.browser = ChromeBrowser(self)
+            self.browser = ChromeBrowser(type(self))
         self.addCleanup(self.browser.stop)
         self.addCleanup(self.browser.clear)
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -905,19 +905,16 @@ def fchain(future, next_callback):
     return new_future
 
 
-def save_test_file(test_name, content, prefix, extension='png', logger=_logger, document_type='Screenshot', date_format="%Y%m%d_%H%M%S_%f"):
+def save_test_file(test_name, content, prefix, extension='png', logger=_logger, document_type='Screenshot', date_format="%Y%m%d_%H%M%S_%f", loglevel=logging.RUNBOT, directory=''):
     assert re.fullmatch(r'\w*_', prefix)
     assert re.fullmatch(r'[a-z]+', extension)
     assert re.fullmatch(r'\w+', test_name)
     now = datetime.now().strftime(date_format)
-    screenshots_dir = pathlib.Path(odoo.tools.config['screenshots']) / get_db_name() / 'screenshots'
-    screenshots_dir.mkdir(parents=True, exist_ok=True)
-    fname = f'{prefix}{now}_{test_name}.{extension}'
-    full_path = screenshots_dir / fname
-
-    with full_path.open('wb') as f:
-        f.write(content)
-    logger.runbot(f'{document_type} in: {full_path}')
+    dest = pathlib.Path(odoo.tools.config['screenshots']) / get_db_name() / directory
+    dest.mkdir(parents=True, exist_ok=True)
+    full_path = dest / f'{prefix}{now}_{test_name}.{extension}'
+    full_path.write_bytes(content)
+    logger.log(loglevel, "%s in: %s", document_type, full_path)
 
 
 if os.name == 'posix' and platform.system() != 'Darwin':
@@ -1064,15 +1061,13 @@ class ChromeBrowser:
         raise unittest.SkipTest("Chrome executable not found")
 
     def _spawn_chrome(self, cmd):
-        log_path = pathlib.Path(self.user_data_dir, 'err.log')
-        with log_path.open('wb') as log_file:
-            # pylint: disable=subprocess-popen-preexec-fn
-            proc = subprocess.Popen(
-                cmd,
-                stderr=log_file,
-                preexec_fn=_preexec,
-                env={**os.environ, 'TMPDIR': self.user_data_dir},
-            )  # noqa: PLW1509
+        # pylint: disable=subprocess-popen-preexec-fn
+        proc = subprocess.Popen(
+            cmd,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=_preexec,
+            env={**os.environ, 'TMPDIR': self.user_data_dir},
+        )  # noqa: PLW1509
 
         port_file = pathlib.Path(self.user_data_dir, 'DevToolsActivePort')
         for _ in range(CHECK_BROWSER_ITERATIONS):
@@ -1089,7 +1084,10 @@ class ChromeBrowser:
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait()
-        self._logger.warning('Chrome headless failed to start:\n%s', log_path.read_text(encoding="utf-8"))
+        self._logger.warning(
+            'Chrome headless failed to start:\n%s',
+            pathlib.Path(self.user_data_dir, "chrome_debug.log").read_text(encoding="utf-8"),
+        )
         # since the chrome never started, it's not going to be `stop`-ed so we
         # need to cleanup the directory here
         shutil.rmtree(self.user_data_dir, ignore_errors=True)
@@ -1117,6 +1115,8 @@ class ChromeBrowser:
             '--disable-device-discovery-notifications': '',
             '--disable-namespace-sandbox': '',
             '--user-data-dir': self.user_data_dir,
+            '--enable-logging': '',
+            '--v': str(int(os.environ.get("ODOO_BROWSER_LOG_VERBOSITY", "0"))),
             '--disable-translate': '',
             # required for tours that use Youtube autoplay conditions (namely website_slides' "course_tour")
             '--autoplay-policy': 'no-user-gesture-required',
@@ -1480,15 +1480,8 @@ which leads to stray network requests and inconsistencies."""
             if not base_png:
                 self._logger.runbot("Couldn't capture screenshot: expected image data, got %r", base_png)
                 return
-
             decoded = base64.b64decode(base_png, validate=True)
-            fname = '{}{:%Y%m%d_%H%M%S_%f}{}.png'.format(
-                prefix, datetime.now(),
-                suffix or '_%s' % self.test_class.__name__)
-            full_path = os.path.join(self.screenshots_dir, fname)
-            with open(full_path, 'wb') as f:
-                f.write(decoded)
-            self._logger.runbot('Screenshot in: %s', full_path)
+            save_test_file(self.test_class.__name__, decoded, prefix, logger=self._logger, directory='screenshots')
 
         self._logger.info('Asking for screenshot')
         f = self._websocket_send('Page.captureScreenshot', with_future=True)
@@ -1598,17 +1591,30 @@ which leads to stray network requests and inconsistencies."""
             raise ChromeBrowserException("Running code returned an error: %s" % res)
 
         err = ChromeBrowserException("failed")
+        save_log = functools.partial(
+            save_test_file,
+            self.test_class.__name__,
+            pathlib.Path(self.user_data_dir, "chrome_debug.log").read_bytes(),
+            prefix='chrome_log_',
+            extension='txt',
+            document_type="Chrome Log",
+            logger=self._logger,
+            directory='chrome_logs',
+        )
         try:
             # if the runcode was a promise which took some time to execute,
             # discount that from the timeout
             if self._result.result(time.time() - start + timeout) and not self.had_failure:
+                save_log(loglevel=logging.INFO)
                 return
         except CancelledError:
             # regular-ish shutdown
+            save_log(loglevel=logging.INFO)
             return
         except Exception as e:
             err = e
 
+        save_log()
         self.take_screenshot()
         self._save_screencast()
         if isinstance(err, ChromeBrowserException):


### PR DESCRIPTION
Followup and partial revert of #232612: turns out chrome's stderr is worthless at best and confusing at worst (because it logs a bunch of dbus errors which don't actually matter), however chrome turns out to have pretty extensive debug logging facilities which are somewhat valuable: https://www.chromium.org/for-testers/enable-logging/

For instance if the oomkiller decides to nuke a chrome tab (example selected for no reason whatsoever), the debug log will have an entry along the lines of

    [...:WARNING::chrome/browser/ui/sad_tab.cc:256] Tab Killed: http://127.0.0.1:8069/

which is a much more helpful hint than just being told a test timed out (to say nothing of being told that chrome was not able to do dbus stuff when we never asked for that).

Because it can be useful for all sort of debugging, this log is saved not just when chrome fails to start, but also when a Chrome completes, successfully or unsucessfully (in the latter case it's logged as RUNBOT to be available from the runbot UI).

The chrome logging facilities are controlled by a new envvar `ODOO_BROWSER_LOG_VERBOSITY`, it can be set to `-1` to disable logging, or a strictly positive integer for ever increasing amounts of logging. At `1` chrome will log every network request it attempts which can be useful for debugging some races but is already extremely noisy.
