### PR TITLE
[FIX] pos_online_payment: prevent error when closing the payment popup

### DIFF
--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -135,7 +135,7 @@ patch(OrderPaymentValidation.prototype, {
                         {
                             onClose: () => {
                                 onlinePaymentLine.onlinePaymentResolver(false);
-                                this.currentOrder.onlinePaymentData = {};
+                                this.order.onlinePaymentData = {};
                             },
                         }
                     );


### PR DESCRIPTION
Before this commit, when the user closed the online payment popup, an error was raised because the currentOrder was not valid and instead order must be used.

opw-6034405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
