### PR TITLE
[FIX] account: fix HOOT test with l10n_in/l10n_ar installed

### DIFF
--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -92,7 +92,9 @@ test("Update description on product line", async() => {
     const pyEnv = await startServer();
     const productId = pyEnv["product"].browse([1]);
     const accountMove = pyEnv["account.move"].browse([1]);
-    pyEnv["account.move.line"].create({ name: productId[0].name, product_id: productId[0].id, move_id: accountMove[0].id });
+    pyEnv["account.move"].write([accountMove[0].id], {
+        invoice_line_ids: [[0, 0, { name: productId[0].name, product_id: productId[0].id }]],
+    });
     await start();
     onRpc("account.move", "web_save", () => { asyncStep("save")});
     await openFormView("account.move", accountMove[0].id, {


### PR DESCRIPTION
Create the invoice line through the `invoice_line_ids` o2m write command instead of a standalone `account.move.line` create with move_id.  

The mock server's `inverse_fname_by_model_name` mapping only keeps one o2m per co-model; when extra modules add another o2m with the same inverse (`l10n_in_withholding_line_ids` from l10n_in, `l10n_ar_withholding_ids` from l10n_ar_withholding), it shadows `invoice_line_ids` and the list renders empty.

runbot-233670