### PR TITLE
[IMP] rating: optimize _search_rating_value() domain

### DIFF
--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -29,12 +29,11 @@ class MailMessage(models.Model):
     def _search_rating_value(self, operator, operand):
         if operator in Domain.NEGATIVE_OPERATORS:
             return NotImplemented
-        ratings = self.env['rating.rating'].sudo()._search([
-            ('rating', operator, operand),
-            ('message_id', '!=', False),
-            ('consumed', '=', True),
-        ])
-        domain = Domain("id", "in", ratings.subselect("message_id"))
+        domain = Domain(
+            "rating_ids",
+            "any!",
+            Domain("consumed", "=", True) & Domain("rating", operator, operand),
+        )
         if operator == "in" and 0 in operand:
             return domain | Domain("rating_ids", "=", False)
         return domain


### PR DESCRIPTION
**Purpose of this PR**:

The previous implementation fetched ratings separately without joining with mail.message, causing the query to consider unrelated ratings.

This change replaces the subquery with a direct domain on `rating_ids` using `any`, ensuring proper filtering on consumed ratings and matching values. This improves both correctness and performance.

Before the PR, on `6 million` records execution was `~0.796` ms and planning `~2.203` ms. After the PR, execution dropped to `~0.043` ms and planning to `~0.120` ms. These are approximate values and may vary between runs, but they consistently show a clear performance improvement.

task-5226961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
