### PR TITLE
[FIX] spreadsheet: remove left-over console.log from tests

### DIFF
--- a/addons/spreadsheet/static/tests/charts/model/link_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/link_chart_plugin.test.js
@@ -157,7 +157,6 @@ test("Datasource link is removed when a pivot is deleted", async function () {
     });
     model.dispatch("REMOVE_PIVOT", { pivotId });
     expect(model.getters.getChartOdooLink(chartId)).toBe(undefined);
-    console.log("exportData", model.exportData());
     expect(model.exportData().odooLinkReferences).toBeEmpty();
 });
 
@@ -176,7 +175,6 @@ test("Datasource link is removed when a list is deleted", async function () {
     });
     model.dispatch("REMOVE_ODOO_LIST", { listId });
     expect(model.getters.getChartOdooLink(chartId)).toBe(undefined);
-    console.log("exportData", model.exportData());
     expect(model.exportData().odooLinkReferences).toBeEmpty();
 });
 
@@ -198,7 +196,6 @@ test("Datasource link is removed when an odoo chart is deleted", async function 
         sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getChartOdooLink(chartId)).toBe(undefined);
-    console.log("exportData", model.exportData());
     expect(model.exportData().odooLinkReferences).toBeEmpty();
 });
 


### PR DESCRIPTION
some debugging lines were left in the final PR.

Task-0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
