### PR TITLE
[IMP] l10n_rs_edi: Set Attachment in the same transaction as The moves

### DIFF
--- a/addons/l10n_rs_edi/wizard/account_move_send.py
+++ b/addons/l10n_rs_edi/wizard/account_move_send.py
@@ -80,15 +80,10 @@ class AccountMoveSend(models.TransientModel):
                     "errors": [error],
                 }
                 continue
-            invoice_data['l10n_rs_edi_attachment_values'] = invoice._l10n_rs_edi_get_attachment_values(xml)
 
-            if self._can_commit():
-                self._cr.commit()
-
-    @api.model
-    def _link_invoice_documents(self, invoice, invoice_data):
-        # EXTENDS 'account'
-        super()._link_invoice_documents(invoice, invoice_data)
-        if attachment_values := invoice_data.get('l10n_rs_edi_attachment_values'):
+            attachment_values = invoice._l10n_rs_edi_get_attachment_values(xml)
             self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachment_values)
             invoice.invalidate_recordset(fnames=['l10n_rs_edi_attachment_id', 'l10n_rs_edi_attachment_file'])
+
+            if self._can_commit():
+                self.env.cr.commit()


### PR DESCRIPTION
Was committing the move fields update, then updating the attachment. This might create an issue were the move update commits successfully, but setting the attachment fails and we end up with an inconsistency.

Set attachment in the same transaction as the move update.

task-6035727


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
