### PR TITLE
[IMP] l10n_ph: add field for entity type

### DIFF
--- a/addons/l10n_ph/models/res_partner.py
+++ b/addons/l10n_ph/models/res_partner.py
@@ -7,6 +7,13 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     branch_code = fields.Char("Branch Code", default='000', compute='_compute_branch_code', store=True)
+    l10n_ph_entity_type = fields.Selection([
+            ('individual', 'Individual'),
+            ('corporation', 'Corporation'),
+        ],
+        string='Type of Entity',
+        help='Philippines: Defines the type of entity.'
+    )
     first_name = fields.Char("First Name")
     middle_name = fields.Char("Middle Name")
     last_name = fields.Char("Last Name")
@@ -23,3 +30,17 @@ class ResPartner(models.Model):
                 match = partner._check_vat_ph_re.match(partner.vat)
                 branch_code = match and match.group(1) and match.group(1)[1:] or branch_code
             partner.branch_code = branch_code
+
+    @api.depends('vat', 'commercial_partner_id', 'country_code', 'l10n_ph_entity_type')
+    def _compute_is_company(self):
+        ph_partners = self.filtered(lambda partner: partner.country_code == 'PH' and partner.l10n_ph_entity_type)
+        for partner in ph_partners:
+            partner.is_company = partner.l10n_ph_entity_type == 'corporation'
+        super(ResPartner, self - ph_partners)._compute_is_company()
+
+    @api.onchange('l10n_ph_entity_type')
+    def _onchange_entity_type(self):
+        if self.l10n_ph_entity_type == 'corporation':
+            self.first_name = False
+            self.middle_name = False
+            self.last_name = False

--- a/addons/l10n_ph/models/res_partner.py
+++ b/addons/l10n_ph/models/res_partner.py
@@ -1,12 +1,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, api, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
     branch_code = fields.Char("Branch Code", default='000', compute='_compute_branch_code', store=True)
+    l10n_ph_entity_type = fields.Selection([
+            ('individual', 'Individual'),
+            ('corporation', 'Corporation'),
+        ],
+        string='Type of Entity',
+        help='Philippines: Defines the type of entity.'
+    )
     first_name = fields.Char("First Name")
     middle_name = fields.Char("Middle Name")
     last_name = fields.Char("Last Name")
@@ -23,3 +31,18 @@ class ResPartner(models.Model):
                 match = partner._check_vat_ph_re.match(partner.vat)
                 branch_code = match and match.group(1) and match.group(1)[1:] or branch_code
             partner.branch_code = branch_code
+
+    def write(self, vals):
+        if vals.get('l10n_ph_entity_type') == 'corporation':
+            vals.update({
+                'first_name': False,
+                'middle_name': False,
+                'last_name': False,
+            })
+        return super().write(vals)
+
+    @api.constrains('l10n_ph_entity_type', 'first_name', 'middle_name', 'last_name')
+    def _check_entity_fields(self):
+        for partner in self:
+            if partner.l10n_ph_entity_type == 'corporation' and (partner.first_name or partner.middle_name or partner.last_name):
+                raise ValidationError(self.env._("First name, middle name, and last name should not be filled for corporation entities."))

--- a/addons/l10n_ph/views/res_partner_views.xml
+++ b/addons/l10n_ph/views/res_partner_views.xml
@@ -5,11 +5,21 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//span[@name='address_name']" position="before">
+                <field name="l10n_ph_entity_type" string="Entity type" invisible="'PH' not in fiscal_country_codes" required="'PH' in fiscal_country_codes"/>
+            </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning"
+                        role="alert"
+                        invisible="l10n_ph_entity_type != 'individual' or (first_name and middle_name and last_name) or 'PH' not in fiscal_country_codes">
+                    First name, middle name, or last name is missing for individual entity. Accounting Reports may be affected.
+                </div>
+            </xpath>
             <xpath expr="//div[@id='vat_div']" position="after">
                 <field name="branch_code" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="first_name" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="middle_name" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="last_name" invisible="'PH' not in fiscal_country_codes"/>
+                <field name="first_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
+                <field name="middle_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
+                <field name="last_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_ph/views/res_partner_views.xml
+++ b/addons/l10n_ph/views/res_partner_views.xml
@@ -5,11 +5,21 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//span[@name='address_name']" position="before">
+                <field name="l10n_ph_entity_type" string="Entity type" invisible="'PH' not in fiscal_country_codes"/>
+            </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning"
+                        role="alert"
+                        invisible="l10n_ph_entity_type != 'individual' or (first_name and middle_name and last_name) or 'PH' not in fiscal_country_codes">
+                    First name, middle name, or last name is missing for individual entity. Accounting Reports may be affected.
+                </div>
+            </xpath>
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="branch_code" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="first_name" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="middle_name" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="last_name" invisible="'PH' not in fiscal_country_codes"/>
+                <field name="first_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
+                <field name="middle_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
+                <field name="last_name" invisible="'PH' not in fiscal_country_codes or l10n_ph_entity_type == 'corporation'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before this PR:
- from version saas-19.1, the field 'Company Type' which was earlier used to distinguish between 'Person' and 'Company' contacts is removed.

After this PR:
- added a field 'Entity type' which is required by Phillipines tax authorities for the distinction between individual and corporation entities.

Related PR: 
Enterprise : https://github.com/odoo/enterprise/pull/111585

task-5928297