### PR TITLE
[FIX] stock_dropshipping,purchase_stock: prevent traceback when mixing date type

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -344,11 +344,11 @@ class PurchaseOrderLine(models.Model):
         # This way, we shoud not lose any valuable information.
         if line_description and product_id.name != line_description:
             res['name'] = (res['name'] + '\n' + line_description).strip()
-        res['date_planned'] = values.get('date_planned')
+        res['date_planned'] = fields.Datetime.to_datetime(values.get('date_planned'))
         # The date must be day before or equal at the supplier target day
         if po.partner_id.group_rfq == 'week' and po.partner_id.group_on != 'default':
             delta_days = (7 + int(po.partner_id.group_on) - res['date_planned'].isoweekday()) % 7
-            res['date_planned'] = fields.Datetime.to_datetime(res['date_planned']) + relativedelta(days=delta_days)
+            res['date_planned'] = res['date_planned'] + relativedelta(days=delta_days)
             if not po.date_planned or po.date_planned >= res['date_planned']:
                 # date_order was computed based on procurement date_planned. If the PO date_planned is
                 # shifted, we also need to shift the date_order.

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+from freezegun import freeze_time
+
 from odoo import Command
 
 from odoo.tests import common, tagged, Form
@@ -459,6 +462,46 @@ class TestDropship(common.TransactionCase):
         po = sorted(sale_order._get_purchase_orders(), key=lambda order: order.id)
         self.assertEqual(len(po), 2)
         self.assertEqual(po[1].order_line.product_uom_qty, 2)
+
+    @freeze_time('2026-01-01')
+    def test_mixed_dropship_product_sale_order(self):
+        """Test confirming an SO with both dropship and dropship+subscription products
+        and ensure the expected purchase line dates are correctly set."""
+        if self.env['ir.module.module']._get('sale_subscription').state != 'installed':
+            self.skipTest('This test requires the following module: sale_subscription')
+        self.dropship_product.route_ids = [Command.set(self.dropshipping_route.ids)]
+        subscription_dropship_product = self.env['product.product'].create({
+            'name': 'Subscription Dropship Product',
+            'recurring_invoice': True,
+            'route_ids': [Command.set(self.dropshipping_route.ids)],
+            'seller_ids': [Command.create({
+                'partner_id': self.supplier.id,
+                'price': 100.0,
+            })],
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({
+                    'name': self.dropship_product.name,
+                    'product_id': self.dropship_product.id,
+                    'product_uom_qty': 2.0,
+                }),
+                Command.create({
+                    'name': subscription_dropship_product.name,
+                    'product_id': subscription_dropship_product.id,
+                    'product_uom_qty': 1.0,
+                }),
+            ],
+        })
+        sale_order.plan_id = sale_order.plan_id.create({})
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.state, 'sale')
+        po = sale_order._get_purchase_orders()
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.dropship_product.id, 'date_planned': datetime(2026, 1, 1)},
+            {'product_id': subscription_dropship_product.id, 'date_planned': datetime(2026, 1, 1)},
+        ])
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
**Steps to reproduce:**
* Install *sale_management*, *sale_subscription*, and *stock* modules.
* Go to *Settings* and enable *Dropshipping*.
* Create two products:
  * One *normal dropship* product.
  * One *dropship + subscription* product.
* Create a *Quotation*.
  Add both products to the order.
* Confirm the quotation.

**Observed behavior:**
* A traceback occurs during confirmation:
   File '/home/odoo/workspace/odoo19/odoo/addons/purchase_stock/models/stock_rule.py', line 159, in _run_buy
    date_planned = po.date_planned or min(v['date_planned'] for v in po_line_values)
TypeError: can't compare datetime.datetime to datetime.date

**Cause:**
* In *_run_buy*, the system computes the earliest *date_planned* using:
https://github.com/odoo/odoo/blob/4056fa8036ddad11c898cd775b7fa21ba4f8a5de/addons/purchase_stock/models/stock_rule.py#L159
* Subscription products set *date_planned* as *datetime.date*,
https://github.com/odoo/enterprise/blob/a88c64a224805d95b60a20c502428897655dba53/sale_subscription_stock/models/sale_order_line.py#L153
`current_period_start = self.order_id.last_invoice_date or
self.order_id.start_date or fields.Date.today()`
*  while normal products set *date_planned* as *datetime.datetime*.
https://github.com/odoo/odoo/blob/4056fa8036ddad11c898cd775b7fa21ba4f8a5de/addons/sale_stock/models/sale_order_line.py#L286

before min() It call  `_prepare_purchase_order_line_from_procurement`,
the value is assigned directly from `values.get('date_planned')`, and conversion
with `fields.Datetime.to_datetime()` only happens conditionally:
https://github.com/odoo/odoo/blob/98e6e929bf8e0c34ec77fb9d07ef253e0abf681c/addons/purchase_stock/models/purchase_order_line.py#L347-L351
As a result, some values remain `date` while others are `datetime`,

* When both are present in *po_line_values*, Python cannot compare the
  two types, causing the crash.

**Fix:**

So by moving the `fields.Datetime.to_datetime()` cast to the initial
assignment of `res['date_planned']`, so it is always a `datetime`
regardless of the source, and removing the now-redundant cast inside
the `if` block.

---

opw-6034079

---

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr