### PR TITLE
[IMP] core: add float_parse_str to parse localized amount string

### DIFF
--- a/odoo/addons/base/tests/test_float.py
+++ b/odoo/addons/base/tests/test_float.py
@@ -3,7 +3,7 @@
 from math import log10
 
 from odoo.tests.common import TransactionCase
-from odoo.tools import float_compare, float_is_zero, float_repr, float_round, float_split, float_split_str
+from odoo.tools import float_compare, float_is_zero, float_parse_str, float_repr, float_round, float_split, float_split_str
 
 
 class TestFloatPrecision(TransactionCase):
@@ -289,3 +289,34 @@ class TestFloatPrecision(TransactionCase):
         amount_test = currency.amount_to_text(0.28)
         self.assertNotEqual(amount_test, amount_target,
                             "Amount in text should not depend on float representation")
+
+    def test_split_amount_string(self):
+        test_cases = [
+            # Plain integer
+            ('1334', ('1334', '0')),
+            ('', ('0', '0')),
+
+            # European format: dot=thousands, comma=decimal
+            ('1.334,00', ('1334', '00')),
+            ('1.334,07', ('1334', '07')),   # leading zero preserved
+            ('1.334.567,89', ('1334567', '89')),
+
+            # US format: comma=thousands, dot=decimal
+            ('1,334.00', ('1334', '00')),
+            ('1,334,567.89', ('1334567', '89')),
+
+            # Unambiguous decimals
+            ('1.50', ('1', '50')),
+            ('1,5', ('1', '5')),
+            ('1.0', ('1', '0')),
+            ('1.00', ('1', '00')),
+        ]
+        for value, expected in test_cases:
+            with self.subTest(value=value):
+                self.assertEqual(float_parse_str(value), expected)
+
+    def test_split_amount_string_ambiguous(self):
+        for value in ('1.000', '1,000'):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    float_parse_str(value)

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -6,7 +6,7 @@ from . import urls
 from .parse_version import parse_version
 from .cache import ormcache, ormcache_context
 from .config import config
-from .float_utils import float_compare, float_is_zero, float_repr, float_round, float_split, float_split_str
+from .float_utils import float_compare, float_is_zero, float_parse_str, float_repr, float_round, float_split, float_split_str
 from .func import classproperty, conditional, lazy, lazy_classproperty, reset_cached_properties
 from .i18n import format_list, py_to_js_locale
 from .json import json_default

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "float_round",
     "float_split",
     "float_split_str",
+    "float_parse_str",
 ]
 
 
@@ -371,6 +372,95 @@ def float_invert(value: float) -> float:
         # invert exponent by changing sign, and coefficient by dividing by its square
         result = float(f'{coefficient}e{-int(exponent)}') / float(coefficient)**2
     return result
+
+
+def float_parse_str(value):
+    """
+    Parse a localized amount string into (int_part, dec_part) as strings,
+    without relying on locale settings.
+    Detects the number format (European/US) purely from the string structure.
+
+    Clear cases:
+        '1334'         -> ('1334', '0')    plain integer
+        '1.334,00'     -> ('1334', '00')   European format (dot=thousands, comma=decimal)
+        '1,334.00'     -> ('1334', '00')   US format (comma=thousands, dot=decimal)
+        '1.334.567,89' -> ('1334567', '89')
+        '1,334,567.89' -> ('1334567', '89')
+        '1.50'         -> ('1', '50')      unambiguous decimal
+        '1,5'          -> ('1', '5')       unambiguous European decimal
+
+    Ambiguous cases (raises ValueError):
+        '1.000'  -> could be 1000 (thousands) or 1.0 (decimal)
+        '1,000'  -> could be 1000 (thousands) or 1.0 (decimal)
+
+    :param value:   The amount string to parse.
+    :return:        Tuple of (int_part, dec_part) as strings e.g. ('1334', '07')
+    :raises ValueError: If the string is ambiguous or unparseable.
+    """
+    if not value:
+        return ('0', '0')
+
+    value = value.strip()
+    commas = value.count(',')
+    dots = value.count('.')
+    last_comma, last_dot = value.rfind(','), value.rfind('.')
+    comma_distance = len(value) - 1 - last_comma if last_comma >= 0 else -1
+    dot_distance = len(value) - 1 - last_dot if last_dot >= 0 else -1
+
+    match (commas, dots):
+        case (0, 0):
+            # '1334' — plain integer
+            tsep, dsep = ',', '.'
+        case (int() as c, 0) if c > 1:
+            # '1,334,567' — multiple commas can only be thousands separators
+            tsep, dsep = ',', '.'
+        case (0, int() as d) if d > 1:
+            # '1.334.567' — multiple dots can only be thousands separators
+            tsep, dsep = '.', ','
+        case (int() as c, 1) if c > 1:
+            # '1,334,567.89' — commas=thousands, dot=decimal
+            tsep, dsep = ',', '.'
+        case (1, int() as d) if d > 1:
+            # '1.334.567,89' — dots=thousands, comma=decimal
+            tsep, dsep = '.', ','
+        case (1, 1):
+            # Both present exactly once — whichever is last is the decimal separator
+            # '1.334,00' — comma is last → comma=decimal, dot=thousands
+            # '1,334.00' — dot is last   → dot=decimal, comma=thousands
+            if last_comma > last_dot:
+                tsep, dsep = '.', ','
+            else:
+                tsep, dsep = ',', '.'
+        case (0, 1):
+            # Only a dot — ambiguous if exactly 3 digits follow it
+            # '1.000' could be 1000 or 1.0
+            # '1.50'  is clearly 1.5
+            if dot_distance == 3 and value[:last_dot].isdigit():
+                raise ValueError(
+                    f"Ambiguous amount {value!r}: could be "
+                    f"{value.replace('.', '')} (thousands) "
+                    f"or {value} (decimal)."
+                )
+            tsep, dsep = ',', '.'
+        case (1, 0):
+            # Only a comma — ambiguous if exactly 3 digits follow it
+            # '1,000' could be 1000 or 1.0
+            # '1,50'  is clearly 1.5
+            if comma_distance == 3 and value[:last_comma].isdigit():
+                raise ValueError(
+                    f"Ambiguous amount {value!r}: could be "
+                    f"{value.replace(',', '')} (thousands) "
+                    f"or {value.replace(',', '.')} (decimal)."
+                )
+            tsep, dsep = '.', ','
+        case _:
+            raise ValueError(f"Unrecognized number format: {value!r}")
+
+    # Strip thousands separator then split on decimal separator
+    parts = value.replace(tsep, '').split(dsep)
+    if len(parts) == 2:
+        return (parts[0], parts[1])   # ('1334', '07') — keeps leading zeros
+    return (parts[0], '0')            # ('1334', '0')  — no decimal part
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new utility function `float_parse_str`
that parses a localized amount string into (int_part, dec_part) as strings, without relying on locale settings.

The function detects the number format (European/US) purely from the string structure by analyzing the position and count of '.' and ',' separators.

Handles:
- Plain integers: '1334' -> ('1334', '0')
- European format: '1.334,00' -> ('1334', '00')
- US format: '1,334.00' -> ('1334', '00')
- Unambiguous decimals: '1.50' -> ('1', '50')

Raises ValueError for genuinely ambiguous cases like '1.000' or '1,000' where the separator could be either thousands or decimal.

Enterprise :- https://github.com/odoo/enterprise/pull/110410

Task [link](https://www.odoo.com/odoo/project/967/tasks/6026748)

task-6026748
