### PR TITLE
[FIX] web_editor: handle caption correctly for display:block images

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -92,7 +92,7 @@ export class CaptionPlugin extends Plugin {
         if (!image) {
             return;
         }
-        const block = closestBlock(image);
+        const block = closestBlock(image.parentElement);
         return (
             block.nodeName === "FIGURE" && !!block.querySelector("[data-embedded='caption'] input")
         );
@@ -118,16 +118,12 @@ export class CaptionPlugin extends Plugin {
         // Move the image within a figure element.
         const figure = this.document.createElement("figure");
         const link = image.parentElement.nodeName === "A" && image.parentElement;
-        if (link && (link.previousSibling || link.nextSibling)) {
+        const target = link || image;
+        const blockEl = closestBlock(target.parentElement);
+        if ((target.nextSibling || target.previousSibling) && isParagraphRelatedElement(blockEl)) {
             // <p>wx<a><img/></a>yz</p> => <p>wx</p><p><a><img/></a></p><p>yz</p>
-            this.dependencies.split.splitAroundUntil(link, closestBlock(link));
-        } else if (
-            !link &&
-            (image.previousSibling || image.nextSibling) &&
-            isParagraphRelatedElement(closestBlock(image))
-        ) {
             // <p>wx<img/>yz</p> => <p>wx</p><p><img/></p><p>yz</p>
-            this.dependencies.split.splitAroundUntil(image, closestBlock(image));
+            this.dependencies.split.splitAroundUntil(target, blockEl);
         }
         // => <p><figure><img/></figure></p>
         // or <p><a><figure><img/></figure></a></p>
@@ -146,7 +142,7 @@ export class CaptionPlugin extends Plugin {
         figure.setAttribute("contenteditable", "false");
         image.classList.add(EDITABLE_MEDIA_CLASS);
         // Ensure it's possible to write before and after the figure.
-        const block = closestBlock(link || image);
+        const block = link ? blockEl : figure;
         if (!block.previousSibling) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             block.before(baseContainer);

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1452,3 +1452,45 @@ test("Should be able to revert image replace", async () => {
     const input = el.querySelector("input");
     expect(input.value).toBe(captionText);
 });
+
+test("should toggle caption on an image with display:block (add and remove caption)", async () => {
+    const captionId = 1;
+    const { el, editor } = await setupEditorWithEmbeddedCaption(
+        `<img class="img-fluid test-image o_editable_media" style="display:block" src="${base64Img}">`
+    );
+    await animationFrame();
+    await toggleCaption();
+    await animationFrame();
+    const input = queryOne("figure > figcaption > input");
+    expect(input.value).toBe("");
+    expect(editor.document.activeElement).toBe(input);
+    // Remove the editor selection for the test because it's irrelevant
+    // since the focus is not in it.
+    const selection = editor.document.getSelection();
+    selection.removeAllRanges();
+    expect(getContent(el)).toBe(
+        unformat(
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" style="display:block" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
+                <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p><br></p>`
+        )
+    );
+    await click("img");
+    const captionButton = ".o-we-toolbar button[name='image_caption']";
+    await waitFor(captionButton);
+    expect(captionButton).toHaveClass("active");
+    await click(captionButton);
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <p>[<img class="img-fluid test-image" style="display:block" src="${base64Img}" data-caption="">]</p>
+            <p><br></p>
+        `)
+    );
+});


### PR DESCRIPTION
Steps to reproduce:
- Go to To-do
- Open a demo record (e.g., "Welcome Mitchell Admin")
- Click on an image
- Click on "Caption" from the toolbar
- Click on the image again

Description of the issue:
- When adding a caption, the parent paragraph block of sibling nodes is removed, making them direct children of the editable area.
- After adding a caption, reopening the powerbox does not show the caption button as active, allowing multiple captions to be added on the same image.

Cause:
- When the image has `display:block`, `closestBlock` returns the image itself as its closest block.
- As a result, when a caption is added to an image, its parent paragraph block is not split around the image even if the image has sibling nodes, and when `unwrapContents` is called, both the image and its siblings get unwrapped, making them direct children of the editable area.
- Since `closestBlock` is the image (and not a `<figure>`), the caption button in the toolbar is not marked as active even when a caption already exists, so clicking it again adds another caption instead of removing the existing one.

Solution:
- Instead of using the image's `closestBlock` directly, find the `closestBlock` of its parent element.
- This ensures the correct block is found even when the image has `display:block`.

task-6051549
