### PR TITLE
[FIX] website_forum: Fix validate and refuse routes

### DIFF
--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -381,7 +381,10 @@ export class WebsiteForum extends Interaction {
         postBeingValidated.classList.add("d-none");
         let ok;
         try {
-            ok = (await this.waitFor(fetch(currentTargetEl.href))).ok;
+            ok = (await this.waitFor(fetch(currentTargetEl.href), {
+                method: "POST",
+                body: JSON.stringify({ csrf_token: odoo.csrf_token, }),
+            })).ok;
         } catch {
             // Calling the endpoint like this returns an HTML page. As we can't
             // extract the error message from that, we disregard it and simply

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -198,10 +198,22 @@
                 <p>This post is currently awaiting moderation and is not published yet.<br/>
                     As a moderator you can either <b>Accept</b> or <b>Reject</b> this post.</p>
                 <div>
-                    <a role="button" t-attf-href="/forum/#{slug(forum)}/post/#{slug(question)}/validate" type="button" class="btn btn-success">
-                        <i class="fa fa-check fa-fw me-1"/>Accept</a>
-                    <a role="button" t-attf-href="/forum/#{slug(forum)}/post/#{slug(question)}/refuse" type="button" class="btn btn-danger">
-                        <i class="fa fa-times fa-fw me-1"/>Reject</a>
+                    <t t-call="website_forum.link_button">
+                        <t t-set="url" t-value="'/forum/' + slug(forum) + '/post/' + slug(question) + '/validate'"/>
+                        <t t-set="classes" t-value="'btn btn-success'"/>
+                        <t t-set="label">Accept</t>
+                        <t t-set="title">Accept</t>
+                        <t t-set="icon" t-value="'fa-check fa-fw me-1'"/>
+                        <t t-set="karma" t-value="forum.karma_moderate if not forum.can_moderate else 0"/>
+                    </t>
+                    <t t-call="website_forum.link_button">
+                        <t t-set="url" t-value="'/forum/' + slug(forum) + '/post/' + slug(question) + '/refuse'"/>
+                        <t t-set="classes" t-value="'btn btn-danger'"/>
+                        <t t-set="label">Reject</t>
+                        <t t-set="title">Reject</t>
+                        <t t-set="icon" t-value="'fa-times fa-fw me-1'"/>
+                        <t t-set="karma" t-value="forum.karma_moderate if not forum.can_moderate else 0"/>
+                    </t>
                 </div>
             </div>
             <div t-if="question.state == 'pending' and user.karma &lt; forum.karma_moderate" class="alert alert-warning mb-0 text-center" role="status" >


### PR DESCRIPTION
Problem
---------
The /validate and /refuse routes were recently updated into POST only. However, some were forgotten in the process. This commit fixes those.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
