### PR TITLE
[IMP] hr_skills: introduce skill+level proficiency model

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -18,6 +18,11 @@ class HrApplicant(models.Model):
         readonly=False,
     )
     skill_ids = fields.Many2many("hr.skill", compute="_compute_skill_ids", store=True)
+    skill_proficiency_ids = fields.Many2many(
+        'hr.skill.proficiency',
+        compute='_compute_skill_proficiency_ids',
+        store=True,
+    )
     matching_skill_ids = fields.Many2many(
         comodel_name="hr.skill",
         string="Matching Skills",
@@ -40,6 +45,11 @@ class HrApplicant(models.Model):
     def _compute_skill_ids(self):
         for applicant in self:
             applicant.skill_ids = applicant.applicant_skill_ids.skill_id
+
+    @api.depends('applicant_skill_ids.skill_id', 'applicant_skill_ids.skill_level_id')
+    def _compute_skill_proficiency_ids(self):
+        for applicant in self:
+            applicant.skill_proficiency_ids = self.env['hr.skill.proficiency']._get_or_create_proficiencies(applicant.applicant_skill_ids)
 
     @api.depends_context("matching_job_id")
     @api.depends("current_applicant_skill_ids", "type_id", "job_id", "job_id.job_skill_ids", "job_id.expected_degree")
@@ -166,6 +176,13 @@ class HrApplicant(models.Model):
             for vals in vals_list:
                 vals["applicant_skill_ids"] = vals.pop("current_applicant_skill_ids", []) + vals.get("applicant_skill_ids", [])
         return super().create(vals_list)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('applicant_skill_ids'):
+            res['applicant_skill_ids']['searchable'] = False
+        return res
 
     def write(self, vals):
         if "current_applicant_skill_ids" in vals or "applicant_skill_ids" in vals:

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -49,7 +49,7 @@
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_search_bis"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='email_from']" position="after">
-                <field name="applicant_skill_ids"/>
+                <field name="skill_proficiency_ids"/>
             </xpath>
             <xpath expr="//filter[@name='talent_pool']" position="after">
                 <filter string="Skills" name="skill_ids" context="{'group_by': 'skill_ids'}"/>
@@ -63,7 +63,7 @@
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='recruiter_id']" position="after">
-                <field name="applicant_skill_ids"/>
+                <field name="skill_proficiency_ids"/>
             </xpath>
             <filter name="stage" position="after">
                 <filter string="Skills" name="groupby_skills" context="{'group_by': 'skill_ids'}"/>

--- a/addons/hr_skills/models/__init__.py
+++ b/addons/hr_skills/models/__init__.py
@@ -6,6 +6,7 @@ from . import hr_job
 from . import hr_resume_line
 from . import hr_resume_line_type
 from . import hr_skill
+from . import hr_skill_proficiency
 from . import hr_individual_skill_mixin
 from . import hr_employee_skill
 from . import hr_job_skill

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -21,6 +21,7 @@ class HrEmployee(models.Model):
     current_employee_skill_ids = fields.One2many('hr.employee.skill',
         compute='_compute_current_employee_skill_ids', readonly=False)
     skill_ids = fields.Many2many('hr.skill', compute='_compute_skill_ids', store=True, groups="hr.group_hr_user")
+    skill_proficiency_ids = fields.Many2many('hr.skill.proficiency', compute='_compute_skill_proficiency_ids', store=True)
     certification_ids = fields.One2many('hr.employee.skill', compute='_compute_certification_ids', readonly=False)
     display_certification_page = fields.Boolean(compute="_compute_display_certification_page")
 
@@ -34,6 +35,11 @@ class HrEmployee(models.Model):
     def _compute_skill_ids(self):
         for employee in self:
             employee.skill_ids = employee.employee_skill_ids.skill_id
+
+    @api.depends('employee_skill_ids.skill_id', 'employee_skill_ids.skill_level_id')
+    def _compute_skill_proficiency_ids(self):
+        for employee in self:
+            employee.skill_proficiency_ids = self.env['hr.skill.proficiency']._get_or_create_proficiencies(employee.employee_skill_ids)
 
     @api.depends('employee_skill_ids')
     def _compute_certification_ids(self):
@@ -212,3 +218,10 @@ class HrEmployee(models.Model):
     def _store_avatar_card_fields(self, res: Store.FieldList):
         super()._store_avatar_card_fields(res)
         res.many("employee_skill_ids", ["color", "display_name"])
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('employee_skill_ids'):
+            res['employee_skill_ids']['searchable'] = False
+        return res

--- a/addons/hr_skills/models/hr_employee_public.py
+++ b/addons/hr_skills/models/hr_employee_public.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HrEmployeePublic(models.Model):
@@ -10,5 +10,13 @@ class HrEmployeePublic(models.Model):
     employee_skill_ids = fields.One2many('hr.employee.skill', 'employee_id', string="Skills",
         domain=[('skill_type_id.active', '=', True)])
     current_employee_skill_ids = fields.One2many('hr.employee.skill', related='employee_id.current_employee_skill_ids')
+    skill_proficiency_ids = fields.Many2many('hr.skill.proficiency', related='employee_id.skill_proficiency_ids')
     certification_ids = fields.One2many('hr.employee.skill', related='employee_id.certification_ids')
     display_certification_page = fields.Boolean(related="employee_id.display_certification_page")
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('employee_skill_ids'):
+            res['employee_skill_ids']['searchable'] = False
+        return res

--- a/addons/hr_skills/models/hr_job.py
+++ b/addons/hr_skills/models/hr_job.py
@@ -22,6 +22,11 @@ class HrJob(models.Model):
         compute="_compute_skill_ids",
         store=True,
     )
+    skill_proficiency_ids = fields.Many2many(
+        'hr.skill.proficiency',
+        compute='_compute_skill_proficiency_ids',
+        store=True,
+    )
 
     @api.depends("job_skill_ids")
     def _compute_current_job_skill_ids(self):
@@ -52,12 +57,26 @@ class HrJob(models.Model):
         for job in self:
             job.skill_ids = job.job_skill_ids.skill_id
 
+    @api.depends('job_skill_ids.skill_id', 'job_skill_ids.skill_level_id')
+    def _compute_skill_proficiency_ids(self):
+        for job in self:
+            job.skill_proficiency_ids = self.env['hr.skill.proficiency']._get_or_create_proficiencies(job.job_skill_ids)
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
             vals_job_skill = vals.pop("current_job_skill_ids", []) + vals.get("job_skill_ids", [])
             vals["job_skill_ids"] = self.env["hr.job.skill"]._get_transformed_commands(vals_job_skill, self)
         return super().create(vals_list)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('job_skill_ids'):
+            res['job_skill_ids']['searchable'] = False
+        if res.get('current_job_skill_ids'):
+            res['current_job_skill_ids']['searchable'] = False
+        return res
 
     def write(self, vals):
         if "current_job_skill_ids" in vals or "job_skill_ids" in vals:

--- a/addons/hr_skills/models/hr_skill_proficiency.py
+++ b/addons/hr_skills/models/hr_skill_proficiency.py
@@ -1,0 +1,64 @@
+from odoo import api, fields, models
+from odoo.fields import Domain
+
+
+class HrSkillProficiency(models.Model):
+    _name = 'hr.skill.proficiency'
+    _description = "Skill Proficiency"
+    _order = "skill_type_id, skill_id, skill_level_id"
+    _rec_name = "skill_id"
+
+    skill_id = fields.Many2one('hr.skill', required=True, ondelete='cascade', index=True)
+    skill_level_id = fields.Many2one('hr.skill.level', required=True, ondelete='cascade', index=True)
+    skill_type_id = fields.Many2one('hr.skill.type', related='skill_id.skill_type_id', store=True)
+
+    _skill_level_uniq = models.Constraint(
+        'unique(skill_id, skill_level_id)',
+        'A proficiency record already exists for this skill and level combination.'
+    )
+
+    @api.depends('skill_id', 'skill_level_id')
+    def _compute_display_name(self):
+        for record in self:
+            record.display_name = f"{record.skill_id.name}: {record.skill_level_id.name}"
+
+    @api.model
+    def _search_display_name(self, operator, value):
+        if operator in Domain.NEGATIVE_OPERATORS:
+            return NotImplemented
+        if ': ' in (value or ''):
+            skill_name, level_name = value.split(': ', 1)
+            return Domain.AND([
+                Domain('skill_id.name', operator, skill_name),
+                Domain('skill_level_id.name', operator, level_name),
+            ])
+        return Domain.OR([
+            Domain('skill_id.name', operator, value),
+            Domain('skill_level_id.name', operator, value),
+        ])
+
+    @api.model
+    def _get_or_create_proficiencies(self, skill_lines):
+        pairs = {
+            (line.skill_id.id, line.skill_level_id.id) for line in skill_lines
+        }
+        if not pairs:
+            return self.browse()
+
+        skill_ids = [p[0] for p in pairs]
+        level_ids = [p[1] for p in pairs]
+        existing = self.search([
+            ('skill_id', 'in', skill_ids),
+            ('skill_level_id', 'in', level_ids),
+        ])
+        existing_map = {(p.skill_id.id, p.skill_level_id.id): p for p in existing}
+        missing = pairs - existing_map.keys()
+        if missing:
+            new_profs = self.sudo().create([
+                {'skill_id': sid, 'skill_level_id': lid}
+                for sid, lid in missing
+            ])
+            for prof in new_profs:
+                existing_map[prof.skill_id.id, prof.skill_level_id.id] = prof
+
+        return self.browse([existing_map[pair].id for pair in pairs])

--- a/addons/hr_skills/security/ir.model.access.csv
+++ b/addons/hr_skills/security/ir.model.access.csv
@@ -9,6 +9,8 @@ access_hr_skill_level,hr.skill.level,model_hr_skill_level,hr.group_hr_user,1,1,1
 access_hr_skill_level_employee,hr.skill.level.employee,model_hr_skill_level,base.group_user,1,0,0,0
 access_hr_skill,hr.skill,model_hr_skill,hr.group_hr_user,1,1,1,1
 access_hr_skill_employee,hr.skill.employee,model_hr_skill,base.group_user,1,0,1,0
+access_hr_skill_proficiency,hr.skill.proficiency,model_hr_skill_proficiency,hr.group_hr_user,1,1,1,1
+access_hr_skill_proficiency_employee,hr.skill.proficiency.employee,model_hr_skill_proficiency,base.group_user,1,0,0,0
 access_hr_employee_skill,hr.employee.skill,model_hr_employee_skill,hr.group_hr_user,1,1,1,1
 access_hr_employee_skill_employee,hr.employee.skill,model_hr_employee_skill,base.group_user,1,1,1,1
 access_hr_employee_skill_report_user,hr.employee.skill.report,model_hr_employee_skill_report,hr.group_hr_user,1,0,0,0

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="hr.view_employee_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='job_id']" position="after">
-                <field name="employee_skill_ids"/>
+                <field name="skill_proficiency_ids"/>
             </xpath>
         </field>
     </record>
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="hr.hr_employee_public_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='job_id']" position="after">
-                <field name="employee_skill_ids"/>
+                <field name="skill_proficiency_ids"/>
             </xpath>
         </field>
     </record>
@@ -488,6 +488,18 @@
                 <field name="color" widget="color_picker" optional="show"/>
                 <field name="skill_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
                 <field name="skill_level_ids" widget="many2many_tags_skills"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="hr_skill_proficiency_view_tree" model="ir.ui.view">
+        <field name="name">hr.skill.proficiency.list</field>
+        <field name="model">hr.skill.proficiency</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="skill_type_id"/>
+                <field name="skill_id"/>
+                <field name="skill_level_id"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
This change addresses ambiguity in skill filtering for employees, applicants, jobs, and appraisals. Previously, skills were represented as a Many2one relation, but the display name (e.g., "English B2") was not unique: skills could differ by certificate, validity dates, or other attributes. This made filtering by skill+level unreliable, as multiple records could exist for the same skill and level, but with different metadata.

To solve this, a new model (hr.skill.proficiency) is introduced as a master for skill+level pairs. All individual skill lines now compute and store a Many2one to this proficiency model, and parent records (employee, applicant, job, appraisal) aggregate these as a Many2many.

Finally, previous ambiguous fields have been excluded from custom filter views.

task-5930483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
