### PR TITLE
[FIX] web_editor: prevent error on saving empty xml in report source editor

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -364,17 +364,18 @@ class IrUiView(models.Model):
 
         views_to_return = view
 
-        node = etree.fromstring(view.arch)
-        xpath = "//t[@t-call]"
-        if bundles:
-            xpath += "| //t[@t-call-assets]"
-        for child in node.xpath(xpath):
-            try:
-                called_view = self._view_obj(child.get('t-call', child.get('t-call-assets')))
-            except ValueError:
-                continue
-            if called_view and called_view not in views_to_return and called_view.id not in visited:
-                views_to_return += self._views_get(called_view, get_children=get_children, bundles=bundles, visited=visited + views_to_return.ids)
+        if view.arch and view.arch.strip():
+            node = etree.fromstring(view.arch)
+            xpath = "//t[@t-call]"
+            if bundles:
+                xpath += "| //t[@t-call-assets]"
+            for child in node.xpath(xpath):
+                try:
+                    called_view = self._view_obj(child.get('t-call', child.get('t-call-assets')))
+                except ValueError:
+                    continue
+                if called_view and called_view not in views_to_return and called_view.id not in visited:
+                    views_to_return += self._views_get(called_view, get_children=get_children, bundles=bundles, visited=visited + views_to_return.ids)
 
         if not get_children:
             return views_to_return


### PR DESCRIPTION
Currently an error is generated when the user tries to save a report with an empty XML format.

Steps to reproduce:
- Install web_studio and sale_management
- Sales > Studio > Reports > New > External > Type Text in report
- Save > Edit Sources > Remove full XML > Save

Error: `XMLSyntaxError:Document is empty, line 1, column 1 (<string>, line 1)`

This error occurs because line [1] in `web_editor` attempts to access nodes by using `etree.fromstring()` with an empty `view.arch`, which is empty, resulting in an error.

In earlier versions, this error was already handled by the `_check_xml` constraint, which raised a validation error when an `etree.ParseError` occurred while parsing `etree.fromstring(view.arch)` with an empty `view.arch` (see code reference [2]). However, recent changes introduced in commit [3] allow  `view.arch` to be empty. As a result, this error is no longer handled by the constraint.

This commit fixes the issue by adding a condition to prevent calling `etree.fromstring()` when `view.arch` is empty, avoiding attempts to access nodes from invalid data. It also updates the logic in the `web_studio` module's `get_xml_editor_resources` method to ensure resources are processed only when a valid view architecture is available.

[1]: https://github.com/odoo/odoo/blob/8a88756bed194910bc5a47e93f0e29610dbeee1f/addons/web_editor/models/ir_ui_view.py#L367
[2]: https://github.com/odoo/odoo/blob/75ca0fec9a0d3b1e3a05a8bf3101bbe21846ac7a/odoo/addons/base/models/ir_ui_view.py#L372-L377
[3]: https://github.com/odoo/odoo/commit/8334ea5c777e5a478f12b8bb7a2f54bcae537d0f

sentry-6288795955

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
