### PR TITLE
[FIX] web_tour: add onHold flag to prevent triggering interactive tours

### DIFF
--- a/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
+++ b/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
@@ -83,6 +83,10 @@ export class TourInteractive {
     }
 
     play() {
+        if (this.onHold) {
+            return;
+        }
+
         this.removeListeners();
         if (this.currentActionIndex === this.actions.length) {
             TourInteractive.observer.disconnect();

--- a/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
+++ b/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
@@ -83,6 +83,10 @@ export class TourInteractive {
     }
 
     play() {
+        if (this.onHold) {
+            return;
+        }
+
         this.removeListeners();
         if (this.currentActionIndex === this.actions.length) {
             this.observer.disconnect();

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -104,8 +104,12 @@ export const tourService = {
                 throw new Error(`Tour '${tourName}' is not found in the database.`);
             }
 
-            if (!tour.steps.length && tourRegistry.contains(tour.name)) {
-                tour.steps = tourRegistry.get(tour.name).steps();
+            if (!tour.steps.length) {
+                if (tourRegistry.contains(tour.name)) {
+                    tour.steps = tourRegistry.get(tour.name).steps();
+                } else {
+                    tour.onHold = true;
+                }
             }
 
             return tour;

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -165,8 +165,12 @@ export class TourService {
             if (!tour) {
                 throw new Error(`Tour '${name}' is not found in the database.`);
             }
-            if (!tour.steps.length && tourRegistry.contains(tour.name)) {
-                tour.steps = tourRegistry.get(tour.name).steps;
+            if (!tour.steps.length) {
+                if (tourRegistry.contains(tour.name)) {
+                    tour.steps = tourRegistry.get(tour.name).steps;
+                } else {
+                    tour.onHold = true;
+                }
             }
             return {
                 ...tour,


### PR DESCRIPTION
When loading the POS, interactive tours were triggered but their steps were not included in the POS bundle.
This caused a traceback each time the POS was opened or refreshed.

To prevent this, we added a flag `onHold` onto the tour if no steps were found from the database and the registry wasn't loaded.

---

Task: https://www.odoo.com/odoo/project/1737/tasks/605029