### PR TITLE
[FIX] website_sale: add missing border on grid layout

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -640,7 +640,7 @@
                 border-left: #{$border-width} solid #{$border-color};
             }
 
-            &.o_wsale_has_sidebar.o_wsale_products_opt_layout_catalog #o_wsale_products_grid {
+            &.o_wsale_has_sidebar .o_wsale_products_opt_layout_catalog#o_wsale_products_grid {
                 @include media-breakpoint-down(lg) {
                     border-left: #{$border-width} solid #{$border-color};
                 }


### PR DESCRIPTION
On smaller viewports the sidebar is hidden and the grid misses a left border. It's because of a selector typo.

task-6059942

<img width="845" height="925" alt="image" src="https://github.com/user-attachments/assets/9ebb8a04-c3ce-40fd-acfa-8a17fbc31e3a" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
