### PR TITLE
[REF] tools: dedicated expr_eval evaluator

### DIFF
--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -4,7 +4,7 @@ import json
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools.safe_eval import expr_eval
 
 from odoo.addons.account_tax_python.tools.formula_utils import check_formula, normalize_formula
 
@@ -109,7 +109,7 @@ class AccountTax(models.Model):
         except TypeError:
             raise ValidationError(_("Only primitive types are allowed in python tax formula context."))
         try:
-            return safe_eval(normalized_formula, formula_context)
+            return expr_eval(normalized_formula, formula_context)
         except ZeroDivisionError:
             return 0.0
 

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -7,7 +7,7 @@ import psycopg2
 from odoo import SUPERUSER_ID, Command, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.modules.registry import Registry
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools.safe_eval import expr_eval
 
 
 class DeliveryCarrier(models.Model):
@@ -604,7 +604,7 @@ class DeliveryCarrier(models.Model):
         criteria_found = False
         price_dict = self._get_price_dict(total, weight, volume, quantity, wv=wv)
         for line in self.price_rule_ids:
-            test = safe_eval(line.variable + line.operator + str(line.max_value), price_dict)
+            test = expr_eval(line.variable + line.operator + str(line.max_value), price_dict)
             if test:
                 price = line.list_base_price + line.list_price * price_dict[line.variable_factor]
                 criteria_found = True

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -500,7 +500,7 @@ class TestRegexRendering(common.MailCommon):
             ('''{{object.contact_name ||| Default}}''', 'Default'),
         )
         for template, expected in static_templates:
-            with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
+            with patch('odoo.tools.safe_eval.evaluation.unsafe_eval', side_effect=eval) as unsafe_eval:
                 self.assertEqual(render(template), expected)
                 self.assertFalse(unsafe_eval.called)
                 self.assertFalse(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template, 'res.partner'))
@@ -511,7 +511,7 @@ class TestRegexRendering(common.MailCommon):
             ('''{{object.env.context.get('test')}}''', ''),
         )
         for template, expected in non_static_templates:
-            with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
+            with patch('odoo.tools.safe_eval.evaluation.unsafe_eval', side_effect=eval) as unsafe_eval:
                 self.assertEqual(render(template), expected)
                 self.assertTrue(unsafe_eval.called)
                 self.assertTrue(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template, 'res.partner'))

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -290,13 +290,13 @@ class TestMailTemplate(MailCommon):
             self.assertTrue(unsafe_eval.called)
 
         employee_template.email_to = 'Test {{ object.name }}'
-        with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
+        with patch('odoo.tools.safe_eval.evaluation.unsafe_eval', side_effect=eval) as unsafe_eval:
             employee_template._render_field('email_to', record.ids)
             self.assertFalse(unsafe_eval.called)
 
         # double check that we can detect the eval call
         mail_template.email_to = 'Test {{ 1+1 }}'
-        with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
+        with patch('odoo.tools.safe_eval.evaluation.unsafe_eval', side_effect=eval) as unsafe_eval:
             mail_template._render_field('email_to', record.ids)
             self.assertTrue(unsafe_eval.called)
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -19,7 +19,7 @@ from odoo.http import request
 from odoo.tools import BinaryBytes, _, frozendict, get_lang
 from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import get_diff, unquote
-from odoo.tools.safe_eval import safe_eval, test_python_expr
+from odoo.tools.safe_eval import expr_eval, safe_eval, test_python_expr
 
 _logger = logging.getLogger(__name__)
 _server_action_logger = _logger.getChild("server_action_safe_eval")
@@ -1427,7 +1427,7 @@ class IrActionsClient(models.Model):
     @api.depends('params_store')
     def _compute_params(self):
         for record in self:
-            record.params = record.params_store and safe_eval(record.params_store, {'uid': self.env.uid})
+            record.params = record.params_store and expr_eval(record.params_store, {'uid': self.env.uid})
 
     def _inverse_params(self):
         for record in self:

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -16,7 +16,7 @@ from odoo import api, fields, models, tools
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.tools import BinaryBytes, frozendict, reset_cached_properties, split_every, sql, unique, OrderedSet, SQL
-from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
+from odoo.tools.safe_eval import expr_eval, safe_eval, datetime, dateutil, time
 from odoo.tools.translate import FIELD_TRANSLATE, LazyTranslate, _
 
 _lt = LazyTranslate(__name__)
@@ -666,8 +666,8 @@ class IrModelFields(models.Model):
     def _check_domain(self):
         for field in self:
             try:
-                safe_eval(field.domain or '[]')
-            except ValueError as e:
+                expr_eval(field.domain or '[]')
+            except Exception as e:  # noqa: BLE001
                 raise ValidationError(
                     _("An error occurred while evaluating the domain:\n%(error)s", error=e)
                 ) from e
@@ -1350,7 +1350,7 @@ class IrModelFields(models.Model):
                 return
             attrs['comodel_name'] = field_data['relation']
             attrs['ondelete'] = field_data['on_delete']
-            attrs['domain'] = safe_eval(field_data['domain'] or '[]')
+            attrs['domain'] = expr_eval(field_data['domain'] or '[]')
             attrs['group_expand'] = '_read_group_expand_full' if field_data['group_expand'] else None
         elif field_data['ttype'] == 'one2many':
             if not self.pool.loaded and not (
@@ -1361,7 +1361,7 @@ class IrModelFields(models.Model):
                 return
             attrs['comodel_name'] = field_data['relation']
             attrs['inverse_name'] = field_data['relation_field']
-            attrs['domain'] = safe_eval(field_data['domain'] or '[]')
+            attrs['domain'] = expr_eval(field_data['domain'] or '[]')
         elif field_data['ttype'] == 'many2many':
             if not self.pool.loaded and field_data['relation'] not in self.env:
                 return
@@ -1370,7 +1370,7 @@ class IrModelFields(models.Model):
             attrs['relation'] = field_data['relation_table'] or rel
             attrs['column1'] = field_data['column1'] or col1
             attrs['column2'] = field_data['column2'] or col2
-            attrs['domain'] = safe_eval(field_data['domain'] or '[]')
+            attrs['domain'] = expr_eval(field_data['domain'] or '[]')
         elif field_data['ttype'] == 'monetary':
             # be sure that custom monetary field are always instanciated
             if not self.pool.loaded and \

--- a/odoo/addons/test_tools/tests/__init__.py
+++ b/odoo/addons/test_tools/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_misc
 from . import test_pdf
 from . import test_profiler
 from . import test_safe_eval
+from . import test_safe_eval_expr
 from . import test_set_expression
 from . import test_sql
 from . import test_translate

--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -1,24 +1,21 @@
 import ast
 import inspect
-
 from textwrap import dedent
 from unittest.mock import patch
 
-from odoo import Command
-from odoo.tests.common import tagged, BaseCase, TransactionCase
+from odoo.tests.common import BaseCase, TransactionCase, tagged
 from odoo.tools import mute_logger
 from odoo.tools.misc import OrderedSet
 from odoo.tools.safe_eval import (
     _BUILTINS,
-    const_eval,
-    expr_eval,
-    safe_checker,
-    safe_eval,
     UnsafeClassError,
     UnsafeFunctionError,
     UnsafeInstanceError,
     UnsafeModuleError,
     UnsafePolicy,
+    const_eval,
+    safe_checker,
+    safe_eval
 )
 
 
@@ -31,19 +28,6 @@ class TestSafeEval(BaseCase):
         self.assertEqual(actual, expected)
         # Test RETURN_CONST
         self.assertEqual(const_eval('10'), 10)
-
-    def test_expr(self):
-        # NB: True and False are names in Python 2 not consts
-        expected = 3 * 4
-        actual = expr_eval('3 * 4')
-        self.assertEqual(actual, expected)
-
-    def test_expr_eval_opcodes(self):
-        for expr, expected in [
-            ('3', 3),  # RETURN_CONST
-            ('[1,2,3,4][1:3]', [2, 3]),  # BINARY_SLICE
-        ]:
-            self.assertEqual(expr_eval(expr), expected)
 
     def test_safe_eval_opcodes(self):
         for expr, context, expected in [
@@ -122,12 +106,12 @@ class TestSafeEval(BaseCase):
     def test_03_literal_eval_arithmetic(self):
         """ Try arithmetic expression in literal_eval to verify it does not work """
         with self.assertRaises(ValueError):
-           ast.literal_eval('(1, {"a": 2*9}, (True, False, None))')
+            ast.literal_eval('(1, {"a": 2*9}, (True, False, None))')
 
     def test_04_literal_eval_forbidden(self):
         """ Try forbidden expressions in literal_eval to verify they are not allowed """
         with self.assertRaises(ValueError):
-           ast.literal_eval('{"a": True.__class__}')
+            ast.literal_eval('{"a": True.__class__}')
 
     @mute_logger('odoo.tools.safe_eval')
     def test_05_safe_eval_forbidden(self):
@@ -212,7 +196,7 @@ class TestSafeEvalRuntime(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.startClassPatcher(patch(
-            'odoo.tools.safe_eval.unsafe_policy',
+            'odoo.tools.safe_eval.evaluation.unsafe_policy',
             lambda: UnsafePolicy.RAISE
         ))
 
@@ -255,7 +239,7 @@ class TestSafeEvalRuntime(TransactionCase):
             'wrapper_A', 'wrapper_B',  # Evaluation order
         ])
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_callee(self):
         expr = """
             UnsafeClass()
@@ -263,7 +247,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_args(self):
         expr = """
             callee = lambda *args, **kwargs: ...
@@ -272,7 +256,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_kwargs(self):
         expr = """
             callee = lambda *args, **kwargs: ...
@@ -281,7 +265,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_structure(self):
         expr = """
             callee = lambda *args, **kwargs: ...
@@ -299,7 +283,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_builtin_callee(self):
         expr = """
             map(UnsafeClass, ['foo'])
@@ -319,7 +303,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_callee_qweb(self):
         arch = '''
             <t t-name="template">
@@ -348,7 +332,7 @@ class TestSafeEvalRuntime(TransactionCase):
         # because after transformer, the code becomes:
         # `_save_eval_call = lambda callee, *args, **kwargs: _save_eval_call(callee, *args, **kwargs)`
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_prevent_bare_except(self):
         expr = """
             try:
@@ -359,7 +343,7 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaises(SyntaxError):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
-    @mute_logger('odoo.tools.safe_eval.runtime')
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_generator(self):
         # Not listen `YIELD` event for external generator
         expr = """

--- a/odoo/addons/test_tools/tests/test_safe_eval_expr.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval_expr.py
@@ -1,0 +1,214 @@
+from odoo.tests.common import BaseCase, tagged
+from odoo.tools.safe_eval import expr_eval
+
+
+@tagged('at_install', '-post_install')
+class TestExprEval(BaseCase):
+    def test_basic_arithmetic(self):
+        cases = {
+            '2 + 3': 5,
+            '10 - 3': 7,
+            '4 * 5': 20,
+            '20 / 4': 5.0,
+            '20 // 4': 5,
+            '10 % 3': 1,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_operator_precedence(self):
+        cases = {
+            '2 + 3 * 4': 14,
+            '(2 + 3) * 4': 20,
+            '10 - 4 / 2': 8.0,
+            '(10 - 4) / 2': 3.0,
+            '10 % 4 + 1': 3,
+            '-2 + 5': 3,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_boolean_logic(self):
+        cases = {
+            'True and False': False,
+            'True or False': True,
+            'not True': False,
+            'not False': True,
+            'True and not False': True,
+            'False or not False': True,
+            '0 and 1': 0,
+            'False or None': None,
+            '0 or 1': 1,
+            '1 or 0': 1,
+            '1 and 0': 0,
+            '[] or \'fallback\'': 'fallback',
+            '[1] and \'ok\'': 'ok',
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_boolean_short_circuit(self):
+        self.assertEqual(expr_eval('False and unknown_variable'), False)
+        self.assertEqual(expr_eval('True or unknown_variable'), True)
+        self.assertEqual(expr_eval('False and (1 / 0)'), False)
+        self.assertEqual(expr_eval('True or (1 / 0)'), True)
+
+    def test_comparisons(self):
+        cases = {
+            '1 < 2': True,
+            '2 > 1': True,
+            '2 == 2': True,
+            '3 != 4': True,
+            '1 <= 1': True,
+            '2 >= 3': False,
+            '1 < 2 < 3': True,
+            '1 < 2 > 3': False,
+            '2 == 2 == 2': True,
+            '2 == 2 != 3': True,
+            '[1] == [1]': True,
+            '[1] is [1]': False,
+            'None is None': True,
+            'None is not None': False,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_min_max_calls(self):
+        cases = {
+            'min(1, 2)': 1,
+            'max(1, 2)': 2,
+            'min(3, 2, 1)': 1,
+            'max(3, 2, 1)': 3,
+            'min([5, 3, 4])': 3,
+            'max([5, 3, 4])': 5,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_contains(self):
+        cases = {
+            '1 in [1, 2, 3]': True,
+            '4 in [1, 2, 3]': False,
+            '"a" in "cat"': True,
+            '"z" not in "cat"': True,
+            'b"a" in b"cat"': True,
+            'b"z" not in b"cat"': True,
+            '2 in (1, 2, 3)': True,
+            '4 not in (1, 2, 3)': True,
+            '2 in {1, 2, 3}': True,
+            '4 in {1, 2, 3}': False,
+            '4 not in {1, 2, 3}': True,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_variables(self):
+        context = {'x': 10, 'y': 5}
+        cases = {
+            'x + y': 15,
+            'x - y': 5,
+            'x * y': 50,
+            'x / y': 2.0,
+            'x // y': 2,
+            'x % y': 0,
+            'x is not y': True,
+            'x > y': True,
+            'x == 10': True,
+            'y < 3': False,
+            'not x < y': True,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr, context=context), expected)
+
+    def test_list_tuple_dict(self):
+        cases = {
+            '[1, 2, 3]': [1, 2, 3],
+            '(1, 2, 3)': (1, 2, 3),
+            '{1, 2, 3}': {1, 2, 3},
+            '{}': {},
+            'set()': set(),
+            '{"a": 1, "b": 2}': {'a': 1, 'b': 2},
+            '[("name", "=", "x")]': [('name', '=', 'x')],
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr), expected)
+
+    def test_subscripts(self):
+        context = {
+            'vals': {'amount': 42, 'items': [10, 20, 30]},
+            'lines': [
+                {'balance': 100},
+                {'balance': 200},
+            ],
+        }
+        cases = {
+            'vals["amount"]': 42,
+            'vals["items"][1]': 20,
+            'lines[0]["balance"]': 100,
+            'lines[1]["balance"] > lines[0]["balance"]': True,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr, context=context), expected)
+
+    def test_domains(self):
+        context = {
+            'user_id': 7,
+            'group_ids': [1, 2, 3],
+        }
+        cases = {
+            '[("user_id", "=", user_id)]': [('user_id', '=', 7)],
+            '[("group_ids", "in", group_ids)]': [('group_ids', 'in', [1, 2, 3])],
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr, context=context), expected)
+
+    def test_unknown_variable(self):
+        with self.assertRaises(NameError):
+            expr_eval('missing + 1')
+
+    def test_runtime_errors_are_not_hidden(self):
+        with self.assertRaises(ZeroDivisionError):
+            expr_eval('1 / 0')
+
+        with self.assertRaises(IndexError):
+            expr_eval('[1][5]')
+
+        with self.assertRaises(KeyError):
+            expr_eval('{}["x"]')
+
+    def test_invalid_syntax(self):
+        for expr in ('2 +', '* 3', 'import os', 'a.b'):
+            with self.subTest(expr=expr):
+                with self.assertRaises((SyntaxError, TypeError)):
+                    expr_eval(expr)
+        with self.assertRaises(NameError):
+            expr_eval('unknown_func()')
+
+    def test_unsupported_constants(self):
+        for expr in ('...', '1j'):
+            with self.subTest(expr=expr):
+                with self.assertRaises(TypeError):
+                    expr_eval(expr)
+
+    def test_no_cache_mutables(self):
+        mutable_lst = expr_eval("[]")
+        mutable_lst.append(1)
+        self.assertNotIn(1, expr_eval("[]"))
+
+        mutable_ctx = {'a': [1, 2]}
+        res1 = expr_eval('a[0] + a[1]', mutable_ctx)
+        self.assertEqual(res1, 3)
+
+        mutable_ctx['a'][0] = 2
+        res2 = expr_eval('a[0] + a[1]', mutable_ctx)
+        self.assertEqual(res2, 4)

--- a/odoo/tools/safe_eval/__init__.py
+++ b/odoo/tools/safe_eval/__init__.py
@@ -1,0 +1,2 @@
+from .evaluation import *
+from .expression import expr_eval

--- a/odoo/tools/safe_eval/evaluation.py
+++ b/odoo/tools/safe_eval/evaluation.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 """
 safe_eval module - methods intended to provide more restricted alternatives to
                    evaluate simple and/or untrusted code.
@@ -26,8 +23,8 @@ import sys
 import types
 import typing
 import zoneinfo
-from collections import defaultdict, OrderedDict
-from enum import auto, IntEnum
+from collections import OrderedDict, defaultdict
+from enum import IntEnum, auto
 from json.encoder import c_make_encoder  # noqa: OLS02001
 from opcode import opmap, opname
 from types import (
@@ -169,6 +166,7 @@ class UnsafeFunctionError(UnsafeObjectError):
 # lp:703841), does import time.
 _ALLOWED_MODULES = ['_strptime', 'math', 'time']
 
+
 # Mock __import__ function, as called by cpython's import emulator `PyImport_Import` inside
 # timemodule.c, _datetimemodule.c and others.
 # This function does not actually need to do anything, its expected side-effect is to make the
@@ -176,6 +174,7 @@ _ALLOWED_MODULES = ['_strptime', 'math', 'time']
 def _import(name, globals=None, locals=None, fromlist=None, level=-1):
     if name not in sys.modules:
         raise ImportError(f'module {name} should be imported before calling safe_eval()')
+
 
 for module in _ALLOWED_MODULES:
     __import__(module)
@@ -205,6 +204,8 @@ def to_opcodes(opnames, _opmap=opmap):
     for x in opnames:
         if x in _opmap:
             yield _opmap[x]
+
+
 # opcodes which absolutely positively must not be usable in safe_eval,
 # explicitly subtracted from all sets of valid opcodes just in case
 _BLACKLIST = set(to_opcodes([
@@ -349,6 +350,7 @@ def assert_no_dunder_name(code_obj, expr):
         if "__" in name or name in _UNSAFE_ATTRIBUTES:
             raise NameError('Access to forbidden name %r (%r)' % (name, expr))
 
+
 def assert_valid_codeobj(allowed_codes, code_obj, expr):
     """ Asserts that the provided code object validates against the bytecode
     and name constraints.
@@ -405,7 +407,7 @@ def compile_codeobj(expr: str, /, filename: str = '<unknown>', mode: typing.Lite
 
     except (SyntaxError, TypeError, ValueError):
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         raise ValueError('%r while compiling\n%r' % (e, expr))
 
 
@@ -576,6 +578,7 @@ Pre-wrapped modules are provided as attributes of `odoo.tools.safe_eval`.
 """)
     return d
 
+
 class wrap_module:
     def __init__(self, module, attributes):
         """Helper for wrapping a package/module to expose selected attributes
@@ -598,8 +601,9 @@ class wrap_module:
     def __repr__(self):
         return self._repr
 
+
 # dateutil submodules are lazy so need to import them for them to "exist"
-import dateutil
+import dateutil  # noqa: E402
 mods = ['parser', 'relativedelta', 'rrule', 'tz']
 for mod in mods:
     __import__('dateutil.%s' % mod)

--- a/odoo/tools/safe_eval/evaluation.py
+++ b/odoo/tools/safe_eval/evaluation.py
@@ -28,7 +28,7 @@ import typing
 import zoneinfo
 from collections import defaultdict, OrderedDict
 from enum import auto, IntEnum
-from json.encoder import c_make_encoder
+from json.encoder import c_make_encoder  # noqa: OLS02001
 from opcode import opmap, opname
 from types import (
     BuiltinMethodType,
@@ -49,16 +49,47 @@ import werkzeug
 from psycopg2 import OperationalError
 
 import odoo.exceptions
-from .config import config
-from .func import lazy
-from .misc import OrderedSet
+from ..config import config
+from ..func import lazy
+from ..misc import OrderedSet
+
+_logger_runtime = logging.getLogger(f'{__name__}.runtime')
 
 unsafe_eval = eval
 
-__all__ = ['const_eval', 'safe_eval']
-
-_logger = logging.getLogger(__name__)
-_logger_runtime = logging.getLogger(f'{__name__}.runtime')
+__all__ = [
+    '_BLACKLIST',
+    '_BUBBLEUP_EXCEPTIONS',
+    '_BUILTINS',
+    '_CONST_OPCODES',
+    '_EXPR_OPCODES',
+    '_SAFE_OPCODES',
+    '_UNSAFE_ATTRIBUTES',
+    'UnsafeClassError',
+    'UnsafeFunctionError',
+    'UnsafeInstanceError',
+    'UnsafeModuleError',
+    'UnsafeObjectError',
+    'UnsafePolicy',
+    '_import',
+    'assert_valid_codeobj',
+    'check_values',
+    'const_eval',
+    'datetime',
+    'dateutil',
+    'json',
+    'safe_call',
+    'safe_checker',
+    'safe_eval',
+    'safe_transform',
+    'safe_whitelist',
+    'test_python_expr',
+    'time',
+    'to_opcodes',
+    'unsafe_eval',
+    'unsafe_policy',
+    'wrap_module'
+]
 
 
 class UnsafePolicy(IntEnum):
@@ -400,27 +431,6 @@ def const_eval(expr):
     assert_valid_codeobj(_CONST_OPCODES, c, expr)
     return unsafe_eval(c)
 
-def expr_eval(expr):
-    """expr_eval(expression) -> value
-
-    Restricted Python expression evaluation
-
-    Evaluates a string that contains an expression that only
-    uses Python constants. This can be used to e.g. evaluate
-    a numerical expression from an untrusted source.
-
-    >>> expr_eval("1+2")
-    3
-    >>> expr_eval("[1,2]*2")
-    [1, 2, 1, 2]
-    >>> expr_eval("__import__('sys').modules")
-    Traceback (most recent call last):
-    ...
-    ValueError: opcode LOAD_NAME not allowed
-    """
-    c = compile_codeobj(expr)
-    assert_valid_codeobj(_EXPR_OPCODES, c, expr)
-    return unsafe_eval(c)
 
 _BUILTINS = {
     '__import__': _import,
@@ -930,7 +940,7 @@ class _SafeWhitelist:
         if module := getattr(cls_obj, '__module__', None):
             if (
                 module in sys.modules or
-                module == 'odoo.tools.safe_eval.<evaluated_code>'
+                module == 'odoo.tools.safe_eval.evaluation.<evaluated_code>'
             ):
                 return f'{module}.{qualname}'.strip('.')
 
@@ -1104,7 +1114,7 @@ def add_monitoring(code):
 @functools.cache
 def _initialize_safe_whitelist():
     # Custom functions
-    safe_whitelist.add_function('odoo.tools.safe_eval.<evaluated_code>.*')
+    safe_whitelist.add_function('odoo.tools.safe_eval.evaluation.<evaluated_code>.*')
     # Wrapped modules
     safe_whitelist.add_class('datetime.date')
     safe_whitelist.add_class('datetime.datetime')

--- a/odoo/tools/safe_eval/expression.py
+++ b/odoo/tools/safe_eval/expression.py
@@ -1,0 +1,236 @@
+"""Evaluate simple expressions with a restricted Python syntax.
+
+Prefer this utility over `safe_eval` when only basic arithmetic,
+comparisons, boolean logic, variables, and simple dict/list/tuple
+access are needed.
+"""
+import ast
+import functools
+import operator
+import threading
+from collections.abc import Callable
+from types import NoneType
+from typing import Any
+
+from odoo.tools.misc import OrderedSet
+
+_BIN_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+    ast.FloorDiv: operator.floordiv,
+}
+
+_UNARY_OPS = {
+    ast.Not: operator.not_,
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+_COMPARE_OPS = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.In: lambda element, container: element in container,
+    ast.NotIn: lambda element, container: element not in container,
+    ast.Is: operator.is_,
+    ast.IsNot: operator.is_not,
+}
+
+_ALLOWED_CALLS = {
+    'min': min,
+    'max': max,
+    'set': OrderedSet,
+}
+
+
+_BOOL_OP_SHORT_CIRCUIT_TEST = {
+    ast.And: operator.not_,
+    ast.Or: operator.truth,
+}
+
+
+def _get_func(ops_set, node):
+    try:
+        return ops_set[type(node)]
+    except KeyError:
+        raise SyntaxError(f"Unsupported operator: {type(node).__name__}") from None
+
+
+class _ExprEval(ast.NodeVisitor):
+    """Evaluate the supported AST nodes for `expr_eval` into an executable function."""
+
+    def visit_Expression(self, node):
+        return self.visit(node.body)
+
+    def visit_BoolOp(self, node):
+        values = tuple(self.visit(value) for value in node.values)
+        test = _get_func(_BOOL_OP_SHORT_CIRCUIT_TEST, node.op)
+
+        def evaluate(context):
+            for value in values:
+                result = value(context)
+                if test(result):
+                    break
+            return result
+
+        return evaluate
+
+    def visit_BinOp(self, node):
+        op = _get_func(_BIN_OPS, node.op)
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        return lambda context: op(left(context), right(context))
+
+    def visit_UnaryOp(self, node):
+        op = _get_func(_UNARY_OPS, node.op)
+        operand = self.visit(node.operand)
+        return lambda context: op(operand(context))
+
+    def visit_Dict(self, node):
+        keys = tuple(self.visit(key) for key in node.keys)
+        values = tuple(self.visit(value) for value in node.values)
+
+        def eval_dict(context):
+            return {
+                key(context): value(context)
+                for key, value in zip(keys, values)
+            }
+
+        return eval_dict
+
+    def visit_Set(self, node):
+        items = tuple(self.visit(item) for item in node.elts)
+        return lambda context: OrderedSet(item(context) for item in items)
+
+    def visit_Compare(self, node):
+        left = self.visit(node.left)
+        ops = tuple(_get_func(_COMPARE_OPS, op_node) for op_node in node.ops)
+        comparators = tuple(self.visit(right_node) for right_node in node.comparators)
+
+        def eval_compare(context):
+            current = left(context)
+
+            for op, right in zip(ops, comparators):
+                next_value = right(context)
+                if not op(current, next_value):
+                    return False
+                current = next_value
+
+            return True
+
+        return eval_compare
+
+    def visit_Call(self, node):
+        if node.keywords:
+            raise SyntaxError("Keyword arguments are not supported in function calls")
+        if not isinstance(node.func, ast.Name) or node.func.id not in _ALLOWED_CALLS:
+            raise NameError("Only %s function calls are allowed" % ", ".join(_ALLOWED_CALLS.keys()))
+
+        func = _ALLOWED_CALLS[node.func.id]
+        args = tuple(self.visit(arg) for arg in node.args)
+
+        def eval_call(context):
+            return func(*(arg(context) for arg in args))
+
+        return eval_call
+
+    def visit_Constant(self, node):
+        value = node.value
+        if isinstance(value, (NoneType, bytes, str, int, float, bool)):
+            return lambda context: value
+        raise TypeError(f"Unsupported constant: {type(value).__name__}")
+
+    def visit_IfExp(self, node):
+        test = self.visit(node.test)
+        body = self.visit(node.body)
+        orelse = self.visit(node.orelse)
+
+        return lambda context: body(context) if test(context) else orelse(context)
+
+    def visit_Subscript(self, node):
+        value = self.visit(node.value)
+        slice_ = self.visit(node.slice)
+
+        return lambda context: value(context)[slice_(context)]
+
+    def visit_Name(self, node):
+        name = node.id
+
+        def eval_name(context):
+            try:
+                return context[name]
+            except KeyError as error:
+                raise NameError(name) from error
+
+        return eval_name
+
+    def visit_List(self, node):
+        items = tuple(self.visit(item) for item in node.elts)
+        return lambda context: [item(context) for item in items]
+
+    def visit_Tuple(self, node):
+        items = tuple(self.visit(item) for item in node.elts)
+        return lambda context: tuple(item(context) for item in items)
+
+    def visit_Slice(self, node):
+        lower = self.visit(node.lower) if node.lower is not None else None
+        upper = self.visit(node.upper) if node.upper is not None else None
+        step = self.visit(node.step) if node.step is not None else None
+
+        return lambda context: slice(
+            lower(context) if lower is not None else None,
+            upper(context) if upper is not None else None,
+            step(context) if step is not None else None,
+        )
+
+    def generic_visit(self, node):
+        raise SyntaxError(f"Unsupported syntax: {type(node).__name__}")
+
+
+_expr_eval = _ExprEval()
+
+
+def _compile_expr_eval_func(expr: str) -> Callable[[dict[str, Any]], Any]:
+    return _expr_eval.visit(ast.parse(expr, mode="eval"))
+
+
+@functools.cache
+def _get_db_expr_compiler(dbname: str) -> Callable[[str], Callable[[dict[str, Any]], Any]]:
+    # Scope the cache per DB: workers are shared, and a global cache leaks whether
+    # another DB recently evaluated the same expression.
+    return functools.lru_cache(maxsize=2048)(_compile_expr_eval_func)
+
+
+def expr_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
+    """Evaluate a restricted Python-like expression.
+
+    Supported syntax includes literals, variables from ``context``,
+    list/tuple/set/dict literals, indexing, slicing, arithmetic,
+    boolean operations, comparisons, and a calls to min() and max().
+
+    Example::
+
+        expr_eval("amount * 2", {"amount": 21})
+        expr_eval("[('user_id', '=', user_id)]", {"user_id": 7})
+
+    :param expr: Expression to evaluate.
+    :param context: Variables available by name in the expression.
+    :returns: The evaluated result.
+    :raises SyntaxError: expression is empty or uses unsupported syntax
+    :raises NameError: expression uses an unknown variable/function name
+    :raises TypeError: expression uses an unsupported constant type
+    """
+    assert type(expr) is str, "Expression must be a string"
+    if not (expr := expr.strip()):
+        raise SyntaxError("Expression cannot be empty")
+    # cache per db to avoid leaking an oracle to read info across dbs
+    db_compiler = _get_db_expr_compiler(getattr(threading.current_thread(), 'dbname', ''))
+    compiled_func = db_compiler(expr)
+    return compiled_func(context or {})

--- a/odoo/tools/safe_eval/expression.py
+++ b/odoo/tools/safe_eval/expression.py
@@ -5,14 +5,23 @@ comparisons, boolean logic, variables, and simple dict/list/tuple
 access are needed.
 """
 import ast
-import functools
 import operator
-import threading
-from collections.abc import Callable
 from types import NoneType
 from typing import Any
 
 from odoo.tools.misc import OrderedSet
+
+MAX_INT_POW_EXP = 1024
+
+
+def _safe_pow(a, b):
+    if isinstance(a, int) and isinstance(b, int) and b > MAX_INT_POW_EXP:
+        raise ValueError("Exponent too large")
+    res = pow(a, b)
+    if isinstance(res, complex):
+        raise TypeError(f"Complex numbers are not supported ({a!r} ** {b!r})")
+    return res
+
 
 _BIN_OPS = {
     ast.Add: operator.add,
@@ -20,7 +29,7 @@ _BIN_OPS = {
     ast.Mult: operator.mul,
     ast.Div: operator.truediv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
+    ast.Pow: _safe_pow,
     ast.FloorDiv: operator.floordiv,
 }
 
@@ -47,6 +56,8 @@ _ALLOWED_CALLS = {
     'min': min,
     'max': max,
     'set': OrderedSet,
+    'int': int,
+    'round': round,
 }
 
 
@@ -64,148 +75,94 @@ def _get_func(ops_set, node):
 
 
 class _ExprEval(ast.NodeVisitor):
-    """Evaluate the supported AST nodes for `expr_eval` into an executable function."""
+    """Evaluate supported expressions for `expr_eval`."""
+    __slots__ = ("context",)
+
+    def __init__(self, context: dict[str, Any]):
+        self.context = context
 
     def visit_Expression(self, node):
         return self.visit(node.body)
 
     def visit_BoolOp(self, node):
-        values = tuple(self.visit(value) for value in node.values)
         test = _get_func(_BOOL_OP_SHORT_CIRCUIT_TEST, node.op)
-
-        def evaluate(context):
-            for value in values:
-                result = value(context)
-                if test(result):
-                    break
-            return result
-
-        return evaluate
+        for value in node.values:
+            result = self.visit(value)
+            if test(result):
+                return result
+        return result
 
     def visit_BinOp(self, node):
         op = _get_func(_BIN_OPS, node.op)
-        left = self.visit(node.left)
-        right = self.visit(node.right)
-        return lambda context: op(left(context), right(context))
+        return op(self.visit(node.left), self.visit(node.right))
 
     def visit_UnaryOp(self, node):
         op = _get_func(_UNARY_OPS, node.op)
-        operand = self.visit(node.operand)
-        return lambda context: op(operand(context))
+        return op(self.visit(node.operand))
 
     def visit_Dict(self, node):
-        keys = tuple(self.visit(key) for key in node.keys)
-        values = tuple(self.visit(value) for value in node.values)
-
-        def eval_dict(context):
-            return {
-                key(context): value(context)
-                for key, value in zip(keys, values)
-            }
-
-        return eval_dict
+        out = {}
+        for key_node, value_node in zip(node.keys, node.values):
+            if key_node is None:
+                raise SyntaxError("Dict unpacking is not supported")
+            out[self.visit(key_node)] = self.visit(value_node)
+        return out
 
     def visit_Set(self, node):
-        items = tuple(self.visit(item) for item in node.elts)
-        return lambda context: OrderedSet(item(context) for item in items)
+        return OrderedSet(self.visit(item) for item in node.elts)
 
     def visit_Compare(self, node):
-        left = self.visit(node.left)
-        ops = tuple(_get_func(_COMPARE_OPS, op_node) for op_node in node.ops)
-        comparators = tuple(self.visit(right_node) for right_node in node.comparators)
-
-        def eval_compare(context):
-            current = left(context)
-
-            for op, right in zip(ops, comparators):
-                next_value = right(context)
-                if not op(current, next_value):
-                    return False
-                current = next_value
-
-            return True
-
-        return eval_compare
+        current = self.visit(node.left)
+        for op_node, right_node in zip(node.ops, node.comparators):
+            op = _get_func(_COMPARE_OPS, op_node)
+            next_value = self.visit(right_node)
+            if not op(current, next_value):
+                return False
+            current = next_value
+        return True
 
     def visit_Call(self, node):
         if node.keywords:
             raise SyntaxError("Keyword arguments are not supported in function calls")
         if not isinstance(node.func, ast.Name) or node.func.id not in _ALLOWED_CALLS:
-            raise NameError("Only %s function calls are allowed" % ", ".join(_ALLOWED_CALLS.keys()))
+            raise NameError("Only %s function calls are allowed" % ", ".join(_ALLOWED_CALLS))
 
         func = _ALLOWED_CALLS[node.func.id]
-        args = tuple(self.visit(arg) for arg in node.args)
-
-        def eval_call(context):
-            return func(*(arg(context) for arg in args))
-
-        return eval_call
+        return func(*(self.visit(arg) for arg in node.args))
 
     def visit_Constant(self, node):
         value = node.value
         if isinstance(value, (NoneType, bytes, str, int, float, bool)):
-            return lambda context: value
+            return value
         raise TypeError(f"Unsupported constant: {type(value).__name__}")
 
     def visit_IfExp(self, node):
-        test = self.visit(node.test)
-        body = self.visit(node.body)
-        orelse = self.visit(node.orelse)
-
-        return lambda context: body(context) if test(context) else orelse(context)
+        return self.visit(node.body) if self.visit(node.test) else self.visit(node.orelse)
 
     def visit_Subscript(self, node):
-        value = self.visit(node.value)
-        slice_ = self.visit(node.slice)
-
-        return lambda context: value(context)[slice_(context)]
+        return self.visit(node.value)[self.visit(node.slice)]
 
     def visit_Name(self, node):
-        name = node.id
-
-        def eval_name(context):
-            try:
-                return context[name]
-            except KeyError as error:
-                raise NameError(name) from error
-
-        return eval_name
+        try:
+            return self.context[node.id]
+        except KeyError as error:
+            raise NameError(node.id) from error
 
     def visit_List(self, node):
-        items = tuple(self.visit(item) for item in node.elts)
-        return lambda context: [item(context) for item in items]
+        return [self.visit(item) for item in node.elts]
 
     def visit_Tuple(self, node):
-        items = tuple(self.visit(item) for item in node.elts)
-        return lambda context: tuple(item(context) for item in items)
+        return tuple(self.visit(item) for item in node.elts)
 
     def visit_Slice(self, node):
-        lower = self.visit(node.lower) if node.lower is not None else None
-        upper = self.visit(node.upper) if node.upper is not None else None
-        step = self.visit(node.step) if node.step is not None else None
-
-        return lambda context: slice(
-            lower(context) if lower is not None else None,
-            upper(context) if upper is not None else None,
-            step(context) if step is not None else None,
+        return slice(
+            self.visit(node.lower) if node.lower is not None else None,
+            self.visit(node.upper) if node.upper is not None else None,
+            self.visit(node.step) if node.step is not None else None,
         )
 
     def generic_visit(self, node):
         raise SyntaxError(f"Unsupported syntax: {type(node).__name__}")
-
-
-_expr_eval = _ExprEval()
-
-
-def _compile_expr_eval_func(expr: str) -> Callable[[dict[str, Any]], Any]:
-    return _expr_eval.visit(ast.parse(expr, mode="eval"))
-
-
-@functools.cache
-def _get_db_expr_compiler(dbname: str) -> Callable[[str], Callable[[dict[str, Any]], Any]]:
-    # Scope the cache per DB: workers are shared, and a global cache leaks whether
-    # another DB recently evaluated the same expression.
-    return functools.lru_cache(maxsize=2048)(_compile_expr_eval_func)
 
 
 def expr_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
@@ -230,7 +187,4 @@ def expr_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
     assert type(expr) is str, "Expression must be a string"
     if not (expr := expr.strip()):
         raise SyntaxError("Expression cannot be empty")
-    # cache per db to avoid leaking an oracle to read info across dbs
-    db_compiler = _get_db_expr_compiler(getattr(threading.current_thread(), 'dbname', ''))
-    compiled_func = db_compiler(expr)
-    return compiled_func(context or {})
+    return _ExprEval(context or {}).visit(ast.parse(expr, mode="eval"))


### PR DESCRIPTION
Replace the legacy eval-based expr_eval with an AST evaluator for simple expressions, that now also supports variables and context
    
The new `expr_eval` has a small subset of python syntax: arithmetic, comparisons, boolean operators, literals, lists, tuples, dicts, sets, variables passed as context, subscripting, and min/max.
    
This works for simple formulas and simple domain expressions and avoids ever going through `eval` for these

enterprise: https://github.com/odoo/enterprise/pull/111530