### PR TITLE
Ke

### DIFF
--- a/addons/l10n_ke/views/account_move_views.xml
+++ b/addons/l10n_ke/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_info_group']/field[@name='delivery_date']" position="after">
-                <div invisible="country_code != 'KE' or move_type != 'out_invoice' or payment_state != 'paid'">
+                <div >
                     <field name="l10n_ke_wh_certificate_number"/>
                     <field name="l10n_ke_wh_certificate_date"/>
                 </div>

--- a/addons/l10n_ke/views/account_move_views.xml
+++ b/addons/l10n_ke/views/account_move_views.xml
@@ -6,10 +6,8 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_info_group']/field[@name='delivery_date']" position="after">
-                <div >
-                    <field name="l10n_ke_wh_certificate_number"/>
-                    <field name="l10n_ke_wh_certificate_date"/>
-                </div>
+                <field name="l10n_ke_wh_certificate_number"/>
+                <field name="l10n_ke_wh_certificate_date"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Two l10n_ke fields do not appear normally because of the div they are in
Current behavior before PR:
The 2 fields appear without a string being shown
Desired behavior after PR is merged:
The 2 fields, relating to WHT, should appear normally, with a string and a blank space for the record. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
