### PR TITLE
[REF] web: patch owl to prepare migration to owl 3

### DIFF
--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -4601,6 +4601,7 @@
             if (ast.context) {
                 ctxVar = generateId("ctx");
                 this.addLine(`let ${ctxVar} = ${compileExpr(ast.context)};`);
+                this.addLine(`${ctxVar}.this = ${ctxVar}`);
             }
             const isDynamic = INTERP_REGEXP.test(ast.name);
             const subTemplate = isDynamic ? interpolate(ast.name) : "`" + ast.name + "`";


### PR DESCRIPTION
In this commit, we add a `this` key to the context given by t-call with t-call-context, so all templates called in such a way can now read the values from the context with `this.`. This is what owl 3 will be doing anyway. For now, we allow both access methods, to make the transition easier.

The goal is to convert all templates in master to use `this.` before owl 3 is merged, so this is a necessary step to keep things working.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
