### PR TITLE
[FIX] stock: fix track inventory visibility for non-storable products

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -185,7 +185,7 @@
                 </xpath>
                 <xpath expr="//div[@name='tracking_and_qty_no_stock']" position="replace">
                     <!-- Replace the single line tacking + qty without stock with 2 individual lines with stock (tracking + tracking method // qty) -->
-                    <field name="is_storable" groups="!stock.group_production_lot"/>
+                    <field name="is_storable" groups="!stock.group_production_lot" invisible="type != 'consu'"/>
                     <field name="tracking" placeholder="None" invisible="type != 'consu'" groups="stock.group_production_lot"/>
                     <!-- Qty line if storable -->
                     <label for="qty_available" class="oe_inline" invisible="not is_storable or not tracking" groups="stock.group_stock_user"/>


### PR DESCRIPTION
Issue before this commit:
=========================
The 'Track Inventory' (is_storable) field is visible for products of 
type service or combo, where it should not be applicable.

Steps to Reproduce:
=========================
- Install the Inventory module without demo data.
- Ensure **'Lots & Serial Numbers'** is disabled in the configuration.
- Go to Inventory > Products > Create a new product.
- Change the product type from 'Goods' to 'Service' (or Combo).

Result: The 'Track Inventory' field remains visible.

Cause of the issue:
=========================
The invisible condition on the field was unintentionally removed in this [PR](https://github.com/odoo/odoo/pull/242834), [here](https://github.com/odoo/odoo/pull/242834/changes#diff-9afa40fdafcf103e7456e139c259f78469ea7e675c79f6d13dfe7db2d43c38d6R188).

Previously, it was restricted using: **invisible="type != 'consu'".**

With This Commit:
=========================
Restore the invisible condition on the 'is_storable' field, ensuring it is only visible 
for storable (goods) products and hidden for service and combo products.
