### PR TITLE
[FIX] product, website_sale: use plan to check if subscription can be added to cart

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -977,7 +977,7 @@ class ProductTemplate(models.Model):
         """ Override to fallback on website current pricelist """
         pricelist = super()._get_contextual_pricelist()
         if request and request.is_frontend and not pricelist:
-            return request.pricelist
+            return request.pricelist.with_context(request.env.context)
         return pricelist
 
     def _website_show_quick_add(self):


### PR DESCRIPTION
A subscription product that has a price of zero on the product form and the price is set on the pricelist instead cannot be added to the cart when the `Prevent Sale of Zero Priced Product` setting is enabled

Steps to reproduce:
1. Install eCommerce and Subscriptions
2. Go to Settings and enable `Prevent Sale of Zero Priced Product`
3. Go to Subscriptions > Products and create a new product "subscription" with Sales Price $0.00 and publish it to the website
4. Go to Subscriptions > Pricelists and edit pricelist "Benelux"
5. In the Recurring Prices tab, create a new entry for product "subscription"  with a Fixed Price of $20.00 and a monthly Recurring Plan
6. Log in as portal user, go to the shop and look for "subscription" (pricelist "Benelux" should be selected)
7. Try to add it to the cart
8. Nothing happens and an error is displayed in the log

Issue:
When we check if a product can be added to the cart https://github.com/odoo/odoo/blob/b1f4647313eb2dbdbbe98b51649604b4e650a8aa/addons/website_sale/controllers/cart.py#L116-L120 we do not use the plan_id specified in kwargs
We reach this code
https://github.com/odoo/odoo/blob/b1f4647313eb2dbdbbe98b51649604b4e650a8aa/addons/website_sale/models/product_product.py#L146-L147 which will prevent the addition of a product in the cart if the option `prevent_zero_price_sale` is enabled and if `_get_contextual_price` returns zero
Calling `_get_contextual_price` tries to find a `product.pricelist.item` by building a domain in `_get_applicable_rules_domain` but calling this method without a plan_id eventually reaches
https://github.com/odoo/enterprise/blob/252c5ab78b51d0d2f06178cf92f0489b4a46958f/sale_subscription/models/product_pricelist.py#L69-L72 which restricts the domain to pricelists that are not subscription plans
Therefore, we cannot find any pricelist that applies to the product and we consider that the product cannot be added to the cart

Solution:
We need to use the plan_id selected by the customer in order to correctly check if a product can be added to the cart.

Use the plan_id in kwargs to update the request context so we can check if a product can be added to the cart according to the plan_id the user has selected. Use this plan_id in `_get_applicable_rules` in order to correctly select the applicable `product.pricelist.item`.

opw-5993614