### PR TITLE
[FIX] account_edi_ubl_cii: Don't show "Export XML" for not-exportable bills

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -57,7 +57,11 @@ class AccountMove(models.Model):
                     'content': ubl_attachment.raw,
                 }
             elif allow_fallback:
-                if self.partner_id and (suggested_edi_format := self.commercial_partner_id._get_suggested_ubl_cii_edi_format()):
+                if (
+                    self.partner_id
+                    and (suggested_edi_format := self.commercial_partner_id._get_suggested_ubl_cii_edi_format())
+                    and self._need_ubl_cii_xml(suggested_edi_format)
+                ):
                     builder = self.env['res.partner']._get_edi_builder(suggested_edi_format)
                     xml_content, errors = builder._export_invoice(self)
                     filename = builder._export_invoice_filename(self)
@@ -75,7 +79,7 @@ class AccountMove(models.Model):
         suggested_edi_formats = {
             suggested_format
             for partner in posted_moves.commercial_partner_id
-            if (suggested_format := partner ._get_suggested_ubl_cii_edi_format())
+            if (suggested_format := partner._get_suggested_ubl_cii_edi_format())
         }
         if posted_moves.ubl_cii_xml_id or suggested_edi_formats:
             print_items.append({


### PR DESCRIPTION
Problem
---------
Currently, in the bills list view, when you select bills > Print > Export XML; not-imported bills gets their customer and supplier party inverted. This is because the XML export of those trigger the XML computation which is not designed for bills but only for invoices or self-bills. For imported bills (coming from Peppols for example), we re-use the imported XML.

Since XML export of created bills is not supported anymore. The button leaves customers confused as to why their partner are inverted in the XML.

Solution
---------
Don't show the "Export XML" if one or more move are selected for the import and don't compute the XML for bills that are not self-bills.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
