### PR TITLE
[FIX] hr_recruitment_skills: Fix custom skill filtering

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -45,3 +45,10 @@ class HrApplicant(models.Model):
             } for skill in skills_to_create])
         self.env['hr.employee.skill'].create(vals_list)
         return super()._update_employee_from_applicant()
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('applicant_skill_ids'):
+            res['applicant_skill_ids']['searchable'] = False
+        return res

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -39,3 +39,10 @@ class Employee(models.Model):
         if 'department_id' in vals:
             self.employee_skill_ids._create_logs()
         return res
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if res.get('employee_skill_ids'):
+            res['employee_skill_ids']['searchable'] = False
+        return res


### PR DESCRIPTION
It fixes inconsistent custom filtering on applicant skills by removing the redundant field from the view. In 17.0 up to versions before 19.0 the applicant_skill_ids and the skill_ids show the same information in the UI and produce equivalent search domains. To avoid this, we just remove the redundant field from the view and keep the canonical skill_ids

task-5930483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
