### PR TITLE
[FIX] core: better message

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -247,7 +247,7 @@ class IrCron(models.Model):
             SELECT latest_version
             FROM ir_module_module
              WHERE name='base'
-        """)
+        """, log_exceptions=False)
         (version,) = cron_cr.fetchone()
         if version is None:
             raise BadModuleState()

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -363,8 +363,7 @@ def load_modules(
     cr.execute("SET SESSION lock_timeout = '15s'")
     if not modules_db.is_initialized(cr):
         if not update_module:
-            _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
-            return
+            raise ImportError(f"Database {cr.dbname} not initialized, you can force it with `-i base`")
         _logger.info("Initializing database %s", cr.dbname)
         modules_db.initialize(cr)
     elif 'base' in reinit_modules:


### PR DESCRIPTION
when the database is not initialized, raise an ImportError but not log and error and return, which makes the returned registry in a strange state.

for cron, since we know the query may fail and have already handled and logged all errors explicitly, we don't need to log the bad sql again in the ``cr.execute()`` call.


The difference can be observed if there is an error while installing `base` module

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
