### PR TITLE
[FIX] sale: default analytic lines to `Project` plan

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -23,7 +23,6 @@ This module contains all the common features of Sales Management and eCommerce.
         'report/ir_actions_report.xml',
         'report/sale_report_views.xml',
 
-        'data/analytic_plan_data.xml',
         'data/ir_cron.xml',
         'data/ir_sequence_data.xml',
         'data/mail_message_subtype_data.xml',

--- a/addons/sale/data/analytic_plan_data.xml
+++ b/addons/sale/data/analytic_plan_data.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
-    <record id="analytic_plan_sale_orders" model="account.analytic.plan">
-        <field name="name">Sales Orders</field>
-        <field name="default_applicability">unavailable</field>
-    </record>
-</odoo>

--- a/addons/sale/models/account_analytic_line.py
+++ b/addons/sale/models/account_analytic_line.py
@@ -241,7 +241,15 @@ class AccountAnalyticLine(models.Model):
         if not self:
             return
 
-        plan_id = self.env.ref('sale.analytic_plan_sale_orders', raise_if_not_found=False)
+        plan_id = self.env['account.analytic.plan'].browse(
+            self.env['ir.config_parameter'].get_int('sale.analytic_plan_sale_orders')
+        )
+        if not plan_id:
+            # This plan was available in 19.2 under which all of the AAs of sale orders were created
+            # which was decided to drop and to always use the `analytic.project_plan` plan, if users
+            # want to use custom plans, they can use the `sale.analytic_plan_sale_orders` parameter
+            # TODO: remove in master
+            plan_id = self.env.ref('sale.analytic_plan_sale_orders', raise_if_not_found=False)
         if not plan_id:
             plan_id, _other_plans = self.env['account.analytic.plan']._get_all_plans()
         column_name = plan_id._column_name()

--- a/addons/sale/tests/test_analytic_to_sale_to_invoice.py
+++ b/addons/sale/tests/test_analytic_to_sale_to_invoice.py
@@ -130,8 +130,8 @@ class TestAnalyticToSaleToInvoice(SaleCommon):
 
         self.assertEqual(
             self.services_sale_order.analytic_account_id.plan_id,
-            self.env.ref('sale.analytic_plan_sale_orders'),
-            "The sale order analytic account should have the sale orders analytic plan",
+            self.env.ref('analytic.analytic_plan_projects'),
+            "The sale order analytic account should have the Project analytic plan",
         )
 
     def test_quantity_update_on_analytic_line_updates_upsale_lines(self):


### PR DESCRIPTION
This change ensures that analytic lines generated from Services and Materials create analytic accounts per Sale Order under the **Project** plan by default, instead of using the dedicated **Sales Orders** plan.

A new system parameter `sale.analytic_plan_sale_orders` has been introduced to allow users to override this behavior and define a custom analytic plan for upsell lines when needed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
