### PR TITLE
[FIX] sale_loyalty: allow reward.line.tax edit in confirmed SO

### DIFF
--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -28,7 +28,7 @@
                 <attribute name="readonly" add="is_reward_line" separator=" or "/>
             </xpath>
             <xpath expr="//list//field[@name='tax_id']" position="attributes">
-                <attribute name="readonly" add="is_reward_line" separator=" or "/>
+                <attribute name="readonly" add="is_reward_line and state in ['draft', 'sent']" separator=" or "/>
             </xpath>
             <group name="note_group" position="after">
                 <group class="d-flex flex-row-reverse oe_subtotal_footer border-0">


### PR DESCRIPTION
Issue:
---
Due to this issue, the tax on reward SOL cannot be edited.

Cause:
---
This is introduced in #172110 to prevent users from editing taxes on reward lines because confirming the order would recompute the tax.

We can make it editable on confirmed SO as the tax wouldn't recomputed on reward lines later.

opw-5918435