### PR TITLE
[FIX] html_builder, *: support `color()` in `BuilderColorPicker`

### DIFF
--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -1,7 +1,7 @@
 import { EDITOR_COLOR_CSS_VARIABLES, isColorCombinationName } from "@html_editor/utils/color";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { backgroundImageCssToParts, getBgImageURLFromURL } from "@html_editor/utils/image";
-import { normalizeCSSColor, isCSSColor, isColorGradient, rgbaToHex } from "@web/core/utils/colors";
+import { normalizeCSSColor, isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { convertNumericToUnit, getCSSVariableValue } from "@html_editor/utils/formatting";
 
 /**
@@ -463,7 +463,7 @@ export function getAllUsedColors(el) {
     const usedCustomColors = new Set();
     const collectColor = (colorValue) => {
         if (isCSSColor(colorValue)) {
-            usedCustomColors.add(rgbaToHex(colorValue));
+            usedCustomColors.add(normalizeCSSColor(colorValue));
         }
     };
     for (const coloredEl of selectElements(el, '[style*="color"]')) {

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -1,7 +1,7 @@
 import { EDITOR_COLOR_CSS_VARIABLES, isColorCombinationName } from "@html_editor/utils/color";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { backgroundImageCssToParts, getBgImageURLFromURL } from "@html_editor/utils/image";
-import { normalizeCSSColor, isCSSColor, isColorGradient, rgbaToHex } from "@web/core/utils/colors";
+import { normalizeCSSColor, isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { convertNumericToUnit, getCSSVariableValue } from "@html_editor/utils/formatting";
 
 /**
@@ -462,7 +462,7 @@ export function getAllUsedColors(el) {
     const usedCustomColors = new Set();
     const collectColor = (colorValue) => {
         if (isCSSColor(colorValue)) {
-            usedCustomColors.add(rgbaToHex(colorValue));
+            usedCustomColors.add(normalizeCSSColor(colorValue));
         }
     };
     for (const coloredEl of selectElements(el, '[style*="color"]')) {

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -19,7 +19,13 @@ import {
 import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { isColorGradient, isCSSColor, RGBA_REGEX, rgbaToHex } from "@web/core/utils/colors";
+import {
+    isColorGradient,
+    isCSSColor,
+    normalizeCSSColor,
+    RGBA_REGEX,
+    rgbaToHex,
+} from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { backgroundImageCssToParts, backgroundImagePartsToCss } from "@html_editor/utils/image";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -189,9 +195,12 @@ export class ColorPlugin extends Plugin {
         }
 
         return {
-            color: hasGradient && hasTextGradientClass ? gradient : rgbaToHex(elStyle.color),
+            color:
+                hasGradient && hasTextGradientClass ? gradient : normalizeCSSColor(elStyle.color),
             backgroundColor:
-                hasGradient && !hasTextGradientClass ? gradient : rgbaToHex(backgroundColor),
+                hasGradient && !hasTextGradientClass
+                    ? gradient
+                    : normalizeCSSColor(backgroundColor),
         };
     }
 
@@ -538,7 +547,7 @@ export class ColorPlugin extends Plugin {
         const usedCustomColors = new Set();
         for (const font of allFont) {
             if (isCSSColor(font.style[mode])) {
-                usedCustomColors.add(rgbaToHex(font.style[mode]));
+                usedCustomColors.add(normalizeCSSColor(font.style[mode]));
             }
         }
         return usedCustomColors;

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -17,7 +17,13 @@ import {
 import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { isColorGradient, isCSSColor, RGBA_REGEX, rgbaToHex } from "@web/core/utils/colors";
+import {
+    isColorGradient,
+    isCSSColor,
+    normalizeCSSColor,
+    RGBA_REGEX,
+    rgbaToHex,
+} from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { backgroundImageCssToParts, backgroundImagePartsToCss } from "@html_editor/utils/image";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -187,9 +193,12 @@ export class ColorPlugin extends Plugin {
         }
 
         return {
-            color: hasGradient && hasTextGradientClass ? gradient : rgbaToHex(elStyle.color),
+            color:
+                hasGradient && hasTextGradientClass ? gradient : normalizeCSSColor(elStyle.color),
             backgroundColor:
-                hasGradient && !hasTextGradientClass ? gradient : rgbaToHex(backgroundColor),
+                hasGradient && !hasTextGradientClass
+                    ? gradient
+                    : normalizeCSSColor(backgroundColor),
         };
     }
 
@@ -524,7 +533,7 @@ export class ColorPlugin extends Plugin {
         const usedCustomColors = new Set();
         for (const font of allFont) {
             if (isCSSColor(font.style[mode])) {
-                usedCustomColors.add(rgbaToHex(font.style[mode]));
+                usedCustomColors.add(normalizeCSSColor(font.style[mode]));
             }
         }
         return usedCustomColors;

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -157,6 +157,7 @@ test("custom text-colors used in the editor are shown in the colorpicker", async
         `<p>
             <font style="color: rgb(255, 0, 0);">test</font>
             <font style="color: rgb(0, 255, 0);">[test]</font>
+            <font style="color: color(srgb 0.4 0.2 0.8 / 0.4);">color_function_test</font>
         </p>`
     );
     await expandToolbar();
@@ -167,10 +168,14 @@ test("custom text-colors used in the editor are shown in the colorpicker", async
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
     expect(".o_rgba_div input").toHaveCount(0);
-    expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
-    expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
-    expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
-    expect(queryOne("button[data-color='#00ff00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
+    expect(queryAll("button[data-color='#FF0000']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#FF0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
+    expect(queryAll("button[data-color='#00FF00']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#00FF00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
+    expect(queryAll("button[data-color='#6632CD66']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#6632CD66']").style.backgroundColor).toBe(
+        "rgba(102, 50, 205, 0.4)"
+    );
 });
 
 test("custom background colors used in the editor are shown in the colorpicker", async () => {
@@ -178,6 +183,7 @@ test("custom background colors used in the editor are shown in the colorpicker",
         `<p>
             <font style="background-color: rgb(255, 0, 0);">test</font>
             <font style="background-color: rgb(0, 255, 0);">[test]</font>
+            <font style="background-color: color(srgb 0.4 0.2 0.8 / 0.4);">color_function_test</font>
         </p>`
     );
     await expandToolbar();
@@ -188,10 +194,14 @@ test("custom background colors used in the editor are shown in the colorpicker",
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
     expect(".o_rgba_div input").toHaveCount(0);
-    expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
-    expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
-    expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
-    expect(queryOne("button[data-color='#00ff00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
+    expect(queryAll("button[data-color='#FF0000']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#FF0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
+    expect(queryAll("button[data-color='#00FF00']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#00FF00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
+    expect(queryAll("button[data-color='#6632CD66']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#6632CD66']").style.backgroundColor).toBe(
+        "rgba(102, 50, 205, 0.4)"
+    );
 });
 
 test("applied custom color should be shown in colorpicker after switching tab", async () => {
@@ -426,6 +436,19 @@ test("selected text color is shown in the toolbar and update when clicking", asy
     await animationFrame();
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 0, 255)" });
 });
+
+test("selected text color using color function is shown in the toolbar", async () => {
+    await setupEditor(
+        `<p>
+            <font style="color: color(srgb 0.4 0.2 0.8 / 0.4);">[color_function_test]</font>
+        </p>`
+    );
+
+    await expandToolbar();
+    await animationFrame();
+    expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgba(102, 50, 205, 0.4)" });
+});
+
 test("selected text color is not shown in the toolbar after removeFormat", async () => {
     const defaultTextColor = "rgb(1, 10, 100)";
     const styleContent = `* {color: ${defaultTextColor};}`;
@@ -472,6 +495,18 @@ test("selected color is shown and updates when selection change", async () => {
     });
     await waitUntil(() => queryOne("i.fa-font").style.borderBottomColor === "rgb(255, 156, 0)");
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 156, 0)" });
+});
+
+test("selected background color using color function is shown in the toolbar", async () => {
+    await setupEditor(
+        `<p>
+            <font style="background: color(srgb 0.4 0.2 0.8 / 0.4);">[color_function_test]</font>
+        </p>`
+    );
+
+    await expandToolbar();
+    await animationFrame();
+    expect("i.fa-paint-brush").toHaveStyle({ borderBottomColor: "rgba(102, 50, 205, 0.4)" });
 });
 
 test("selected background color is shown in the toolbar and update when clicking", async () => {
@@ -688,7 +723,7 @@ test("custom tab color navigation using keys", async () => {
     await press("Tab");
     await press("Tab");
     expect(getActiveElement()).toBe(
-        queryFirst(`.o_font_color_selector button[data-color="#ff0000"]`)
+        queryFirst(`.o_font_color_selector button[data-color="#FF0000"]`)
     );
     await press("ArrowDown");
     expect(getActiveElement()).toBe(

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -187,7 +187,7 @@ test("Can set icon color", async () => {
     await waitFor(".o_color_button[data-color='#6BADDE']");
     await click(".o_color_button[data-color='#6BADDE']");
     await expectElementCount(".o_font_color_selector", 0); // selector closed
-    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6badde']");
+    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6BADDE']");
     expect(getContent(el)).toBe(
         `<p>\ufeff[<span class="fa fa-glass" contenteditable="false" style="color: rgb(107, 173, 222);">\u200b</span>]\ufeff</p>`
     );

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -90,7 +90,7 @@
             <div class="d-flex flex-column align-items-start p-1" t-on-keydown="colorPickerNavigation">
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
-                        <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                        <button t-if="color?.toLowerCase() !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
                     <button t-if="!defaultColorSet" class="o_color_button btn p-0" t-att-class="{'selected': defaultColorSet === false}" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
@@ -38,3 +38,19 @@ test("should remove o_cc color on reset", async () => {
     expect(":iframe .test-options-target").toHaveClass("test-options-target");
     expect(":iframe .test-options-target").not.toHaveClass("o_cc o_cc3");
 });
+
+test("should support colors defined using the color function", async () => {
+    addOption({
+        selector: ".test-color",
+        template: xml`<BuilderColorPicker enabledTabs="['custom']" styleAction="'background-color'" />`,
+    });
+    await setupWebsiteBuilder(
+        `<div class="test-color" style="background-color: color(srgb 0.4 0.2 0.8 / 0.4);">Test Color</div>`
+    );
+    await contains(":iframe .test-color").click();
+    expect(".options-container button.o_we_color_preview").toHaveStyle({
+        backgroundColor: "rgba(102, 50, 205, 0.4)",
+    });
+    await contains(".options-container button.o_we_color_preview").click();
+    expect(".o_colorpicker_section button.o_color_button[data-color='#6632CD66']").toHaveCount(1);
+});


### PR DESCRIPTION
Following the website refactoring (commit 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2) `BuilderColorPicker` no longer recognizes colors defined using `color()`, introducing a regression.

This commit restores support for `color()` values.

Steps to reproduce:
1. Add the snippet `s_text_image`.
2. Manually, in the DOM, set the style of the first column to "background-color: color(srgb 0.4 0.2 0.8 / 0.4);".
3. In edit mode, click on the column to observe that the colorpicker does not recognize the background color. The same behavior can also be observed in the custom tab.

Task: [5453922](https://www.odoo.com/odoo/project/974/tasks/5453922)