### PR TITLE
[IMP] point_of_sale: add close button to alert component

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.scss
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.scss
@@ -43,7 +43,7 @@
     padding: 0;
 }
 
-.pos .o-dropdown-item {
+.pos .pos-burger-menu-items .o-dropdown-item {
     padding: map-get($spacers, 2);
     border-radius: $border-radius;
 

--- a/addons/point_of_sale/static/src/app/screens/action_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/action_screen.js
@@ -6,6 +6,7 @@ export class ActionScreen extends Component {
     static components = { ActionContainer };
     static props = {
         actionName: String,
+        viewMode: { type: String, optional: true },
     };
     static storeOnOrder = false;
     static template = xml`

--- a/addons/point_of_sale/static/src/app/services/alert_service.js
+++ b/addons/point_of_sale/static/src/app/services/alert_service.js
@@ -1,10 +1,12 @@
 import { Component, xml } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
 
 class Alert extends Component {
     static template = xml`
-        <div t-attf-class="alert pos-navbar-height fixed-top p-1 rounded-0 alert-{{this.props.type}} fade show d-flex align-items-center justify-content-center" role="alert">
+        <div t-attf-class="alert pos-navbar-height fixed-top py-3 px-1 mt-2 lh-sm alert-{{this.props.type}} fade show d-flex align-items-center justify-content-center rounded {{this.ui.isSmall ? 'w-100': 'w-50 fs-5 m-auto'}}" role="alert">
             <strong class="flex-grow-1 text-center" t-out="this.props.message" />
+            <button t-if="this.props.closable" t-on-click="this.props.onClose" class="btn btn-lg btn-close position-absolute end-0 me-2"/>
         </div>
     `;
     static props = {
@@ -14,10 +16,22 @@ class Alert extends Component {
             optional: true,
             validate: (type) => ["info", "warning", "danger", "success"].includes(type),
         },
+        onClose: {
+            type: Function,
+        },
+        closable: {
+            type: Boolean,
+            optional: true,
+        },
     };
     static defaultProps = {
         type: "info",
+        closable: false,
     };
+    setup() {
+        super.setup(...arguments);
+        this.ui = useService("ui");
+    }
 }
 
 export const alertService = {
@@ -32,6 +46,10 @@ export const alertService = {
                 {
                     message,
                     ...options,
+                    onClose: () => {
+                        dismiss?.();
+                        options.onClose?.();
+                    },
                 },
                 overlayOptions
             );


### PR DESCRIPTION
In this commit:
---------
- Add a close button to the alert service component.
- Introduce a new viewMode prop in ActionScreen to control the target view
  during redirection.
- Added an extra class for the navbar burger menu style to target only the burger menu dropdown item because it is affecting the calendar event search view.

Related PRs:
- Enterprise: https://github.com/odoo/enterprise/pull/111567
- Upgrade: https://github.com/odoo/upgrade/pull/9746

Task-6018428
