### PR TITLE
[FIX] hr_holidays: allow gantt view leave confirmation for approval user

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -3,6 +3,7 @@
 from odoo import api, fields, models, tools
 
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.exceptions import ValidationError
 
 
 class LeaveReportCalendar(models.Model):
@@ -106,10 +107,37 @@ class LeaveReportCalendar(models.Model):
             leave.is_manager = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or leave.leave_manager_id == self.env.user
 
     def action_approve(self):
-        self.leave_id.action_approve(check_state=False)
+        current_user = self.env.user
+        if current_user.has_group('hr_holidays.group_hr_holidays_user'):
+            # If the user is a leave manager, approve the leave
+            self.leave_id.action_approve()
+        elif self.leave_manager_id == current_user and self.sudo().holiday_status_id.leave_validation_type in ('manager', 'both'):
+            # If the user is the employee's time off approver, approve the leave
+            self.sudo().leave_id.sudo(False).action_approve()
+        else:
+            # If the user is not a leave manager, raise an error
+            raise ValidationError(self.env._("You are not allowed to approve this leave request."))
 
     def action_validate(self):
-        self.leave_id.action_validate()
+        current_user = self.env.user
+        if current_user.has_group('hr_holidays.group_hr_holidays_user'):
+            # If the user is a leave manager, validate the leave
+            self.leave_id.action_validate()
+        elif self.leave_manager_id == current_user and self.sudo().holiday_status_id.leave_validation_type in ('manager', 'both'):
+            # If the user is the employee's time off approver, validate the leave
+            self.sudo().leave_id.sudo(False).action_validate()
+        else:
+            # If the user is not a leave manager, raise an error
+            raise ValidationError(self.env._("You are not allowed to validate this leave request."))
 
     def action_refuse(self):
-        self.leave_id.action_refuse()
+        current_user = self.env.user
+        if current_user.has_group('hr_holidays.group_hr_holidays_user'):
+            # If the user is a leave manager, refuse the leave
+            self.leave_id.action_refuse()
+        elif self.leave_manager_id == current_user and self.sudo().holiday_status_id.leave_validation_type in ('manager', 'both'):
+            # If the user is the employee's time off approver, refuse the leave
+            self.sudo().leave_id.sudo(False).action_refuse()
+        else:
+            # If the user is not a leave manager, raise an error
+            raise ValidationError(self.env._("You are not allowed to refuse this leave request."))

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -11,6 +11,7 @@ from odoo import Command
 from odoo.tools import date_utils, mute_logger, test_reports
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 class TestHolidaysFlow(TestHrHolidaysCommon):
@@ -281,3 +282,34 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                         'request_date_from': date.today() + relativedelta(day=11),
                         'request_date_to': date.today() + relativedelta(day=10),
                     })
+
+    def test_manager_can_approve_from_leave_report_calendar(self):
+        """Check if an approval user that has not additional access rights for Time Off can approve a leave for an employee."""
+
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Manager Approval Time Off',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'manager',
+            'time_type': 'leave',
+        })
+
+        manager_user = mail_new_test_user(
+            self.env,
+            login='manager_no_timeoff',
+            groups='base.group_user',
+        )
+
+        self.employee_emp.leave_manager_id = manager_user
+
+        leave = self.env['hr.leave'].with_user(self.user_employee).create({
+            'name': 'Employee Leave',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': date.today() + relativedelta(days=1),
+            'request_date_to': date.today() + relativedelta(days=1),
+        })
+
+        leave_report = self.env['hr.leave.report.calendar'].with_user(manager_user).browse(leave.id)
+        self.assertEqual(leave.state, 'confirm')
+        leave_report.action_approve()
+        self.assertEqual(leave.state, 'validate')


### PR DESCRIPTION
### Issue before this commit:
A manager without the Time Off Officer access rights was unable to approve, validate, or refuse a leave request from the Time Off Gantt. Attempting to perform these actions raised an access error on the leave_id field of the hr.leave.report.calendar model.

### Steps to reproduce the issue:
1. In employee app create a manager, go to settings tab and create also a user for the manager as Related User
2. Create also an employee setting in the Work Information tab the manager as Time Off
3. Go to Users and for the manager deselect rights for Time Off and Payroll
4. Set a contract for the created employee and allocate some Paid days to him
5. Create a Time Off request for the employee.
6. Switch to manager account
7. Go to Time Off -> Overview -> Gantt View and try to approve the request.
8. Error: _You do not have enough rights to access the fields "leave_id" on Time Off Calendar (hr.leave.report.calendar). Please contact your system administrator._

### Cause of the issue:
The action_approve, action_validate, and action_refuse methods on the hr.leave.report.calendar model relied on accessing the leave_id field, which is restricted to users belonging to the
hr_holidays.group_hr_holidays_user group. As a result, managers without this group could not read the field, triggering an AccessError even though they were legitimately allowed to approve leaves as managers. Backporting this PR: https://github.com/odoo/odoo/pull/207675

### Reason to introduce the fix:
Allow managers to perform leave approval, validation, and refusal actions without granting them broader Time Off access rights.
This fix extends the permission logic to ensure that the employee’s designated leave manager can execute these actions when the validation type allows it, while preserving the standard access restrictions for other users.

opw-6023628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
