### PR TITLE
[FIX] mail: fix meeting panel unreadable in light theme

### DIFF
--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -10,6 +10,10 @@
     .btn {
         &:hover, &.show {
             background-color: var(--mail-NotificationSettings-btnHoverBg, mix($gray-100, $gray-200));
+
+            .o-simulateDarkTheme & {
+                background-color: mix($gray-700, $gray-800);
+            }
         }
     }
 }

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -178,7 +178,9 @@ registerThreadAction("invite-people", {
     actionPanelOuterClass: ({ owner, store }) =>
         `o-discuss-ChannelInvitation ${
             owner.props.chatWindow ? "bg-inherit" : ""
-        } border border-secondary ` + store.discussDropdownMenuClass(owner),
+        } border border-secondary ${
+            owner.env.inMeetingView ? "" : store.discussDropdownMenuClass(owner)
+        }`,
     condition: ({ channel, owner }) =>
         channel &&
         !owner.env.pipWindow &&

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -13,7 +13,8 @@ registerThreadAction("show-threads", {
             channel: channel.parent_channel_id || channel,
         });
     },
-    actionPanelOuterClass: ({ owner, store }) => store.discussDropdownMenuClass(owner),
+    actionPanelOuterClass: ({ owner, store }) =>
+        owner.env.inMeetingView ? "" : store.discussDropdownMenuClass(owner),
     condition: ({ channel, owner }) =>
         (channel?.hasSubChannelFeature || channel?.parent_channel_id?.hasSubChannelFeature) &&
         !owner.isDiscussSidebarChannelActions,


### PR DESCRIPTION
Before this PR, .o-simulateDarkTheme is applied to the panel in meeting mode. This class inverts the text color, making it white on white.

This PR removes the class, which seems to have been applied by mistake.

task-6054300
Before:
<img width="776" height="1009" alt="image" src="https://github.com/user-attachments/assets/6d7ad6c3-6593-43ba-9101-c8960f3e649f" />
After: 
<img width="766" height="994" alt="image" src="https://github.com/user-attachments/assets/0cf6b3b6-388c-44bc-b697-760132c06ede" />
