### PR TITLE
[FIX] im_livechat: various transcript template fixes

### DIFF
--- a/addons/im_livechat/data/mail_templates.xml
+++ b/addons/im_livechat/data/mail_templates.xml
@@ -6,14 +6,21 @@
 <t t-set="header_background_color" t-value="channel.livechat_channel_id.sudo().header_background_color or '#875A7B'" />
 <!-- sudo: visitor can access title color -->
 <t t-set="title_color" t-value="channel.livechat_channel_id.sudo().title_color or '#FFFFFF'" />
-<div style="font-size: 13px; max-width: 600px; margin: 10px; padding: 24px 32px 0px 32px; background-color: #ffffff; border-radius: 0 0 8px 8px; border: thin solid #dee2e6;">
-<div style="font-size: 13px; padding: 5px 0; white-space:nowrap;">
+<div style="font-size: 13px; margin: 10px; padding: 24px 32px 0px 32px; background-color: #ffffff; border: thin solid #dee2e6;">
+<div style="font-size: 13px; padding: 5px 0;">
     Here's a copy of your conversation with
     <span t-attf-style="color: {{header_background_color}};" t-out="correspondent_names"/> on
     <span t-out="channel.create_date.astimezone(tz).strftime('%m/%d/%y')"/> at
     <span t-out="channel.create_date.astimezone(tz).strftime('%I:%M %p')"/>.
 </div>
+<style>
+    .o-LivechatReport-bodyContent &gt; p {
+        margin: 0;
+        padding: 0;
+    }
+</style>
 <table cellspacing="0" cellpadding="0" class="table-borderless" style="width:100%; margin: 16px 0;">
+    <t t-set="deleted_messages" t-value="channel.message_ids._filter_empty()"/>
     <t t-foreach="channel.message_ids.sorted(lambda m: (m.date, m.id))" t-as="message">
         <t t-if="message.message_type != 'notification'">
             <t t-set="author_name"><t t-if="message.author_id" t-out="message.author_id.sudo().user_livechat_username or message.author_id.sudo().name"/><t t-else="">You</t></t>
@@ -34,9 +41,30 @@
                                     <strong t-attf-style="color:{{header_background_color}}; font-size: 13px; margin-right: 2px;" t-out="author_name"/>
                                     <span style="font-size:10px; color:#666666;" t-out="message.date.astimezone(tz).strftime('%I:%M %p')"/>
                                 </div>
-                                <div style="display: flex;">
-                                    <div style="background-color: #E2F3F6; padding: 16px 12px 0; border-radius: 0 0.46875rem 0.46875rem 0.46875rem; display: inline-block; max-width: 100%;">
-                                        <span style="font-size: 13px; word-break: break-word;" t-out="message.body"/>
+                                <t t-if="is_html_empty" t-set="is_body_empty" t-value="is_html_empty(message.body)"/>
+                                <t t-else="" t-set="is_body_empty" t-value="not message.body"/>
+                                <div t-if="not is_body_empty or is_deleted_message" style="background-color: #E2F3F6; padding: 12px; border-radius: 0 0.46875rem 0.46875rem 0.46875rem; display: inline-block; max-width: 100%;">
+                                    <span class="o-LivechatReport-bodyContent" style="font-size: 13px; word-break: break-word;">
+                                        <p t-if="is_deleted_message" style="color: #6c757d; font-style: italic;">This message has been removed</p>
+                                        <t t-else="" t-out="message.body"/>
+                                    </span>
+                                </div>
+                                <t t-set="img_attachments" t-value="message.attachment_ids.filtered(lambda a: a.mimetype.startswith('image/'))"/>
+                                <t t-set="other_attachments" t-value="message.attachment_ids - img_attachments"/>
+                                <div t-if="img_attachments" style="display: flex; flex-wrap: wrap; margin-top: 8px;">
+                                    <img t-foreach="img_attachments"
+                                        t-as="attachment"
+                                        t-attf-src="data:{{attachment.mimetype}};base64,{{attachment.datas}}"
+                                        style="max-height: 300px; object-fit: contain; border-radius: 0.75rem; margin-bottom: 4px; margin-right: 4px;"/>
+                                </div>
+                                <div t-if="other_attachments" style="display: flex; flex-wrap: wrap; margin-top: 8px;">
+                                    <div
+                                        t-foreach="other_attachments"
+                                        t-as="attachment"
+                                        style="display: inline-block; padding: 2px 4px; padding-bottom: 4px; border: 1px solid #d2d2d2; border-radius: 6px; margin-right: 8px; background-color: #f9f9f9; margin-bottom: 4px;"
+                                    >
+                                        <strong style="background-color: #875A7B; color: white; padding: 2px 5px; border-radius: 3px; text-transform: uppercase; font-size: 10px; margin-right: 4px;" t-out="attachment.mimetype"/>
+                                        <span style="color: #495057; font-size: 12px;" t-out="attachment.display_name"/>
                                     </div>
                                 </div>
                             </td>

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -8,7 +8,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, _, tools
 from odoo.addons.base.models.ir_qweb_fields import nl2br
 from odoo.addons.mail.tools.discuss import Store
-from odoo.tools import email_split, format_list, html2plaintext
+from odoo.tools import email_split, format_list, html2plaintext, is_html_empty
 from odoo.tools.mimetypes import get_extension
 from odoo.tools.translate import LazyTranslate
 
@@ -572,6 +572,7 @@ class DiscussChannel(models.Model):
         render_context = {
             "company": company,
             "channel": self,
+            "is_html_empty": is_html_empty,
             "tz": ZoneInfo(tz),
             "correspondent_names": correspondent_names,
         }


### PR DESCRIPTION
Before this commit, the live chat transcript had some issues:
- Delete messages were shown as an empty bubble.
- Attachments were not shown.
- Guests avatar was incorrect.
- Transcript was limited to 600px, while there is no reason to do so.

This commit fixes all the above issues.

task-6008968

|||
|-|-|
|Before|![before](https://github.com/user-attachments/assets/c07ac51a-7a19-4f36-8542-40f62445a1d4)|
|After|![after](https://github.com/user-attachments/assets/16758874-414b-4e77-bc8a-0ec36e4976d3)|