### PR TITLE
[IMP] setup,iot_drivers: proxy token for egypt

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -85,6 +85,7 @@ class Manager(Thread):
             'ip': self.domain,
             'token': helpers.get_token(),
             'version': self.version,
+            "l10n_eg_proxy_token": helpers.get_conf("proxy_access_token", "default"),
         }
         devices_list = {}
         for device in self.previous_iot_devices.values():

--- a/setup/win32/setup-iot.nsi
+++ b/setup/win32/setup-iot.nsi
@@ -89,6 +89,7 @@ RequestExecutionLevel admin
 !insertmacro GetOptions
 
 Var /GLOBAL cmdLineParams
+Var /GLOBAL ProxyTokenPwd
 
 !define STATIC_PATH "static"
 !define PIXMAPS_PATH "${STATIC_PATH}\pixmaps"
@@ -208,6 +209,11 @@ Section $(TITLE_Odoo_IoT) SectionOdoo_IoT
     nsExec::ExecToLog '"$INSTDIR\nssm\win64\nssm.exe" set ${SERVICENAME} AppParameters "\"$INSTDIR\odoo\odoo-bin\" -c "\"$INSTDIR\odoo.conf\"'
     nsExec::ExecToLog '"$INSTDIR\nssm\win64\nssm.exe" set ${SERVICENAME} ObjectName "LOCALSERVICE"'
     AccessControl::GrantOnFile  "$INSTDIR" "LOCALSERVICE" "FullAccess"
+
+    nsExec::ExecToStack '"$INSTDIR\python\python.exe" "$INSTDIR\odoo\odoo-bin" genproxytoken'
+    pop $0
+    pop $ProxyTokenPwd
+    WriteIniStr "$INSTDIR\odoo.conf" "options" "proxy_access_token" "$ProxyTokenPwd"
 
     Call RestartOdooService
 SectionEnd


### PR DESCRIPTION
Proxy token generation was removed to avoid showing a modal with a token nobody cares about except Egypt. We reintroduce token generation, but send it to the database instead of showing a modal.

see odoo/enterprise#111496