### PR TITLE
[FIX] im_livechat: fix runbot livechat digest test

### DIFF
--- a/addons/im_livechat/tests/test_digest.py
+++ b/addons/im_livechat/tests/test_digest.py
@@ -17,6 +17,7 @@ class TestLiveChatDigest(TestDigestCommon):
         super().setUpClass()
 
         other_partner = cls.env["res.partner"].create({"name": "Other Partner"})
+        cls.env["discuss.channel"].search([("channel_type", "=", "livechat")]).unlink()
         with (
             freeze_time(fields.Datetime.now() - datetime.timedelta(days=10)),
             patch.object(cls.env.cr, "_now", datetime.datetime.now() - datetime.timedelta(days=10)),


### PR DESCRIPTION
Before this commit, running the livechat digest test with demo data would fail due to additional channels created.

This commit removes the rating on those channels preceding the test so that it stays unaffected by those demo data.

fixes-runbot-242091


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
