### PR TITLE
[FIX] hr_recruitment: prevent error when creating alias ID

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment_source.py
+++ b/addons/hr_recruitment/models/hr_recruitment_source.py
@@ -39,7 +39,7 @@ class HrRecruitmentSource(models.Model):
                 },
                 'alias_domain_id': source.job_id.company_id.alias_domain_id.id or self.env.company.alias_domain_id.id,
                 'alias_model_id': self.env['ir.model']._get_id('hr.applicant'),
-                'alias_name': f"{source.job_id.alias_name or source.job_id.name}+{source.name}",
+                'alias_name': f"{source.job_id.alias_name or source.job_id.name}+{source.source_id.name}",
                 'alias_parent_thread_id': source.job_id.id,
                 'alias_parent_model_id': self.env['ir.model']._get_id('hr.job'),
             }

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -511,3 +511,17 @@ class TestRecruitment(MailCase, TransactionCase):
         applicant_get_refuse_reason._prepare_send_refusal_mails()
         mail = self.env['mail.mail'].search([('subject', '=', 'Application refused: Mario')], limit=1)
         self.assertEqual(mail.partner_ids, app_1.partner_id)
+
+    def test_create_and_get_alias_for_source(self):
+        """Test that create and get alias on a recruitment source."""
+        job = self.env['hr.job'].create({'name': 'Test Job'})
+        source = self.env['hr.recruitment.source'].create({
+            'job_id': job.id,
+        })
+
+        source.create_and_get_alias()
+        self.assertTrue(source.alias_id)
+        expected_alias_name = self.env['mail.alias']._sanitize_alias_name(
+            f"{source.job_id.name}+{source.source_id.name}"
+        )
+        self.assertEqual(source.alias_id.alias_name, expected_alias_name)


### PR DESCRIPTION
Currently, an error occurs when a user creates an alias ID.

**Steps to Reproduce:**
 - Install the `hr_recruitment` module.
 - Go to `your current company` and set the `Email Domain` value.
 - Go to `Recruitment` > `Applications` > `By Job Positions`.
 - In `list view`, create or open an existing `Job Position`.
 - In the `Trackers` tab, create a record through “Add a line”.
 - Click the `copy clipboard` button next to the `email` field.

**Error:**
`AttributeError: 'hr.recruitment.source' object has no attribute 'name'`

After [this commit], the dependency of utm.source.mixin was removed, along with the 
source_id field referencing a source. The name field was provided by utm.source.mixin, 
and it is now being accessed in recruitment source, which raises the error [1].

This commit ensures that the system uses the name of source_id, as it has been 
replaced by _rec_name to "source_id".

[this commit]: https://github.com/odoo/odoo/commit/927682ce8f5e6faea0da7216ac1163411f5e83bd

[1]- https://github.com/odoo/odoo/blob/949d368eda3d6f2c9b5fb04ec3a41fa1b2cc90d4/addons/hr_recruitment/models/hr_recruitment_source.py#L42

sentry-7353030705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
