### PR TITLE
[FIX] calendar: ensure organizer receives alarm bus notifications

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -78,8 +78,8 @@ class CalendarAlarm_Manager(models.AbstractModel):
             SELECT *
                 FROM ( %s ) AS ALL_EVENTS
             WHERE ALL_EVENTS.first_alarm < %s
-                AND ALL_EVENTS.last_alarm > (now() at time zone 'utc')
-        """ % (delta_request, base_request, first_alarm_max_value), tuple_params)
+                AND ALL_EVENTS.last_alarm > ('%s' at time zone 'utc')
+        """ % (delta_request, base_request, first_alarm_max_value, fields.Datetime.now()), tuple_params)
 
         for event_id, first_alarm, last_alarm, first_meeting, last_meeting, min_duration, max_duration in self._cr.fetchall():
             result[event_id] = {
@@ -248,7 +248,7 @@ class CalendarAlarm_Manager(models.AbstractModel):
         """ Sends through the bus the next alarm of given partners """
         users = self.env['res.users'].search([
             ('partner_id', 'in', tuple(partner_ids)),
-            ('group_ids', 'in', self.env.ref('base.group_user').ids),
+            ('share', '=', False),
         ])
         for user in users:
             notif = self.with_user(user).with_context(allowed_company_ids=user.company_ids.ids).get_next_notif()

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -303,6 +303,52 @@ class TestEventNotifications(CalendarMailCommon):
                     'alarm_ids': [(4, alarm.id)]
                 })
 
+    def test_bus_notif_organizer(self):
+        """Test that Admin user receives bus alarm notifications."""
+        alarm = self.env['calendar.alarm'].create({
+            'name': "Alarm",
+            'alarm_type': "notification",
+            'interval': "minutes",
+            'duration': 30,
+        })
+        now = fields.Datetime.now()
+        admin_partner = self.user_admin.partner_id
+        event = self.env['calendar.event'].with_user(self.user_admin).with_context(no_mail_to_attendees=True).create({
+            'name': "Admin Meeting",
+            'start': now + relativedelta(minutes=50),
+            'stop': now + relativedelta(minutes=55),
+            'user_id': self.user_admin.id,
+            'partner_ids': [fields.Command.set(admin_partner.ids)],
+            'alarm_ids': [fields.Command.set([alarm.id])],
+        })
+        self._reset_bus()
+
+        def get_bus_params():
+            return (
+                [(self.env.cr.dbname, "res.partner", admin_partner.id)],
+                [
+                    {
+                        'type': "calendar.alarm",
+                        'payload': [
+                            {
+                                'alarm_id': alarm.id,
+                                'event_id': event.id,
+                                'title': "Admin Meeting",
+                                'message': event.display_time,
+                                'timer': 20 * 60,
+                                'notify_at': fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                            },
+                        ],
+                    },
+                ],
+            )
+
+        with freeze_time(now):
+            with self.assertBus(get_params=get_bus_params):
+                event.with_context(no_mail_to_attendees=True).write({
+                    'alarm_ids': [fields.Command.set([alarm.id])],
+                })
+
     def test_email_alarm(self):
         now = fields.Datetime.now()
         with self.capture_triggers('calendar.ir_cron_scheduler_alarm') as capt:


### PR DESCRIPTION
Steps to reproduce:
---------------------------------
1. Install Calendar module with demo
2. For both Users: User > Preferences > Notifications > In Odoo
3. Log in through Admin > Calendar > New meeting
4. Set a start time in the near future
5. Add Marc Demo as an attendee
6. Under Options > Reminders, add a reminder that triggers shortly before the meeting (e.g., 15 minutes)
7. Save the meeting
8. Log in as Marc Demo in another browser window
9. Wait until the reminder time is reached

Observation:
---------------------------------
The reminder notification is displayed for Marc Demo. The Administrator (Mitchell Admin) does not receive any notification.

Issue:
---------------------------------
In `_notify_next_alarm`, the domain
`('group_ids', 'in', self.env.ref('base.group_user').ids)`
 was used to filter internal users. However, the admin user does not have
`base.group_user` directly in their `group_ids`, it is only present in `group_ids.all_implied_ids` (inherited through group hierarchy). This caused the admin user to be excluded from the user search, so no bus alarm notification was sent to them.

Solution:
---------------------------------
The `share` field on `res.users` correctly identifies internal users (`share=False`) vs portal/public users (`share=True`) by checking the full group hierarchy, including implied groups. This ensures the admin (and all internal users) receive alarm notifications while still excluding portal and public users.
https://github.com/odoo/odoo/blob/b261223c8e15c412a06a0d938d217bdf0ab9f9ff/odoo/addons/base/models/res_users.py#L459-L464

opw-6010337