### PR TITLE
[REF] core: refactor selection field

### DIFF
--- a/addons/account_edi_proxy_client/tests/test_account_edi_proxy_client.py
+++ b/addons/account_edi_proxy_client/tests/test_account_edi_proxy_client.py
@@ -41,7 +41,7 @@ class TestAccountEdiProxyUser(AccountTestInvoicingCommon):
 
         # Overcome the abstract selection field `proxy_type` that has no selection
         # We actually dont need it, so we put a placeholder
-        with patch.object(Selection, 'convert_to_cache', side_effect=lambda value, record: value):
+        with patch.object(Selection, 'convert_to_cache', side_effect=lambda value, record, validate=True: value):
             cls.base_proxy_user = cls.env['account_edi_proxy_client.user'].create({
                 'id_client': 'id_client_test',
                 'company_id': cls.company.id,

--- a/addons/calendar/tests/test_recurrence_rule.py
+++ b/addons/calendar/tests/test_recurrence_rule.py
@@ -32,7 +32,7 @@ class TestRecurrenceRule(TransactionCase):
         recurrence = self.env['calendar.recurrence'].create({
             'rrule_type': 'daily',
             'interval': 2,
-            'end_type': '',
+            'end_type': False,
             'event_tz': 'UTC',
         })
         self.assertEqual(recurrence.name, 'Every 2 Days')
@@ -70,7 +70,7 @@ class TestRecurrenceRule(TransactionCase):
             'tue': True,
             'wed': True,
             'interval': 2,
-            'end_type': '',
+            'end_type': False,
             'event_tz': 'UTC',
         })
         self.assertEqual(recurrence.name, 'Every 2 Weeks on Tuesday, Wednesday')
@@ -108,7 +108,7 @@ class TestRecurrenceRule(TransactionCase):
             'month_by': 'day',
             'byday': '1',
             'weekday': 'MON',
-            'end_type': '',
+            'end_type': False,
             'event_tz': 'UTC',
         })
         self.assertEqual(recurrence.name, 'Every 2 Months on the First Monday')
@@ -146,7 +146,7 @@ class TestRecurrenceRule(TransactionCase):
             'month_by': 'date',
             'day': 27,
             'weekday': 'MON',
-            'end_type': '',
+            'end_type': False,
             'event_tz': 'UTC',
         })
         self.assertEqual(recurrence.name, 'Every 2 Months day 27')
@@ -175,7 +175,7 @@ class TestRecurrenceRule(TransactionCase):
         recurrence = self.env['calendar.recurrence'].create({
             'rrule_type': 'yearly',
             'interval': 2,
-            'end_type': '',
+            'end_type': False,
             'event_tz': 'UTC',
         })
         self.assertEqual(recurrence.name, 'Every 2 Years')

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -331,7 +331,7 @@ class FleetVehicle(models.Model):
             else:
                 record.contract_renewal_overdue = False
                 record.contract_renewal_due_soon = False
-                record.contract_state = ""
+                record.contract_state = False
 
     def _get_analytic_name(self):
         # This function is used in fleet_account and is overrided in l10n_be_hr_payroll_fleet

--- a/addons/l10n_dk/models/res_partner.py
+++ b/addons/l10n_dk/models/res_partner.py
@@ -72,7 +72,7 @@ class ResPartner(models.Model):
             if country_code == 'DK' and not partner.nemhandel_identifier_type:
                 partner.nemhandel_identifier_type = '0184'
             elif country_code != 'DK':
-                partner.nemhandel_identifier_type = ''
+                partner.nemhandel_identifier_type = False
 
     @api.depends('country_code', 'vat', 'company_registry', 'nemhandel_identifier_type')
     def _compute_nemhandel_identifier_value(self):

--- a/addons/l10n_gr_edi/tests/test_mydata_invoice.py
+++ b/addons/l10n_gr_edi/tests/test_mydata_invoice.py
@@ -139,7 +139,7 @@ class TestMyDATAInvoice(AccountTestInvoicingCommon):
     ####################################################################################################
 
     def test_mydata_available_inv_type_values(self):
-        invoice = self._create_mydata_invoice(inv_type='1.1', cls_category='', cls_type='')
+        invoice = self._create_mydata_invoice(inv_type='1.1', cls_category=False, cls_type=False)
         self.assertRecordValues(invoice, [{
             'l10n_gr_edi_available_inv_type': '1.1,1.2,1.3,1.4,1.5,1.6,2.1,2.2,2.3,2.4,3.1,3.2,5.1,5.2,'
                                               '6.1,6.2,7.1,8.1,8.2,11.1,11.2,11.3,11.4,11.5,17.3,17.4',
@@ -184,7 +184,7 @@ class TestMyDATAInvoice(AccountTestInvoicingCommon):
 
     def test_mydata_send_multi_invoices(self):
         invoice_1 = self._create_mydata_invoice(inv_type='2.1', cls_category='category1_3', cls_type='E3_561_002')
-        invoice_2 = self._create_mydata_invoice(inv_type='11.1', cls_category='category1_95', cls_type='')
+        invoice_2 = self._create_mydata_invoice(inv_type='11.1', cls_category='category1_95', cls_type=False)
         self.assert_mydata_xml_tree(invoice_1 + invoice_2, expected_file_path='from_odoo/mydata_multi_invoices.xml')
 
     def test_mydata_send_bill_cls_expense(self):
@@ -212,12 +212,12 @@ class TestMyDATAInvoice(AccountTestInvoicingCommon):
         self.assert_mydata_error(invoice, 'Missing myDATA Invoice Type.')
 
         # No classification category
-        invoice = self._create_mydata_invoice(cls_category='')
+        invoice = self._create_mydata_invoice(cls_category=False)
         invoice.l10n_gr_edi_try_send_invoices()
         self.assert_mydata_error(invoice, 'Missing myDATA classification category on line 1.')
 
         # No classification type, and inv_type + cls_category combination doesn't allow empty cls_type
-        invoice = self._create_mydata_invoice(cls_type='')
+        invoice = self._create_mydata_invoice(cls_type=False)
         invoice.l10n_gr_edi_try_send_invoices()
         self.assert_mydata_error(invoice, 'Missing myDATA classification type on line 1.')
 
@@ -225,7 +225,7 @@ class TestMyDATAInvoice(AccountTestInvoicingCommon):
         """Allow no cls_type on some combinations with available cls_type"""
         allowed_inv_type_category = (('1.1', 'category1_95'), ('3.2', 'category1_95'), ('5.1', 'category1_95'))
         for inv_type, category in allowed_inv_type_category:
-            invoice = self._create_mydata_invoice(inv_type=inv_type, cls_category=category, cls_type='')
+            invoice = self._create_mydata_invoice(inv_type=inv_type, cls_category=category, cls_type=False)
             self.assertFalse(invoice._l10n_gr_edi_get_pre_error_string())
 
     def test_l10n_gr_edi_try_send_invoices_invalid_tax_amount(self):

--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -7,7 +7,7 @@
         <field name="country_id" ref="base.it"/>
         <field name="allow_foreign_vat" eval="True"/>
         <field name="availability_condition">country</field>
-        <field name="integer_rounding"></field>
+        <field name="integer_rounding" eval="False"></field>
         <field name="column_ids">
             <record id="tax_monthly_report_vat_debit" model="account.report.column">
                 <field name="name">Debit</field>

--- a/addons/l10n_pe/data/l10n_latam_document_type_data.xml
+++ b/addons/l10n_pe/data/l10n_latam_document_type_data.xml
@@ -229,7 +229,7 @@
         <field name="name@es_419">Comprobante de retención</field>
         <field name='country_id' ref='base.pe'/>
         <field name='doc_code_prefix'>R</field>
-        <field name='internal_type'/>
+        <field name='internal_type' eval="False"/>
     </record>
     <record model='l10n_latam.document.type' id='document_type21'>
         <field name='sequence'>60</field>
@@ -416,7 +416,7 @@
         <field name="name@es_419">Comprobante de percepción</field>
         <field name='country_id' ref='base.pe'/>
         <field name='doc_code_prefix'>P</field>
-        <field name='internal_type'/>
+        <field name='internal_type' eval="False"/>
     </record>
     <record model='l10n_latam.document.type' id='document_type41'>
         <field name='sequence'>70</field>

--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
         self.l10n_ro_edi_state = False
         for move in self:
             # set the state of the move depending on the last document created
-            move.l10n_ro_edi_state = move.l10n_ro_edi_document_ids and move.l10n_ro_edi_document_ids.sorted()[0].state
+            move.l10n_ro_edi_state = move.l10n_ro_edi_document_ids.sorted()[:1].state
 
     @api.depends('l10n_ro_edi_state')
     def _compute_show_reset_to_draft_button(self):

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -279,7 +279,7 @@ class MailMail(models.Model):
                     )
                 (notifications - failed).sudo().write({
                     'notification_status': 'sent',
-                    'failure_type': '',
+                    'failure_type': False,
                     'failure_reason': '',
                 })
                 if failed:

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -628,6 +628,13 @@ class CustomerPortal(Controller):
                 field = partner_fields[key]
                 if field.type == 'many2one' and isinstance(value, str) and value.isdigit():
                     address_values[key] = field.convert_to_cache(int(value), ResPartner)
+                elif (
+                    field.type == 'selection'
+                    and value == ''  # noqa: PLC1901
+                    and '' not in field.get_values(request.env)
+                ):
+                    # An empty string from an HTML select means "no selection"; map it to False.
+                    address_values[key] = False
                 else:
                     # Always keep field values, even if falsy, as it might be for resetting a field.
                     address_values[key] = field.convert_to_cache(value, ResPartner)

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -206,7 +206,7 @@ class MailThread(models.AbstractModel):
                 partner_id=False,
                 number=n,
                 state='outgoing' if n else 'error',
-                failure_type='' if n else 'sms_number_missing',
+                failure_type=False if n else 'sms_number_missing',
             ) for n in tocreate_numbers if n not in existing_partners_numbers]
 
         # create sms and notification
@@ -223,7 +223,7 @@ class MailThread(models.AbstractModel):
                 'sms_tracker_ids': [Command.create({'sms_uuid': sms.uuid})] if sms.state == 'outgoing' else False,
                 'is_read': True,  # discard Inbox notification
                 'notification_status': 'ready' if sms.state == 'outgoing' else 'exception',
-                'failure_type': '' if sms.state == 'outgoing' else sms.failure_type,
+                'failure_type': False if sms.state == 'outgoing' else sms.failure_type,
             } for sms in sms_all]
             if notif_create_values:
                 self.env['mail.notification'].sudo().create(notif_create_values)

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -345,7 +345,7 @@ class SmsComposer(models.TransientModel):
                 failure_type = 'sms_number_format' if recipients['number'] else 'sms_number_missing'
             else:
                 state = 'outgoing'
-                failure_type = ''
+                failure_type = False
 
             result[record.id] = {
                 'body': all_bodies[record.id],

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -108,7 +108,7 @@ class TestAutoComplete(TransactionCase):
 
         test_page.visibility = 'connected'
         self._autocomplete_page('testTotallyUnique', 1, False)
-        test_page.visibility = False
+        test_page.visibility = 'public'
 
         test_page.group_ids = self.env.ref('base.group_public')
         self._autocomplete_page('testTotallyUnique', 1, False)

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -27,12 +27,13 @@ class IrUiView(models.Model):
     track = fields.Boolean(string='Track', default=False, help="Allow to specify for one page of the website to be trackable or not")
     visibility = fields.Selection(
         [
-            ('', 'Public'),
+            ('public', 'Public'),
             ('connected', 'Signed In'),
             ('restricted_group', 'Restricted Group'),
             ('password', 'With Password')
         ],
-        default='',
+        default='public',
+        required=True,
     )
     visibility_password = fields.Char(groups='base.group_system', copy=False)
     visibility_password_display = fields.Char(compute='_get_pwd', inverse='_set_pwd', groups='website.group_website_designer')
@@ -415,7 +416,7 @@ class IrUiView(models.Model):
 
         visibility = self._get_cached_visibility()
 
-        if visibility and not request.env.user.has_group('website.group_website_designer'):
+        if visibility != 'public' and not request.env.user.has_group('website.group_website_designer'):
             if (visibility == 'connected' and request.website.is_public_user()):
                 error = werkzeug.exceptions.Forbidden()
             elif visibility == 'password' and \

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1613,7 +1613,7 @@ class Website(models.CachedModel):
         if not force:
             domain += [
                 ('website_indexed', '=', True),
-                ('visibility', 'in', (False, '')),
+                ('visibility', '=', 'public'),
                 ('website_published', '=', True),
             ]
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1613,7 +1613,7 @@ class Website(models.CachedModel):
         if not force:
             domain += [
                 ('website_indexed', '=', True),
-                ('visibility', '=', False),
+                ('visibility', 'in', (False, '')),
                 ('website_published', '=', True),
             ]
 

--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -158,7 +158,7 @@ class WebsitePagePropertiesBase(models.TransientModel):
             if self.can_publish:
                 if self.is_published:
                     # Publish
-                    target.visibility = ''
+                    target.visibility = 'public'
                     target.group_ids -= self._get_ir_ui_view_unpublish_group()
                 else:
                     # Unpublish

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -70,7 +70,7 @@
     <record id="view_rule_visibility_public" model="ir.rule">
         <field name="name">Website View Visibility Public</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>
-        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', ('public', False))]</field>
+        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', (False, ''))]</field>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
@@ -80,7 +80,7 @@
     <record id="view_rule_visibility_connected" model="ir.rule">
         <field name="name">Website View Visibility Connected</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>
-        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', ('public', 'connected', False))]</field>
+        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', ('connected', False, ''))]</field>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -70,7 +70,7 @@
     <record id="view_rule_visibility_public" model="ir.rule">
         <field name="name">Website View Visibility Public</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>
-        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', (False, ''))]</field>
+        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', '=', 'public')]</field>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
@@ -80,7 +80,7 @@
     <record id="view_rule_visibility_connected" model="ir.rule">
         <field name="name">Website View Visibility Connected</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>
-        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', ('connected', False, ''))]</field>
+        <field name="domain_force">['|', ('type', '!=', 'qweb'), ('visibility', 'in', ('connected', 'public'))]</field>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>

--- a/odoo/addons/base/tests/test_ir_ui_view.py
+++ b/odoo/addons/base/tests/test_ir_ui_view.py
@@ -1929,6 +1929,9 @@ class TestViews(ViewCase):
             else:
                 kw['type'] = etree.fromstring(arch_db).tag
             kw['arch_db'] = Json({'en_US': arch_db}) if self.env.lang in (None, 'en_US') else Json({'en_US': arch_db, self.env.lang: arch_db})
+        for field_name, field in self.env['ir.ui.view']._fields.items():
+            if field.required and field_name not in kw:
+                kw[field_name] = field.default(self.env['ir.ui.view'])
 
         keys = sorted(kw)
         fields = ','.join('"%s"' % (k.replace('"', r'\"'),) for k in keys)

--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -66,9 +66,10 @@ class Selection(Field[str | typing.Literal[False]]):
     validate: bool = True       # whether validating upon write
     ondelete: dict[str, OnDeletePolicy] | None = None  # {value: policy} (what to do when value is deleted)
 
+    _selection: dict[str, str] | None = None
+
     def __init__(self, selection=SENTINEL, string: str | Sentinel = SENTINEL, **kwargs):
         super().__init__(selection=selection, string=string, **kwargs)
-        self._selection = dict(selection) if isinstance(selection, list) else None
 
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)
@@ -83,8 +84,9 @@ class Selection(Field[str | typing.Literal[False]]):
 
     def _get_attrs(self, model_class, name):
         attrs = super()._get_attrs(model_class, name)
-        # arguments 'selection' and 'selection_add' are processed below
+        # arguments 'selection' and 'selection_add' are processed in _setup_attrs__ below
         attrs.pop('selection_add', None)
+        attrs.pop('selection', None)
         # Selection fields have an optional default implementation of a group_expand function
         if attrs.get('group_expand') is True:
             attrs['group_expand'] = self._default_group_expand
@@ -92,18 +94,17 @@ class Selection(Field[str | typing.Literal[False]]):
 
     def _setup_attrs__(self, model_class, name):
         super()._setup_attrs__(model_class, name)
-        if not self._base_fields__:
-            return
 
         # determine selection (applying 'selection_add' extensions) as a dict
         values = None
 
-        for field in self._base_fields__:
+        for field in (*self._base_fields__, self):
             # We cannot use field.selection or field.selection_add here
             # because those attributes are overridden by ``_setup_attrs__``.
             if 'selection' in field._args__:
                 if self.related:
                     _logger.warning("%s: selection attribute will be ignored as the field is related", self)
+                    continue
                 selection = field._args__['selection']
                 if isinstance(selection, (list, tuple)):
                     if values is not None and list(values) != [kv[0] for kv in selection]:
@@ -117,16 +118,17 @@ class Selection(Field[str | typing.Literal[False]]):
                 else:
                     raise ValueError(f"{self!r}: selection={selection!r} should be a list, a callable or a method name")
 
-            if 'selection_add' in field._args__:
+            if self._base_fields__ and 'selection_add' in field._args__:
                 if self.related:
                     _logger.warning("%s: selection_add attribute will be ignored as the field is related", self)
+                    continue
                 selection_add = field._args__['selection_add']
                 assert isinstance(selection_add, list), \
                     "%s: selection_add=%r must be a list" % (self, selection_add)
                 assert values is not None, \
                     "%s: selection_add=%r on non-list selection %r" % (self, selection_add, self.selection)
 
-                values_add = {kv[0]: (kv[1] if len(kv) > 1 else None) for kv in selection_add}
+                values_add = {kv[0]: (kv[1] if len(kv) > 1 else values[kv[0]]) for kv in selection_add}
                 ondelete = field._args__.get('ondelete') or {}
                 new_values = [key for key in values_add if key not in values]
                 for key in new_values:
@@ -164,15 +166,15 @@ class Selection(Field[str | typing.Literal[False]]):
                         )
 
                 values = {
-                    key: values_add.get(key) or values[key]
+                    key: values_add[key] if key in values_add else values[key]
                     for key in merge_sequences(values, values_add)
                 }
                 self.ondelete.update(ondelete)
 
         if values is not None:
             self.selection = list(values.items())
-            assert all(isinstance(key, str) for key in values), \
-                "Field %s with non-str value in selection" % self
+            assert all(isinstance(key, str) and isinstance(val, str) for key, val in values.items()), \
+                "Field %s with non-str key or value in selection" % self
 
         self._selection = values
 
@@ -203,7 +205,6 @@ class Selection(Field[str | typing.Literal[False]]):
         selection = self.selection
         if isinstance(selection, str) or callable(selection):
             selection = determine(selection, env[self.model_name])
-            # force all values to be strings (check _get_year_selection)
             return [(str(key), str(label)) for key, label in selection]
 
         translations = dict(env['ir.model.fields'].get_field_selection(self.model_name, self.name))
@@ -221,18 +222,14 @@ class Selection(Field[str | typing.Literal[False]]):
         return [value for value, _ in selection]
 
     def convert_to_column(self, value, record, values=None, validate=True):
-        if validate and self.validate:
-            value = self.convert_to_cache(value, record)
-        return super().convert_to_column(value, record, values, validate)
+        return self.convert_to_cache(value, record, validate=validate)
 
     def convert_to_cache(self, value, record, validate=True):
-        if not validate or self._selection is None:
-            return value or None
-        if value in self._selection:
-            return value
-        if not value:
+        if value is False or value is None:
             return None
-        raise ValueError("Wrong value for %s: %r" % (self, value))
+        if self.validate and validate and self._selection is not None and str(value) not in self._selection:
+            raise ValueError("Wrong value for %s: %r" % (self, value))
+        return str(value)
 
     def convert_to_export(self, value, record):
         for item in self._description_selection(record.env):


### PR DESCRIPTION
1. Set up `selection` and `selection_add` in the same place to improve
   readability.
2. Empty string `''` is now treated as a technically valid option: if it
   is not present in the selection options, assigning it will raise an
   error during validation.
3. Remove side effects in converters when `''` is a valid option.

   For example:

   a. `default=''` does not work as expected:
      When calling `Model.defaults_get`, the empty string computed from
      the default is converted as:
        `''` --convert_to_cache(..., validate=False)--> `None`
            --convert_to_write--> `False`

   b. Writing `''` to a related field does not work as expected:
      When writing `''` to a related field, the value is converted as:
        `''` --convert_to_cache(..., validate=True)--> `None` (cache)
            --> `False` (record value)
      The ORM then uses the record value `False` to update the original
      selection field, so the original field value becomes `False`
      instead of `''`.

   c. `record.write({'visibility': ''})` updates the record value to
     `''`. But `record.visibility = ''` updates it to `False`, because
     `''` is converted to `False` by `convert_to_write`.

https://github.com/odoo/enterprise/pull/111457
https://github.com/odoo/upgrade/pull/9745

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
