### PR TITLE
[FIX] point_of_sale: allow zero amount invoice with untrusted accounts

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -562,7 +562,7 @@ class PosOrder(models.Model):
 
     def _get_partner_bank_id(self):
         bank_partner_id = False
-        if self.amount_total <= 0 and self.partner_id.bank_ids:
+        if self.amount_total < 0 and self.partner_id.bank_ids:
             bank_partner_id = self.partner_id.bank_ids[0].id
         elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
             bank_partner_id = self.company_id.partner_id.bank_ids[0].id

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2670,3 +2670,55 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             and l.partner_id == self.partner1
         ).balance
         self.assertEqual(order_balance + payment_balance, 0)
+
+    def test_zero_amount_invoice_marked_unallowed(self):
+        """
+        Checks that the partner_bank_id used in the case of an invoice
+        with zero value is the company's one and not the partner, as
+        it is still an invoice and should be treated as such
+        """
+        self.pos_config.open_ui()
+        blocked_bank, partner_bank = self.env["res.partner.bank"].create([
+            {
+                "acc_number": "FR7612345678901234567890124",
+                "partner_id": self.company.partner_id.id,
+                "bank_name": "Test Bank",
+            },
+            {
+                "acc_number": "FR0012345678901234567890123",
+                "partner_id": self.partner1.id,
+                "bank_name": "Partner Bank",
+            }
+        ])
+        self.cash_payment_method.journal_id.bank_account_id = blocked_bank
+        self.env.company.partner_id.bank_ids[0].allow_out_payment = True
+        partner_bank.allow_out_payment = False
+        current_session = self.pos_config.current_session_id
+        order = self.env["pos.order"].create({
+            "company_id": self.env.company.id,
+            "session_id": current_session.id,
+            "partner_id": self.partner1.id,
+            "lines": [[0, 0, {
+                "name": "OL/0001",
+                "product_id": self.product_a.id,
+                "price_unit": 0,
+                "qty": 1,
+                "price_subtotal": 0,
+                "price_subtotal_incl": 0,
+                "total_cost": 0,
+            }]],
+            "amount_paid": 0,
+            "amount_total": 0,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "to_invoice": True,
+            "last_order_preparation_change": "{}",
+        })
+        ctx = {"active_ids": [order.id], "active_id": order.id}
+        self.PosMakePayment.with_context(ctx).create({
+            "amount": 10,
+            "payment_method_id": self.cash_payment_method.id,
+        }).with_context(ctx).check()
+        res = order.action_pos_order_invoice()
+        invoice = self.env["account.move"].browse(res["res_id"])
+        self.assertEqual(self.env.company.partner_id.bank_ids[0].id, invoice.partner_bank_id.id)


### PR DESCRIPTION
**Steps to reproduce:**
- In the contact app, chose your company
- Go to the Accounting tab
- Create a bank account and check "Send Money"
- Create a partner, create a bank account for it
- Do not Check the "Send Money"
- Go to the POS, click on a product and refund it 100% to make the price 0
- Chose the partner we created as the client and ask for an invoice
- Try to pay, the account is not trusted

**Why the fix:**

With this same steps, if we make a normal order with a price different than zero, it will work. But if the price is negative,
we will get the same error.

This happens because the *partner_bank_id* is chosen depending on if this is a refund or not. With an amount of zero, the order is considered to be a refund, and we chose the partner's partner_bank_id, which is not trusted.

On a normal positive flow, we chose the company's which is trusted, so we can send the money and it works.

This does not make sense to assume a zero amounted order is a refund, because when we invoice something that is zero or greater, we get an invoice, but only for the *partner_bank_id* we chose it as if it was a credit note.

So we should take the partner's *partner_bank_id* for every order that has a strictly negative amount, and take the company's for every order that is zero or positive.

Another way to fix this would be to backport this commit that also resolves this issue starting in 18.0 by adding a fallback to the company's *partner_bank_id*, but it might be a bit much of a change for version 17.0 https://github.com/odoo/odoo/commit/7e63991dceb6e443b950e6a1b94454a82d5668c7

opw-6005384