### PR TITLE
[18.0][FIX] purchase: Add check_company_auto for purchase order

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -21,6 +21,7 @@ class PurchaseOrder(models.Model):
     _description = "Purchase Order"
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
+    _check_company_auto = True
 
     @api.depends('order_line.price_subtotal', 'company_id', 'currency_id')
     def _amount_all(self):
@@ -126,7 +127,7 @@ class PurchaseOrder(models.Model):
     amount_total = fields.Monetary(string='Total', store=True, readonly=True, compute='_amount_all')
     amount_total_cc = fields.Monetary(string="Company Total", store=True, readonly=True, compute="_amount_all", currency_field="company_currency_id")
 
-    fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", check_company=True)
     tax_country_id = fields.Many2one(
         comodel_name='res.country',
         compute='_compute_tax_country_id',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The purchase Order model does not have the property `_check_company_auto` even though some fields have the property `check_company=True`
Also the field fiscal_position_id does not have the property `check_company=True`.
Because of this, it is possible to create a purchase order with a fiscal position from another company
On similar models like sale.order, the `check_company` property is set and working for fiscal position for instance.

**Current behavior before PR:**
It is possible to create a purchase order with a fiscal position belonging to another company.
Same with the partner_id or the user_id or the dest_address_id

**Desired behavior after PR is merged:**
Not possible to create a purchase order with a fiscal position having a different company than the one on the PO.
Make work the property check_company on the fields of the purchase order.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

cc @alexis-via 
