### PR TITLE
[FIX] point_of_sale: format tip startingValue with locale decimal separator

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -1,5 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { parseFloat } from "@web/views/fields/parsers";
+import { formatCurrency } from "@web/core/currency";
 import { useErrorHandlers, useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -229,7 +230,10 @@ export class PaymentScreen extends Component {
 
         this.dialog.add(NumberPopup, {
             title: tip.amount > 0 ? _t("Change Tip") : _t("Add Tip"),
-            startingValue: String(tip.value || amount || 0),
+            startingValue:
+                tip.type === "percent"
+                    ? String(tip.value || 0)
+                    : formatCurrency(tip.amount || amount || 0),
             startingType: tip.type || "fixed",
             types: [
                 { name: "fixed", symbol: this.pos.currency.symbol },

--- a/addons/point_of_sale/static/tests/unit/components/payment_screen.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/payment_screen.test.js
@@ -1,9 +1,10 @@
-import { test, animationFrame } from "@odoo/hoot";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { test, expect, animationFrame } from "@odoo/hoot";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupPosEnv, getFilledOrder, expectFormattedPrice } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
 import { queryOne } from "@odoo/hoot-dom";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+import { localization } from "@web/core/l10n/localization";
 
 definePosModels();
 
@@ -24,4 +25,35 @@ test("Change always incl", async () => {
     await animationFrame();
     const subtotal = queryOne(".amount");
     expectFormattedPrice(subtotal.attributes.amount.value, "$ -2.15");
+});
+
+test("addTip startingValue uses locale decimal separator on overpayment", async () => {
+    const store = await setupPosEnv();
+    store.config.iface_tipproduct = true;
+    patchWithCleanup(localization, { decimalPoint: ",", thousandsSep: "." });
+
+    const order = await getFilledOrder(store);
+    const cashPm = store.models["pos.payment.method"].get(1);
+    const { data: paymentLine } = order.addPaymentline(cashPm);
+    paymentLine.setAmount(22);
+    expect(Math.abs(order.change)).toBe(4.15);
+
+    let capturedStartingValue;
+    const screen = {
+        pos: store,
+        currentOrder: order,
+        env: { services: { localization } },
+        dialog: {
+            add: (_, props) => {
+                capturedStartingValue = props.startingValue;
+            },
+        },
+    };
+    await PaymentScreen.prototype.addTip.call(screen);
+
+    const tipAmount = PaymentScreen.prototype.computeNewTip.call(screen, {
+        value: capturedStartingValue,
+        type: "fixed",
+    });
+    expect(tipAmount).toBe(4.15);
 });


### PR DESCRIPTION

Steps to reproduce
1. Set language decimal separator to "," and thousands separator to "."
2. Open PoS, create an order (e.g. total 17.85)
3. Pay more than the total (e.g. 22)
4. Open the Tip popup — it shows 415 instead of 4,15
5. Confirm — tip is set to 415

Issue
When overpaying, the change is passed as `startingValue` to the NumberPopup via
`String(amount)` (https://github.com/odoo/odoo/blob/b3d78644bc873b3b22f3fd5f8fc0cd27ce38999f/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js#L232),
which always uses "." as decimal separator. This value is used directly as the
display buffer in NumberPopup
(https://github.com/odoo/odoo/blob/b3d78644bc873b3b22f3fd5f8fc0cd27ce38999f/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js#L53),
so the user already sees "415" instead of "4,15" when the popup opens. When the
user confirms, `computeNewTip` parses this value with the locale-aware `parseFloat`
from `@web/views/fields/parsers`
(https://github.com/odoo/odoo/blob/b3d78644bc873b3b22f3fd5f8fc0cd27ce38999f/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js#L279
and https://github.com/odoo/odoo/blob/b3d78644bc873b3b22f3fd5f8fc0cd27ce38999f/addons/web/static/src/views/fields/parsers.js#L73-L83),
which uses `localization.thousandsSep` and `localization.decimalPoint` to interpret
the string. With "," as decimal separator and "." as thousands separator,
`parseFloat("4.15")` treats the "." as a thousands separator, strips it, and
returns 415 instead of 4.15.

opw-5895622