### PR TITLE
[FIX] web: fix dropdown closing logic

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -268,7 +268,8 @@ export class Dropdown extends Component {
         if (rootNode instanceof ShadowRoot) {
             target = rootNode.host;
         }
-        return this.uiService.getActiveElementOf(target) === this.activeEl;
+        const targetActiveEl = this.uiService.getActiveElementOf(target);
+        return targetActiveEl === this.activeEl || targetActiveEl?.contains(this.activeEl);
     }
 
     setTargetElement(target) {

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -268,6 +268,9 @@ export class Dropdown extends Component {
         if (rootNode instanceof ShadowRoot) {
             target = rootNode.host;
         }
+        if (!this.activeEl?.isConnected) {
+            return true;
+        }
         const targetActiveEl = this.uiService.getActiveElementOf(target);
         return targetActiveEl === this.activeEl || targetActiveEl?.contains(this.activeEl);
     }

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -29,6 +29,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { CheckboxItem } from "@web/core/dropdown/checkbox_item";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useActiveElement } from "@web/core/ui/ui_service";
 
 const DROPDOWN_TOGGLE = ".o-dropdown.dropdown-toggle";
 const DROPDOWN_MENU = ".o-dropdown--menu.dropdown-menu";
@@ -173,6 +174,42 @@ test("close on outside click", async () => {
         await click(".o_bottom_sheet_backdrop");
     } else {
         await click("div.outside");
+    }
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(0);
+});
+
+test("close on click outside an active element", async () => {
+    class ActiveElementDropdown extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+            <div class="outside">outside</div>
+            <div t-ref="active">
+                <Dropdown>
+                    <button>Dropdown</button>
+                    <t t-set-slot="content">
+                        <DropdownItem class="'item-a'">Item A</DropdownItem>
+                    </t>
+                </Dropdown>
+            </div>
+        `;
+
+        setup() {
+            useActiveElement("active");
+        }
+    }
+
+    await mountWithCleanup(ActiveElementDropdown);
+
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(1);
+
+    if (getMockEnv().isSmall) {
+        await click(".o_bottom_sheet_backdrop");
+    } else {
+        await click(".outside");
     }
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(0);
@@ -723,7 +760,7 @@ test("Dropdown with CheckboxItem: toggle value", async () => {
     expect(DROPDOWN_ITEM).toHaveClass(["selected", "focus"]);
 });
 
-test("don't close dropdown outside the active element", async () => {
+test("don't close parent dropdown when clicking in a child active element", async () => {
     const env = await makeMockEnv();
 
     // This test checks that if a dropdown element opens a dialog with a dropdown inside,

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -215,6 +215,50 @@ test("close on click outside an active element", async () => {
     expect(DROPDOWN_MENU).toHaveCount(0);
 });
 
+test("close on click outside when the opening active element was removed", async () => {
+    class ActiveElementDropdown extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+            <div class="outside">outside</div>
+            <div t-if="state.showActive" t-ref="active">
+                <button class="active-button">Active</button>
+            </div>
+            <Dropdown>
+                <button>Dropdown</button>
+                <t t-set-slot="content">
+                    <DropdownItem class="'item-a'">Item A</DropdownItem>
+                </t>
+            </Dropdown>
+        `;
+
+        setup() {
+            this.state = useState({ showActive: true });
+            useActiveElement("active");
+        }
+    }
+
+    const comp = await mountWithCleanup(ActiveElementDropdown);
+
+    const activeEl = queryOne(".active-button").parentElement;
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(1);
+
+    comp.state.showActive = false;
+    await animationFrame();
+    expect(activeEl.isConnected).toBe(false);
+    expect(DROPDOWN_MENU).toHaveCount(1);
+
+    if (getMockEnv().isSmall) {
+        await click(".o_bottom_sheet_backdrop");
+    } else {
+        await click(".outside");
+    }
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(0);
+});
+
 test("close on outside click in shadow dom", async () => {
     class DropdownInShadowDom extends Component {
         static components = { SimpleDropdown };


### PR DESCRIPTION
[FIX] web: fix dropdown closing logic when clicking outside active UI
    
    Before this commit, the dropdown were closed when clicking outside...
    but only if the element that was clicked belongs to the same "UI
    active element" as the one that was the current one when the dropdown
    was opened.
    
    That is not perfect:
    - Open some popover that becomes the "UI active element"
    - Open the user menu dropdown (which is thus outside the current "UI
      active element")
    - Click just below that user menu dropdown
    => It does not close.
    
    It will only close when clicking in the registered "UI active element",
    which is not logical.
    
    This commit improves the logic: the close also occurs if the click
    occurs in *an ancestor* of the old registered "UI active element". That
    still keep the idea of checking "UI active elements" at all, for example
    in the case "dropdown -> dialog -> dropdown -> click outside", which
    should not close the first dropdown, as in that case it is the opposite
    situation: the click occurs  in a *child* "UI active element" of the old
    registered one.
    
    This fix is needed to fix a VoIP issue, where the "popover" mentioned
    in the example above is the VoIP softphone. See enterprise counter-part
    for more precisions.

[FIX] web: fix dropdown closing logic after closing active UI elements
    
    The parent commit fixes the dropdown closing logic when clicking outside
    "UI active elements". But it was not enough:
    - Open some popover that becomes the "UI active element"
    - Open the user menu dropdown (which is thus outside the current "UI
      active element")
    - Close the popover with some keyboard shortcut
    - Click just below that user menu dropdown
    => It still does not close, although we are in a situation without any
       "UI active element".
    
    This commit improves the logic again: the close also occurs if the click
    occurs while the old registered "UI active element" is gone.
    
    This fix is needed to fix a VoIP issue, where the "popover" mentioned
    in the example above is the VoIP softphone. See enterprise counter-part
    for more precisions.
    
task-6055692