### PR TITLE
[FIX] {stock,mrp}_account: avoid erasing lot on MO valuated by lot

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -6,9 +6,11 @@ from datetime import timedelta
 from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.addons.stock_account.tests.test_account_move import TestAccountMoveStockCommon
+
+from odoo import fields, Command
+from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 from odoo.tests.common import new_test_user
-from odoo import fields, Command
 
 
 class TestMrpAccount(TestMrpCommon, MailCase):
@@ -380,6 +382,30 @@ class TestMrpAccount(TestMrpCommon, MailCase):
         self.assertEqual(production.workorder_ids.mapped('time_ids').mapped('account_move_line_id').mapped('credit'), [
             0.01, 0.01
         ])
+
+    def test_lot_valuation_remove_lot_from_MO(self):
+        self.product_table_leg.write({'lot_valuated': True})
+        leg_lot = self.env['stock.lot'].create({
+            'name': 'leg lot',
+            'product_id': self.product_table_leg.id,
+        })
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_table_leg.id,
+            'product_qty': 1,
+            'move_raw_ids': [
+                Command.create({
+                    'product_id': self.product_bolt.id,
+                    'product_uom_qty': 1,
+                })
+            ],
+            'lot_producing_id': leg_lot.id,
+        })
+        mo.action_confirm()
+        mo.button_mark_done()
+        with self.assertRaises(UserError, msg='Product Table Leg is valuated by lot: an explicit Lot/Serial number is required.'):
+            mo.lot_producing_id = False
+        self.assertEqual(mo.lot_producing_id, leg_lot)
+        self.assertEqual(mo.move_finished_ids.lot_ids, leg_lot)
 
     def test_parent_after_child_done(self):
         """

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -31,9 +31,12 @@ class StockMoveLine(models.Model):
             for move_line in self:
                 move_id = vals.get('move_id', move_line.move_id.id)
                 analytic_move_to_recompute.add(move_id)
-        new_lot = False
-        if 'lot_id' in vals:
-            new_lot = vals.get('lot_id')
+        new_lot = vals.get('lot_id')
+        if 'lot_id' in vals and not new_lot:
+            for move_line in self:
+                if move_line.product_id.lot_valuated and move_line.state == "done":
+                    raise UserError(_('Product %(product)s is valuated by lot: an explicit Lot/Serial number is required.',
+                        product=move_line.product_id.display_name))
         if 'quant_id' in vals:
             new_quant = vals.get('quant_id')
             new_lot = self.env['stock.quant'].browse(new_quant).lot_id.id


### PR DESCRIPTION
When we erase a sn/lot on a MO for a product that is tracked by lot, we will be deadlocked.

### Steps to reproduce:
* Create a product tracked by lot and lot_valuated
* Create a BoM for this product
* Create a MO for this product
* Confirm and Produce all
* erase the lot and save -> the MO is deadlock, it's not possible to modify the lot number, nor it's possible to unbuild.

### Current behavior:
A user is able to erase a lot/SN from a MO of a lot_valuated product.

### Expected behavior:
It should not be possible to erase a lot/SN form a MO of a lot_valuated product.

### Observation:
When the MO is done, its valuation will be calculated which in our case, it means, we have to have a lot number. When trying to add a lot/SN of a MO where it has been erased, we will remove the quantities from the previous lot, but in our case, since we don't have one, it will trigger the user error. https://github.com/odoo/odoo/commit/33e192de30526ea7fe320bcaa7a16dac8108feff
This error is not triggered when removing the SN/lot because when we remove the value, it will be update to False which means it will skip _update_svl_quantity():
https://github.com/odoo/odoo/blob/109f829c2b461b14167e9227e42d096d4410a3b3/addons/stock_account/models/stock_move_line.py#L35-L36
https://github.com/odoo/odoo/blob/109f829c2b461b14167e9227e42d096d4410a3b3/addons/stock_account/models/stock_move_line.py#L62-L65
This use case is also protected when creating a product tracked by lot but not lot_valuated: https://github.com/odoo/odoo/commit/4963103e5587d36364b8df84d0b3407a1977efdf

opw-6039885

