### PR TITLE
[FIX] sale: prevent computation of package when changing package number in quotation

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -988,6 +988,10 @@ class SaleOrderLine(models.Model):
                     },
                 }
 
+    @api.onchange('product_packaging_qty')
+    def _onchange_product_packaging_qty(self):
+        self.env.remove_to_compute(self._fields['product_packaging_id'], self)
+
     #=== CRUD METHODS ===#
 
     @api.model_create_multi

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -279,6 +279,48 @@ class TestSaleOrder(SaleCommon):
         self.assertEqual(so2.order_line.product_packaging_id, company2_pack_of_10)
         self.assertEqual(so2.order_line.product_packaging_qty, 1.0)
 
+    def test_compute_packaging_02(self):
+        """Create a SO and use packaging. Check product_qty and product_packaging
+        are correctly calculated when packaging_qty is manually changed.
+        """
+        # Required for `product_packaging_qty` to be visible in the view
+        self.env.user.groups_id += self.env.ref('product.group_stock_packaging')
+        packaging_one, packaging_four = self.env['product.packaging'].create([{
+            'name': "One pack",
+            'product_id': self.product.id,
+            'qty': 1.0,
+        }, {
+            'name': "Four pack",
+            'product_id': self.product.id,
+            'qty': 4.0,
+        }])
+
+        so = self.empty_order
+        so_form = Form(so)
+        with so_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_uom_qty = 1.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+        self.assertEqual(so.order_line.product_packaging_qty, 1.0)
+        with so_form.order_line.edit(0) as line:
+            line.product_packaging_qty = 4.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_uom_qty, 4.0)
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+
+        with so_form.order_line.edit(0) as line:
+            line.product_packaging_qty = 5.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+        self.assertEqual(so.order_line.product_packaging_qty, 5.0)
+
+        with so_form.order_line.edit(0) as line:
+            line.product_uom_qty = 4.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_four)
+        self.assertEqual(so.order_line.product_packaging_qty, 1.0)
+
     def _create_sale_order(self):
         """Create dummy sale order (without lines)"""
         return self.env['sale.order'].with_context(


### PR DESCRIPTION
**Behaviour:**
When creating a sale order line for an item with multiple packagings, modifying the packaging quantity will trigger the computation of the product quantity which will trigger the computation for the packaging itself. This creates a dependency between the chosen package and the quantity selected which can end up triggering unexpected reactions when following specific flows.

**Steps to reproduce:**
- Enable packages for sales in configuration
- Create a product, in the inventory tab, add two packages: Pack of one, and Pack of four and set corresponding unit.
- Create a quotation and set the SO line to Quantity to one, this should set Packaging and Packaging Quantity to 1 aswell
- Now change Packaging Quantity to 4, this should visually only change the Quantity to 4
- Now if you change Quantity to 5, you should see Packaging switch to packs of 4 and Quantity jump to 20.

This is caused because when in` _compute_product_uom_qty` we try to get the `product_packaging_id` which in turn triggers `_compute_product_packaging_id `before completing the previous compute. https://github.com/odoo/odoo/blob/cf9805874722b6729b5301fdea4f107ae221a1d2/addons/sale/models/sale_order_line.py#L397-L411
When we change the packaging_qty to 4, the packaging_id doesnt change as the compute is triggered before assigning 4 to the uom_qty. But when we change packaging_qty to 5, the packaging_id changes to packs of 4 as the compute is triggered before the uom_qty should go to 5 which then results in the uom_qty switching to 20.

The solution removes the dependency between package_id and qty.