### PR TITLE
[FIX] hr_org_chart : wrong employee displayed

### DIFF
--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -35,6 +35,7 @@
             <div id="o_work_employee_main" position="after">
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5 pe-lg-0">
                     <separator string="Organization Chart"/>
+                    <field name="employee_id" invisible="1"/>
                     <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
                 </div>
             </div>


### PR DESCRIPTION
steps (on runbot):
-archive the user views for modules (or uninstall them):
	- hr_holidays_attendance
	- hr_maintenance
	- hr_skills
- go to the my preference page of your user -> in most of the cases, your employee is replaced by a "random" one

This happens because the hr_org_chart widget relies on the employee_id linked to the user, but the view itself doesn't load it itself, so it relies on other modules being installed to display properly.

If those other modules are uninstalled, it will fetch an employee using your user's id, which can be different than your user's id.

example:
<img width="1562" height="800" alt="image" src="https://github.com/user-attachments/assets/bfb4b7a1-605c-4b2f-81c1-b332fabfe7e0" />


opw-6022415
