### PR TITLE
[FIX] float_utils: prevent rounding error

### DIFF
--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -12,7 +12,7 @@ from odoo import Command, fields, models
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tests import Form, TransactionCase, tagged, users
-from odoo.tools import float_repr, mute_logger
+from odoo.tools import float_repr, float_round, mute_logger
 from odoo.tools.image import image_data_uri
 
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
@@ -1018,6 +1018,9 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         precision = self.env.ref('test_orm.decimal_orm_number')
         description = self.env['test_orm.mixed'].fields_get()['number2']
         self.assertEqual(description['digits'], (16, precision.digits))
+
+    def test_float_round_100_digits(self):
+        self.assertEqual(float_round(50, 100), 50)
 
     def check_monetary(self, record, amount, currency, msg=None):
         # determine the possible roundings of amount

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -130,6 +130,9 @@ def float_round(
     # more tolerant of inaccuracies accumulated after multiple floating point operations
     epsilon = 2**(epsilon_magnitude - 50)
 
+    if normalized_value.is_integer():
+        return denormalize(value)
+
     match rounding_method:
         case 'HALF-UP':  # 0.5 rounds away from 0
             result = round(normalized_value + math.copysign(epsilon, normalized_value))


### PR DESCRIPTION
Exit early in `float_round` when the value already matches the precision step, avoiding unnecessary rounding operations and floating-point error.

For example, issue occurs when importing EDI documents, as _get_edi_creation disables discount precision, leading to a precision of 100 digits in float_round. A discount value of 50 may become 50.00000000000004 instead of 50, so this can lead to incorrect price_subtotal and price_total values on the invoice lines, and thus incorrect invoice totals.

opw-6046324