### PR TITLE
[REF] payment{,_asiapay}: extract language code resolution to utils

### DIFF
--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -191,6 +191,26 @@ def to_minor_currency_units(major_amount, currency, arbitrary_decimal_number=Non
     )
 
 
+def get_language_code(lang, mapping, fallback='en'):
+    """ Return the language code corresponding to the provided lang.
+
+    If the lang is not mapped to any language code, the country code is used instead. In
+    case the country code has no match either, we fall back to the provided fallback.
+
+    :param str lang: The lang, in IETF language tag format.
+    :param dict mapping: The dictionary mapping the lang or country code to the language code.
+    :param str fallback: The fallback language code key to use if no match is found.
+    :return: The corresponding language code.
+    :rtype: str
+    """
+    language_code = mapping.get(lang)
+    if not language_code:
+        country_code = lang.split('_')[0]
+        language_code = mapping.get(country_code)
+    if not language_code:
+        language_code = mapping.get(fallback)
+    return language_code
+
 # Partner values formatting
 
 

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -55,25 +55,6 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific processing values.
         :rtype: dict
         """
-
-        def get_language_code(lang_):
-            """Return the language code corresponding to the provided lang.
-
-            If the lang is not mapped to any language code, the country code is used instead. In
-            case the country code has no match either, we fall back to English.
-
-            :param str lang_: The lang, in IETF language tag format.
-            :return: The corresponding language code.
-            :rtype: str
-            """
-            language_code_ = const.LANGUAGE_CODES_MAPPING.get(lang_)
-            if not language_code_:
-                country_code_ = lang_.split("_")[0]
-                language_code_ = const.LANGUAGE_CODES_MAPPING.get(country_code_)
-            if not language_code_:
-                language_code_ = const.LANGUAGE_CODES_MAPPING["en"]
-            return language_code_
-
         if self.provider_code != "asiapay":
             return super()._get_specific_rendering_values(processing_values)
 
@@ -92,7 +73,7 @@ class PaymentTransaction(models.Model):
             "failUrl": return_url,
             "cancelUrl": return_url,
             "payType": "N",
-            "lang": get_language_code(lang),
+            "lang": payment_utils.get_language_code(lang, const.LANGUAGE_CODES_MAPPING),
             "payMethod": const.PAYMENT_METHODS_MAPPING.get(self.payment_method_id.code, "ALL"),
         }
         url_params["secureHash"] = self.provider_id._asiapay_calculate_signature(


### PR DESCRIPTION
Currently, the `payment_asiapay` module defines an internal helper function `get_language_code` to determine the correct provider-specific language code from the user's language or country code.

Because this mapping fallback logic is generic and can be utilized by other payment providers, this commit extracts the function into the base `payment` module's utility functions (`payment.utils`). The `payment_asiapay` transaction rendering logic is updated to call this shared utility.

To be used in https://github.com/odoo/odoo/pull/235069

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
