### PR TITLE
[FIX] mail: change fetchmail cron logic

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -245,7 +245,17 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
     def _fetch_mails(self, **kw):
         """ Method called by cron to fetch mails from servers """
         assert self.env.context.get('cron_id') == self.env.ref('mail.ir_cron_mail_gateway_action').id, "Meant for cron usage only"
-        self.search(MAIL_SERVER_DOMAIN)._fetch_mail(**kw)
+        # We sort by priority first (lowest first).
+        # Then by date ASC (oldest first), date is updated after server is processed by cron
+        # This ensures that the fetchmail servers are rotated for each job run
+        custom_order = "priority asc, date asc nulls first, id asc"
+        records = self.search(MAIL_SERVER_DOMAIN, order=custom_order)
+        # To ensure that all N inbox can be looped over to be checked (when empty),
+        # we add a time buffer of 4*N sec, assuming an EXTREME edge-case of 2*2s latency
+        # to connect and check the empty inbox.
+        # Should be adapted if ir_cron is refactored in the future
+        time_buffer = self.env.context['cron_end_time'] + (4 * len(records))
+        records.with_context(cron_end_time=time_buffer)._fetch_mail(**kw)
         if not self.search_count(MAIL_SERVER_DOMAIN):
             # no server is active anymore
             self.env['ir.cron']._commit_progress(deactivate=True)
@@ -257,8 +267,9 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
         """
         result_exception = None
         servers = self.with_context(fetchmail_cron_running=True)
-        total_remaining = len(servers)  # number of remaining messages + number of unchecked servers
+        total_remaining = len(servers)  # number of unseen messages + number of unchecked servers
         self.env['ir.cron']._commit_progress(remaining=total_remaining)
+        _logger.info("Fetchmail servers (in order) to be processed %s", servers.mapped('name'))
 
         for server in servers:
             total_remaining -= 1  # the server is checked
@@ -296,7 +307,8 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         MailThread.env.cr.rollback()
                         failed += 1
                         _logger.info('Failed to process mail from %s server %s.', *server_type_and_name, exc_info=True)
-                        remaining_time = MailThread.env['ir.cron']._commit_progress()
+                        # mail failed, but still "seen", so one unit of work
+                        remaining_time = MailThread.env['ir.cron']._commit_progress(1)
                     server_connection.handled_message(message_num)
                     if count >= batch_limit or not remaining_time:
                         break
@@ -326,7 +338,9 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
             # updated for messages using another transaction. Without a commit
             # before updating the progress, we would have a serialization error.
             self.env.cr.commit()
-            if not self.env['ir.cron']._commit_progress(remaining=total_remaining):
+            # checked server, so one unit of work done (even if no messages fetched on server)
+            remaining_time = self.env['ir.cron']._commit_progress(1, remaining=total_remaining)
+            if not remaining_time:
                 break
         return result_exception
 


### PR DESCRIPTION
Since Odoo 18.4, the general logic for the fetchmail Cron Job was
refactored to align it with the new changes to how cron jobs are
handled (i.e. the _commit_progress etc.)
See https://github.com/odoo/odoo/pull/191911

But it certain (legitimate) edge-cases, the current logic might not
handle real-life scenario correctly

Analysis:

When having a high number of legitimate and working fetchmail.server records (>10).
The cron job was repeatably finishing in a "partially done" state,
reporting 0 done progress and retriggering immediately.
Also if there was a notable latency when establishing the IMAP connection,
this had for effect of:

- The cron would process the first few (empty, no new unseen mail) inboxes
 stop break early because of this
 https://github.com/odoo/odoo/blob/4056fa8036ddad11c898cd775b7fa21ba4f8a5de/addons/mail/models/fetchmail.py#L329
 , i.e. if no progess is commited, the cron job handler stops the job
 after 10 secs see https://github.com/odoo/odoo/blob/4056fa8036ddad11c898cd775b7fa21ba4f8a5de/odoo/addons/base/models/ir_cron.py#L495-L498
- Thus the job would stop early in the partially done state, which would
create a cron trigger and relaunch it at the earliest
(usally 1 min later if no other jobs running)
- In the new run, because _fetch_mails always browses the fetchmail.server
 records in the same order, it will check the same inboxes again, and
 because they are empty and there is a connection lag, it would take
 longer than 10 secs again and stop the cron early
 in partially done → rinse and repeat
- In practice in this edge-case we will never check the remaining
fetchmail servers, so unseen emails on those would never be processed →
customer complains that emails are not coming in
- The repeated triggering of the job and it never officially reporting
progress seems to trigger the automatic deactivation on the odoo.sh
platform, further aggravating the situation

Issues with current business logic of the cron:

1) The `total_remaining` variable (tracking the "units" of work to be done)
 does not distinguish between number of servers to be process and the
 number of unseen emails to be processes on the current fetchmail server.
 At the same time it does not commit an explicit progress when finishing
 an outer loop (at the server level) when the inbox was empty
2) The use of `remaining_time` as a circuit-breakers seems like a good
idea at first, but combined with point 1, will terminate the cron early
if checking empty inboxes takes too long and will break the inner loop
(fetching emails) early on subsequent loops of the cron
3) `_fetch_mails` will always return the model records in the same order,
and everything being equal, will not account for that fact if some
fetchmail.server records have been fetched more recently than others

Proposed changes to logic:

1. We add a time buffer to the 'cron_end_time' context value, initialized at the beginning of a job an usually accounting for 10 secs of wall-time per job. We scale the time buffer as 4 * N secs, N being the number of total fetchmail records that need to be checked. This is to ensure that, assuming that all mail inboxes are empty, we have enough time to loop over all of them even if there is "extreme" latency of 2s to connect and 2s to get a response from the mail server.

2. We make the ordering in _fetch_mails "smarter" by  adding a
    custom order argument for more dynamic queuing:
	A) Records with the lowest priority first
	B) Records having the oldest date first, i.e we dynamically penalize
    records that were fetched recently given the date fields get's
    updated every time it fetched/checked a server successfully

3. If a customer still hits the implicit threshold (i.e. it takes longer than 10 + 4 *N s to loop over all current fetchmail servers), the cron will simply rerun at the next recurrence and the custom order should ensure that the backlog get's resorbed. If the time buffer is still not enough in extreme latency scenarios, then users should either fix the root cause (connection latency between the Odoo DB and the mail servers) or opt for an alternative to route the emails to the DB (setting up an MX record and redirecting mails into a mailgate).

OPW-6054244
OPW-6019730