### PR TITLE
[FIX] im_livechat: duplicated name in self livechat

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -308,17 +308,16 @@ class Im_LivechatChannel(models.Model):
                 Command.create({"livechat_member_type": "visitor", "guest_id": guest.id})
             )
         visitor_user = self.env["res.users"]
-        if not self.env.user._is_public():
+        if not self.env.user._is_public() and self.env.user != agent:
             visitor_user = self.env.user
-            if visitor_user and visitor_user != agent:
-                members_to_add.append(
-                    Command.create(
-                        {
-                            "livechat_member_type": "visitor",
-                            "partner_id": visitor_user.partner_id.id,
-                        }
-                    )
+            members_to_add.append(
+                Command.create(
+                    {
+                        "livechat_member_type": "visitor",
+                        "partner_id": visitor_user.partner_id.id,
+                    }
                 )
+            )
 
         channel_name = self._get_channel_name(
             visitor_user=visitor_user,
@@ -355,10 +354,11 @@ class Im_LivechatChannel(models.Model):
         if operator_model == 'chatbot.script':
             channel_name = chatbot_script.title
         else:
-            channel_name = ' '.join([
+            member_names = [
                 visitor_user.display_name if visitor_user else guest.name,
                 agent.livechat_username or agent.name
-            ])
+            ]
+            channel_name = " ".join(filter(None, member_names))
         return channel_name
 
     def _get_operator_info(self, /, *, lang, country_id, previous_operator_id=None, chatbot_script_id=None, **kwargs):

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -234,7 +234,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         ]
         operator_member = self.env['discuss.channel.member'].search(operator_member_domain)
         self.assertEqual(channel_info['livechat_operator_id'], operator.partner_id.id)
-        self.assertEqual(channel_info["name"], "Michel Michel Operator")
+        self.assertEqual(channel_info["name"], "Michel Operator")
         self.assertEqual(channel_info['country_id'], False)
         self.assertEqual(
             data["res.partner"],


### PR DESCRIPTION
Since PR #212150 when getting the livechat channel values, the `visitor_user` value is set to the current visitor user even when the visitor user is the same as the agent (self chat). The code is guarded in the next step and so this visitor is not added to the channel members but the already set value affects the livechat channel name. The bug becomes visible when the `displayName` computation is changed later by the PR #227240.
This change ensures that the visitor user remains falsy throughout the process when the visitor and agent are the same.

task-6015652
