### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Tech Doc](https://img.shields.io/badge/master-docs-875A7B.svg?style=flat&colorA=8F8F8F)](https://www.odoo.com/documentation/master)
 [![Help](https://img.shields.io/badge/master-help-875A7B.svg?style=flat&colorA=8F8F8F)](https://www.odoo.com/forum/help-1)
 [![Nightly Builds](https://img.shields.io/badge/master-nightly-875A7B.svg?style=flat&colorA=8F8F8F)](https://nightly.odoo.com/)
+[![gitcgr](https://gitcgr.com/badge/odoo/odoo.svg)](https://gitcgr.com/odoo/odoo)
 
 Odoo is a suite of web based open source business apps.
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/odoo/odoo.svg)](https://gitcgr.com/odoo/odoo)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).