### PR TITLE
[FIX] account: align subtotal column in invoices with hidden sections

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -275,7 +275,7 @@
                                     <t t-else="">
                                         <t t-set="grouped_lines" t-value="line._get_child_lines()"/>
                                         <t t-foreach="grouped_lines" t-as="grouped_line">
-                                            <t t-if="grouped_line['display_type'] == 'product'">
+                                            <t t-if="grouped_line['display_type'] == 'product' or hide_details">
                                                 <t t-set="line_colspan" t-value="1"/>
                                             </t>
                                             <t t-else="">
@@ -334,18 +334,18 @@
                                                     </div>
                                                 </td>
                                                 <td name="td_price_unit_grouped"
-                                                    t-if="grouped_line['display_type'] not in ('line_section', 'line_subsection')"
+                                                    t-if="hide_details or grouped_line['display_type'] not in ('line_section', 'line_subsection')"
                                                     colspan="1"
                                                     t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                    <span t-if="not hide_prices" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
+                                                    <span t-if="not hide_prices and not hide_details" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
                                                 </td>
                                                 <td name="td_discount_grouped"
-                                                    t-if="display_discount and grouped_line['display_type'] == 'product'"
+                                                    t-if="display_discount and (hide_details or grouped_line['display_type'] == 'product')"
                                                     colspan="1"
                                                     t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"/>
                                                 <td name="td_taxes_grouped"
                                                     colspan="1"
-                                                    t-if="display_taxes and (grouped_line['display_type'] == 'product' or grouped_line.get('taxes'))"
+                                                    t-if="display_taxes and (hide_details or grouped_line['display_type'] == 'product' or grouped_line.get('taxes'))"
                                                     t-attf-class="text-end {{'d-none d-md-table-cell' if report_type == 'html' else ''}}">
                                                     <span t-if="grouped_line.get('taxes')" t-out="','.join(grouped_line['taxes'])" id="grouped_line_tax_ids">Tax 15%</span>
                                                 </td>


### PR DESCRIPTION
**Problem:**
In invoice PDF reports, when a section has Hide Composition enabled having a product inside, the description cell reserves too many columns (that are not available like quantity, unit price) while the quantity is still rendered as (1.00 Units), and unit price/discount/tax cells are conditionally omitted for section/subsection display types. This adds the extra table cells (quantity "1.00 units", total amount) after the first few reserved columns, this shifts the quantity/amount column a few positions to the right resulting in inconsistency mapping between the values and the name of the column.

Before:
<img width="1622" height="867" alt="2026-03-25_10-56" src="https://github.com/user-attachments/assets/57d6857a-7763-48d3-8131-fdc4e37a6704" />

After:
<img width="1628" height="771" alt="2026-03-25_13-55" src="https://github.com/user-attachments/assets/d9df6cbe-3c23-4874-b50f-6797ef644c03" />


**Steps to reproduce:**
1- Create a customer invoice
2- Add a section.
3- Add products under the section with quantity and price
4- Enable hide composition on the section
5- Confirm and print the invoice PDF
6- Observe the section subtotal rows shifted by one column

**Cause:**
In grouped rendering, line_colspan for non-product rows still reserves Quantity,Unit Price columns, while hide_details also renders a dedicated quantity cell (1.00 Units). This makes the row consume extra columns and breaks alignment.

**Solution:**
For grouped rows in hide_details mode, We need to render the description cell with a minimal colspan (1) and explicitly keep the remaining column slots stable:
keep Quantity cell (1.00 units), Unit Price, Discount, taxes as an empty placeholder cells if not available.

---
opw-6030372