### PR TITLE
[IMP] purchase: align UoM behavior in mobile PO lines with desktop

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -312,7 +312,10 @@
                                                 <label for="product_qty"/>
                                                 <div class="o_row">
                                                     <field name="product_qty"/>
-                                                    <field name="uom_id" groups="uom.group_uom" required="not display_type and not is_downpayment" widget="many2one_uom"/>
+                                                    <field name="uom_id" groups="uom.group_uom"
+                                                        readonly="state in ('purchase', 'cancel') or is_downpayment"
+                                                        required="not display_type and not is_downpayment"
+                                                        widget="many2one_uom" options="{'no_create': True, 'no_open': True}"/>
                                                 </div>
                                                 <field name="qty_received_method" invisible="1"/>
                                                 <field name="qty_received" string="Received Quantity" invisible="parent.state != 'purchase'" readonly="qty_received_method != 'manual'"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -331,7 +331,10 @@
                                                 <label for="product_qty"/>
                                                 <div class="o_row">
                                                     <field name="product_qty"/>
-                                                    <field name="uom_id" groups="uom.group_uom" required="not display_type and not is_downpayment" widget="many2one_uom"/>
+                                                    <field name="uom_id" groups="uom.group_uom"
+                                                        readonly="state in ('purchase', 'cancel') or is_downpayment"
+                                                        required="not display_type and not is_downpayment"
+                                                        widget="many2one_uom" options="{'no_create': True, 'no_open': True}"/>
                                                 </div>
                                                 <field name="qty_received_method" invisible="1"/>
                                                 <field name="qty_received" string="Received Quantity" invisible="parent.state != 'purchase'" readonly="qty_received_method != 'manual'"/>


### PR DESCRIPTION
- Make the Unit field readonly based on a condition and disable creation in the 
  mobile PO line form view to ensure consistency with the desktop behaviour.

TaskID-6026074