### PR TITLE
[PERF] html_editor: improve normalize_handlers performance

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -213,11 +213,7 @@ export class BaseContainerPlugin extends Plugin {
             return;
         }
         const newBaseContainers = [];
-        const divSelector = `div:not(.${BASE_CONTAINER_CLASS})`;
-        const targets = [...element.querySelectorAll(divSelector)];
-        if (element.matches(divSelector)) {
-            targets.unshift(element);
-        }
+        const targets = selectElements(element, `div:not(.${BASE_CONTAINER_CLASS})`);
         for (const div of targets) {
             if (
                 // Ensure that newly created `div` baseContainers are never themselves
@@ -233,7 +229,10 @@ export class BaseContainerPlugin extends Plugin {
             ) {
                 div.classList.add(BASE_CONTAINER_CLASS);
                 newBaseContainers.push(div);
-                fillEmpty(div);
+                if (!div.hasChildNodes()) {
+                    const br = document.createElement("br");
+                    div.appendChild(br);
+                }
             }
         }
     }

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -701,8 +701,8 @@ export class FormatPlugin extends Plugin {
         }
         return (
             !isSelfClosingElement(node) &&
-            areSimilarElements(node, previousSibling) &&
-            isMergeable(node)
+            isMergeable(node) &&
+            areSimilarElements(node, previousSibling)
         );
     }
 }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -8,6 +8,7 @@ import { DIRECTIONS, leftPos, nodeSize, rightPos } from "@html_editor/utils/posi
 import { EMAIL_REGEX, URL_REGEX, cleanZWChars, deduceURLfromText } from "./utils";
 import {
     isElement,
+    isPhrasingContent,
     isProtected,
     isProtecting,
     isVisible,
@@ -742,7 +743,7 @@ export class LinkPlugin extends Plugin {
             // create a font tag inside it, and move the color to the font tag.
             // This ensures the color is applied to the font element instead of
             // the anchor element itself.
-            if (color && childNodes.every((n) => !isBlock(n))) {
+            if (color && childNodes.every(isPhrasingContent)) {
                 anchorEl.style.removeProperty("color");
                 const font = selectElements(anchorEl, "font").next().value;
                 if (font && cleanZWChars(anchorEl.textContent) === font.textContent) {

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -49,16 +49,6 @@ export class LinkSelectionPlugin extends Plugin {
         normalize_handlers: () => this.resetLinkInSelection(),
         feff_providers: this.addFeffsToLinks.bind(this),
         system_classes: ["o_link_in_selection"],
-        selection_placeholder_container_predicates: (container) => {
-            if (container.nodeName === "BUTTON" || container.nodeName === "A") {
-                // We sometimes have buttons or links that are blocks with
-                // contenteditable=true but we never want to insert a paragraph
-                // in them.
-                // Note: this can be removed if `allowsParagraphRelatedElements`
-                // is adapted to return false in these cases.
-                return false;
-            }
-        },
     };
 
     addFeffsToLinks(root, cursors) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -14,6 +14,7 @@ import {
     isListElement,
     isListItemElement,
     isParagraphRelatedElement,
+    isPhrasingContent,
     isProtected,
     isProtecting,
     isShrunkBlock,
@@ -495,15 +496,14 @@ export class ListPlugin extends Plugin {
         if (!isOrphan) {
             return;
         }
-        if (element.children.length && [...element.children].every(isBlock)) {
-            // Unwrap <li> if each of its children is a block element.
-            unwrapContents(element);
-        } else {
-            // Otherwise, wrap its content in a new <p> element.
-            const paragraph = this.dependencies.baseContainer.createBaseContainer();
-            element.replaceWith(paragraph);
-            paragraph.replaceChildren(...element.childNodes);
-        }
+        const cursors = this.dependencies.selection.preserveSelection();
+        wrapInlinesInBlocks(element, {
+            baseContainerNodeName: this.dependencies.baseContainer.getDefaultNodeName(),
+            cursors,
+        });
+        callbacksForCursorUpdate.unwrap(element);
+        unwrapContents(element);
+        cursors.restore();
     }
 
     mergeSimilarLists(element) {
@@ -551,7 +551,8 @@ export class ListPlugin extends Plugin {
 
         if (
             [...element.children].some(
-                (child) => isBlock(child) && !this.dependencies.split.isUnsplittable(child)
+                (child) =>
+                    !isPhrasingContent(child) && !this.dependencies.split.isUnsplittable(child)
             )
         ) {
             const cursors = this.dependencies.selection.preserveSelection();
@@ -1241,7 +1242,7 @@ export class ListPlugin extends Plugin {
      * @param {HTMLElement} list - The `<ul>` element used to determine the parent list and marker width.
      */
     adjustListPadding(list) {
-        if (!isListElement(list)) {
+        if (!isListElement(list) || ![...list.children].some(getFontSizeOrClass)) {
             return;
         }
         list.style.removeProperty("padding-inline-start");

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -86,6 +86,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
             (container) => checkPredicate("selection_placeholder_container_predicates", container)
         );
 
+        const marginUpdates = [];
         // 1. Update current placeholders.
         for (const placeholder of this.editable.querySelectorAll(PLACEHOLDER_SELECTOR)) {
             const siblings = ["before", "after"].map((side) =>
@@ -102,7 +103,10 @@ export class SelectionPlaceholderPlugin extends Plugin {
                 placeholder.remove();
             } else {
                 // Update the margins.
-                this.applyMargin(placeholder, ...siblings);
+                const update = this.prepareMarginUpdate(placeholder, ...siblings);
+                if (update) {
+                    marginUpdates.push(update);
+                }
             }
         }
 
@@ -112,6 +116,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
         ].filter((element) => isSelectionBlocker(element));
 
         // 2. Add placeholders before and after every blocker where necessary.
+        const pendingMarginUpdates = [];
         for (const blocker of blockers) {
             for (const side of ["before", "after"]) {
                 // Get the first non-whitespace sibling.
@@ -125,12 +130,29 @@ export class SelectionPlaceholderPlugin extends Plugin {
                     placeholder.setAttribute(PLACEHOLDER_ATTRIBUTE, "");
                     // Position the placeholder.
                     const siblings = side === "before" ? [sibling, blocker] : [blocker, sibling];
-                    this.applyMargin(placeholder, ...siblings);
                     // Insert the placeholder.
                     blocker[side](placeholder);
+                    pendingMarginUpdates.push({
+                        placeholder,
+                        siblings,
+                    });
                 }
             }
         }
+
+        // READ phase
+        for (const { placeholder, siblings } of pendingMarginUpdates) {
+            const update = this.prepareMarginUpdate(placeholder, ...siblings);
+            if (update) {
+                marginUpdates.push(update);
+            }
+        }
+
+        // WRITE phase
+        for (const update of marginUpdates) {
+            update();
+        }
+
         // 3. Reset blinker classes.
         this.resetBlinkerClasses();
     }
@@ -142,7 +164,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
      * @param {Element} previous
      * @param {Element} next
      */
-    applyMargin(placeholder, previous, next) {
+    prepareMarginUpdate(placeholder, previous, next) {
         const marginBefore = previous ? getMargin(previous, "bottom") : 0;
         const marginAfter = next ? getMargin(next, "top") : 0;
         const middleMargin = Math.abs(marginBefore - marginAfter) / 2;
@@ -153,7 +175,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
             const negativeMargin = -1 - middleMargin;
             const marginTop = marginAfter >= marginBefore ? positiveMargin : negativeMargin;
             const marginBottom = marginAfter >= marginBefore ? negativeMargin : positiveMargin;
-            placeholder.style.margin = `${marginTop}px 0 ${marginBottom}px`;
+            return () => (placeholder.style.margin = `${marginTop}px 0 ${marginBottom}px`);
         }
     }
 

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -5,6 +5,7 @@ import {
     allowsParagraphRelatedElements,
     isEmpty,
     isNotEditableNode,
+    isPhrasingContent,
 } from "@html_editor/utils/dom_info";
 import {
     closestElement,
@@ -37,20 +38,16 @@ export class SelectionPlaceholderPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if (
-                (blocker.nodeType === Node.ELEMENT_NODE &&
-                    blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) ||
-                !isBlock(blocker)
-            ) {
-                return false;
-            } else if (isNotEditableNode(blocker)) {
-                return true;
+            if (isNotEditableNode(blocker)) {
+                return isBlock(blocker);
             }
         },
         selection_placeholder_container_predicates: (container) => {
-            if (!container.isContentEditable || !allowsParagraphRelatedElements(container)) {
-                return false;
-            } else if (container.getAttribute("contenteditable") === "true") {
+            if (
+                container.getAttribute("contenteditable") === "true" &&
+                !isPhrasingContent(container) &&
+                allowsParagraphRelatedElements(container)
+            ) {
                 return true;
             }
         },

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -140,7 +140,7 @@ export class TablePlugin extends Plugin {
         selection_placeholder_container_predicates: (container) => {
             if (container.nodeName === "TABLE") {
                 return false;
-            } else if (["TD", "TH"].includes(container.nodeName)) {
+            } else if (["TD", "TH"].includes(container.nodeName) && container.closest(".o_table")) {
                 return true;
             }
         },

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -109,10 +109,12 @@ export class QWebPlugin extends Plugin {
     }
 
     normalizeInline(root) {
-        for (const el of selectElements(root, "t")) {
-            if (this.checkAllInline(el)) {
-                el.setAttribute("data-oe-t-inline", "true");
-            }
+        const targets = [...root.querySelectorAll("t")];
+        if (root.matches("t")) {
+            targets.unshift(root);
+        }
+        for (const el of targets.filter((el) => this.checkAllInline(el))) {
+            el.setAttribute("data-oe-t-inline", "true");
         }
     }
 

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -168,7 +168,7 @@ export function removeStyle(element, ...styleProperties) {
  */
 export function fillEmpty(el) {
     const document = el.ownerDocument;
-    if (!isBlock(el) && !isVisible(el) && !el.hasAttribute("data-oe-zws-empty-inline")) {
+    if (!isVisible(el) && !el.hasAttribute("data-oe-zws-empty-inline") && !isBlock(el)) {
         const zws = document.createTextNode("\u200B");
         el.appendChild(zws);
         el.setAttribute("data-oe-zws-empty-inline", "");

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -524,7 +524,7 @@ export const paragraphRelatedElements = ["P", "H1", "H2", "H3", "H4", "H5", "H6"
  * @returns {boolean}
  */
 export function allowsParagraphRelatedElements(node) {
-    return isBlock(node) && !isParagraphRelatedElement(node);
+    return !isParagraphRelatedElement(node) && isBlock(node);
 }
 
 export const phrasingContent = new Set(["#text", ...phrasingTagNames]);

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -648,7 +648,12 @@ export function isEmptyBlock(blockEl) {
  * @returns {boolean}
  */
 export function isShrunkBlock(blockEl) {
-    return isEmptyBlock(blockEl) && !blockEl.querySelector("br") && !isSelfClosingElement(blockEl);
+    return (
+        isElement(blockEl) &&
+        !blockEl.querySelector("br") &&
+        !isSelfClosingElement(blockEl) &&
+        isEmptyBlock(blockEl)
+    );
 }
 
 export function isEditorTab(node) {

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -110,7 +110,7 @@ describe("findAdjacentPosition method", () => {
                 const [node, offset] = findAdjacentPosition(editor, "backward");
                 setSelection({ anchorNode: node, anchorOffset: offset });
                 expect(getContent(el)).toBe(
-                    `<div class="o-paragraph">\ufeff[]<span contenteditable="false" class="o_file_box"></span>\ufeff<br></div>`
+                    `<div class="o-paragraph">\ufeff[]<span contenteditable="false" class="o_file_box"></span>\ufeff</div>`
                 );
             });
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR improves the performance of several `normalize_handlers` by reducing expensive DOM/style checks, avoiding unnecessary layout recalculations.

This PR:
1. Replaces the usage of `fillEmpty` with manual filling of empty blocks.
2. Replaces `isBlock` with `!isPhrasingContent`, which better matches the actual use case and avoids unnecessary work.
3. Optimizes list normalization by reducing checks for `isBlock`.
4. Avoids style recalculations in `normalizeInline` of `qweb_plugin`.
5. Delays the `isBlock` check at certain places so it is only performed when needed.
6. Reduces the number of `isBlock` calls in `selection_placeholder_container_predicates` and `selection_blocker_predicates`.
7. Fixes layout thrashing by separating style reads from style writes.

task-5245157

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
