### PR TITLE
[FIX] web_editor: fix s_numbers snippet column height in sent emails

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -676,6 +676,15 @@ function enforceImagesResponsivity(editable) {
         image.removeAttribute('height');
     }
 }
+
+function fixSNumbersSnippet(editable) {
+    [...editable.querySelectorAll(".s_numbers")].forEach((numbersSnippet) => {
+        const row = numbersSnippet.querySelector(".container > .row");
+        if (row) {
+            row.classList.add("d-flex", "align-items-stretch");
+        }
+    });
+}
 /**
  * Convert the contents of an editable area (as a JQuery element) into content
  * that is widely compatible with email clients. If no CSS Rules are given, they
@@ -722,7 +731,7 @@ async function toInline($editable, cssRules, $iframe) {
     for (const imgTop of editable.querySelectorAll('.card-img-top')) {
         imgTop.style.setProperty('height', _getHeight(imgTop) + 'px');
     }
-
+    fixSNumbersSnippet(editable);
     attachmentThumbnailToLinkImg($editable);
     fontToImg($editable);
     await svgToPng($editable);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -370,6 +370,7 @@ function cardToTable(editable) {
                 col.append(child);
             }
             const subTable = _createTable();
+            subTable.style.height = '100%';
             const superRow = document.createElement('tr');
             const superCol = document.createElement('td');
             row.append(col);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -36,7 +36,8 @@ export const TABLE_ATTRIBUTES = {
 };
 // Cancel tables default styles.
 export const TABLE_STYLES = {
-    'border-collapse': 'collapse',
+    'border-collapse': 'separate',
+    'border-spacing': '0px',
     'text-align': 'inherit',
     'font-size': 'unset',
     'line-height': 'inherit',

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -307,21 +307,21 @@ QUnit.module('convert_inline', {}, function () {
                 .replace(/<td[^>]*>\(0, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
-                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
                         `font-size: unset; line-height: inherit;\"><tr>` +
                             `<td class="card-header"><span>HEADER</span></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(1, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
-                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
                         `font-size: unset; line-height: inherit;\"><tr>` +
                             `<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(2, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
-                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
                         `font-size: unset; line-height: inherit;\"><tr>` +
                             `<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>` +
                         `</tr></table></td>`),

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -308,21 +308,21 @@ QUnit.module('convert_inline', {}, function () {
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
-                        `font-size: unset; line-height: inherit;\"><tr>` +
+                        `font-size: unset; line-height: inherit; height: 100%;\"><tr>` +
                             `<td class="card-header"><span>HEADER</span></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(1, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
-                        `font-size: unset; line-height: inherit;\"><tr>` +
+                        `font-size: unset; line-height: inherit; height: 100%;\"><tr>` +
                             `<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(2, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: separate; border-spacing: 0px; text-align: inherit; ` +
-                        `font-size: unset; line-height: inherit;\"><tr>` +
+                        `font-size: unset; line-height: inherit; height: 100%;\"><tr>` +
                             `<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>` +
                         `</tr></table></td>`),
         });


### PR DESCRIPTION
Problem:
`s_numbers` snippet columns do not stretch to match the tallest column
in the received email, while the editor preview renders them correctly.

Cause:
The `div.row` is missing `d-flex` and `align-items-stretch` classes,
which are required for equal-height columns in the sent email.
These classes are already present in the `s_three_columns` snippet.

Fix:
Add `d-flex` and `align-items-stretch` to the `div.row` at sending time
via `fixSNumbersSnippet`.

Steps to reproduce:
- Drop `s_numbers` snippet.
- Add text to one column so it is taller than the others.
- Send the email.
- Observe columns in the received email only fitting their own content.

opw-6044725

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
