### PR TITLE
[FIX] mail: handle message/rfc822 as content_type

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1566,11 +1566,11 @@ class MailThread(models.AbstractModel):
             elif message.get_content_type() == 'text/html':
                 # we only strip_classes here everything else will be done in by html field of mail.message
                 body = html_sanitize(body, sanitize_tags=False, strip_classes=True)
-        else:
+        elif message.is_multipart():
             alternative = False
             mixed = False
             html = False
-            for part in message.walk():
+            for part in message.get_payload():
                 if message_dict.get('is_bounce') and body:
                     # bounce email, keep only the first body and ignore
                     # the parent email that might be added at the end


### PR DESCRIPTION
Prior to this fix, the parser walked through message parts that should have been ignored.

Emails utilize the MIME mechanism (RFC 2045), where the structure of an email is defined by boundaries that delineate different parts. Each part contains its own Content-Type (RFC 2045) and an optional Content-Disposition (RFC 2183). The Content-Type header describes the body content so the receiving user agent can select the appropriate mechanism to present the data. The Content-Disposition header defines whether the content should be displayed inline (in Odoo, understand this has "add it in the body") or treated as an attachment (in Odoo, create an ir.attachment and attach it to this mail.message). See `_message_parse_extract_payload` in https://github.com/odoo/odoo/blob/9218d302b0fd56c1854d95d3756c0f5e9c9c8700/addons/mail/models/mail_thread.py#L1547-L1549


The Issue:
When an email has a `Content-Type: message/rfc822`, it contains the body of a previously sent EML as an attachment. This embedded message possesses its own internal boundaries and parts. These sub-parts should not be processed as part of the top-level email’s primary structure.

In the case of opw-5892642, the email contained two text/html parts: one in the main email and one within the message/rfc822 attachment. The parser incorrectly reached into the attachment, allowing the second text/html part to override the first, leading to significant data loss. This override occurred within the _message_parse_extract_payload function: https://github.com/odoo/odoo/blob/9218d302b0fd56c1854d95d3756c0f5e9c9c8700/addons/mail/models/mail_thread.py#L1615-L1618


The Fix:
The new implementation adopts the logic used in the CPython email library iterator (cpython/Lib/email/iterators.py), specifically the _structure function. The updated logic ensures the parser walks through the mail structure without descending into nested levels it should ignore, staying focused only on the relevant part.

RFC1341 - 7.3.1:
A Content-Type of "message/rfc822" indicates that  
the  body contains  an encapsulated message, 
with the syntax of an RFC 822 message.

opw-5892642
