### PR TITLE
[IMP] orm: link signaling to transaction lifecycle

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -201,7 +201,6 @@ class AccountChartTemplate(models.AbstractModel):
         module = self.env['ir.module.module'].search([('name', '=', module_name), ('state', '=', 'uninstalled')])
         if module:
             module.button_immediate_install()
-            self.env.transaction.reset()  # clear the transaction with an old registry
             self = self.env()['account.chart.template']  # noqa: PLW0642 create a new env with the new registry
         # To be able to use code translation we load everything in 'en_US'
         # The demo data is still loaded "normally" since code translations cannot be used for them reliably.

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -999,8 +999,6 @@ class ResCompany(models.Model):
             return False
         if res := super().install_l10n_modules():
             env = self.env
-            env.flush_all()
-            env.transaction.reset()
             for company in self.filtered(lambda c: c.country_id and not c.chart_template):
                 template_code = company.parent_id.chart_template or self.env['account.chart.template']._guess_chart_template(company.country_id)
                 if template_code != 'generic_coa':

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -916,12 +916,12 @@ class TestSequenceMixinConcurrency(TransactionCase):
             moves.name = False
             moves[0].action_post()
             self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', False, False])
-            env.cr.commit()
         self.data = {
             'move_ids': moves.ids,
             'account_id': account.id,
             'journal_id': journal.id,
             'envs': [
+                # all transactions are started here...
                 api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
                 api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
                 api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
@@ -940,7 +940,6 @@ class TestSequenceMixinConcurrency(TransactionCase):
             journal.unlink()
             account = env['account.account'].browse(self.data['account_id'])
             account.unlink()
-            env.cr.commit()
         for env in self.data['envs']:
             env.cr.close()
 
@@ -962,6 +961,7 @@ class TestSequenceMixinConcurrency(TransactionCase):
         env1.cr.commit()
 
         # check the values
+        env0.cr.rollback()
         moves = env0['account.move'].browse(self.data['move_ids'])
         self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', 'CT/2016/01/0002', 'CT/2016/01/0003'])
         self.assertEqual(moves.mapped('sequence_prefix'), ['CT/2016/01/', 'CT/2016/01/', 'CT/2016/01/'])
@@ -988,6 +988,7 @@ class TestSequenceMixinConcurrency(TransactionCase):
         env1.cr.commit()
 
         # check the values
+        env0.cr.rollback()
         moves = env0['account.move'].browse(self.data['move_ids'])
         self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', False, 'CT/2016/01/0002'])
 

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -67,7 +67,7 @@ class TestAccountEdiUblCii(TestUblCiiCommon, HttpCase):
 
     def setUp(self):
         self.addCleanup(self.registry.reset_changes)
-        self.addCleanup(self.registry.clear_all_caches)
+        self.addCleanup(self.drop_ormcaches)
         super().setUp()
 
     def test_export_import_product(self):

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -65,11 +65,6 @@ class TestAccountEdiUblCii(TestUblCiiCommon, HttpCase):
             'ubl_cii_tax_exemption_reason_code': 'VATEX-EU-132-1G'
         })
 
-    def setUp(self):
-        self.addCleanup(self.registry.reset_changes)
-        self.addCleanup(self.drop_ormcaches)
-        super().setUp()
-
     def test_export_import_product(self):
         products = self.env['product.product'].create([{
             'name': 'XYZ',

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -685,9 +685,9 @@ class BaseAutomation(models.Model):
         """ Update the registry after a modification on automation rules. """
         if self.env.registry.ready and not self.env.context.get('import_file'):
             # re-install the model patches, and notify other workers
+            self.env.transaction.will_change_registry()
             self._unregister_hook()
             self._register_hook()
-            self.env.registry.registry_invalidated = True
 
     def _get_actions(self, records, triggers):
         """ Return the automations of the given triggers for records' model. The

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1472,9 +1472,12 @@ class Base_ImportImport(models.TransientModel):
         with contextlib.suppress(psycopg2.InternalError):
             import_savepoint.close(rollback=dryrun)
         if dryrun:
+            # TODO why isn't this a flushing savepoint?
             # cancel all changes done to the registry/ormcache
-            # we need to clear the cache in case any created id was added to an ormcache and would be missing afterward
-            self.pool.clear_all_caches()
+            # clear main caches only, these should already be invalidated while
+            # importing data and will be cleared when resetting changes
+            for cache_name in ('default', 'groups', 'stable'):
+                self.pool.clear_cache(cache_name)
             # don't propagate to other workers since it was rollbacked
             self.pool.reset_changes()
             _logger.info('Previous import was a dry/test run, changes were reset')

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -3,7 +3,6 @@
 import base64
 import codecs
 import collections
-import contextlib
 import csv
 import datetime
 import difflib
@@ -18,7 +17,6 @@ from collections import defaultdict
 from collections.abc import Sequence
 
 import chardet
-import psycopg2
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
@@ -1438,48 +1436,46 @@ class Base_ImportImport(models.TransientModel):
         :rtype: dict(ids: list(int), messages: list({type, message, record}))
         """
         self.ensure_one()
-        import_savepoint = self.env.cr.savepoint(flush=False)
-
+        import_savepoint = self.env.cr.savepoint()
         try:
-            input_file_data, import_fields = self._convert_import_data(fields, options)
-            # Parse date and float field
-            input_file_data = self._parse_import_data(input_file_data, import_fields, options)
-        except ImportValidationError as error:
-            return {'messages': [error.__dict__]}
+            try:
+                input_file_data, import_fields = self._convert_import_data(fields, options)
+                # Parse date and float field
+                input_file_data = self._parse_import_data(input_file_data, import_fields, options)
+            except ImportValidationError as error:
+                return {'messages': [error.__dict__]}
 
-        _logger.info('importing %d rows...', len(input_file_data))
+            _logger.info('importing %d rows...', len(input_file_data))
 
-        binary_filenames = self._extract_binary_filenames(import_fields, input_file_data)
+            binary_filenames = self._extract_binary_filenames(import_fields, input_file_data)
 
-        import_fields, merged_data = self.with_context(import_options=options)._handle_multi_mapping(import_fields, input_file_data)
+            import_fields, merged_data = self.with_context(import_options=options)._handle_multi_mapping(import_fields, input_file_data)
 
-        if options.get('fallback_values'):
-            merged_data = self._handle_fallback_values(import_fields, merged_data, options['fallback_values'])
+            if options.get('fallback_values'):
+                merged_data = self._handle_fallback_values(import_fields, merged_data, options['fallback_values'])
 
-        name_create_enabled_fields = options.pop('name_create_enabled_fields', {})
-        import_limit = options.pop('limit', None)
-        model = self.env[self.res_model].with_context(
-            import_file=True,
-            name_create_enabled_fields=name_create_enabled_fields,
-            import_set_empty_fields=options.get('import_set_empty_fields', []),
-            import_skip_records=options.get('import_skip_records', []),
-            _import_limit=import_limit)
-        import_result = model.load(import_fields, merged_data)
-        _logger.info('done importing data into model: %s', model._name)
+            name_create_enabled_fields = options.pop('name_create_enabled_fields', {})
+            import_limit = options.pop('limit', None)
+            model = self.env[self.res_model].with_context(
+                import_file=True,
+                name_create_enabled_fields=name_create_enabled_fields,
+                import_set_empty_fields=options.get('import_set_empty_fields', []),
+                import_skip_records=options.get('import_skip_records', []),
+                _import_limit=import_limit)
+            import_result = model.load(import_fields, merged_data)
+            _logger.info('done importing data into model: %s', model._name)
 
-        # If transaction aborted, RELEASE SAVEPOINT is going to raise
-        # an InternalError (ROLLBACK should work, maybe). Ignore that.
-        with contextlib.suppress(psycopg2.InternalError):
             import_savepoint.close(rollback=dryrun)
+        finally:
+            # rollback if not already closed
+            import_savepoint.close(rollback=True)
+            if dryrun:
+                # cancel all changes done to the ormcache
+                # clear main caches only, these should already be invalidated while
+                # importing data and will be cleared when resetting changes
+                for cache_name in ('default', 'groups', 'stable'):
+                    self.pool.clear_cache(cache_name)
         if dryrun:
-            # TODO why isn't this a flushing savepoint?
-            # cancel all changes done to the registry/ormcache
-            # clear main caches only, these should already be invalidated while
-            # importing data and will be cleared when resetting changes
-            for cache_name in ('default', 'groups', 'stable'):
-                self.pool.clear_cache(cache_name)
-            # don't propagate to other workers since it was rollbacked
-            self.env.transaction.reset()
             _logger.info('Previous import was a dry/test run, changes were reset')
 
         # Insert/Update mapping columns when import complete successfully

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1479,7 +1479,7 @@ class Base_ImportImport(models.TransientModel):
             for cache_name in ('default', 'groups', 'stable'):
                 self.pool.clear_cache(cache_name)
             # don't propagate to other workers since it was rollbacked
-            self.pool.reset_changes()
+            self.env.transaction.reset()
             _logger.info('Previous import was a dry/test run, changes were reset')
 
         # Insert/Update mapping columns when import complete successfully

--- a/addons/bus/session_helpers.py
+++ b/addons/bus/session_helpers.py
@@ -4,7 +4,6 @@ import time
 
 from odoo.api import Environment
 from odoo.http.session import SessionExpiredException, session_store
-from odoo.modules.registry import Registry
 from odoo.sql_db import SQL
 from odoo.tools.lru import LRU
 from odoo.tools.misc import consteq
@@ -23,7 +22,6 @@ def _get_session_token_query_params(cr, session):
         cr.execute('SELECT MAX(id) FROM orm_signaling_registry')
         if cached_value['registry_sequence'] == cr.fetchone()[0]:
             return cached_value['query_params']
-    Registry(cr.dbname).check_signaling()
     env = new_env(cr, session)
     params = env.user._get_session_token_query_params()
     _query_params_by_user[cache_key] = {

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -26,7 +26,7 @@ from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
 from werkzeug.local import LocalStack
 
 import odoo
-from odoo import modules
+from odoo import api, modules
 from odoo.http.requestlib import Request
 from odoo.http.response import Response
 from odoo.http.retrying import retrying
@@ -695,12 +695,13 @@ class Websocket:
         if code is CloseCode.SERVER_ERROR:
             reason = None
             registry = Registry(self._session.db)
-            sequence = registry.registry_sequence
-            registry = registry.check_signaling()
-            if sequence != registry.registry_sequence:
+            with registry.cursor() as cr:
+                env = api.Environment(cr, api.SUPERUSER_ID, {})
+                changed_registry = registry is not env.registry
+            if changed_registry:
                 _logger.warning("Bus operation aborted; registry has been reloaded")
             else:
-                _logger.error(exc, exc_info=True)
+                _logger.error(exc, exc_info=exc)
         if self.state is ConnectionState.OPEN:
             self._disconnect(code, reason)
         else:
@@ -919,15 +920,14 @@ class WebsocketRequest:
         data = jsonrequest.get('data')
         self.session = self._get_session()
 
-        try:
-            self.registry = Registry(self.db).check_signaling()
-        except (
-            AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError
-        ) as exc:
-            raise InvalidDatabaseException() from exc
-
         with acquire_cursor(self.db) as cr:
-            self.env = new_env(cr, self.session, set_lang=True)
+            try:
+                self.env = new_env(cr, self.session, set_lang=True)
+                self.registry = self.env.registry
+            except (
+                AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError
+            ) as exc:
+                raise InvalidDatabaseException() from exc
             retrying(
                 functools.partial(self._serve_ir_websocket, event_name, data),
                 self.env,

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -734,13 +734,17 @@ class Websocket:
             env = new_env(cr, self._session, set_lang=True)
             for callback in self.__event_callbacks[event_type]:
                 try:
-                    retrying(functools.partial(callback, env, self), env)
+                    retrying(functools.partial(callback, env, self), env, close_on_commit=False)
                 except Exception:
                     _logger.warning(
                         'Error during Websocket %s callback',
                         LifecycleEvent(event_type).name,
                         exc_info=True
                     )
+                finally:
+                    # retrying leave the cursor in a bad state state, since we
+                    # continue to use it, we must rollback
+                    cr.rollback()
 
     def _assert_session_validity(self):
         """Ensure the current session exists and validate it using

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -148,7 +148,7 @@ class TestSyncGoogle(HttpCase):
         """
         manually calls postcommit hooks defined with the decorator @after_commit
         """
-
+        self.env.cr.flush()  # flush changes first
         funcs = self.env.cr.postcommit._funcs.copy()
         while funcs:
             func = funcs.popleft()

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -130,7 +130,7 @@ class TestTimesheet(TestCommonTimesheet):
     def setUp(self):
         super().setUp()
         # Make sure to clean the plan fields
-        self.env.registry._setup_models__(self.env.cr)
+        self.env.transaction.will_change_registry()
 
         # Crappy hack to disable the rule from timesheet grid, if it exists
         # The registry doesn't contain the field timesheet_manager_id.

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -556,6 +556,7 @@ class TestCommon(HttpCase):
 
         # need to manually handle post-commit hooks calls as `self.env.cr.postcommit.run()` clean
         # the queue at the end of the first post-commit hook call ...
+        self.env.cr.flush()  # flush changes first
         funcs = self.env.cr.postcommit._funcs.copy()
         while funcs:
             func = funcs.popleft()

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -1398,7 +1398,7 @@ class TestUpdateEvents(TestCommon):
 
         # Ensure that the event was deleted and recreated with the new organizer and the organizer listed as attendee.
         mock_delete.assert_any_call(
-            event.microsoft_id,
+            "test_id_for_organizer",
             token=mock_get_token(self.attendee_user),
             timeout=ANY,
         )

--- a/addons/spreadsheet/tests/test_currency_rate.py
+++ b/addons/spreadsheet/tests/test_currency_rate.py
@@ -117,7 +117,7 @@ class TestCurrencyRates(TransactionCase):
         cad = self.env.ref("base.CAD")
         self.env.user.tz = "UTC"
         self.env.flush_all()
-        self.env.transaction.reset()
+        self.env.transaction.clear()
         self.env["res.currency.rate"].create(
             {
                 "name": fields.Date.subtract(fields.Date.context_today(self), days=1),
@@ -127,7 +127,7 @@ class TestCurrencyRates(TransactionCase):
         )
         self.env.user.tz = "Australia/Sydney"
         self.env.flush_all()
-        self.env.transaction.reset()
+        self.env.transaction.clear()
         self.env["res.currency.rate"].create(
             {
                 "name": fields.Date.subtract(fields.Date.context_today(self), days=1),

--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
@@ -10,7 +9,5 @@ from odoo.addons.website.tests.test_performance import UtilPerf
 class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
-        select_tables_perf = {
-            'orm_signaling_registry': 1,
-        }
-        self._check_url_hot_query(url, 1, select_tables_perf)
+        select_tables_perf = {}
+        self._check_url_hot_query(url, 0, select_tables_perf)

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -70,7 +70,6 @@ def test_01_cow_views_unlink_on_module_update(env):
     # Upgrade the module
     test_website_module = env['ir.module.module'].search([('name', '=', 'test_website')])
     test_website_module.button_immediate_upgrade()
-    env.transaction.reset()     # clear the set of environments
 
     # Ensure generic views got removed
     view = env.ref('test_website.update_module_view_to_be_t_called', raise_if_not_found=False)
@@ -181,7 +180,6 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
 
     # Upgrade the module
     theme_default.button_immediate_upgrade()
-    env.transaction.reset()  # clear the set of environments
 
     # Beware: records do not belong to the correct registry anymore
     assert env.registry is not old_registry
@@ -215,7 +213,6 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
     # Upgrade the module
     with MockRequest(env, website=website_1):
         theme_default.button_immediate_upgrade()
-    env.transaction.reset()  # clear the set of environments
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -228,7 +228,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
 
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -255,7 +254,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertEqual(self._get_cart_quantity(), 1)
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -279,7 +277,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertEqual(self._get_cart_quantity(), 0)
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -295,9 +292,8 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 42  # To increase this number you must ask the permission to al
+        query_count = 41  # To increase this number you must ask the permission to al
         queries = {
-            'orm_signaling_registry': 1,
             'website': 1,
             'res_company': 2,
             'product_pricelist': 4,

--- a/addons/web/tests/test_ir_model.py
+++ b/addons/web/tests/test_ir_model.py
@@ -82,13 +82,6 @@ class TestIrModel(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
-        # The test mode is necessary in this case.  After each test, we call
-        # registry.reset_changes(), which opens a new cursor to retrieve custom
-        # models and fields.  A regular cursor would correspond to the state of
-        # the database before setUpClass(), which is not correct.  Instead, a
-        # test cursor will correspond to the state of the database of cls.cr at
-        # that point, i.e., before the call to setUp().
         cls.registry_enter_test_mode_cls()
 
         # model and records for banana stages
@@ -142,11 +135,6 @@ class TestIrModel(TransactionCase):
             'x_length': 10,
             'x_color': 6,
         }])
-
-    def setUp(self):
-        # this cleanup is necessary after each test, and must be done last
-        self.addCleanup(self.registry.reset_changes)
-        super().setUp()
 
     def test_model_order_constraint(self):
         """Check that the order constraint is properly enforced."""

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -26,11 +26,16 @@ class TestPerfSessionInfo(common.HttpCase):
     def setUp(self):
         super().setUp()
         self.uid = self.user
+        self._prepare()
+
+    def _prepare(self):
+        self.env.invalidate_all()
+        self.drop_ormcaches()
 
     def test_performance_session_info(self):
         self.authenticate(self.user.login, "info")
+        self._prepare()
 
-        self.env.registry.clear_all_caches()
         # cold ormcache:
         # - Only web: 35
         # - All modules: 122
@@ -52,8 +57,6 @@ class TestPerfSessionInfo(common.HttpCase):
             )
 
     def test_load_web_menus_perf(self):
-        self.env.registry.clear_all_caches()
-        self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 17
         # - All modules 60
@@ -70,8 +73,6 @@ class TestPerfSessionInfo(common.HttpCase):
             self.env['ir.ui.menu'].load_web_menus(False)
 
     def test_load_menus_perf(self):
-        self.env.registry.clear_all_caches()
-        self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 17
         # - All modules 60
@@ -88,8 +89,6 @@ class TestPerfSessionInfo(common.HttpCase):
             self.env['ir.ui.menu'].load_menus(False)
 
     def test_visible_menu_ids(self):
-        self.env.registry.clear_all_caches()
-        self.env.invalidate_all()
         # cold ormcache:
         # - Only web 16
         # - All modules: 27

--- a/addons/website/tests/test_disable_unused_snippets_assets.py
+++ b/addons/website/tests/test_disable_unused_snippets_assets.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import TransactionCase, tagged
-from unittest.mock import patch
+
 
 @tagged('post_install', '-at_install')
 class TestDisableSnippetsAssets(TransactionCase):
@@ -65,20 +65,14 @@ class TestDisableSnippetsAssets(TransactionCase):
             'mega_menu_content': MEGA_MENU_OUTDATED,
         })
         self.mega_menu.flush_recordset()
-        cache_clears = []
+        self.addCleanup(self.drop_ormcaches)
 
-        init_clear_cache = self.env.registry.clear_cache
-
-        def patched_clear_cache(cache_name):
-            cache_clears.append(cache_name)
-            init_clear_cache(cache_name)
-
-        with patch.object(self.env.registry, 'clear_cache', patched_clear_cache):
-            self.Website._disable_unused_snippets_assets()
-            self.assertIn('assets', cache_clears, 'Assets cache should have been invalidated when updating ir_assets')
-            cache_clears.clear()
-            self.Website._disable_unused_snippets_assets()
-            self.assertNotIn('assets', cache_clears, 'No update on ir_assets expected, no invalidation should be triggered')
+        cache_invalidated = self.env.registry.cache_invalidated
+        self.Website._disable_unused_snippets_assets()
+        self.assertIn('assets', cache_invalidated, 'Assets cache should have been invalidated when updating ir_assets')
+        cache_invalidated.clear()
+        self.Website._disable_unused_snippets_assets()
+        self.assertNotIn('assets', cache_invalidated, 'No update on ir_assets expected, no invalidation should be triggered')
 
         s_website_form_000_scss = self._get_snippet_asset('s_website_form', '000', 'scss')
         s_website_form_001_scss = self._get_snippet_asset('s_website_form', '001', 'scss')

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -133,7 +133,7 @@ class TestStandardPerformance(UtilPerf):
         self.assertEqual(self.env.ref('base.user_admin').sudo().website_published, False)
         user_id = self.ref('base.user_admin')
         url = f'/web/image/res.users/{user_id}/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 7)
+        self.assertEqual(self._get_url_hot_query(url), 6)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):
@@ -142,19 +142,17 @@ class TestStandardPerformance(UtilPerf):
         user_id = self.ref('base.user_admin')
         url = f'/web/image/res.users/{user_id}/image_256'
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'res_users': 2,
             'res_partner': 1,
             'ir_attachment': 1,
         }
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
     @mute_logger('odoo.http')
     def test_20_perf_sql_img_controller_bis(self):
         website_id = self.ref('website.default_website')
         url = f'/web/image/website/{website_id}/favicon'
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'website': 2,
             # 1. `_find_record()` performs an access right check through
             #    `exists()` which perform a request on the website.
@@ -164,10 +162,10 @@ class TestStandardPerformance(UtilPerf):
             # 1. `_record_to_stream()` does a `search()`..
             # 2. ..followed by a `_read()`
         }
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
         self.authenticate('portal', 'portal')
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
 
 class TestWebsitePerformanceCommon(UtilPerf):
@@ -213,11 +211,10 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                 }
-                expected_query_count = 2
+                expected_query_count = 1
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -225,7 +222,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
 
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -236,7 +232,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'website_menu': 1,
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 7
+                expected_query_count = 6
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, nocache=True)
                 self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), expected_query_count)
 
@@ -246,11 +242,9 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                 } if cache else {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -261,7 +255,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'website_menu': 1,
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 2 if cache else 7
+                expected_query_count = 1 if cache else 6
                 insert_tables_perf = {}
                 self.page.track = True
 
@@ -274,16 +268,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         for readonly_enabled in (True, False):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
-                select_tables_perf = {
-                    'orm_signaling_registry': 1,
-                }
-                expected_query_count = 1
+                select_tables_perf = {}
+                expected_query_count = 0
                 insert_tables_perf = {}
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
                 self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
 
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'website_menu': 1,
                     # homepage controller is prefetching all menus for perf in one go
                     'website_page': 2,
@@ -293,7 +284,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # layout
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 6
+                expected_query_count = 5
                 insert_tables_perf = {}
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf, nocache=True)
                 self.assertEqual(self._get_url_hot_query('/', nocache=True), expected_query_count)
@@ -303,15 +294,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         self.page.arch = '<div>I am a blank page</div>'
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
         }
-        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+        self._check_url_hot_query(self.page.url, 1, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 1)
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 1,
@@ -320,8 +309,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 4, select_tables_perf, nocache=True)
-        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 4)
+        self._check_url_hot_query(self.page.url, 3, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 3)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -334,15 +323,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         menu_aa.parent_id = menu_a
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
         }
-        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+        self._check_url_hot_query(self.page.url, 1, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 1)
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
@@ -352,8 +339,9 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'website_menu': 1,
             'ir_ui_view': 1,
         }
-        self._check_url_hot_query(self.page.url, 7, select_tables_perf, nocache=True)
-        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 7)
+        self._check_url_hot_query(self.page.url, 6, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 6)
+
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):
@@ -363,11 +351,10 @@ class TestWebsitePerformancePost(UtilPerf):
         assets_url = self.env['ir.qweb']._get_asset_bundle('web.assets_frontend_lazy', css=False, js=True).get_links()[0]
         self.assertIn('web.assets_frontend_lazy.min.js', assets_url)
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 2,
             # All 2 coming from the /web/assets and ir.binary stack
             # 1. `search() the attachment`
             # 2. `_record_to_stream` reads the other attachment fields
         }
-        self._check_url_hot_query(assets_url, 3, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(assets_url), 3)
+        self._check_url_hot_query(assets_url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(assets_url), 2)

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -42,7 +42,6 @@ def test_01_cow_views_inherit_on_module_update(env):
     # 3. Upgrade the module
     portal_module = env['ir.module.module'].search([('name', '=', 'portal')])
     portal_module.button_immediate_upgrade()
-    env.transaction.reset()     # clear the set of environments
 
     # 4. Ensure cow view also got its inherit_id updated
     expected_parent_view = env.ref('portal.frontend_layout')  # XML data
@@ -78,7 +77,6 @@ def test_02_cow_views_inherit_on_module_update(env):
     # 3. Upgrade the module
     portal_module = env['ir.module.module'].search([('name', '=', 'portal')])
     portal_module.button_immediate_upgrade()
-    env.transaction.reset()     # clear the set of environments
 
     # 4. Ensure cow view also got its inherit_id updated
     assert view_D.inherit_id == view_B, "Generic view security check."

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -19,7 +19,6 @@ from odoo import api, fields, models, sql_db
 from odoo.exceptions import LockError, UserError
 from odoo.http.dispatcher import serialize_exception
 from odoo.modules import Manifest
-from odoo.modules.registry import Registry
 from odoo.tools import SQL, config
 from odoo.tools.constants import GC_UNLINK_LIMIT
 from odoo.tools.func import deprecated
@@ -222,7 +221,6 @@ class IrCron(models.Model):
         The `cron_cr` is used to lock the currently processed job and relased
         by committing after each job.
         """
-        db_name = cron_cr.dbname
         for job_id in job_ids:
             try:
                 job = IrCron._acquire_one_job(cron_cr, job_id)
@@ -234,8 +232,8 @@ class IrCron(models.Model):
                 _logger.debug("job %s is being processed by another worker, skip", job_id)
                 continue
             _logger.debug("job %s acquired", job_id)
-            # take into account overridings of _process_job() on that database
-            registry = Registry(db_name).check_signaling()
+            # take into account overridings of _process_job() on that database, check_signaling
+            registry = api.Environment(cron_cr, api.SUPERUSER_ID, {}).registry
             registry[IrCron._name]._process_job(cron_cr, job)
             cron_cr.commit()
             _logger.debug("job %s updated and released", job_id)
@@ -677,10 +675,6 @@ class IrCron(models.Model):
         is the user calling this method. """
         self.ensure_one()
         try:
-            if self.pool != self.pool.check_signaling():
-                # the registry has changed, reload self in the new registry
-                self.env.transaction.reset()
-
             _logger.debug(
                 "cron.object.execute(%r, %d, '*', %r, %d)",
                 self.env.cr.dbname,
@@ -690,10 +684,8 @@ class IrCron(models.Model):
             )
             self.env['ir.actions.server'].browse(server_action_id).run()
             self.env.flush_all()
-            self.pool.signal_changes()
             self.env.cr.commit()
         except Exception:
-            self.pool.reset_changes()
             self.env.cr.rollback()
             raise
 

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1042,7 +1042,7 @@ class IrModelFields(models.Model):
                 pass
 
         # clean the registry from the fields to remove
-        self.pool.registry_invalidated = True
+        self.env.transaction.will_change_registry()
         self.pool._discard_fields(fields)
 
         # discard the removed fields from fields to compute

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -643,13 +643,11 @@ class IrModuleModule(models.Model):
 
         self.env.cr.commit()
         registry = modules.registry.Registry.new(self.env.cr.dbname, update_module=True)
-        self.env.cr.commit()
-        if request and request.registry is self.env.registry:
-            request.env.transaction.reset()
-            request.registry = request.env.registry
-            assert request.env.registry is registry
         self.env.transaction.reset()
         assert self.env.registry is registry
+        if request:
+            assert request.env.transaction is self.env.transaction, "request on another transaction than the model"
+            request.registry = request.env.registry
 
         # pylint: disable=next-method-called
         config = self.env['ir.module.module'].next() or {}

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -280,6 +280,7 @@ class ResCompany(models.CachedModel):
             company.uninstalled_l10n_module_ids = self.env['ir.module.module'].browse(mapping.get(company.country_id.id))
 
     def install_l10n_modules(self):
+        self.env.flush_all()
         uninstalled_modules = self.uninstalled_l10n_module_ids
         is_ready_and_not_test = (
             not tools.config['test_enable']

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -389,7 +389,7 @@ class TestPermissions(TransactionCaseWithUserDemo):
 
         # Patch the field `res.partner.image_128` to make it unreadable by the demo user
         self.patch(self.env.registry['res.partner']._fields['image_128'], 'groups', 'base.group_system')
-        self.env.transaction.reset()
+        self.env.transaction.clear()
 
         # Assert the field can't be read
         with self.assertRaises(AccessError):

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -385,7 +385,7 @@ class TestCommonCustomFields(TransactionCase):
             assert set(self.registry[self.MODEL]._fields) == fnames
 
         self.addCleanup(self.registry.reset_changes)
-        self.addCleanup(self.registry.clear_all_caches)
+        self.addCleanup(self.drop_ormcaches)
 
         super().setUp()
 

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -384,10 +384,10 @@ class TestCommonCustomFields(TransactionCase):
         def check_registry():
             assert set(self.registry[self.MODEL]._fields) == fnames
 
-        self.addCleanup(self.registry.reset_changes)
         self.addCleanup(self.drop_ormcaches)
 
         super().setUp()
+        self.env.transaction.will_change_registry()
 
     def create_field(self, name, *, field_type='char'):
         """ create a custom field and return it """

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -104,6 +104,8 @@ class TestIrSequenceNoGap(BaseCase):
                 n0 = env0['ir.sequence'].next_by_code('test_sequence_type_2')
                 self.assertTrue(n0)
                 env1['ir.sequence'].next_by_code('test_sequence_type_2')
+            env0.cr.rollback()
+            env1.cr.rollback()
 
     @classmethod
     def tearDownClass(cls):

--- a/odoo/addons/test_orm/tests/test_acl.py
+++ b/odoo/addons/test_orm/tests/test_acl.py
@@ -32,7 +32,7 @@ class TestACL(TransactionCaseWithUserDemo):
     def _set_field_groups(self, model, field_name, groups):
         field = model._fields[field_name]
         self.patch(field, 'groups', groups)
-        self.env.transaction.reset()
+        self.env.transaction.clear()
         self.env.registry.clear_cache('templates')
 
     def test_field_visibility_restriction(self):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -29,7 +29,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
     def setUp(self):
         # for tests methods that create custom models/fields
         self.addCleanup(self.registry.reset_changes)
-        self.addCleanup(self.registry.clear_all_caches)
+        self.addCleanup(self.drop_ormcaches)
         super().setUp()
         self.env.ref('test_orm.discussion_0').write({'participants': [Command.link(self.user_demo.id)]})
         # YTI FIX ME: The cache shouldn't be inconsistent (rco is gonna fix it)

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -28,7 +28,6 @@ _logger = logging.getLogger(__name__)
 class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
     def setUp(self):
         # for tests methods that create custom models/fields
-        self.addCleanup(self.registry.reset_changes)
         self.addCleanup(self.drop_ormcaches)
         super().setUp()
         self.env.ref('test_orm.discussion_0').write({'participants': [Command.link(self.user_demo.id)]})
@@ -4266,7 +4265,7 @@ class TestRequiredMany2one(TransactionCase):
         field = Model._fields['foo']
 
         # clean up registry after this test
-        self.addCleanup(self.registry.reset_changes)
+        self.env.transaction.will_change_registry()
         self.patch(field, 'ondelete', 'set null')
 
         with self.assertRaises(ValueError):
@@ -4289,7 +4288,7 @@ class TestRequiredMany2oneTransient(TransactionCase):
         field = Model._fields['foo']
 
         # clean up registry after this test
-        self.addCleanup(self.registry.reset_changes)
+        self.env.transaction.will_change_registry()
         self.patch(field, 'ondelete', 'set null')
 
         with self.assertRaises(ValueError):
@@ -5013,7 +5012,7 @@ class TestPrecomputeModel(TransactionCase):
         self.assertTrue(Model.upper.precompute)
 
         # see what happens if not both are precompute
-        self.addCleanup(self.registry.reset_changes)
+        self.env.transaction.will_change_registry()
         self.patch(Model.upper, 'precompute', False)
         with self.assertWarns(UserWarning):
             self.registry._setup_models__(self.cr, ['test_orm.precompute'])
@@ -5024,10 +5023,9 @@ class TestPrecomputeModel(TransactionCase):
         self.assertTrue(Model.lower.precompute)
         self.assertTrue(Model.upper.precompute)
         self.assertTrue(Model.lowup.precompute)
+        self.env.transaction.will_change_registry()
 
         # see what happens if precompute depends on non-precompute
-        self.addCleanup(self.registry.reset_changes)
-
         def reset():
             Model.lowup.precompute = True
         self.addCleanup(reset)
@@ -5052,9 +5050,9 @@ class TestPrecomputeModel(TransactionCase):
         Line = self.registry['test_orm.precompute.line']
         self.assertTrue(Model.size.precompute)
         self.assertTrue(Line.size.precompute)
+        self.env.transaction.will_change_registry()
 
         # see what happens if precompute depends on non-precompute
-        self.addCleanup(self.registry.reset_changes)
         # ensure that Model.size.precompute is restored after _setup_models__()
         self.patch(Model.size, 'precompute', True)
         self.patch(Line.size, 'precompute', False)

--- a/odoo/addons/test_orm/tests/test_registry_signaling.py
+++ b/odoo/addons/test_orm/tests/test_registry_signaling.py
@@ -23,7 +23,7 @@ class TestOrmCache(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        if cls.registry.registry_invalidated:
+        if cls.env.transaction._registry_invalidated:
             raise AssertionError('Registry should not be invalidated when starting this test')
         if cls.registry.cache_invalidated:
             raise AssertionError('Cache should not be invalidated when starting this test')
@@ -73,11 +73,11 @@ class TestOrmCache(TransactionCase):
         self.env.registry.clear_cache()
         self.env.registry.clear_cache('templates')
         self.assertEqual(self.env.registry.cache_invalidated, {'default', 'templates'})
-        self.env.registry.reset_changes()
+        self.env.transaction.reset()
         self.assertEqual(self.env.registry.cache_invalidated, set())
         self.env.registry.clear_cache('assets')
         self.assertEqual(self.env.registry.cache_invalidated, {'assets'})
-        self.env.registry.reset_changes()
+        self.env.transaction.reset()
         self.assertEqual(self.env.registry.cache_invalidated, set())
 
     def test_signaling_gc(self):
@@ -128,56 +128,77 @@ class TestOrmCacheSignaling(BaseCase):
         # an autoretry hidding errors
         cls._retry = False
         cls.registry = Registry(common.get_db_name())
-        if cls.registry.registry_invalidated:
-            raise AssertionError('Registry should not be invalidated when starting this test')
+
+    def setUp(self):
+        super().setUp()
+        self.cr = self.cursor()
+        self.addCleanup(self.cr.close)
+        self.transaction = api.Environment(self.cr, api.SUPERUSER_ID, {}).transaction
+
+        def simulated_commit():
+            # similar to flushing_cursor, but specific for this case with no support for test cursor
+            cr = self.cr
+            with cr.transaction.committing():
+                pass  # no real commit
+
+        assert not self._registry_patched, "registry must not be patched"
+        self.patch(self.cr, 'commit', simulated_commit)
+        self.registry.cache_invalidated.clear()
+        # flush once to set the nextval from the sequence
+        self.registry.clear_cache('default')
+        self.registry.clear_cache('assets')
+        self.cr.commit()
+        self.old_sequences = dict(self.registry.cache_sequences)
+
+    @property
+    def cache_invalidated(self):
+        return self.registry.cache_invalidated
 
     def test_signaling_01_single(self):
-        self.assertFalse(self._registry_patched)
-        self.registry.cache_invalidated.clear()
+        transaction = self.transaction
         registry = self.registry
-        old_sequences = dict(registry.cache_sequences)
+
         with self.assertLogs('odoo.registry') as logs:
-            registry.cache_invalidated.add('assets')
-            self.assertEqual(registry.cache_invalidated, {'assets'})
-            registry.signal_changes()
-            self.assertFalse(registry.cache_invalidated)
+            registry.clear_cache('assets')
+            self.assertEqual(self.cache_invalidated, {'assets'})
+            self.cr.commit()
+            self.assertFalse(self.cache_invalidated)
 
         self.assertEqual(
             logs.output,
             ["INFO:odoo.registry:Caches invalidated, signaling through the database: ['assets']"],
         )
 
-        for key, value in old_sequences.items():
+        for key, value in self.old_sequences.items():
             if key == 'assets':
                 self.assertEqual(value + 1, registry.cache_sequences[key], "Assets cache sequence should have changed")
             else:
-                self.assertEqual(value, registry.cache_sequences[key], "other registry sequence shouldn't have changed")
+                self.assertEqual(value, registry.cache_sequences[key], f"other registry sequence shouldn't have changed {key}")
 
         with self.assertNoLogs(None, None):  # the registry sequence should be up to date on the same worker
-            registry.check_signaling()
+            transaction.reset()
 
         # simulate other worker state
 
-        registry.cache_sequences.update(old_sequences)
+        registry.cache_sequences.update(self.old_sequences)
 
         with self.assertLogs() as logs:
-            registry.check_signaling()
+            transaction.reset()
         self.assertEqual(
             logs.output,
             ["INFO:odoo.registry:Invalidating caches after database signaling: ['assets', 'templates.cached_values']"],
         )
 
     def test_signaling_01_multiple(self):
-        self.assertFalse(self._registry_patched)
-        self.registry.cache_invalidated.clear()
+        transaction = self.transaction
         registry = self.registry
-        old_sequences = dict(registry.cache_sequences)
+
         with self.assertLogs('odoo.registry') as logs:
-            registry.cache_invalidated.add('assets')
-            registry.cache_invalidated.add('default')
-            self.assertEqual(registry.cache_invalidated, {'assets', 'default'})
-            registry.signal_changes()
-            self.assertFalse(registry.cache_invalidated)
+            registry.clear_cache('assets')
+            registry.clear_cache('default')
+            self.assertEqual(self.cache_invalidated, {'assets', 'default'})
+            self.cr.commit()
+            self.assertFalse(self.cache_invalidated)
 
         self.assertEqual(
             logs.output,
@@ -186,21 +207,21 @@ class TestOrmCacheSignaling(BaseCase):
             ],
         )
 
-        for key, value in old_sequences.items():
+        for key, value in self.old_sequences.items():
             if key in ('assets', 'default'):
                 self.assertEqual(value + 1, registry.cache_sequences[key], "Assets and default cache sequence should have changed")
             else:
-                self.assertEqual(value, registry.cache_sequences[key], "other registry sequence shouldn't have changed")
+                self.assertEqual(value, registry.cache_sequences[key], f"other registry sequence shouldn't have changed {key}")
 
         with self.assertNoLogs(None, None):  # the registry sequence should be up to date on the same worker
-            registry.check_signaling()
+            transaction.reset()
 
         # simulate other worker state
 
-        registry.cache_sequences.update(old_sequences)
+        registry.cache_sequences.update(self.old_sequences)
 
         with self.assertLogs() as logs:
-            registry.check_signaling()
+            transaction.reset()
         self.assertEqual(
             logs.output,
             ["INFO:odoo.registry:Invalidating caches after database signaling: ['assets', 'default', 'templates.cached_values']"],

--- a/odoo/addons/test_orm/tests/test_registry_signaling.py
+++ b/odoo/addons/test_orm/tests/test_registry_signaling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
 import logging
@@ -20,10 +19,6 @@ from odoo.tools.cache import get_cache_key_counter
 ADMIN_USER_ID = common.ADMIN_USER_ID
 
 
-def registry():
-    return Registry(common.get_db_name())
-
-
 class TestOrmCache(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -32,13 +27,6 @@ class TestOrmCache(TransactionCase):
             raise AssertionError('Registry should not be invalidated when starting this test')
         if cls.registry.cache_invalidated:
             raise AssertionError('Cache should not be invalidated when starting this test')
-
-        # this test verifies the actual side effects of signaling changes
-        cls._signal_changes_patcher.stop()
-        # if something invalidate the cache or registry before test_signaling_01_multiple,
-        # the test may fail the first time but succeed on retry
-        # disabling autoretry to avoid hidding "real" errrors
-        cls._retry = False
 
     def test_ormcache(self):
         """ Test the effectiveness of the ormcache() decorator. """
@@ -91,6 +79,57 @@ class TestOrmCache(TransactionCase):
         self.assertEqual(self.env.registry.cache_invalidated, {'assets'})
         self.env.registry.reset_changes()
         self.assertEqual(self.env.registry.cache_invalidated, set())
+
+    def test_signaling_gc(self):
+        cr = self.env.cr
+        cr.execute('SELECT last_value FROM orm_signaling_registry_id_seq')
+        sequence_start = cr.fetchone()[0]
+
+        def assertSignalCount(expected_count, expected_max_id, message):
+            cr.execute("SELECT count(*), max(id) FROM orm_signaling_registry")
+            count, max_id = cr.fetchone()
+            self.assertEqual(expected_count, count, message)
+            self.assertEqual(expected_max_id, max_id - sequence_start, message)
+
+        cr.execute('DELETE FROM orm_signaling_registry')
+
+        for _ in range(7):
+            cr.execute("INSERT INTO orm_signaling_registry (date) VALUES (NOW() - interval '2 hours')")
+
+        cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
+
+        assertSignalCount(8, 8, "8 signals were inserted")
+        self.env['ir.autovacuum']._gc_orm_signaling()
+        assertSignalCount(8, 8, "less than 10 signals, no deletion")
+
+        for _ in range(5):
+            cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
+
+        assertSignalCount(13, 13, "5 more signals were inserted")
+        self.env['ir.autovacuum']._gc_orm_signaling()
+        assertSignalCount(10, 13, "more than 10 signals, some should have been deleted")
+
+        for _ in range(7):
+            cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
+
+        assertSignalCount(17, 20, "7 more signals were inserted")
+        self.env['ir.autovacuum']._gc_orm_signaling()
+        assertSignalCount(13, 20, "Keeping the 13 signals having less than one hour")
+
+        # reset sequence to avoid side effects
+        cr.execute(f"SELECT setval('orm_signaling_registry_id_seq', {sequence_start})")
+
+
+class TestOrmCacheSignaling(BaseCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # do not retry, these tests must always succeed the first time and avoid
+        # an autoretry hidding errors
+        cls._retry = False
+        cls.registry = Registry(common.get_db_name())
+        if cls.registry.registry_invalidated:
+            raise AssertionError('Registry should not be invalidated when starting this test')
 
     def test_signaling_01_single(self):
         self.assertFalse(self._registry_patched)
@@ -167,54 +206,19 @@ class TestOrmCache(TransactionCase):
             ["INFO:odoo.registry:Invalidating caches after database signaling: ['assets', 'default', 'templates.cached_values']"],
         )
 
-    def test_signaling_gc(self):
-        cr = self.env.cr
-        cr.execute('SELECT last_value FROM orm_signaling_registry_id_seq')
-        sequence_start = cr.fetchone()[0]
-
-        def assertSignalCount(expected_count, expected_max_id, message):
-            cr.execute("SELECT count(*), max(id) FROM orm_signaling_registry")
-            count, max_id = cr.fetchone()
-            self.assertEqual(expected_count, count, message)
-            self.assertEqual(expected_max_id, max_id-sequence_start, message)     
-
-        cr.execute('DELETE FROM orm_signaling_registry')
-    
-        for _ in range (7):
-            cr.execute("INSERT INTO orm_signaling_registry (date) VALUES (NOW() - interval '2 hours')")
-
-        cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
-
-        assertSignalCount(8, 8, "8 signals were inserted")
-        self.env['ir.autovacuum']._gc_orm_signaling()
-        assertSignalCount(8, 8, "less than 10 signals, no deletion")
-
-        for _ in range (5):
-            cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
-
-        assertSignalCount(13, 13, "5 more signals were inserted")
-        self.env['ir.autovacuum']._gc_orm_signaling()
-        assertSignalCount(10, 13, "more than 10 signals, some should have been deleted")
-
-        for _ in range (7):
-            cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
-
-        assertSignalCount(17, 20, "7 more signals were inserted")
-        self.env['ir.autovacuum']._gc_orm_signaling()
-        assertSignalCount(13, 20, "Keeping the 13 signals having less than one hour")
-
-        # reset sequence to avoid side effects
-        cr.execute(f"SELECT setval('orm_signaling_registry_id_seq', {sequence_start})")
-
 
 @tagged('at_install', '-post_install')
 class TestRealCursor(BaseCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.registry = Registry(common.get_db_name())
 
     def test_execute_bad_params(self):
         """
         Try to use iterable but non-list or int params in query parameters.
         """
-        with registry().cursor() as cr:
+        with self.cursor() as cr:
             with self.assertRaises(ValueError):
                 cr.execute("SELECT id FROM res_users WHERE login=%s", 'admin')
             with self.assertRaises(ValueError):
@@ -223,29 +227,28 @@ class TestRealCursor(BaseCase):
                 cr.execute("SELECT id FROM res_users WHERE id=%s", '1')
 
     def test_using_closed_cursor(self):
-        with registry().cursor() as cr:
+        with self.cursor() as cr:
             cr.close()
             with self.assertRaises(psycopg2.InterfaceError):
                 cr.execute("SELECT 1")
 
     def test_multiple_close_call_cursor(self):
-        cr = registry().cursor()
+        cr = self.cursor()
         cr.close()
         cr.close()
 
     def test_transaction_isolation_cursor(self):
-        with registry().cursor() as cr:
+        with self.cursor() as cr:
             self.assertEqual(cr.connection.isolation_level, ISOLATION_LEVEL_REPEATABLE_READ)
 
     def test_connection_readonly(self):
         # even without db_replica, we expect the connection to be readonly for consistency
-        registry_ = registry()
-        with registry_.cursor(readonly=False) as cr:
+        with self.registry.cursor(readonly=False) as cr:
             cr.execute('SHOW transaction_read_only')
             self.assertEqual(cr.fetchone(), ('off',))
             self.assertFalse(cr._cnx.readonly)
 
-        with registry_.cursor(readonly=True) as cr:
+        with self.registry.cursor(readonly=True) as cr:
             cr.execute('SHOW transaction_read_only')
             self.assertEqual(cr.fetchone(), ('on',))
             self.assertTrue(cr._cnx.readonly)
@@ -293,7 +296,6 @@ class TestHTTPCursor(HttpCase):
             ok, readonly = result_read.json()['result']
             self.assertEqual(ok, 'ok')
             self.assertEqual(readonly, True, 'Call to read are expecte to be read only')
-
 
         with patch.object(type(self.env['res.partner']), 'write', return_readonly):
             result_write = self.url_open('/web/dataset/call_kw', data=json.dumps({

--- a/odoo/addons/test_orm/tests/test_registry_signaling.py
+++ b/odoo/addons/test_orm/tests/test_registry_signaling.py
@@ -16,7 +16,6 @@ from odoo.tests.common import BaseCase, HttpCase, TransactionCase
 from odoo.tests.test_cursor import TestCursor
 from odoo.tools.misc import config
 from odoo.tools.cache import get_cache_key_counter
-from threading import Thread, Barrier
 
 ADMIN_USER_ID = common.ADMIN_USER_ID
 
@@ -92,54 +91,6 @@ class TestOrmCache(TransactionCase):
         self.assertEqual(self.env.registry.cache_invalidated, {'assets'})
         self.env.registry.reset_changes()
         self.assertEqual(self.env.registry.cache_invalidated, set())
-
-    def test_invalidation_thread_local(self):
-        # this test ensures that the registry.cache_invalidated set is thread local
-
-        caches = ['default', 'templates', 'assets']
-        nb_treads = len(caches)
-
-        # use barriers to ensure threads synchronization
-        sync_clear_cache = Barrier(nb_treads, timeout=5)
-        sync_assert_equal = Barrier(nb_treads, timeout=5)
-        sync_reset = Barrier(nb_treads, timeout=5)
-
-        operations = []
-        def run(cache):
-            self.assertEqual(self.env.registry.cache_invalidated, set())
-
-            self.env.registry.clear_cache(cache)
-            operations.append('clear_cache')
-            sync_clear_cache.wait()
-
-            self.assertEqual(self.env.registry.cache_invalidated, {cache})
-            operations.append('assert_contains')
-            sync_assert_equal.wait()
-
-            self.env.registry.reset_changes()
-            operations.append('reset_changes')
-            sync_reset.wait()
-
-            self.assertEqual(self.env.registry.cache_invalidated, set())
-            operations.append('assert_empty')
-
-        # run all threads
-        threads = []
-        for cache in caches:
-            threads.append(Thread(target=run, args=(cache,)))
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
-        # ensure that the threads operations where executed in the expected order
-        self.assertEqual(
-            operations,
-            ['clear_cache'] * nb_treads +
-            ['assert_contains'] * nb_treads +
-            ['reset_changes'] * nb_treads +
-            ['assert_empty'] * nb_treads
-        )
 
     def test_signaling_01_single(self):
         self.assertFalse(self._registry_patched)

--- a/odoo/addons/test_orm/tests/test_search_order.py
+++ b/odoo/addons/test_orm/tests/test_search_order.py
@@ -240,7 +240,7 @@ class TestSearch(TransactionCase):
         # test that a custom field x_active filters like active
         # we take the model res.country as a test model as it is included in base and does
         # not have an active field
-        self.addCleanup(self.registry.reset_changes) # reset the registry to avoid polluting other tests
+        self.env.transaction.will_change_registry()
 
         model_country = self.env['res.country']
         self.assertNotIn('active', model_country._fields)  # just in case someone adds the active field in the model

--- a/odoo/addons/test_orm/tests/test_transactions.py
+++ b/odoo/addons/test_orm/tests/test_transactions.py
@@ -16,7 +16,7 @@ class TestTransactionEnvs(TransactionCase):
         self.assertEqual(id(base_x.env), base_x_env_id, "We should get the same environment")
         del base_x
 
-        transaction.reset()
+        transaction.clear()
         self.assertEqual(set(transaction.envs), starting_envs)
 
     def test_transaction_envs_many(self):
@@ -44,14 +44,14 @@ class TestTransactionEnvs(TransactionCase):
         transaction = self.env.transaction
         starting_envs = set(transaction.envs)
         self.do_stuff_with_env()
-        transaction.reset()
+        transaction.clear()
         self.assertEqual(set(transaction.envs), starting_envs)
 
     def test_transation_envs_weakrefs_return(self):
         transaction = self.env.transaction
         starting_envs = set(transaction.envs)
         base_test = self.do_stuff_with_env()
-        transaction.reset()
+        transaction.clear()
         self.assertEqual(set(transaction.envs), starting_envs | {base_test.env})
 
     def test_transation_envs_ordered(self):
@@ -64,5 +64,5 @@ class TestTransactionEnvs(TransactionCase):
         env_items = [env.context['item'] for env in transaction.envs if env not in starting_envs]
         self.assertEqual(env_items, items)
         del envs
-        transaction.reset()
+        transaction.clear()
         self.assertEqual(set(transaction.envs), starting_envs)

--- a/odoo/addons/test_tools/tests/test_translate.py
+++ b/odoo/addons/test_tools/tests/test_translate.py
@@ -540,7 +540,7 @@ class TestTranslation(TransactionCase):
         category.with_context(lang='nl_NL').name = 'Klanten'
         self.env.ref('base.lang_nl').active = False
         self.env.flush_all()
-        self.env.transaction.reset()  # remove environments
+        self.env.transaction.clear()  # remove environments
 
         category.invalidate_recordset()
         self.assertEqual(category.with_context(lang=None).name, 'Customers')
@@ -818,7 +818,7 @@ class TestTranslationWrite(TransactionCase):
         self.category.with_context(lang='nl_NL').name = 'Reblochon nl_NL'
         self.env.ref('base.lang_nl').active = False
         self.env.flush_all()
-        self.env.transaction.reset()  # remove environments
+        self.env.transaction.clear()  # remove environments
 
         # [inactive_lang, non_existing_lang, technical_lang, sql_injection_lang]
         langs = ['nl_NL', 'Dummy', '_en_US', "'', NOW("]

--- a/odoo/http/retrying.py
+++ b/odoo/http/retrying.py
@@ -46,8 +46,9 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
         and the cursor are taken.
     """
     try:
-        for tryno in range(1, MAX_TRIES_ON_CONCURRENCY_FAILURE + 1):
-            tryleft = MAX_TRIES_ON_CONCURRENCY_FAILURE - tryno
+        tryno = 0
+        while True:
+            tryno += 1
             try:
                 result = func()
                 if not env.cr.closed:
@@ -61,8 +62,6 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
                 if env.cr.closed:
                     raise
                 env.cr.rollback()
-                env.transaction.reset()
-                env.registry.reset_changes()
                 if request:
                     # We need to reset the `session` attribute of `request`
                     # which may have been modified during the transaction.
@@ -93,6 +92,8 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
                     error = repr(exc)
                 else:
                     raise
+
+                tryleft = MAX_TRIES_ON_CONCURRENCY_FAILURE - tryno
                 if not tryleft:
                     _logger.info("%s, maximum number of tries reached!", error)
                     raise
@@ -101,19 +102,14 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
                 _logger.info("%s, %s tries left, try again in %.04f sec...",
                     error, tryleft, wait_time)
                 time.sleep(wait_time)
-        else:
-            # handled in the "if not tryleft" case
-            raise RuntimeError("unreachable")  # noqa: EM101, TRY301
+
+        if not env.cr.closed:
+            env.cr.commit()  # effectively commits and execute post-commits
+        return result
 
     except Exception:
         env.transaction.reset()
-        env.registry.reset_changes()
         raise
-
-    if not env.cr.closed:
-        env.cr.commit()  # effectively commits and execute post-commits
-    env.registry.signal_changes()
-    return result
 
 
 # ruff: noqa: E402

--- a/odoo/http/retrying.py
+++ b/odoo/http/retrying.py
@@ -21,7 +21,7 @@ MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
 """ How many times retrying() is allowed to retry. """
 
 
-def retrying[T](func: Callable[[], T], env: Environment) -> T:
+def retrying[T](func: Callable[[], T], env: Environment, *, close_on_commit: bool = True) -> T:
     """
     Call ``func``in a loop until the SQL transaction commits with no
     serialisation error. It rollbacks the transaction in between calls.
@@ -40,10 +40,11 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
     backoff: ``random.uniform(0.0, 2 ** i)`` where ``i`` is the n° of
     the current attempt and starts at 1.
 
-    :param callable func: The function to call, you can pass arguments
+    :param func: The function to call, you can pass arguments
         using :func:`functools.partial`.
-    :param odoo.api.Environment env: The environment where the registry
+    :param env: The environment where the registry
         and the cursor are taken.
+    :param close_on_commit: Close the cursor after committing
     """
     try:
         tryno = 0
@@ -104,6 +105,7 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
                 time.sleep(wait_time)
 
         if not env.cr.closed:
+            env.cr._closing = close_on_commit  # cursor should not be used after the commit
             env.cr.commit()  # effectively commits and execute post-commits
         return result
 

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -386,12 +386,13 @@ def serve_db(request: Request) -> Response:
         try:
             registry = Registry(request.db)
             cr = registry.cursor(readonly=True)
-            request.registry = registry.check_signaling(cr)
+            # check signaling
+            request.env = Environment(cr, request.session.uid, request.session.context)
+            request.registry = request.env.registry
         except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError) as e:
             raise RegistryError(f"Cannot get registry {request.db}") from e
 
         # find the controller endpoint to use
-        request.env = Environment(cr, request.session.uid, request.session.context)
         try:
             rule, args = request.registry['ir.http']._match(request.httprequest.path)
         except NotFound as not_found_exc:

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -269,7 +269,6 @@ def load_module_graph(
             package.state = 'installed'
             module.env.flush_all()
             module.env.cr.commit()
-            registry.signal_changes()
 
         test_time = 0.0
         test_queries = 0
@@ -397,6 +396,7 @@ def load_modules(
 
     report = registry._assertion_report
     env = api.Environment(cr, api.SUPERUSER_ID, {})
+    assert registry is env.registry, "Registry changed while loading!"
     load_module_graph(
         env,
         graph,
@@ -513,6 +513,8 @@ def load_modules(
     registry.finalize_constraints(cr)
 
     # STEP 4: Finish and cleanup installations
+    if update_module:
+        env.transaction.will_change_registry()
     if registry.updated_modules:
 
         cr.execute("SELECT model from ir_model")

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -731,21 +731,31 @@ class Transaction:
             env.__dict__.pop('_field_cache_memo', None)
 
     def clear(self):
-        """ Clear the caches and pending computations and updates in the transactions. """
-        self.invalidate_access_cache()
+        """ Clear the transaction data (for testing or internal).
+
+        Clear the caches and pending computations, access and updates in the
+        transaction and linked environments.
+        """
+        self.access_read.clear()  # faster invalidate_access_cache
         self.invalidate_field_data()
         self.field_data_patches.clear()
         self.field_dirty.clear()
         self.tocompute.clear()
+        self._recent_envs.clear()
         self.compactify_envs()
+        env = None
         for env in self.envs:
+            reset_cached_properties(env)
+        if env is not None:
+            # all envs of the transaction share the same cursor
             env.cr.cache.clear()
-            break  # all envs of the transaction share the same cursor
 
     def reset(self) -> None:
-        """ Reset the transaction.  This clears the transaction, and reassigns
-            the registry on all its environments.  This operation is strongly
-            recommended after reloading the registry.
+        """ Reset the transaction.
+
+        This clears the transaction, and reassigns the registry on all its
+        environments. Use it *only after a commit or rollback* when the registry
+        may have changed!
         """
         # get the registry and rebuild the stack of states
         self.registry = Registry(self.registry.db_name)
@@ -756,11 +766,6 @@ class Transaction:
                 registry_sequence=self._registry_sequence,
             ) for state in self._state_stack]
 
-        for env in self.envs:
-            reset_cached_properties(env)
-        self.access_read.clear()
-        # make all environments weak
-        self._recent_envs.clear()
         self.clear()
 
     @contextmanager
@@ -802,8 +807,6 @@ class Transaction:
             return
 
         self.clear()
-        for env in self.envs:
-            reset_cached_properties(env)
 
 
 class TransactionState(typing.NamedTuple):

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -66,6 +66,8 @@ class Environment(Mapping[str, "BaseModel"]):
         # determine transaction object
         transaction = cr.transaction
         if transaction is None:
+            if cr._closing:
+                _logger.error("The cursor is being closed, but starts a new transaction", stack_info=True)
             transaction = cr.transaction = Transaction(Registry(cr.dbname))
 
         # if env already exists, return it
@@ -773,7 +775,16 @@ class Transaction:
         """ Context for committing the connection. """
         assert not self._state_stack, "Pending savepoints not released, cannot commit!"
         yield
-        self.clear()
+
+        env = self.default_env or next(iter(self.envs), None)
+        cr = env.cr if env is not None else None
+        if cr is None or not cr._closing or cr.postcommit:
+            # if not closing or if we have some postcommit to execute,
+            # reset the cursor entirely
+            self.reset()
+        else:
+            # we are closing the cursor, just a quick clean-up
+            self.clear()
 
     @contextmanager
     def rollbacking(self):
@@ -781,6 +792,10 @@ class Transaction:
         assert not self._state_stack, "Pending savepoints not released, cannot rollback!"
         yield
         self.restore_state()
+
+    def _free_resources(self) -> None:
+        """ Free resources used by the transaction."""
+        self.default_env = None  # break the cyclic reference
 
     def save_state(self):
         """ Save the current state of the transaction for future restore. """
@@ -801,7 +816,10 @@ class Transaction:
         if self._state_stack:
             state = self._state_stack[-1]
             self.default_env = state.default_env
-        if self.registry.registry_sequence != self._registry_sequence:
+
+        env = self.default_env or next(iter(self.envs), None)
+        cr = env.cr if env is not None else None
+        if (cr is None or not cr._closing or cr.postrollback) and self.registry.registry_sequence != self._registry_sequence:
             # registry changed, reset the transaction
             self.reset()
             return

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -22,7 +22,7 @@ from odoo.tools.func import deprecated
 from odoo.tools.translate import get_translation, get_translated_module, LazyGettext
 from odoo.tools.misc import StackMap, SENTINEL
 
-from .registry import Registry
+from .registry import Registry, _CACHES_BY_KEY
 from .query import Query
 from .utils import SUPERUSER_ID
 
@@ -34,6 +34,7 @@ if typing.TYPE_CHECKING:
     from .types import BaseModel, Field
 
 _logger = logging.getLogger('odoo.api')
+_logger_signaling = logging.getLogger('odoo.registry')
 
 MAX_FIXPOINT_ITERATIONS = 10
 ENVS_SIZE = 20  # used as a reference size in a transaction's environments
@@ -69,11 +70,13 @@ class Environment(Mapping[str, "BaseModel"]):
             if cr._closing:
                 _logger.error("The cursor is being closed, but starts a new transaction", stack_info=True)
             transaction = cr.transaction = Transaction(Registry(cr.dbname))
+            transaction._check_signaling(cr)
 
-        # if env already exists, return it
-        env = transaction.lookup_env(uid, context, su)
-        if env is not None:
-            return env
+        else:
+            # if env already exists, return it
+            env = transaction.lookup_env(uid, context, su)
+            if env is not None:
+                return env
 
         # otherwise create environment, and add it in the set
         self = object.__new__(cls)
@@ -563,11 +566,27 @@ class Environment(Mapping[str, "BaseModel"]):
 
 
 class Transaction:
-    """ A object holding ORM data structures for a transaction. """
+    """ A object holding ORM data structures for a transaction.
+
+    Signaling summary:
+
+    - Creating the first `Environment` for a cursor triggers checks signaling.
+    - `cr.commit` signals changes and resets the transaction.
+    - `cr.rollback` resets the transaction without signaling.
+    - Resetting a transaction checks signaling unless we are closing the
+      cursor and won't be using the transaction anymore.
+
+    Notes:
+
+    - `transaction.will_change_registry()` before modifying registry
+    - `Registry.new` should be followed by `transaction.reset()`.
+
+    """
     __slots__ = (
         '_Transaction__file_open_tmp_paths',
-        '_cache', '_recent_envs', '_registry_sequence',
-        '_state_stack', '_weak_envs',
+        '_cache', '_recent_envs',
+        '_registry_invalidated', '_registry_sequence',
+        '_state_stack__', '_weak_envs',
         'access_read', 'default_env',
         'field_data', 'field_data_patches', 'field_dirty',
         'protected', 'registry', 'tocompute',
@@ -582,9 +601,10 @@ class Transaction:
 
         # default environment (for flushing)
         self.default_env: Environment | None = None
+        self._registry_invalidated: int = 0
         self._registry_sequence = registry.registry_sequence
         # transaction state manipulated by savepoints
-        self._state_stack: list[TransactionState] = []
+        self._state_stack__: list[TransactionState] = []
 
         # cache data {field: cache_data_managed_by_field} often uses a dict
         # to store a mapping from id to a value, but fields may use this field
@@ -707,6 +727,78 @@ class Transaction:
                 Environment(env.cr, public_user.id, {}).flush_all()
                 break
 
+    def _check_signaling(self, cr: BaseCursor) -> None:
+        """ Check the sequences in the database an invalidate accordingly.
+
+        When the registry changed, create a new registry and rebind to it.
+        Otherwise, invalidate named caches and their dependencies.
+        """
+        registry = self.registry
+        if not registry.ready:
+            _logger_signaling.debug("%s: skip check signaling, registry not ready", self.registry.db_name)
+            return
+
+        db_registry_sequence, db_cache_sequences = registry.get_sequences(cr)
+        changes = ''
+        # Check if the model registry must be reloaded
+        registry_sequence = registry.registry_sequence
+        if registry_sequence != db_registry_sequence:
+            _logger_signaling.info("Reloading the model registry after database signaling.")
+            self.registry = registry = Registry.new(registry.db_name)
+            if _logger_signaling.isEnabledFor(logging.DEBUG):
+                changes += "[Registry - %s -> %s]" % (registry_sequence, db_registry_sequence)
+        # Check if the model caches must be invalidated.
+        else:
+            invalidated = set()
+            for cache_name, expected_sequence in db_cache_sequences.items():
+                cache_sequence = registry.cache_sequences[cache_name]
+                if cache_sequence == expected_sequence:
+                    continue
+                registry.cache_sequences[cache_name] = expected_sequence
+                for name in _CACHES_BY_KEY[cache_name]:
+                    if '.' in name:
+                        registry.cache_sequences[name] = expected_sequence
+                    invalidated.add(name)
+                if _logger_signaling.isEnabledFor(logging.DEBUG):
+                    changes += "[Cache %s - %s -> %s]" % (cache_name, cache_sequence, expected_sequence)
+            self.registry.cache_invalidated.clear()
+            if invalidated:
+                _logger_signaling.info("Invalidating caches after database signaling: %s", sorted(invalidated))
+                caches = self.registry._Registry__caches
+                for name in sorted(invalidated):
+                    caches[name].clear()
+        if changes:
+            _logger_signaling.debug("Multiprocess signaling check: %s", changes)
+
+    def will_change_registry(self) -> None:
+        """ Invalidate the current registry.
+
+        Note: registry changes are not thread-safe.
+        """
+        self._registry_invalidated += 1
+
+    def _reset_registry_change(self):
+        """ When the registry was invalidated, re-setup models. """
+        if not self._registry_invalidated:
+            return
+
+        env = self.default_env or next(iter(self.envs), None)
+        if env is None:
+            raise RuntimeError("resetting registry changes, but no cursor found!")
+        cr = env.cr
+
+        # retrieve the latest registry sequence to avoid recreating the
+        # registry while checking signaling
+        registry = self.registry
+        new_sequence, _caches = registry.get_sequences(cr)
+        # if we are executing post-rollback and the registry sequence changed,
+        # skip resetup of the registry, a new one will be created
+        if cr._closing and registry.registry_sequence != new_sequence:
+            return
+        registry.registry_sequence = self._registry_sequence = new_sequence
+        registry._setup_models__(cr)
+        self._registry_invalidated = 0  # mark transaction with valid registry
+
     @deprecated("Since 20.0, renamed to invalidate_access_cache")
     def clear_access_cache(self, model_name: str = '') -> None:
         self.invalidate_access_cache(model_name)
@@ -755,41 +847,80 @@ class Transaction:
     def reset(self) -> None:
         """ Reset the transaction.
 
+        This is performed automatically after a commit or rollback!
+
         This clears the transaction, and reassigns the registry on all its
         environments. Use it *only after a commit or rollback* when the registry
         may have changed!
         """
         # get the registry and rebuild the stack of states
+        self._reset_registry_change()
         self.registry = Registry(self.registry.db_name)
         self._registry_sequence = self.registry.registry_sequence
-        self._state_stack = [
+        self._state_stack__ = [
             TransactionState(
                 default_env=state.default_env,
+                registry_invalidated=self._registry_invalidated,
                 registry_sequence=self._registry_sequence,
-            ) for state in self._state_stack]
+            ) for state in self._state_stack__]
 
         self.clear()
+
+        # recheck signaling for the ormcache
+        env = self.default_env or next(iter(self.envs), None)
+        if env is not None and not env.cr._closing:
+            self._check_signaling(env.cr)
 
     @contextmanager
     def committing(self):
         """ Context for committing the connection. """
-        assert not self._state_stack, "Pending savepoints not released, cannot commit!"
+        assert not self._state_stack__, "Pending savepoints not released, cannot commit!"
+        registry = self.registry
+        env = self.default_env or next(iter(self.envs), None)
+        if env is None:
+            _logger_signaling.debug("no cursor to flush signaling", stack_info=True)
+            self.flush()
+            yield
+            self.reset()
+            return
+        cr = env.cr
+        cr.flush()  # first flush remaining changes
+
+        # TODO move cache invalidation to transaction
+        names = set()
+        if self._registry_invalidated:
+            names.add('registry')
+        for cache_name in registry.cache_invalidated:
+            if '.' not in cache_name:
+                names.add(cache_name)
+            registry.cache_sequences[cache_name] += 1
+        registry._signal_changes(cr, names)
+        registry.cache_invalidated.clear()
+
         yield
 
-        env = self.default_env or next(iter(self.envs), None)
-        cr = env.cr if env is not None else None
-        if cr is None or not cr._closing or cr.postcommit:
-            # if not closing or if we have some postcommit to execute,
-            # reset the cursor entirely
+        # We can skip registry reuilding here... TODO why?
+        self._registry_invalidated = 0
+        if cr.postcommit:
+            # We have postcommit hooks, which can use the current cursor,
+            # so reset the transaction before running hooks; generally, the
+            # hook uses a new cursor. Since it uses a new cursor, rollback our
+            # cursor after the postcommit hook has been done to see changes.
+            # To reproduce, install l10n_be,l10n_us_1099 with demo data.
             self.reset()
-        else:
+        elif cr._closing:
             # we are closing the cursor, just a quick clean-up
             self.clear()
+        else:
+            # if not closing, reset the cursor entirely
+            # skip resetting the registry because the transaction should
+            # re-setup the registry correctly
+            self.reset()
 
     @contextmanager
     def rollbacking(self):
         """ Context for rollbacking the connection. """
-        assert not self._state_stack, "Pending savepoints not released, cannot rollback!"
+        assert not self._state_stack__, "Pending savepoints not released, cannot rollback!"
         yield
         self.restore_state()
 
@@ -800,36 +931,45 @@ class Transaction:
     def save_state(self):
         """ Save the current state of the transaction for future restore. """
         self.flush()
-        self._state_stack.append(TransactionState(
+        self._state_stack__.append(TransactionState(
             default_env=self.default_env,
+            registry_invalidated=self._registry_invalidated,
             registry_sequence=self._registry_sequence,
         ))
 
     def merge_state(self):
         """ Merge current state into the last saved state. """
-        assert self._state_stack, "no state to pop"
-        self._state_stack.pop()
+        assert self._state_stack__, "no state to pop"
+        self._state_stack__.pop()
 
     def restore_state(self):
         """ Restore the previously saved state of the transaction after
         rollback execution (on savepoint or connection). """
-        if self._state_stack:
-            state = self._state_stack[-1]
+        if self._state_stack__:
+            state = self._state_stack__[-1]
             self.default_env = state.default_env
+            registry_invalidated = state.registry_invalidated
+        else:
+            registry_invalidated = 0
 
         env = self.default_env or next(iter(self.envs), None)
         cr = env.cr if env is not None else None
         if (cr is None or not cr._closing or cr.postrollback) and self.registry.registry_sequence != self._registry_sequence:
             # registry changed, reset the transaction
             self.reset()
+            self._registry_invalidated = registry_invalidated
             return
 
         self.clear()
+        if self._registry_invalidated != registry_invalidated:
+            self._reset_registry_change()
+            self._registry_invalidated = registry_invalidated
 
 
 class TransactionState(typing.NamedTuple):
     """ The state of the transaction that can be stacked for savepoint operations. """
     default_env: Environment | None
+    registry_invalidated: int
     registry_sequence: int
 
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1087,7 +1087,7 @@ class BaseModel(metaclass=MetaModel):
             savepoint.rollback()
             ids = False
             # cancel all changes done to the registry/ormcache
-            self.pool.reset_changes()
+            self.env.transaction.reset()
         savepoint.close(rollback=False)
 
         nextrow = info['rows']['to'] + 1

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -1012,19 +1012,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
             caller_info = format_frame(inspect.currentframe().f_back)  # type: ignore
             _logger.debug('Invalidating %s model cache from %s', cache_name, caller_info)
 
-    def clear_all_caches(self) -> None:
-        """ Clear the caches associated to methods decorated with
-        ``tools.ormcache``.
-        """
-        for cache_name, caches in _CACHES_BY_KEY.items():
-            for cache in caches:
-                self.__caches[cache].clear()
-            self.cache_invalidated.add(cache_name)
-
-        caller_info = format_frame(inspect.currentframe().f_back)  # type: ignore
-        log = _logger.info if self.loaded else _logger.debug
-        log('Invalidating all model caches from %s', caller_info)
-
     def is_an_ordinary_table(self, model: BaseModel) -> bool:
         """ Return whether the given model has an ordinary table. """
         if self._ordinary_tables is None:

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -15,7 +15,7 @@ import typing
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Mapping
-from contextlib import closing, nullcontext, ExitStack
+from contextlib import closing, ExitStack
 from functools import partial
 from operator import attrgetter
 
@@ -261,8 +261,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
         registry = cls.registries[db_name]  # pylint: disable=unsubscriptable-object
 
         registry.ready = True
-        registry.registry_invalidated = bool(update_module)
-        registry.signal_changes()
 
         _logger.info("Registry loaded in %.3fs", time.time() - t0)
         return registry
@@ -325,10 +323,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self._is_modifying_relations: dict[Field, bool] = {}
 
         # Inter-process signaling:
-        # The `orm_signaling_registry` sequence indicates the whole registry
-        # must be reloaded.
-        # The `orm_signaling_... sequence` indicates the corresponding cache must be
-        # invalidated (i.e. cleared).
+        # The `orm_signaling_... sequence` indicates that the corresponding
+        # cache must be invalidated. The 'registry' sequence indicates that this
+        # registry must be rebuilt.
         self.registry_sequence: int = -1
         self.cache_sequences: dict[str, int] = {}
 
@@ -447,6 +444,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
         from .environments import Environment  # noqa: PLC0415
         env = Environment(cr, SUPERUSER_ID, {})
         env.invalidate_all()
+        if self.ready:
+            env.transaction.will_change_registry()
 
         # Uninstall registry hooks. Because of the condition, this only happens
         # on a fully loaded registry, and not on a registry being loaded.
@@ -461,7 +460,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
         reset_cached_properties(self)
         self._field_trigger_trees.clear()
         self._is_modifying_relations.clear()
-        self.registry_invalidated = True
 
         # model classes on which to *not* recompute field_depends[_context]
         models_field_depends_done = set()
@@ -787,6 +785,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         from .environments import Environment  # noqa: PLC0415
         env = Environment(cr, SUPERUSER_ID, context)
         models = [env[model_name] for model_name in model_names]
+        env.transaction.will_change_registry()
 
         try:
             self._post_init_queue: deque[Callable] = deque()
@@ -1030,15 +1029,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
         return model._table in self._ordinary_tables
 
     @property
-    def registry_invalidated(self) -> bool:
-        """ Determine whether the current thread has modified the registry. """
-        return getattr(self._invalidation_flags, 'registry', False)
-
-    @registry_invalidated.setter
-    def registry_invalidated(self, value: bool):
-        self._invalidation_flags.registry = value
-
-    @property
     def cache_invalidated(self) -> set[str]:
         """ Determine whether the current thread has modified the cache. """
         try:
@@ -1049,6 +1039,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
 
     def setup_signaling(self) -> None:
         """ Setup the inter-process signaling on this registry. """
+        assert self.registry_sequence < 0 and not self.cache_sequences, "Setup signaling already performed"
         with self.cursor() as cr:
             # The `orm_signaling_registry` sequence indicates when the registry
             # must be reloaded.
@@ -1072,10 +1063,13 @@ class Registry(Mapping[str, type["BaseModel"]]):
 
             db_registry_sequence, db_cache_sequences = self.get_sequences(cr)
             self.registry_sequence = db_registry_sequence
-            self.cache_sequences.update(db_cache_sequences)
+            self.cache_sequences = {
+                name: db_cache_sequences.get(name) or 0
+                for name in _REGISTRY_CACHES
+            }
 
             _logger.debug("Multiprocess load registry signaling: [Registry: %s] %s",
-                          self.registry_sequence, ' '.join('[Cache %s: %s]' % cs for cs in self.cache_sequences.items()))
+                          db_registry_sequence, ' '.join('[Cache %s: %s]' % cs for cs in db_cache_sequences.items()))
 
     def get_sequences(self, cr: BaseCursor) -> tuple[int, dict[str, int]]:
         signaling_tables = tuple(f'orm_signaling_{cache_name}' for cache_name in ['registry', *_CACHES_BY_KEY])
@@ -1089,79 +1083,25 @@ class Registry(Mapping[str, type["BaseModel"]]):
             cr._now = now
         return registry_sequence, cache_sequences
 
-    def check_signaling(self, cr: BaseCursor | None = None) -> Registry:
-        """ Check whether the registry has changed, and performs all necessary
-        operations to update the registry. Return an up-to-date registry.
-        """
-        with nullcontext(cr) if cr is not None else closing(self.cursor(readonly=True)) as cr:
-            assert cr is not None
-            db_registry_sequence, db_cache_sequences = self.get_sequences(cr)
-            changes = ''
-            # Check if the model registry must be reloaded
-            if self.registry_sequence != db_registry_sequence:
-                _logger.info("Reloading the model registry after database signaling.")
-                old_sequence = self.registry_sequence
-                self = Registry.new(self.db_name)
-                if _logger.isEnabledFor(logging.DEBUG):
-                    changes += "[Registry - %s -> %s]" % (old_sequence, self.registry_sequence)
-            # Check if the model caches must be invalidated.
-            else:
-                invalidated = []
-                for cache_name, cache_sequence in self.cache_sequences.items():
-                    expected_sequence = db_cache_sequences[cache_name]
-                    if cache_sequence != expected_sequence:
-                        for cache in _CACHES_BY_KEY[cache_name]: # don't call clear_cache to avoid signal loop
-                            if cache not in invalidated:
-                                invalidated.append(cache)
-                                self.__caches[cache].clear()
-                        self.cache_sequences[cache_name] = expected_sequence
-                        if _logger.isEnabledFor(logging.DEBUG):
-                            changes += "[Cache %s - %s -> %s]" % (cache_name, cache_sequence, expected_sequence)
-                if invalidated:
-                    _logger.info("Invalidating caches after database signaling: %s", sorted(invalidated))
-            if changes:
-                _logger.debug("Multiprocess signaling check: %s", changes)
-        return self
-
-    def signal_changes(self) -> None:
+    def _signal_changes(self, cr: BaseCursor, names: Collection[str]) -> None:
         """ Notifies other processes if registry or cache has been invalidated. """
-        if self.registry_invalidated:
+        if not names:
+            return
+        if 'registry' in names:
             _logger.info("Registry changed, signaling through the database")
-            with self.cursor() as cr:
-                cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
-                # If another process concurrently updates the registry,
-                # self.registry_sequence will actually be out-of-date,
-                # and the next call to check_signaling() will detect that and trigger a registry reload.
-                # otherwise, self.registry_sequence should be equal to cr.fetchone()[0]
-                self.registry_sequence += 1
+            cr.execute("INSERT INTO orm_signaling_registry DEFAULT VALUES")
+            # If another process concurrently updates the registry, the sequence
+            # will actually be out-of-date, and the next call to
+            # _check_signaling() will detect that and trigger a registry reload.
+            return
 
-        # no need to notify cache invalidation in case of registry invalidation,
-        # because reloading the registry implies starting with an empty cache
-        elif self.cache_invalidated:
-            _logger.info("Caches invalidated, signaling through the database: %s", sorted(self.cache_invalidated))
-            with self.cursor() as cr:
-                for cache_name in self.cache_invalidated:
-                    cr.execute(SQL("INSERT INTO %s DEFAULT VALUES", SQL.identifier(f'orm_signaling_{cache_name}')))
-                    # If another process concurrently updates the cache,
-                    # self.cache_sequences[cache_name] will actually be out-of-date,
-                    # and the next call to check_signaling() will detect that and trigger cache invalidation.
-                    # otherwise, self.cache_sequences[cache_name] should be equal to cr.fetchone()[0]
-                    self.cache_sequences[cache_name] += 1
-
-        self.registry_invalidated = False
-        self.cache_invalidated.clear()
-
-    def reset_changes(self) -> None:
-        """ Reset the registry and cancel all invalidations. """
-        if self.registry_invalidated:
-            with closing(self.cursor()) as cr:
-                self._setup_models__(cr)
-                self.registry_invalidated = False
-        if self.cache_invalidated:
-            for cache_name in self.cache_invalidated:
-                for cache in _CACHES_BY_KEY[cache_name]:
-                    self.__caches[cache].clear()
-            self.cache_invalidated.clear()
+        names = sorted(names)
+        _logger.info("Caches invalidated, signaling through the database: %s", names)
+        # If another process concurrently updates the cache, the sequences
+        # will actually be out-of-date, and the next call to
+        # _check_signaling() will detect use the new sequence.
+        for cache_name in names:
+            cr.execute(SQL("INSERT INTO %s DEFAULT VALUES", SQL.identifier(f'orm_signaling_{cache_name}')))
 
     def cursor(self, /, readonly: bool = False) -> BaseCursor:
         """ Return a new cursor for the database. The cursor itself may be used

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -97,7 +97,7 @@ def dispatch(method, params):
 
 def execute_cr(cr, uid, obj, method, args, kw):
     env = api.Environment(cr, uid, {})
-    env.transaction.reset()  # clean cache etc if we retry the same transaction
+    env.transaction.reset()  # clean cache, rebind to registry if we retry the same transaction
     env.transaction.default_env = env  # ensure this is the default env for the call
     recs = env.get(obj)
     if recs is None:

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -72,27 +72,20 @@ def dispatch(method, params):
     # access checked once we open a cursor
 
     threading.current_thread().uid = uid
-    registry = Registry(db).check_signaling()
-    try:
-        if method == 'execute':
+    if method == 'execute':
+        kw = {}
+    elif method == 'execute_kw':
+        # accept: (args, kw=None)
+        if len(args) == 1:
+            args += ({},)
+        args, kw = args
+        if kw is None:
             kw = {}
-        elif method == 'execute_kw':
-            # accept: (args, kw=None)
-            if len(args) == 1:
-                args += ({},)
-            args, kw = args
-            if kw is None:
-                kw = {}
-        else:
-            raise NameError(f"Method not available {method}")  # noqa: TRY301
-        with registry.cursor() as cr:
-            api.Environment(cr, api.SUPERUSER_ID, {})['res.users']._check_uid_passwd(uid, passwd)
-            res = execute_cr(cr, uid, model, method_, args, kw)
-        registry.signal_changes()
-    except Exception:
-        registry.reset_changes()
-        raise
-    return res
+    else:
+        raise NameError(f"Method not available {method}")  # noqa: TRY301
+    with Registry(db).cursor() as cr:
+        api.Environment(cr, api.SUPERUSER_ID, {})['res.users']._check_uid_passwd(uid, passwd)
+        return execute_cr(cr, uid, model, method_, args, kw)
 
 
 def execute_cr(cr, uid, obj, method, args, kw):

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1655,6 +1655,7 @@ def preload_registries(dbnames):
                     if post_install_suite.has_http_case():
                         with registry.cursor() as cr:
                             env = api.Environment(cr, api.SUPERUSER_ID, {})
+                            env.registry._assertion_report = registry._assertion_report
                             env['ir.qweb']._pregenerate_assets_bundles()
                     result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
                     registry._assertion_report.update(result)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1085,7 +1085,8 @@ class PreforkServer(CommonServer):
                 return
             for registry in registries.values():
                 with registry.cursor() as cr:
-                    registry.check_signaling(cr)
+                    # check signaling by instantiating an environment
+                    api.Environment(cr, api.SUPERUSER_ID, {})
             registries.clear()
             # Close all opened cursors
             sql_db.close_all()

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -255,6 +255,7 @@ class Cursor(_CursorProtocol):
         # avoid the call of close() (by __del__) if an exception
         # is raised by any of the following initializations
         self._closed: bool = True
+        self._closing: bool = False
 
         self.dbname = dbname
         self._cnx = cnx
@@ -306,6 +307,7 @@ class Cursor(_CursorProtocol):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self._closing = True
         try:
             if exc_type is None and not self.closed:
                 self.commit()
@@ -465,6 +467,7 @@ class Cursor(_CursorProtocol):
             _logger.setLevel(level)
 
     def close(self) -> None:
+        self._closing = True
         if self._closed:
             return
 
@@ -472,11 +475,6 @@ class Cursor(_CursorProtocol):
         # logic.
         try:
             self.rollback()
-            if self.transaction is not None:
-                self.transaction.default_env = None  # break the cyclic reference
-                self.transaction.reset()
-
-            self.cache.clear()
 
         except psycopg2.InterfaceError:
             # mask 'connection already closed' error
@@ -484,30 +482,39 @@ class Cursor(_CursorProtocol):
                 raise
 
         finally:
-            # The connection may have been closed, so give it back in finally block.
-            self._closed = True
+            # Close even if we had failures during rollback
+            if not self._closed:
+                self._close()
 
-            # Advanced stats only at logging.DEBUG level
-            if _logger.isEnabledFor(logging.DEBUG):
-                self.print_log()
+    def _close(self) -> None:
+        # The connection may have been closed, so give it back in finally block.
+        assert not self._closed, "Connection already closed"
+        self._closed = True
 
-            # This force the cursor to be freed, and thus, available again. It is
-            # important because otherwise we can overload the server very easily
-            # because of a cursor shortage (because cursors are not garbage
-            # collected as fast as they should). The problem is probably due in
-            # part because browse records keep a reference to the cursor.
-            self._obj.close()
-            del self._obj
+        # Advanced stats only at logging.DEBUG level
+        if _logger.isEnabledFor(logging.DEBUG):
+            self.print_log()
 
-            # Put the connection back to the pool
-            # Forget already closed connections and system-related databases
-            keep_in_pool = not self._cnx.closed and self.dbname not in (
-                'template0', 'template1',
-                # keep open if one of preloaded databases
-                config['db_system'] if config['db_system'] not in config['db_name'] else '',
-                config['db_template'],
-            )
-            self._cnx.give_back(keep_in_pool=keep_in_pool)
+        # This force the cursor to be freed, and thus, available again. It is
+        # important because otherwise we can overload the server very easily
+        # because of a cursor shortage (because cursors are not garbage
+        # collected as fast as they should). The problem is probably due in
+        # part because browse records keep a reference to the cursor.
+        self._obj.close()
+        del self._obj
+
+        # Put the connection back to the pool
+        # Forget already closed connections and system-related databases
+        keep_in_pool = not self._cnx.closed and self.dbname not in (
+            'template0', 'template1',
+            # keep open if one of preloaded databases
+            config['db_system'] if config['db_system'] not in config['db_name'] else '',
+            config['db_template'],
+        )
+        self._cnx.give_back(keep_in_pool=keep_in_pool)
+
+        if self.transaction is not None:
+            self.transaction._free_resources()
 
     def commit(self) -> None:
         """ Commit the current transaction. """
@@ -518,6 +525,8 @@ class Cursor(_CursorProtocol):
             self._now = None
         self.prerollback.clear()
         self.postrollback.clear()
+        if self._closing:
+            self._close()
         self.postcommit.run()
 
     def rollback(self) -> None:
@@ -529,6 +538,8 @@ class Cursor(_CursorProtocol):
         with rollbacking:
             self._cnx.rollback()
             self._now = None
+        if self._closing:
+            self._close()
         self.postrollback.run()
 
     def __getattr__(self, name):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1065,6 +1065,13 @@ class BaseCase(case.TestCase):
             return BinaryBytes(f.read())
 
     @classmethod
+    def drop_ormcaches(cls) -> None:
+        """ Remove all data in ORM caches without signaling, just like in a new Registry. """
+        _logger.debug("Clearing all ORM caches")
+        for lru in cls.registry._Registry__caches.values():
+            lru.clear()
+
+    @classmethod
     def _registry_test_mode_patches(cls, *, cr: Cursor, registry: Registry):
         """
         Returns the patches required for entering registry test mode.
@@ -1340,7 +1347,7 @@ class TransactionCase(BaseCase):
             cls.registry.registry_invalidated = cls.registry_start_invalidated
             cls.registry.registry_sequence = cls.registry_start_sequence
             with cls.muted_registry_logger:
-                cls.registry.clear_all_caches()
+                cls.drop_ormcaches()
             cls.registry.cache_invalidated.clear()
             cls.registry.cache_sequences = cls.registry_cache_sequences
         cls.addClassCleanup(reset_changes)
@@ -1410,7 +1417,7 @@ class TransactionCase(BaseCase):
 
         self.addCleanup(_check_registry_lock)
 
-        self.addCleanup(self.muted_registry_logger(self.registry.clear_all_caches))
+        self.addCleanup(self.drop_ormcaches)
 
         # flush everything in setUpClass before introducing a savepoint
         cr = self.cr

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -152,6 +152,7 @@ class RegistryRLock(threading._RLock):
 # Further filtering on cursors can be done by extending `assertCanOpenTestCursor`.
 _registry_test_lock = RegistryRLock()
 _registry_test_lock.acquire()
+_disable_flushing_cursor = False
 
 
 @contextmanager
@@ -174,6 +175,12 @@ def flushing_cursor(cr: Cursor):
     changes made on the main cursor. You can still continue using the main
     cursor inside the block, it will be flushed on exit and then reset.
     """
+    if _disable_flushing_cursor:
+        # execution of wkhtml happens in parallel, we don't want to flush the
+        # cursor in that case
+        yield
+        return
+
     # simulating a cr.commit()
     cr.flush()
     if cr.transaction is None:  # no environment to clear
@@ -1453,7 +1460,11 @@ class TransactionCase(BaseCase):
             old_run_wkhtmltopdf = ir_actions_report._run_wkhtmltopdf
 
             def _patched_run_wkhtmltopdf(args):
-                with patch.object(self, 'http_request_key', 'wkhtmltopdf'), release_test_lock():
+                with (
+                    patch.object(self, 'http_request_key', 'wkhtmltopdf'),
+                    release_test_lock(),
+                    patch('odoo.tests.common._disable_flushing_cursor', True),
+                ):
                     args = ['--cookie', TEST_CURSOR_COOKIE_NAME, 'wkhtmltopdf', *args]
                     return old_run_wkhtmltopdf(args)
 
@@ -2544,7 +2555,11 @@ class HttpCase(TransactionCase):
         old_run_wkhtmltopdf = ir_actions_report._run_wkhtmltopdf
 
         def _patched_run_wkhtmltopdf(args):
-            with patch.object(self, 'http_request_key', 'wkhtmltopdf'), release_test_lock():
+            with (
+                patch.object(self, 'http_request_key', 'wkhtmltopdf'),
+                release_test_lock(),
+                patch('odoo.tests.common._disable_flushing_cursor', True),
+            ):
                 args = ['--cookie', TEST_CURSOR_COOKIE_NAME, 'wkhtmltopdf', *args]
                 return old_run_wkhtmltopdf(args)
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1358,8 +1358,7 @@ class TransactionCase(BaseCase):
             cls.registry.registry_invalidated = False
             cls.registry.cache_invalidated.clear()
 
-        cls._signal_changes_patcher = patch.object(cls.registry, 'signal_changes', signal_changes)
-        cls.startClassPatcher(cls._signal_changes_patcher)
+        cls.startClassPatcher(patch.object(cls.registry, 'signal_changes', signal_changes))
 
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(typing.cast('Cursor', cls.cr).close)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -39,7 +39,6 @@ from datetime import datetime
 from functools import cache, partial, wraps
 from itertools import islice, zip_longest
 from textwrap import shorten
-from typing import TYPE_CHECKING
 from unittest import TestResult
 from unittest.mock import Mock, _patch, patch
 from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
@@ -84,8 +83,6 @@ from . import case, test_cursor
 from odoo.addons.base.models import ir_actions_report
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable
-if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from .result import OdooTestResult
@@ -175,29 +172,42 @@ def flushing_cursor(cr: Cursor):
     changes made on the main cursor. You can still continue using the main
     cursor inside the block, it will be flushed on exit and then reset.
     """
+    assert isinstance(odoo.modules.module.current_test, TransactionCase), "only available for TransactionCase"
+
     if _disable_flushing_cursor:
         # execution of wkhtml happens in parallel, we don't want to flush the
         # cursor in that case
         yield
         return
 
-    # simulating a cr.commit()
-    cr.flush()
     if cr.transaction is None:  # no environment to clear
+        cr.flush()
         yield
         return
 
-    registry = cr.transaction.registry
-    if registry.cache_invalidated:
-        registry.signal_changes()
-    cr.transaction.clear()
+    # simluate cr.commit()
+    state_stack, closing = cr.transaction._state_stack__, cr._closing
+    try:
+        cr._closing = True  # do a quick clean
+        cr.transaction._state_stack__ = []  # replace the stack
+        with cr.transaction.committing():
+            pass  # no real commit
+    finally:
+        cr.transaction._state_stack__ = state_stack
+        cr._closing = closing
 
     yield
 
-    # flush and invalidate changes made by the main cursor
-    cr.transaction.default_env.invalidate_all(flush=True)
-    # then reset it to start fresh
-    cr.transaction.reset()
+    # simulate cr.commit() again to flush changes made by the main cursor
+    state_stack, closing = cr.transaction._state_stack__, cr._closing
+    try:
+        cr._closing = False  # do a reset
+        cr.transaction._state_stack__ = []  # replace the stack
+        with cr.transaction.committing():
+            pass  # no real commit
+    finally:
+        cr.transaction._state_stack__ = state_stack
+        cr._closing = closing
 
 
 def standalone(*tags):
@@ -1086,8 +1096,7 @@ class BaseCase(case.TestCase):
             patch.object(registry, 'cursor', _patched_cursor),
             # Disable locking and signaling
             patch.object(Registry, '_lock', DummyRLock()),
-            patch.object(registry, 'setup_signaling', return_value=None), #noop
-            patch.object(registry, 'check_signaling', return_value=registry),
+            patch.object(registry, 'setup_signaling', return_value=None),  # noop
         ]
 
     @classmethod
@@ -1301,7 +1310,6 @@ class Approx:  # noqa: PLW1641
         return self.cmp(self.value, other) == 0
 
 
-
 class TransactionCase(BaseCase):
     """ Test class in which all test methods are run in a single transaction,
     but each test method is run in a sub-transaction managed by a savepoint.
@@ -1315,7 +1323,7 @@ class TransactionCase(BaseCase):
     After being run, each test method cleans up the record cache and the
     registry cache. However, there is no cleanup of the registry models and
     fields. If a test modifies the registry (custom models and/or fields), it
-    should prepare the necessary cleanup (`self.registry.reset_changes()`).
+    should prepare the necessary cleanup (`self.env.transaction.will_change_registry()`).
     """
     muted_registry_logger = mute_logger(odoo.orm.registry._logger.name)
     freeze_time = None
@@ -1327,45 +1335,49 @@ class TransactionCase(BaseCase):
         # they can addup during test and take some disc space.
         # since cron are not running during tests, we need to gc manually
         # We need to check the status of the file system outside of the test cursor
-        with Registry(get_db_name()).cursor() as cr:
+        with cls.registry.cursor() as cr:
             gc_env = api.Environment(cr, api.SUPERUSER_ID, {})
             gc_env['ir.attachment']._gc_file_store_unsafe()
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.addClassCleanup(cls._gc_filestore)
         cls.registry = Registry(get_db_name())
-        cls.registry_start_invalidated = cls.registry.registry_invalidated
-        cls.registry_start_sequence = cls.registry.registry_sequence
-        cls.registry_cache_sequences = dict(cls.registry.cache_sequences)
+        registry_start_sequence = cls.registry.registry_sequence
 
-        def reset_changes():
-            if (cls.registry_start_sequence != cls.registry.registry_sequence) or cls.registry.registry_invalidated:
-                with cls.registry.cursor() as cr:
-                    cls.registry._setup_models__(cr)
-            cls.registry.registry_invalidated = cls.registry_start_invalidated
-            cls.registry.registry_sequence = cls.registry_start_sequence
-            with cls.muted_registry_logger:
+        def reset_registry_changes(*a, drop_caches=False, **kw):
+            nonlocal registry_start_sequence
+            registry = cls.registry
+            setup_registry = registry_start_sequence != registry.registry_sequence
+            with contextlib.closing(registry.cursor(readonly=not setup_registry)) as cr:
+                seq, _cache_sequences = registry.get_sequences(cr)
+                registry_start_sequence = registry.registry_sequence = seq
+                if setup_registry:
+                    _logger.info("Setup registry models during testing")
+                    registry._setup_models__(cr)
+            if drop_caches:
                 cls.drop_ormcaches()
-            cls.registry.cache_invalidated.clear()
-            cls.registry.cache_sequences = cls.registry_cache_sequences
-        cls.addClassCleanup(reset_changes)
+            return registry
 
-        def signal_changes():
-            if not cls.registry.ready:
-                _logger.info('Skipping signal changes during tests')
-                return
-            if cls.registry.registry_invalidated or cls.registry.cache_invalidated:
+        cls.startClassPatcher(patch.object(Registry, 'new', reset_registry_changes))
+        cls.addClassCleanup(cls._gc_filestore)
+        cls.addClassCleanup(reset_registry_changes, drop_caches=True)
+
+        def signal_changes(cr, names):
+            if 'registry' in names:
+                if not cls.registry.ready:
+                    _logger.info('Skipping signal changes during tests')
+                    return
                 _logger.info('Simulating signal changes during tests')
-            if cls.registry.registry_invalidated:
                 cls.registry.registry_sequence += 1
-            for cache_name in cls.registry.cache_invalidated or ():
-                cls.registry.cache_sequences[cache_name] += 1
-            cls.registry.registry_invalidated = False
-            cls.registry.cache_invalidated.clear()
+                for key, seq in cls.registry.cache_sequences.items():
+                    cls.registry.cache_sequences[key] = seq + 1
+            elif names:
+                _logger.debug('Simulating signal changes during tests')
+                for name in names:
+                    cls.registry.cache_sequences[name] += 1
 
-        cls.startClassPatcher(patch.object(cls.registry, 'signal_changes', signal_changes))
+        cls.startClassPatcher(patch.object(cls.registry, '_signal_changes', signal_changes))
 
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(typing.cast('Cursor', cls.cr).close)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1091,6 +1091,7 @@ class BaseCase(case.TestCase):
             return test_cursor.TestCursor(
                 cr, _registry_test_lock, readonly and cls._registry_readonly_enabled
             )
+
         return [
             # New cursor should point to the test's cursor
             patch.object(registry, 'cursor', _patched_cursor),
@@ -1377,7 +1378,11 @@ class TransactionCase(BaseCase):
                 for name in names:
                     cls.registry.cache_sequences[name] += 1
 
+        def get_sequences(cr):
+            return cls.registry.registry_sequence, cls.registry.cache_sequences.copy()
+
         cls.startClassPatcher(patch.object(cls.registry, '_signal_changes', signal_changes))
+        cls.startClassPatcher(patch.object(cls.registry, 'get_sequences', get_sequences))
 
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(typing.cast('Cursor', cls.cr).close)

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -64,6 +64,11 @@ class TestCursor(Cursor):
                 and last_cursor._cnx._savepoint
             ):
                 raise Exception('Opening a read/write test cursor from a readonly one')  # noqa: TRY301
+            # Flush the main cursor
+            from .common import flushing_cursor  # noqa: PLC0415
+            flushing = flushing_cursor(cursor)
+            flushing.__enter__()
+            self._cnx._when_closed = lambda: flushing.__exit__(None, None, None)
         except Exception:
             self._lock.release()
             raise
@@ -116,12 +121,14 @@ class MockedPsycoConnection(_base_PsycoConnection):
         # savepoint at its last commit. This savepoint is created lazily.
         self._savepoint: Savepoint | None = None
         self._obj = None
+        self._when_closed = lambda: None
 
     def set_session(self, *a, **kw):
         pass  # ignoring
 
     def give_back(self, keep_in_pool=True):
         del self._obj
+        self._when_closed()
 
     def _check_savepoint(self) -> None:
         if self._savepoint:

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -83,11 +83,9 @@ class TestCursor(Cursor):
         self._cnx._check_savepoint()
         return super().execute(*args, **kwargs)
 
-    def close(self):
-        if self._closed:
-            return
+    def _close(self):
         try:
-            super().close()
+            super()._close()
         finally:
             tos = self._cursors_stack.pop()
             if tos is not self:
@@ -104,7 +102,8 @@ class TestCursor(Cursor):
         super().rollback()
         # rollback again to release the savepoint that may be created during
         # reset of the registry (after the rollback) which may perform queries
-        self._cnx.rollback()
+        if not self.closed:
+            self._cnx.rollback()
 
     def now(self) -> datetime:
         """ Return the transaction's timestamp ``datetime.now()``. """


### PR DESCRIPTION
Move the implementation of cache and registry invalidation to the
Transaction object where they can be performed automatically.

Behavior is now tied to the transaction lifecycle:

- Creating the first `Environment` for a cursor triggers checks signaling.
- `cr.commit` signals changes and resets the transaction.
- `cr.rollback` resets the transaction without signaling.
- Resetting a transaction checks signaling unless we are closing the
  cursor and won't be using the transaction anymore.

This means that the following code handles all signaling correctly:

```py
with cursor() as cr:  # signal or reset on exit
  env = api.Environment(cr, ...)  # check signaling
  cr.commit()  # signal changes and reset transaction
  cr.rollback()  # reset changes and transaction
```

Registry-specific notes:

- When creating a new registry via `Registry.new`, the transaction must
  still be manually reset using
  `transaction.reset(skip_reset_registry=True)`. We skip reset because
  a new registry was just built.
- `registry_invalidated` flag is replaced by a call to
  `transaction.will_change_registry()` that should be performed before
  making changes.
- The registry still implement how changes are signaled.

Testing notes:

- Signaling is patched for `TransactionCase` and test cursors.
- In `flushing_cursor`, an entire commit is simulated to validate
  signaling and transaction reset behavior. We need to patch the
  transaction so that it is not aware that we are inside a savepoint
  used for testing.


https://github.com/odoo/enterprise/pull/111436
task-6116958

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
