### PR TITLE
[FIX] account_peppol: Concurrency Issue with Sending Data

### DIFF
--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -269,6 +269,10 @@ class AccountMoveSend(models.AbstractModel):
         if self._can_commit():
             self.env.cr.commit()
 
+        if len(to_lock_peppol_invoices) > 1:
+            while True:
+                pass
+
     def action_what_is_peppol_activate(self, moves):
         companies = moves.company_id
         if len(companies) == 1 and not companies.peppol_can_send:


### PR DESCRIPTION
When sending Peppol messages, the same message could be sent multiple times due to the following limitation. 

1- T1 locks the moves to process them and commit once they call the peppol service so the lock is released .
2- T2 picks up the same moves and process them again because they aren't locked anymore.

If we don't commit early, we won't be having this situation as the moves would've been locked. but since we can't just remove committing early for other concerns, I've no solution for now.  


Steps to reproduce

1- Send 2 moves in the background to peppol testing server (will be stuck at the while true loop after committing)
2- Go and send one of the moves from the wizard. 

You will find that the move was sent to peppol twice.  

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
