### PR TITLE
[FIX] mail: no crash on test test_04_meeting_view_tour avatarUrl

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -67,10 +67,10 @@
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
         <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="attClass" t-on-click="(ev) => this.onClickParticipant(ev, session)">
             <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px;margin:1px;">
-                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle object-fit-cover" t-att-src="session.channel_member_id.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.name"/>
+                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle object-fit-cover" t-att-src="session.channel_member_id?.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id?.name"/>
             </div>
-            <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
-                <t t-esc="session.channel_member_id.name"/>
+            <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id?.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
+                <t t-esc="session.channel_member_id?.name"/>
             </span>
             <div t-if="!isCompact" class="flex-grow-1"/>
             <div class="o-mail-DiscussSidebarCallParticipants-status small opacity-75" t-att-class="{ 'position-absolute bottom-0 end-0 bg-inherit p-0 rounded-circle o-compact d-flex o-xsmaller text-start': isCompact, 'ms-1 d-flex align-items-center justify-content-center': !isCompact }">


### PR DESCRIPTION
Before this commit, test `test_04_meeting_view_tour` could crash non-deterministically with the following error:

```
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
Caused by: TypeError: Cannot read properties of undefined (reading 'avatarUrl')
    at DiscussSidebarCallParticipants.template
```

This happens because the template was reading a deep field in a JS relation without guard in `rtc_session.channel_member_id.avatarUrl`.

When a rtc_session is known in client code, the `channel_member_id` is not necessarily known, therefore code should guard it unless context is explicit that this is known.

This commit adds optional guarding in the template to take into account possibility to know rtc session without the related channel member id.

Fixes runbot-error-242142

Backport of https://github.com/odoo/odoo/pull/233232