### PR TITLE
[IMP] web: Make Count Obvious

### DIFF
--- a/addons/web/static/src/core/pager/pager.scss
+++ b/addons/web/static/src/core/pager/pager.scss
@@ -1,0 +1,13 @@
+.o_pager {
+    // Same color as .o_field_widget:focus-within
+    @include print-variable(o-input-border-color, $o-action);
+
+    span.o_pager_value:not(:hover) {
+        --border-opacity: 1;
+        border-color: transparent !important;
+    }
+
+    input.o_pager_value {
+        border-color: var(--o-input-border-color) !important;
+    }
+}

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -8,7 +8,7 @@
                     <input type="text" class="o_pager_value o_input d-inline-block w-auto text-end mb-n1" size="7" t-custom-ref="autofocus" t-att-value="this.value" t-on-blur="this.onInputBlur" t-on-change="this.onInputChange" t-on-keydown.stop="this.onInputKeydown" />
                 </t>
                 <t t-else="">
-                    <span class="o_pager_value d-inline-block border-bottom border-transparent mb-n1" t-out="this.value" t-on-click="this.onValueClick" />
+                    <span class="o_pager_value d-inline-block border-bottom mb-n1" t-out="this.value" t-on-click="this.onValueClick" />
                 </t>
                 <span> / </span>
                 <t t-if="this.props.updateTotal">

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -620,10 +620,7 @@ export class SearchBar extends Component {
 
     onFacetLabelClick(target, facet) {
         const { domain, groupId } = facet;
-        if (this.env.searchModel.canOrderByCount && facet.type === "groupBy") {
-            this.env.searchModel.switchGroupBySort();
-            return;
-        } else if (!domain) {
+        if ((this.env.searchModel.canOrderByCount && facet.type === "groupBy") || !domain) {
             return;
         }
         const { resModel } = this.env.searchModel;

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -18,7 +18,6 @@
                     t-att-role="facet.domain ? 'button' : 'img'"
                     t-att-class="{
                         'text-bg-action': facet.type == 'groupBy',
-                        'btn': facet.type == 'groupBy' and this.env.searchModel.canOrderByCount,
                         'btn btn-primary': facet.type == 'field' || facet.type == 'filter',
                         'btn btn-favourite': facet.type == 'favorite'
                     }"
@@ -32,12 +31,6 @@
                         t-att-class="{'px-2 transition-base': !facet.icon}"
                         >
                         <i class="fa fa-fw fa-pencil"/>
-                    </span>
-                    <span t-if="this.env.searchModel.canOrderByCount and facet.type === 'groupBy' and !this.env.searchModel.orderByCount"
-                        class="position-absolute start-0 top-0 bottom-0 end-0 bg-inherit opacity-0 opacity-100-hover"
-                        t-att-class="{'px-2 transition-base': !facet.icon}"
-                        >
-                        <i class="fa fa-fw fa-sort"/>
                     </span>
                 </div>
 

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1928,12 +1928,7 @@ export class SearchModel extends EventBus {
             if (type === "field") {
                 facet.title = title;
             } else {
-                if (type === "groupBy" && this.orderByCount) {
-                    facet.icon =
-                        FACET_ICONS[this.orderByCount === "Asc" ? "groupByAsc" : "groupByDesc"];
-                } else {
-                    facet.icon = FACET_ICONS[type];
-                }
+                facet.icon = FACET_ICONS[type];
                 facet.color = FACET_COLORS[type];
             }
             if (tooltip) {

--- a/addons/web/static/src/search/utils/misc.js
+++ b/addons/web/static/src/search/utils/misc.js
@@ -1,8 +1,6 @@
 export const FACET_ICONS = {
     filter: "fa fa-filter",
     groupBy: "oi oi-group",
-    groupByAsc: "fa fa-sort-numeric-asc",
-    groupByDesc: "fa fa-sort-numeric-desc",
     favorite: "fa fa-star",
 };
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -200,6 +200,12 @@ export class ListRenderer extends Component {
             altKeyMode: false,
         });
         this.currencyRates = null;
+        this.countColumn = {
+            type: "count",
+            hasLabel: true,
+            label: _t("Count"),
+            name: "__count",
+        };
         onWillStart(async () => {
             const needsCurrencyRates = this.props.archInfo.columns.some((column) => {
                 if (column.type !== "field") {
@@ -893,6 +899,9 @@ export class ListRenderer extends Component {
     }
 
     isNumericColumn(column) {
+        if (column.type === "count") {
+            return true;
+        }
         const { type } = this.fields[column.name];
         return ["float", "integer", "monetary"].includes(type);
     }
@@ -910,7 +919,10 @@ export class ListRenderer extends Component {
     }
 
     isSortable(column) {
-        const { hasLabel, name, options } = column;
+        const { hasLabel, name, options, type } = column;
+        if (type === "count") {
+            return true;
+        }
         const { sortable } = this.fields[name];
         return (sortable || options.allow_order) && hasLabel;
     }
@@ -1153,8 +1165,7 @@ export class ListRenderer extends Component {
         return colspan;
     }
 
-    // TODO: rename in master
-    getGroupPagerCellColspan(group) {
+    getGroupCellColspan(group) {
         // this colspan is the number of columns after the last column with aggregates
         const lastIndex = this.getLastAggregateIndex(group);
         return lastIndex > -1 ? this.columns.length - lastIndex - 1 : 0;
@@ -1203,8 +1214,12 @@ export class ListRenderer extends Component {
         if (this.editedRecord || this.props.list.model.useSampleModel) {
             return;
         }
-        const fieldName = column.name;
         const list = this.props.list;
+        if (column.type === "count") {
+            this.env.searchModel.switchGroupBySort();
+            return;
+        }
+        const fieldName = column.name;
         if (this.isSortable(column)) {
             list.sortBy(fieldName);
         }
@@ -1984,6 +1999,10 @@ export class ListRenderer extends Component {
     get showNoContentHelper() {
         const { model } = this.props.list;
         return this.props.noContentHelp && (model.useSampleModel || !model.hasData());
+    }
+
+    get showCountColumn() {
+        return this.props.list.isGrouped && !this.env.isSmall;
     }
 
     /**

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -264,10 +264,24 @@
             }
         }
 
+        .o_count_header, .o_count_column {
+            min-width: 105px;
+            white-space: nowrap;
+            background-color: var(--ListRenderer-thead-bg-color);
+            .o_pager {
+                > .btn-group {
+                    display: none;
+                }
+            }
+        }
+        .o_pager_cell_buttons .o_pager_counter {
+            display: none;
+        }
+
         // Grouped list views
         tbody > tr.o_group_header {
-            --table-bg: var(--table-striped-bg);
-            --table-color: var(--table-striped-color);
+            --table-bg: var(--ListRenderer-thead-bg-color);
+            --table-color: var(--ListRenderer-thead-bg-color);
             height: 40px;
 
             &:hover .o_group_config {
@@ -293,34 +307,44 @@
                     margin-right: 3px;
                 }
             }
-            .o_pager {
-                cursor: text;
-                user-select: none;
-                text-align: right;
-                padding-top: 0 !important;
-                padding-bottom: 0 !important;
-                margin-top: -2px;
-                margin-bottom: -2px;
+            .o_pager_cell_buttons {
+                width: 100%;
+                display: flex;
+                justify-content: center;
 
-                .o_pager_previous,
-                .o_pager_next {
-                    max-height: 30px;
-                    padding: 0 5px;
-                    background-color: lighten($o-brand-lightsecondary, 10%);
-                    &:hover {
-                        background-color: $o-brand-lightsecondary;
-                    }
-                }
-            }
-            .o_pager_hidden {
                 .o_pager {
-                    visibility: hidden;
+                    gap: 0 !important;
+                    margin: 0;
+                    padding: 0;
 
-                    .o_pager_counter {
-                        display: none;
+                    .btn-group {
+                        display: flex;
+                    }
+
+                    .o_pager_previous,
+                    .o_pager_next {
+                        padding: 0 !important;
+                        width: 16px !important;
+                        height: 24px !important;
+
+                        display: flex !important;
+                        align-items: center !important;
+                        justify-content: center !important;
+
+                        background-color: lighten($o-brand-lightsecondary, 10%);
+                        &:hover {
+                            background-color: $o-brand-lightsecondary;
+                        }
+                        i {
+                            // Needed to avoid the chevrons to be misaligned
+                            line-height: 0 !important;
+                            font-size: 10px;
+                            margin: 0;
+                        }
                     }
                 }
             }
+
             .o_group_caret {
                 margin-inline-start: calc(var(--o-list-group-level, 0) * #{map-get($spacers, 4)});
             }
@@ -378,8 +402,8 @@
         }
 
         .o_list_actions_header {
-            width: 32px;
-            min-width: 32px;
+            width: 36px !important;
+            min-width: 36px;
             background-color: var(--ListRenderer-thead-bg-color);
         }
 

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -44,8 +44,21 @@
                             </th>
                             <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{'o_list_button w-print-0 p-print-0': column.type === 'button_group'}"/>
                         </t>
+                        <th
+                            class="o_count_header opacity-trigger-hover w-print-auto"
+                            t-att-class="this.getColumnClass(this.countColumn)"
+                            t-if="this.showCountColumn"
+                            t-on-click="() => this.onClickSortColumn(this.countColumn)"
+                            tabindex="-1"
+                        >
+                            <div class="d-flex align-items-center">
+                                <span class="d-block min-w-0 text-truncate flex-grow-1 flex-shrink-1 o_list_number_th" t-out="this.countColumn.label"/>
+                                <div class="o_list_header_label_spacer"/>
+                                <i class="o_list_sortable_icon" t-att-class="this.getSortableIconClass(this.countColumn)"/>
+                            </div>
+                        </th>
                         <th t-if="this.hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
-                        <th t-if="this.hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0 z-2">
+                        <th t-if="this.hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0 z-2 ps-2">
                             <div t-if="this.displayOptionalFields or this.hasOptionalOpenFormViewColumn" class="o_optional_columns_dropdown d-print-none text-center border-top-0">
                                 <Dropdown position="'bottom-end'" menuRef="this.optionalColumnsDropdownRef">
                                     <button class="btn p-0" tabindex="-1" data-available-offline="">
@@ -246,14 +259,6 @@
                             </t>
                         </t>
                     </div>
-                    <div class="d-flex align-items-center ms-auto gap-2">
-                        <t t-if="!this.showGroupPager(group)" class="m-1">
-                            <span><t t-out="group.count"/></span>
-                        </t>
-                        <div t-att-class="this.showGroupPager(group) ? '' : 'o_pager_hidden'" t-on-click.stop="">
-                            <Pager t-props="this.getGroupPagerProps(group)"/>
-                        </div>
-                    </div>
                 </div>
             </th>
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-foreach="this.getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
@@ -270,10 +275,29 @@
                     </span>
                 </t>
             </td>
-            <t t-set="groupPagerColspan" t-value="this.getGroupPagerCellColspan(group)"/>
-            <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-if="groupPagerColspan > 0" t-att-colspan="groupPagerColspan"/>
-            <th class="p-0" t-on-keydown="(ev) => this.onCellKeydown(ev, group)">
-                <GroupConfigMenu t-if="this.showGroupConfigMenu(group)" t-props="this.getGroupConfigMenuProps(group)"/>
+            <t t-set="groupCellColspan" t-value="this.getGroupCellColspan(group)"/>
+            <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-if="groupCellColspan > 0" t-att-colspan="groupCellColspan"/>
+            <th class="o_count_column" t-if="this.showCountColumn">
+                <div class="d-flex justify-content-end align-items-center w-100 h-100">
+                    <span t-if="!showGroupPager(group)" class="m-1" >
+                        <t t-out="group.count"/>
+                    </span>
+                    <div t-else="" t-on-click.stop="" class="o_pager_cell_counter">
+                        <Pager t-props="getGroupPagerProps(group)"/>
+                    </div>
+                </div>
+            </th>
+            <th class="px-1 position-sticky end-0 z-2" t-on-keydown="(ev) => this.onCellKeydown(ev, group)">
+                <div
+                    t-if="this.showGroupPager(group)"
+                    t-on-click.stop="" class="o_pager_cell_buttons"
+                >
+                    <Pager t-props="this.getGroupPagerProps(group)"/>
+                </div>
+                <GroupConfigMenu
+                    t-elif="this.showGroupConfigMenu(group)"
+                    t-props="this.getGroupConfigMenuProps(group)"
+                />
             </th>
         </tr>
     </t>
@@ -357,6 +381,7 @@
 
             <t t-set="useUnlink" t-value="'unlink' in this.activeActions" />
             <t t-set="hasX2ManyAction" t-value="this.isX2Many and (useUnlink ? this.activeActions.unlink : this.activeActions.delete)" />
+            <td t-if="this.showCountColumn" tabindex="-1" class="w-print-0 p-print-0"/>
             <t t-if="this.displayOptionalFields or this.props.list.isGrouped or hasX2ManyAction">
                 <t t-if="hasX2ManyAction">
                     <t t-set="hasDeleteButton" t-value="this.displayDeleteIcon(record)"/>

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -40,7 +40,6 @@ import {
     mountWithSearch,
     onRpc,
     removeFacet,
-    selectGroup,
     serverState,
     toggleMenuItem,
     toggleSearchBarMenu,
@@ -1789,7 +1788,9 @@ test("facets display with any / not any operator (check brackets)", async functi
 
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([
-        `Company : ( Bar : ( Bool ${label("not set")} and Bool ${label("not set")} ) and Bar : ( Bool ${label("set")} ) ) or Bar ${label("not set")}`,
+        `Company : ( Bar : ( Bool ${label("not set")} and Bool ${label(
+            "not set"
+        )} ) and Bar : ( Bool ${label("set")} ) ) or Bar ${label("not set")}`,
     ]);
     expect.verifySteps([`/web/domain/validate`]);
 });
@@ -1896,59 +1897,6 @@ test("dropdown menu last element is 'Custom Filter...'", async () => {
     await editSearch("a");
     await animationFrame();
     expect(".o_searchview_autocomplete .o-dropdown-item:last").toHaveText("Custom Filter...");
-});
-
-test("order by count resets when there is no group left", async () => {
-    const searchBar = await mountWithSearch(SearchBar, {
-        resModel: "partner",
-        searchMenuTypes: ["groupBy", "filter"],
-        searchViewId: false,
-        searchViewArch: `
-            <search>
-                <filter string="Foo" name="foo" domain="[('foo', '=', 'qsdf')]"/>
-            </search>
-        `,
-    });
-    searchBar.env.searchModel.canOrderByCount = true;
-    await toggleSearchBarMenu();
-    await selectGroup("bool");
-    await selectGroup("bar");
-    await toggleMenuItem("Foo");
-    expect(".fa-sort").toHaveCount(1);
-    await contains(".fa-sort", { visible: false }).click();
-    expect(".fa-sort-numeric-desc").toHaveCount(1);
-    await contains(".fa-sort-numeric-desc").click();
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Foo");
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-
-    await toggleMenuItem("Foo");
-    await toggleMenuItem("Bool");
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-    await toggleMenuItem("Bar");
-    expect(".fa-sort-numeric-asc").toHaveCount(0);
-
-    await toggleMenuItem("Bar");
-    expect(".fa-sort-numeric-asc").toHaveCount(0);
-    expect(".fa-sort").toHaveCount(1);
-    await contains(".fa-sort", { visible: false }).click();
-    await contains(".fa-sort-numeric-desc").click();
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Bool");
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-
-    await contains(".o_facet_remove").click();
-    expect(".fa-sort-numeric-asc").toHaveCount(1);
-    await contains(".o_facet_remove").click();
-    expect(".o_searchview_facet").toHaveCount(0);
-
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Bar");
-    expect(".fa-sort-numeric-asc").toHaveCount(0);
-    expect(".fa-sort").toHaveCount(1);
 });
 
 test("subitems have a load more item if there is more records available", async () => {

--- a/addons/web/static/tests/search/search_from_url.test.js
+++ b/addons/web/static/tests/search/search_from_url.test.js
@@ -1,5 +1,5 @@
 import { expect, test, waitFor, fill } from "@odoo/hoot";
-import { animationFrame, click, press, queryAllTexts } from "@odoo/hoot-dom";
+import { animationFrame, press, queryAllTexts } from "@odoo/hoot-dom";
 import {
     contains,
     defineModels,
@@ -125,7 +125,6 @@ test("URL with groupBy and orderBy activates ordered groupBy", async () => {
         searchViewId: false,
     });
     expect(`.o_searchview .o_searchview_facet`).toHaveCount(1);
-    expect(`.fa-sort-numeric-desc`).toHaveCount(1); // OrderBy desc icon
     expect(searchBar.env.searchModel.groupBy).toEqual(["partner_id"]);
     expect(searchBar.env.searchModel.orderBy).toEqual([{ asc: false, name: "__count" }]);
 });
@@ -145,7 +144,6 @@ test("URL with filter + groupBy + orderBy activates filters", async () => {
     expect(`.o_searchview .o_searchview_facet`).toHaveCount(2); // One for the shared filter and one for the groupby
     expect(searchBar.env.searchModel.domain).toEqual([["state", "=", "sent"]]);
     expect(searchBar.env.searchModel.groupBy).toEqual(["partner_id"]);
-    expect(`.fa-sort-numeric-asc`).toHaveCount(1); // OrderBy ascending icon
     expect(searchBar.env.searchModel.orderBy).toEqual([{ asc: true, name: "__count" }]);
 
     // Regenerating the url should give the same result as before, without the "?"
@@ -454,7 +452,7 @@ test("hotkey sharing copies complex search to clipboard", async () => {
     await toggleMenuItem("Cool Vendors");
     await toggleMenuItem("Vendor");
 
-    await click(".o_searchview .oi-group"); // Facet click to trigger orderBy
+    await contains(".o_count_header").click();
     await animationFrame();
 
     await press(["alt", "shift", "h"]);

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -259,7 +259,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 34, 32]);
+    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 34, 64, 36]);
 });
 
 test(`width computation: with records, few fields`, async () => {
@@ -1245,20 +1245,20 @@ test(`freeze widths: toggle optional fields`, async () => {
         `,
     });
 
-    expectedColumnWidthsToBeCloseTo([40, 99, 440, 188, 32]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 436, 188, 36]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input:eq(0)").click();
-    expectedColumnWidthsToBeCloseTo([40, 99, 337, 102, 189, 32]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 334, 102, 189, 36]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 99, 526, 102, 32]);
+    expect(getColumnWidths()).toEqual([40, 99, 522, 102, 36]);
 
     await contains(".dropdown-item input:eq(2)").click();
-    expect(getColumnWidths()).toEqual([40, 99, 89, 102, 437, 32]);
+    expect(getColumnWidths()).toEqual([40, 99, 89, 102, 433, 36]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expectedColumnWidthsToBeCloseTo([40, 99, 89, 103, 189, 247, 32]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 89, 103, 189, 244, 36]);
 });
 
 test(`freeze widths: x2many, add first record`, async () => {
@@ -1353,16 +1353,16 @@ test(`freeze widths: x2many, toggle optional field`, async () => {
             </form>`,
     });
 
-    expect(getColumnWidths()).toEqual([110, 626, 32]);
+    expect(getColumnWidths()).toEqual([110, 622, 36]);
 
     // create a record to store the current widths, but discard it directly to keep
     // the list empty (otherwise, the browser automatically computes the optimal widths)
     await contains(".o_field_x2many_list_row_add button").click();
-    expect(getColumnWidths()).toEqual([110, 626, 32]);
+    expect(getColumnWidths()).toEqual([110, 622, 36]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input").click();
-    expect(getColumnWidths()).toEqual([110, 545, 80, 32]);
+    expect(getColumnWidths()).toEqual([110, 541, 80, 36]);
 });
 
 // manually resize columns

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2230,16 +2230,16 @@ test(`basic grouped list rendering with widget="handle" col`, async () => {
     `,
         groupBy: ["bar"],
     });
-    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(4, {
+    expect(`thead th:not(.o_list_record_selector):not(.o_count_header)`).toHaveCount(4, {
         message:
-            "should have 1 th for checkbox (desktop only), 1 th for handle, 1 th for Foo, 1 th for Bar and 1 for eventual cog",
+            "should have 1 th for checkbox (desktop only), 1 th for handle, 1 th for Foo, 1 th for Bar 1 for Count (desktop only) and 1 for eventual cog",
     });
     expect(`thead th[data-name=foo]`).toHaveCount(1);
     expect(`thead th[data-name=bar]`).toHaveCount(1);
     expect(`thead th[data-name=int_field]`).toHaveCount(1);
     expect(`tr.o_group_header`).toHaveCount(2);
     expect(`th.o_group_name`).toHaveCount(2);
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2); // group name + cog placeholder
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2); // group name + count (desktop only) + cog placeholder
     expect(`.o_group_header:eq(0) .o_list_number`).toHaveCount(0);
 });
 
@@ -2256,11 +2256,11 @@ test(`basic grouped list rendering with a date field between two fields with a a
         `,
         groupBy: ["bar"],
     });
-    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(4, {
+    expect(`thead th:not(.o_list_record_selector):not(.o_count_header)`).toHaveCount(4, {
         message:
-            "should have 1 th for checkbox (desktop only), 1 th for Foo, 1 Int, 1 Date, 1 Int, 1 cog placeholder",
+            "should have 1 th for checkbox (desktop only), 1 th for Foo, 1 Int, 1 Date, 1 Int, 1 for Count (desktop only), 1 cog placeholder",
     });
-    expect(queryAllTexts(`thead th:not(.o_list_record_selector)`)).toEqual([
+    expect(queryAllTexts(`thead th:not(.o_list_record_selector):not(.o_count_header)`)).toEqual([
         "Int field",
         "Date",
         "Int field",
@@ -2279,7 +2279,7 @@ test(`basic grouped list rendering 1 col without selector and with optional fiel
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -2291,7 +2291,7 @@ test(`basic grouped list rendering 1 col without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -2303,7 +2303,7 @@ test(`basic grouped list rendering 1 col with selector on desktop`, async () => 
         arch: `<list><field name="foo"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -2327,7 +2327,7 @@ test(`basic grouped list rendering 2 cols without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -2339,7 +2339,7 @@ test(`basic grouped list rendering 3 cols without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
 });
 
@@ -2358,7 +2358,7 @@ test(`basic grouped list rendering 3 cols without selector and with optional fie
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th:not(.o_count_column)`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
 });
 
@@ -2371,7 +2371,7 @@ test(`basic grouped list rendering 2 col with selector on desktop`, async () => 
         groupBy: ["bar"],
         allowSelectors: true,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
 });
 
@@ -2398,7 +2398,7 @@ test(`basic grouped list rendering 3 cols with selector on desktop`, async () =>
         allowSelectors: true,
     });
 
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "4");
 });
 
@@ -2434,13 +2434,13 @@ test(`basic grouped list rendering 7 cols with aggregates and selector on deskto
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(7);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(4)`).toHaveAttribute("colspan", "2", {
-        message: "pager cell in the group header should span on the two last fields (colspan 2)",
+    expect(`.o_group_header th:eq(4)`).toHaveAttribute("colspan", "3", {
+        message: "group cell in the group header should span on the three last fields (colspan 3)",
     });
 });
 
@@ -2467,8 +2467,8 @@ test(`basic grouped list rendering 7 cols with aggregates and selector on mobile
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2", {
-        message: "pager cell in the group header should span on the two last fields (colspan 2)",
+    expect(`.o_group_header th:eq(-3)`).toHaveAttribute("colspan", "2", {
+        message: "group cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2490,13 +2490,13 @@ test(`basic grouped list rendering 7 cols with aggregates, selector and optional
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(7);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2", {
-        message: "pager cell in the group header should span on the two last fields (colspan 2)",
+    expect(`.o_group_header th:eq(-3)`).toHaveAttribute("colspan", "2", {
+        message: "group cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2545,7 +2545,7 @@ test(`basic grouped list rendering 4 cols with aggregates, selector and openForm
         groupBy: ["bar"],
     });
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
-    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2");
+    expect(`.o_group_header th:eq(-3)`).toHaveAttribute("colspan", "2");
 });
 
 test.tags("mobile");
@@ -2624,7 +2624,8 @@ test(`group a list view with the aggregable field 'value'`, async () => {
         groupBy: ["bar"],
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1 1", "Yes 3 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["No", "Yes"]);
+    expect(queryAllTexts(`.o_list_number`)).toEqual(["1", "3", "4"]);
 });
 
 test(`basic grouped list rendering with groupby m2m field`, async () => {
@@ -2641,11 +2642,11 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     });
     expect(`.o_group_header`).toHaveCount(4, { message: "should contain 4 open groups" });
     expect(`.o_group_open`).toHaveCount(0, { message: "no group is open" });
-    expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 2",
-        "Value 3 1",
-        "None 1",
+    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+        "Value 1",
+        "Value 2",
+        "Value 3",
+        "None",
     ]);
 
     // Open all groups
@@ -2654,17 +2655,13 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     await contains(`.o_group_name:eq(2)`).click();
     await contains(`.o_group_name:eq(3)`).click();
     expect(`.o_group_open`).toHaveCount(4, { message: "all groups are open" });
-    expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
+    expect(queryAllTexts(`.o_data_row`, { inline: true })).toEqual([
         "yop Value 1 Value 2",
         "blip Value 1 Value 2 Value 3",
         "blip Value 1",
-        "Value 2 2",
         "yop Value 1 Value 2",
         "blip Value 1 Value 2 Value 3",
-        "Value 3 1",
         "blip Value 1 Value 2 Value 3",
-        "None 1",
         "gnap",
     ]);
 });
@@ -2685,27 +2682,28 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     expect(`.o_list_footer td > button`).toHaveCount(0, {
         message: "no quick create since no default groupby",
     });
-    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "Value 2"]);
 
     await contains(`th.o_group_name`).click();
-    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 1 2",
-        "Value 2 1",
-        "None 1",
-        "Value 2 1",
+    expect(queryAllTexts(`.o_group_name`)).toEqual([
+        "Value 1",
+        "Value 1",
+        "Value 2",
+        "None",
+        "Value 2",
     ]);
 
     await contains(`tbody th.o_group_name:eq(4)`).click();
-    expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 1 2",
-        "Value 2 1",
-        "None 1",
-        "Value 2 1",
-        "Value 1 1",
-        "Value 2 1",
-        "Value 3 1",
+
+    expect(queryAllTexts(`.o_group_name`)).toEqual([
+        "Value 1",
+        "Value 1",
+        "Value 2",
+        "None",
+        "Value 2",
+        "Value 1",
+        "Value 2",
+        "Value 3",
     ]);
 });
 
@@ -2719,8 +2717,7 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
         type: "list",
         arch: `<list default_group_by="m2o"><field name="foo"/></list>`,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
-    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(".o_group_name")).toEqual(["Value 1", "Value 2"]);
     expect(`.o_list_footer td > button`).toHaveText("Add a M2o");
     await contains(`.o_list_footer td > button`).click();
     expect(`.o_list_footer td > button`).toHaveCount(0);
@@ -2728,11 +2725,7 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
     await contains(`.o_list_footer td input`).edit("New group", { confirm: false });
     await contains(`.o_list_footer .o_list_group_confirm`).click();
     expect.verifySteps(["name_create"]);
-    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 1",
-        "New group 0",
-    ]);
+    expect(queryAllTexts(".o_group_name")).toEqual(["Value 1", "Value 2", "New group"]);
 });
 
 test(`grouped list rendering with groupby m2o field: group_create = false`, async () => {
@@ -2769,7 +2762,7 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
 
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "Value 2"]);
     expect(`.o_group_header:first th:last .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2782,7 +2775,7 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await contains(`.o_dialog .o_form_button_save`).click();
     expect(`.o_dialog`).toHaveCount(0);
     expect.verifySteps(["web_save"]);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value edit 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value edit", "Value 2"]);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     if (getMockEnv().isSmall) {
         await contains(".o_bottom_sheet_backdrop").click();
@@ -2806,7 +2799,7 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
         groupBy: ["m2o"],
     });
 
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "Value 2"]);
     expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2815,7 +2808,7 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
     expect(`.o_dialog .modal-body`).toHaveText("Are you sure you want to delete this column?");
     await contains(`.o_dialog footer button:contains(Delete)`).click();
     expect.verifySteps(["unlink"]);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 2 1", "None 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 2", "None"]);
 });
 
 test(`grouped list rendering with groupby non m2o field`, async () => {
@@ -2849,18 +2842,21 @@ test(`grouped list with (disabled) pager inside group`, async () => {
     await contains(".o_group_header:first").click();
 
     expect(".o_data_row").toHaveCount(2);
-    expect(".o_group_header .o_pager:eq(0)").toBeVisible();
-    expect(".o_group_header .o_pager:eq(1)").not.toBeVisible();
+    // Group Pagers are composed of 1 pager with visible counter and 1 pager with visible buttons
+    expect(".o_group_header:eq(0) .o_pager_cell_counter .o_pager_counter").toBeVisible();
+    expect(".o_group_header:eq(0) .o_pager_cell_buttons").toBeVisible();
+    expect(".o_group_header:eq(1) .o_pager_counter").toHaveCount(0);
+    expect(".o_group_header:eq(1) .o_pager_buttons").toHaveCount(0);
 
     def = new Deferred();
 
-    await click(".o_group_header .o_pager_next:enabled");
+    await contains(".o_group_header .o_pager_next:enabled").click();
     await animationFrame();
 
-    expect(".o_group_header .o_pager_next").toHaveAttribute("disabled");
+    expect(".o_group_header .o_pager_next:eq(1)").toHaveAttribute("disabled");
 
-    await click(".o_group_header .o_pager_next");
-    await click(".o_group_header .o_pager_next");
+    await contains(".o_group_header .o_pager_next:eq(1)").click();
+    await contains(".o_group_header .o_pager_next:eq(1)").click();
     await animationFrame();
 
     expect(".o_data_row").toHaveCount(2);
@@ -2876,7 +2872,7 @@ test(`list view with multiple groupbys`, async () => {
     });
     expect(`.o_view_nocontent`).toHaveCount(0);
     expect(`.o_group_has_content`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_has_content`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["No", "Yes"]);
 });
 
 test(`enabling archive in list when groupby m2m field`, async () => {
@@ -3225,12 +3221,7 @@ test(`add record in list grouped by m2m`, async () => {
     });
 
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 2",
-        "Value 3 1",
-        "None 1",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "Value 2", "Value 3", "None"]);
 
     await contains(`.o_group_header`).click();
     expect(`.o_data_row`).toHaveCount(3);
@@ -4112,6 +4103,7 @@ test(`list view not groupable`, async () => {
     expect(getFacetTexts()).toEqual([]);
 });
 
+test.tags("desktop");
 test("group order by count", async () => {
     let readGroupCount = 0;
     onRpc("foo", "web_read_group", ({ kwargs, method }) => {
@@ -4133,16 +4125,17 @@ test("group order by count", async () => {
     await selectGroup("foo");
     await selectGroup("currency_id");
     expect("tr.o_group_header").toHaveCount(3, { message: "list should be grouped" });
-    await contains(".o_searchview_facet_label").click();
+    await contains(".o_count_header").click();
     expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
     await contains("tr.o_group_header:eq(0)").click();
     expect.verifySteps(["web_read_group currency_id order by __count DESC"]);
-    await contains(".o_searchview_facet_label").click();
+    await contains(".o_count_header").click();
     expect.verifySteps(["web_read_group foo,currency_id order by __count ASC"]);
-    await contains(".o_searchview_facet_label").click();
+    await contains(".o_count_header").click();
     expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
 });
 
+test.tags("desktop");
 test("order by count reset", async () => {
     let readGroupCount = 0;
     onRpc("foo", "web_read_group", ({ kwargs, method }) => {
@@ -4169,7 +4162,7 @@ test("order by count reset", async () => {
     await selectGroup("foo");
     await selectGroup("currency_id");
     await toggleMenuItem("My Filter");
-    await contains(".o_searchview_facet_label").click();
+    await contains(".o_count_header").click();
     expect.verifySteps([
         "web_read_group foo,currency_id order by ",
         "web_read_group foo,currency_id order by __count DESC",
@@ -5036,8 +5029,16 @@ test(`monetary aggregates in grouped list`, async () => {
     await contains(`.o_group_header:last`).click();
     // Don't handle currencies in aggregates for non monetary fields even with the widget:
     // it is bad practice and the server won't send the information anyway
-    expect(`.o_group_header:first`).toHaveText("USD 3 $ 800.00 19.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("EUR 1 1,200.00 € 0.40", { inline: true });
+    expect(`.o_group_header:first .o_group_name`).toHaveText("USD");
+    expect(queryAllTexts(`.o_group_header:first .o_list_number`, { inline: true })).toEqual([
+        "$ 800.00",
+        "19.00",
+    ]);
+    expect(`.o_group_header:last .o_group_name`).toHaveText("EUR");
+    expect(queryAllTexts(`.o_group_header:last .o_list_number`, { inline: true })).toEqual([
+        "1,200.00 €",
+        "0.40",
+    ]);
     expect(`.o_list_footer .o_list_number span:first`).toHaveText("$ 1,400.00?");
     await toggleMultiCurrencyPopover(".o_list_footer .o_list_number span:first sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
@@ -5060,8 +5061,10 @@ test(`monetary aggregates in grouped list (!= currencies in same group)`, async 
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No 1 $ 0.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", { inline: true });
+    expect(`.o_group_header:first .o_group_name`).toHaveText("No");
+    expect(`.o_group_header:first .o_list_number`).toHaveText("$ 0.00", { inline: true });
+    expect(`.o_group_header:last .o_group_name`).toHaveText("Yes");
+    expect(`.o_group_header:last .o_list_number`).toHaveText("$ 2,000.00?", { inline: true });
     expect(`.o_list_footer .o_list_number span`).toHaveText("$ 2,000.00?");
 });
 
@@ -5080,7 +5083,8 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
         actionMenus: {},
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", { inline: true });
+    expect(`.o_group_name:last`).toHaveText("Yes");
+    expect(`.o_group_header .o_list_number:last`).toHaveText("$ 2,000.00?", { inline: true });
     await contains(`.o_group_header:last`).click();
     expect(`.o_data_row`).toHaveCount(3);
     await selectAllRecords();
@@ -5089,7 +5093,8 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
     await toggleMenuItem("Delete");
     await contains(`.o_dialog footer .btn-danger`).click(); // confirm
     expect(`.o_data_row`).toHaveCount(0);
-    expect(`.o_group_header:last`).toHaveText("Yes 0 0.00", { inline: true });
+    expect(`.o_group_name:last`).toHaveText("Yes");
+    expect(`.o_group_header .o_list_number:last`).toHaveText("0.00", { inline: true });
 });
 
 test(`list with monetary field with attribute column_invisible="1"`, async () => {
@@ -5142,11 +5147,21 @@ test(`handle false values in aggregates`, async () => {
         groupBy: ["bar"],
     });
     expect.verifySteps(["web_read_group"]);
-    expect(`.o_group_header:first`).toHaveText("No 1 9.00 $ 0.00 $ 0.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", {
-        inline: true,
-        message: "false values are just hidden except for monetary field with multiple currencies",
-    });
+    expect(`.o_group_name:first`).toHaveText("No", { inline: true });
+    expect(queryAllTexts(`.o_group_header:first .o_list_number`, { inline: true })).toEqual([
+        "9.00",
+        "$ 0.00",
+        "$ 0.00",
+    ]);
+
+    expect(`.o_group_name:last`).toHaveText("Yes");
+    expect(queryAllTexts(`.o_group_header:last .o_list_number`, { inline: true })).toEqual(
+        ["", "$ 2,000.00?", ""],
+        {
+            message:
+                "false values are just hidden except for monetary field with multiple currencies",
+        }
+    );
 });
 
 test(`aggregates in grouped lists with buttons`, async () => {
@@ -5188,7 +5203,7 @@ test(`date field aggregates in grouped lists`, async () => {
         `,
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([`Value 1 3`, `Value 2 1`]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual([`Value 1`, `Value 2`]);
 });
 
 test(`hide aggregated value in grouped lists when no data provided by RPC call`, async () => {
@@ -5534,8 +5549,8 @@ test(`groups can be sorted on the first field of the groupBy`, async () => {
         arch: `<list default_order="bar desc"><field name="foo"/><field name="bar"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("Yes 3", { inline: true });
-    expect(`.o_group_header:eq(-1)`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_name:eq(0)`).toHaveText("Yes");
+    expect(`.o_group_name:eq(-1)`).toHaveText("No");
     expect.verifySteps(["web_read_group"]);
 });
 
@@ -6411,9 +6426,9 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
         groupBy: ["foo", "bar"],
         actionMenus: {},
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("blip 6", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("No 2", { inline: true });
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes 4", { inline: true });
+    expect(`.o_group_name:eq(0)`).toHaveText("blip");
+    expect(`.o_group_name:eq(1)`).toHaveText("No");
+    expect(`.o_group_name:eq(2)`).toHaveText("Yes");
 
     await contains(`.o_group_header:eq(2)`).click();
     expect(`.o_data_row`).toHaveCount(4);
@@ -6422,8 +6437,8 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
     await toggleActionMenu();
     await toggleMenuItem("Delete");
     await contains(`.modal .btn-danger`).click();
-    expect(`.o_group_header:eq(0)`).toHaveText("blip 5", { inline: true });
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_name:eq(0)`).toHaveText("blip");
+    expect(`.o_group_name:eq(2)`).toHaveText("Yes");
 });
 
 test(`grouped list, reload aggregates when a record is deleted`, async () => {
@@ -6810,13 +6825,13 @@ test(`pager, grouped, with count limit reached`, async () => {
     expect(`.o_group_header:first-of-type .o_group_name`).toHaveCount(1, {
         message: "first group should have a name",
     });
-    expect(`.o_group_header:first-of-type .o_pager`).not.toBeVisible({
+    expect(`.o_group_header:first-of-type .o_pager`).toHaveCount(0, {
         message: "pager shouldn't be visible until unfolded",
     });
 
     // unfold
     await contains(`.o_group_header:first-of-type`).click();
-    expect(`.o_group_header:first-of-type .o_group_name .o_pager`).toHaveCount(1, {
+    expect(`.o_group_header:first-of-type .o_pager:eq(0)`).toHaveCount(1, {
         message: "first group should have a pager",
     });
     expect(`.o_group_header:first-of-type .o_pager_value`).toHaveText("1");
@@ -6840,7 +6855,7 @@ test(`multi-level grouped list, pager inside a group`, async () => {
 
     await contains(`.o_group_header`).click();
     expect(`.o_group_header`).toHaveCount(4);
-    expect(`.o_group_header:first-of-type .o_group_name .o_pager`).not.toBeVisible();
+    expect(`.o_group_header:first-of-type .o_pager`).toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -6865,14 +6880,14 @@ test(`multi-level grouped list, pager inside a group, reload`, async () => {
 
     await contains(`.o_group_header`).click();
     expect(`.o_group_header`).toHaveCount(3);
-    expect(`.o_group_header .o_group_name .o_pager:visible`).toHaveCount(1);
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([1, 2]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    expect(`.o_group_header .o_pager_cell_counter .o_pager_counter:visible`).toHaveCount(1);
+    expect(getPagerValue(queryFirst(`.o_count_column:eq(0)`))).toEqual([1, 2]);
+    expect(getPagerLimit(queryFirst(`.o_count_column:eq(0)`))).toBe(3);
     expect(queryAllTexts`td.o_list_number`).toEqual(["32", "5", "17"]);
 
     await contains(`.o_list_table thead th[data-name=int_field]`).click();
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([1, 2]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    expect(getPagerValue(queryFirst(`.o_count_column:eq(0)`))).toEqual([1, 2]);
+    expect(getPagerLimit(queryFirst(`.o_count_column:eq(0)`))).toBe(3);
     expect(queryAllTexts`td.o_list_number`).toEqual(["32", "5", "10"]);
 });
 
@@ -6964,11 +6979,11 @@ test(`pager, grouped, group pager should update after removing a filter`, async 
 
     // expand group
     await contains(`th.o_group_name`).click();
-    expect(`th.o_group_name .o_pager:visible`).toHaveCount(0);
+    expect(`th.o_count_column .o_pager:visible`).toHaveCount(0);
 
     // remove filter
     await removeFacet("Foo");
-    expect(`th.o_group_name:eq(0) .o_pager:visible`).toHaveText("1-2 / 6");
+    expect(`th.o_count_column .o_pager:visible`).toHaveText("1-2 / 6");
 });
 
 test(`grouped, show only limited records when the list view is initially expanded`, async () => {
@@ -7928,13 +7943,13 @@ test(`list grouped by m2o with sample data with more than 5 real groups`, async 
     expect(`.o_list_view .o_content`).toHaveClass("o_view_sample_data");
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(6);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 3",
-        "Value 3 3",
-        "Value 4 3",
-        "Value 5 2",
-        "Value 6 2",
+    expect(queryAllTexts(`.o_group_name`)).toEqual([
+        "Value 1",
+        "Value 2",
+        "Value 3",
+        "Value 4",
+        "Value 5",
+        "Value 6",
     ]);
 });
 
@@ -9005,7 +9020,7 @@ test(`list view with nested groups`, async () => {
 
     // basic rendering tests
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 4", "Value 2 2"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "Value 2"]);
     expect(`.o_group_name .fa-caret-right`).toHaveCount(2);
     expect(`.o_group_header:eq(0) span:first`).toHaveStyle({ "--o-list-group-level": "0" });
     expect(queryAllTexts(`.o_group_header .o_list_number`)).toEqual(["16", "14"]);
@@ -9013,13 +9028,7 @@ test(`list view with nested groups`, async () => {
     // open the first group
     await contains(`.o_group_header:eq(0)`).click();
     expect.verifySteps(["web_read_group"]);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "Value 1 4",
-        "blip 2",
-        "gnap 1",
-        "yop 1",
-        "Value 2 2",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1", "blip", "gnap", "yop", "Value 2"]);
     expect(`.o_group_name:eq(0) .fa-caret-down`).toHaveCount(1);
     expect(`.o_group_header:eq(1) span:first`).toHaveStyle({ "--o-list-group-level": "1" });
     expect(queryAllTexts(`.o_group_header .o_list_number`)).toEqual([
@@ -9093,12 +9102,12 @@ test(`grouped list on selection field at level 2`, async () => {
     expect(`.o_group_header`).toHaveCount(5, {
         message: "should contain 2 groups at first level and 3 groups at second level",
     });
-    expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
-        "Value 1 5",
-        "Low 3",
-        "Medium 1",
-        "High 1",
-        "Value 2 1",
+    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+        "Value 1",
+        "Low",
+        "Medium",
+        "High",
+        "Value 2",
     ]);
 });
 
@@ -11011,18 +11020,18 @@ test(`editable grouped list with handle widget`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No 1 0", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 2,000", { inline: true });
-    expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("0", {
+    expect(`.o_group_header:first`).toHaveText("No 0 1", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes 2,000 3", { inline: true });
+    expect(`tbody .o_data_row:eq(0) td:eq(-3)`).toHaveText("0", {
         message: "default fourth record should have amount 0",
     });
-    expect(`tbody .o_data_row:eq(1) td:eq(-2)`).toHaveText("1,200", {
+    expect(`tbody .o_data_row:eq(1) td:eq(-3)`).toHaveText("1,200", {
         message: "default first record should have amount 1,200",
     });
-    expect(`tbody .o_data_row:eq(2) td:eq(-2)`).toHaveText("500", {
+    expect(`tbody .o_data_row:eq(2) td:eq(-3)`).toHaveText("500", {
         message: "default second record should have amount 500",
     });
-    expect(`tbody .o_data_row:eq(3) td:eq(-2)`).toHaveText("300", {
+    expect(`tbody .o_data_row:eq(3) td:eq(-3)`).toHaveText("300", {
         message: "default third record should have amount 300",
     });
 
@@ -11035,23 +11044,23 @@ test(`editable grouped list with handle widget`, async () => {
         ["web_resequence", [3], "int_field", 2],
     ]);
     // Aggregates are not updated, todo later?
-    expect(`.o_group_header:first`).toHaveText("No 2 0", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 2 2,000", { inline: true });
-    expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("300", {
+    expect(`.o_group_header:first`).toHaveText("No 0 2", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes 2,000 2", { inline: true });
+    expect(`tbody .o_data_row:eq(0) td:eq(-3)`).toHaveText("300", {
         message: "new first record should have amount 300",
     });
-    expect(`tbody .o_data_row:eq(1) td:eq(-2)`).toHaveText("0", {
+    expect(`tbody .o_data_row:eq(1) td:eq(-3)`).toHaveText("0", {
         message: "new second record should have amount 0",
     });
-    expect(`tbody .o_data_row:eq(2) td:eq(-2)`).toHaveText("1,200", {
+    expect(`tbody .o_data_row:eq(2) td:eq(-3)`).toHaveText("1,200", {
         message: "new third record should have amount 1,200",
     });
-    expect(`tbody .o_data_row:eq(3) td:eq(-2)`).toHaveText("500", {
+    expect(`tbody .o_data_row:eq(3) td:eq(-3)`).toHaveText("500", {
         message: "new fourth record should have amount 500",
     });
 
     await contains(`tbody .o_data_row:eq(0) div[name='amount']`).click();
-    expect(`tbody .o_data_row:eq(0) td:eq(-2) input`).toHaveValue("300", {
+    expect(`tbody .o_data_row:eq(0) td:eq(-3) input`).toHaveValue("300", {
         message: "the edited record should be the good one",
     });
 });
@@ -11071,8 +11080,11 @@ test(`editable grouped list with handle widget (group by date)`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("January 2017 1 1,200", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("None 3 800", { inline: true });
+
+    expect(`.o_group_header:first .o_group_name`).toHaveText("January 2017");
+    expect(`.o_group_header:first .o_list_number`).toHaveText("1,200");
+    expect(`.o_group_header:last .o_group_name`).toHaveText("None");
+    expect(`.o_group_header:last .o_list_number`).toHaveText("800");
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -11091,8 +11103,10 @@ test(`editable grouped list with handle widget (multiple group by)`, async () =>
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:eq(1)`).click(); // sub group
-    expect(`.o_group_header:first`).toHaveText("No 1 0", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("blip 1 0", { inline: true });
+    expect(`.o_group_name:first`).toHaveText("No");
+    expect(`.o_list_number:first`).toHaveText("0");
+    expect(`.o_group_name:eq(1)`).toHaveText("blip");
+    expect(`.o_list_number:eq(1)`).toHaveText("0");
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -13025,12 +13039,9 @@ test(`list grouped by date:month`, async () => {
         arch: `<list><field name="date"/></list>`,
         groupBy: ["date:month"],
     });
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(
-        ["January 2017 1", "None 3"],
-        {
-            message: "the group names should be correct",
-        }
-    );
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["January 2017", "None"], {
+        message: "the group names should be correct",
+    });
 });
 
 test(`grouped list edition with boolean_favorite widget`, async () => {
@@ -13240,22 +13251,22 @@ test(`grouped list view move to previous page of group when all records from las
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`th:contains(Value 1 3)`).toHaveCount(1, {
+    expect(`th:contains(Value 1)`).toHaveCount(1, {
         message: "Value 1 should contain 3 records",
     });
-    expect(`th:contains(Value 2 1)`).toHaveCount(1, {
+    expect(`th:contains(Value 2)`).toHaveCount(1, {
         message: "Value 2 should contain 1 record",
     });
 
-    await contains(`.o_group_header:eq(0)`).click();
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([1, 2]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    await contains(`.o_count_column:eq(0)`).click();
+    expect(getPagerValue(queryFirst(`.o_count_column`))).toEqual([1, 2]);
+    expect(getPagerLimit(queryFirst(`.o_count_column`))).toBe(3);
     expect.verifySteps(["web_search_read 2 - 0"]);
 
     // move to next page
-    await pagerNext(queryFirst(`.o_group_header`));
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([3, 3]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    await pagerNext(queryFirst(`.o_pager_cell_buttons`));
+    expect(getPagerValue(queryFirst(`.o_count_column`))).toEqual([3, 3]);
+    expect(getPagerLimit(queryFirst(`.o_count_column`))).toBe(3);
     expect.verifySteps(["web_search_read 2 - 2"]);
 
     // delete a record
@@ -13281,22 +13292,22 @@ test(`grouped list view move to previous page of group when all records from las
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`th:contains(Value 1 5)`).toHaveCount(1, {
+    expect(`th:contains(Value 1)`).toHaveCount(1, {
         message: "Value 1 should contain 3 records",
     });
-    expect(`th:contains(Value 2 1)`).toHaveCount(1, {
+    expect(`th:contains(Value 2)`).toHaveCount(1, {
         message: "Value 2 should contain 1 record",
     });
     await contains(`.o_group_header:eq(0)`).click();
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([1, 2]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(5);
+    expect(getPagerValue(queryFirst(`.o_count_column`))).toEqual([1, 2]);
+    expect(getPagerLimit(queryFirst(`.o_count_column`))).toBe(5);
     expect.verifySteps(["web_search_read 2 - 0"]);
 
     // move to next page
-    await pagerNext(queryFirst(`.o_group_header`));
-    await pagerNext(queryFirst(`.o_group_header`));
-    expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([5, 5]);
-    expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(5);
+    await pagerNext(queryFirst(`.o_pager_cell_buttons`));
+    await pagerNext(queryFirst(`.o_pager_cell_buttons`));
+    expect(getPagerValue(queryFirst(`.o_count_column`))).toEqual([5, 5]);
+    expect(getPagerLimit(queryFirst(`.o_count_column`))).toBe(5);
     expect.verifySteps(["web_search_read 2 - 2", "web_search_read 2 - 4"]);
 
     // delete a record
@@ -13304,7 +13315,7 @@ test(`grouped list view move to previous page of group when all records from las
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
     await contains(`.modal .btn-danger`).click();
-    expect(`th.o_group_name:eq(0) .o_pager_counter`).toHaveCount(1);
+    expect(`th.o_count_column .o_pager_counter`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(2);
 });
 
@@ -13325,20 +13336,20 @@ test(`grouped list view move to next page when all records from the current page
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 6", { inline: true });
-    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 1", { inline: true });
+    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1");
+    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2");
 
-    const firstGroup = queryFirst(`tr.o_group_header:eq(0)`);
-    await contains(firstGroup).click();
-    expect(getPagerValue(firstGroup)).toEqual([1, 2]);
-    expect(getPagerLimit(firstGroup)).toBe(6);
+    // const firstGroup = queryFirst(`tr.o_count_column:eq(0)`);
+    await contains(`tr.o_group_header:eq(0)`).click();
+    expect(getPagerValue(".o_pager_cell_counter")).toEqual([1, 2]);
+    expect(getPagerLimit(".o_pager_cell_counter")).toBe(6);
 
     // delete all records from current page
     await contains(`thead .o_list_record_selector input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
     await contains(`.modal .btn-danger`).click();
-    expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1 1-2 / 4`, {
+    expect(`.o_group_header:eq(0)`).toHaveText(`Value 1 1-2 / 4`, {
         inline: true,
     });
     expect(queryAllTexts(`.o_data_row`)).toEqual(["yop3", "yop4"]);
@@ -13734,31 +13745,23 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     expect(`.o_group_header`).toHaveCount(10); // page 1
     expect(`.o_data_row`).toHaveCount(10); // two groups contains two records
     expect(`.o_pager:eq(0)`).toBeVisible(); // has a pager
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "-4 1",
-        "0 1",
-        "1 1",
-        "2 1",
-        "3 1",
-        "4 1",
-        "5 1",
-        "6 1",
-        "7 1",
-        "8 1",
+    expect(queryAllTexts(`.o_group_name`)).toEqual([
+        "-4",
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
     ]);
 
     await pagerNext(); // switch to page 2
     expect(`.o_group_header`).toHaveCount(7); // page 2
     expect(`.o_data_row`).toHaveCount(9); // two groups contains two records
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "9 2",
-        "10 2",
-        "11 1",
-        "12 1",
-        "13 1",
-        "14 1",
-        "17 1",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["9", "10", "11", "12", "13", "14", "17"]);
     expect.verifySteps([
         "web_read_group", // web_read_group page 1
         "web_read_group", // web_read_group page 2
@@ -14725,7 +14728,7 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     expect(`.o_selected_row`).toHaveCount(0);
 
     // Click on last data row of first group
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 1", { inline: true });
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
     expect(`.o_data_row:eq(0) [name=foo] input`).toBeFocused();
 
@@ -14733,13 +14736,13 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 2", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 1", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14751,12 +14754,12 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 2", { inline: true });
 
     // Edit the row and press enter: should add a new row
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 3 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 3", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14827,7 +14830,7 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
     expect(`.o_selected_row`).toHaveCount(0);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 1", { inline: true });
 
     // Click on last data row of first group
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
@@ -14837,13 +14840,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 2", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 1", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14855,13 +14858,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 2", { inline: true });
 
     // Edit the row and press enter: should add a new row
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 3 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No -4 3", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14972,22 +14975,22 @@ test(`editable grouped list: adding a second record pass the first in readonly`,
     await contains(`.o_group_header:eq(0)`).click();
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_name:eq(0)`).toHaveText("No");
+    expect(`.o_group_name:eq(1)`).toHaveText("Yes");
 
     // add a row in first group
     await contains(`.o_group_field_row_add:eq(0) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2", { inline: true });
+    expect(`.o_group_name:eq(0)`).toHaveText("No");
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // add a row in second group
     await contains(`.o_group_field_row_add:eq(1) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes 4", { inline: true });
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_name:eq(1)`).toHaveText("Yes");
+    expect(`.o_group_name:eq(0)`).toHaveText("No");
     expect(`.o_data_row:eq(4) [name=foo] input`).toBeFocused();
 });
 
@@ -15319,8 +15322,7 @@ test(`add a new row in grouped editable="top" list`, async () => {
     expect(`.o_data_row`).toHaveCount(4);
 
     await contains(`.o_group_field_row_add a:eq(1)`).click(); // create row in second group "Yes"
-    expect(`.o_group_name:eq(1)`).toHaveText("Yes 4", {
-        inline: true,
+    expect(`.o_group_name:eq(1)`).toHaveText("Yes", {
         message: "group should have correct name and count",
     });
     expect(`.o_data_row`).toHaveCount(5);
@@ -16745,7 +16747,7 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
     });
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_name`).toHaveText("No");
 
     // unfold the second group
     await contains(`.o_group_header`).click();
@@ -16758,11 +16760,11 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
 
     await contains(`.breadcrumb-item a, .o_back_button`).click();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_name`).toHaveText("No");
 
     await pagerNext();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_name`).toHaveText("Yes");
 });
 
 test(`keep order after grouping`, async () => {
@@ -16785,7 +16787,7 @@ test(`keep order after grouping`, async () => {
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Foo");
-    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual(["yop 1", "gnap 1", "blip 2"]);
+    expect(queryAllTexts(".o_group_name")).toEqual(["yop", "gnap", "blip"]);
 
     await toggleMenuItem("Foo");
     expect(queryAllTexts`.o_data_row td[name=foo]`).toEqual(["yop", "gnap", "blip", "blip"]);
@@ -18180,12 +18182,16 @@ test(`properties: optional show/hide (at reload, config from local storage)`, as
     // list is grouped, no record displayed
     expect(`.o_group_header`).toHaveCount(2);
     expect(`.o_data_row`).toHaveCount(0);
-    expect(`.o_list_table thead th:not(.o_list_record_selector)`).toHaveCount(2);
+    expect(`.o_list_table thead th:not(.o_list_record_selector):not(.o_count_header)`).toHaveCount(
+        2
+    );
     expect(`.o_list_table thead th[data-name=m2o]`).toHaveCount(1);
 
     await contains(`.o_group_header`).click(); // open group Value 1
     expect(`.o_data_row`).toHaveCount(3);
-    expect(`.o_list_table thead th:not(.o_list_record_selector)`).toHaveCount(3);
+    expect(`.o_list_table thead th:not(.o_list_record_selector):not(.o_count_header)`).toHaveCount(
+        3
+    );
     expect(`.o_list_table thead th[data-name=m2o]`).toHaveCount(1);
     expect(`.o_list_table thead th[data-name='properties.property_char']`).toHaveCount(1);
     expect(`.o_list_table thead th.o_list_actions_header`).toHaveCount(1);
@@ -18841,8 +18847,8 @@ test("two pages, go page 2, record deleted meanwhile (grouped case)", async () =
 
     await contains(".o_group_header").click();
     expect(".o_data_row").toHaveCount(3);
-    expect(getPagerValue(queryFirst(".o_group_header"))).toEqual([1, 3]);
-    expect(getPagerLimit(queryFirst(".o_group_header"))).toBe(4);
+    expect(getPagerValue(queryFirst(".o_pager_cell_counter"))).toEqual([1, 3]);
+    expect(getPagerLimit(queryFirst(".o_pager_cell_counter"))).toBe(4);
 
     MockServer.env["foo"].unlink(4);
     await pagerNext(queryFirst(".o_group_header"));
@@ -19070,7 +19076,7 @@ test(`display 'None' for false group, when grouped by char field`, async () => {
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("None 1", { inline: true });
+    expect(`.o_group_name:eq(-1)`).toHaveText("None");
 });
 
 test(`display '0' for false group, when grouped by int field`, async () => {
@@ -19083,7 +19089,7 @@ test(`display '0' for false group, when grouped by int field`, async () => {
         groupBy: ["int_field"],
     });
 
-    expect(`tbody tr:nth-child(2)`).toHaveText("0 1", { inline: true });
+    expect(`.o_group_name:eq(1)`).toHaveText("0");
 });
 
 test(`display the field's falsy_value_label for false group, if defined`, async () => {
@@ -19097,7 +19103,7 @@ test(`display the field's falsy_value_label for false group, if defined`, async 
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("I'm the false group 1", { inline: true });
+    expect(`.o_group_name:eq(2)`).toHaveText("I'm the false group");
 });
 
 test(`hide pager in the list view with sample data`, async () => {
@@ -19572,7 +19578,7 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["No", "Yes"]);
 
     // execute another action to remove the list from the DOM
     await getService("action").doAction(2);
@@ -19583,14 +19589,14 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["No", "Yes"]);
 
     // simulate the return of web_read_group => nothing should have changed
     def.resolve();
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["No", "Yes"]);
 });
 
 test(`cache web_read_group (change)`, async () => {
@@ -19631,12 +19637,7 @@ test(`cache web_read_group (change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 1",
-        "9 1",
-        "10 1",
-        "17 1",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["-4", "9", "10", "17"]);
 
     // simulate the create of new records by someone else
     MockServer.env.foo.create([{ int_field: 44 }, { int_field: -4 }]);
@@ -19650,25 +19651,14 @@ test(`cache web_read_group (change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 1",
-        "9 1",
-        "10 1",
-        "17 1",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["-4", "9", "10", "17"]);
 
     // simulate the return of web_read_group => the data should have been updated
     def.resolve();
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(5);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 2",
-        "9 1",
-        "10 1",
-        "17 1",
-        "44 1",
-    ]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["-4", "9", "10", "17", "44"]);
 });
 
 test(`cache web_read_group (with sample data, no change)`, async () => {
@@ -19781,7 +19771,7 @@ test(`cache web_read_group (with sample data, change)`, async () => {
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["-4 1", "44 1"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["-4", "44"]);
 });
 
 test.tags("desktop");
@@ -20581,4 +20571,56 @@ test(`x2many list: create control supports hotkey`, async () => {
     expect(`.o_field_x2many_list_row_add button:eq(0)`).not.toHaveAttribute("data-hotkey");
     expect(`.o_field_x2many_list_row_add button:eq(1)`).toHaveAttribute("data-hotkey", "n");
     expect(`.o_field_x2many_list_row_add button:eq(2)`).toHaveAttribute("data-hotkey", "k");
+});
+
+test.tags("desktop");
+test(`Grouped list: count and pager behavior - desktop`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list limit="2">
+                <field name="int_field"/>
+                <field name="date"/>
+                <field name="int_field"/>
+            </list>
+        `,
+        groupBy: ["bar"],
+    });
+    expect(queryAllTexts(`thead th`)).toEqual(["", "Int field", "Date", "Int field", "Count", ""]);
+    expect(`tr.o_group_header`).toHaveCount(2);
+    await contains(`.o_group_header:eq(1)`).click();
+
+    // No pager buttons in the 'Count' column.
+    expect(`.o_group_header:eq(1) th:eq(-2) .o_pager_counter`).toBeVisible();
+    expect(`.o_group_header:eq(1) th:eq(-2) .btn-group`).not.toBeVisible();
+    // No pager counter in the 'Cog' column
+    expect(`.o_group_header:eq(1) th:eq(-1) .btn-group`).toBeVisible();
+    expect(`.o_group_header:eq(1) th:eq(-1) .o_pager_counter`).not.toBeVisible();
+});
+
+test.tags("mobile");
+test(`Grouped list: count and pager behavior - mobile`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list limit="2">
+                <field name="int_field"/>
+                <field name="date"/>
+                <field name="int_field"/>
+            </list>
+        `,
+        groupBy: ["bar"],
+    });
+    expect(queryAllTexts(`thead th`)).toEqual(["Int field", "Date", "Int field", ""]);
+    expect(`tr.o_group_header`).toHaveCount(2);
+    await contains(`.o_group_header:eq(1)`).click();
+
+    // No pager in 'Count' column when env.isSmall.
+    expect(`.o_group_header:eq(1) th:eq(-2) .o_pager_counter`).toHaveCount(0);
+    expect(`.o_group_header:eq(1) th:eq(-2) .btn-group`).toHaveCount(0);
+    // Only the pager buttons are present in the last column when env.isSmall.
+    expect(`.o_group_header:eq(1) th:eq(-1) .btn-group`).toBeVisible();
+    expect(`.o_group_header:eq(1) th:eq(-1) .o_pager_counter`).toHaveCount(0);
 });


### PR DESCRIPTION
In a grouped list view, the count on the header was sometimes
misleading. In some views, it was displayed in the same column as a
field and could be wrongly interpreted as such.

This commit moves the group count to the right of the view underneath
the new 'Count' column. The `Pager` buttons are `sticky`.
Some minor changes were made to the `Pager`:
- optional `props` were added in order to hide the count or the buttons.
- the counts are underlined on hover (if `isEditable`).

Moreover, the bg color for group header was changed to a non-transparent
one since it was arbitrary chosen to use the `--table-striped-bg`
instead of the `--ListRenderer-thead-bg-colors` in https://github.com/odoo/odoo/pull/235250.

The hability to sort a grouped list view by count when clicking on the
facet group icon was moved to clicking on the count column header.
Following this, change the test `order by count resets when there is no
group left` in `search_bar.test.js` was deleted. The use case is covered in `list_view.test.js` (see `order by count resets`).

task-5976034

