### PR TITLE
[FIX] mrp: prevent duplicated MO from reusing same reference

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -238,7 +238,7 @@ class MrpProduction(models.Model):
 
     qty_produced = fields.Float(compute="_get_produced_qty", string="Quantity Produced")
     reference_ids = fields.Many2many(
-        'stock.reference', 'stock_reference_production_rel', 'production_id', 'reference_id', 'References',
+        'stock.reference', 'stock_reference_production_rel', 'production_id', 'reference_id', 'References', copy=False,
     )
     product_description_variants = fields.Char('Custom Description')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Orderpoint', copy=False, index='btree_not_null')

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1596,6 +1596,9 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.qty_produced, 1)
         self.assertEqual(mo.move_raw_ids.state, 'cancel')
+        # Check that the duplicated production does not have the same reference
+        mo2 = mo.copy()
+        self.assertNotEqual(mo2.reference_ids, mo.reference_ids)
 
     def test_product_produce_14(self):
         """ Check two component move with the same product are not merged."""


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product "P1" with the following BoM:
    - Component: C1 with the following routes: - Buy + MTO

- Create a MO to produce one unit of P1:
    - Confirm the MO -> a purchase order is created because the component uses MTO

- Duplicate the MO

Problem:
A new MO is created, but the reference is copied. As a result, the purchase order becomes linked to the new MO and the quantity in the purchase order line is updated from 1 to 2 units.

Explanation:
When the purchase order is created, the MO reference is stored on the PO, which links both records together. Since the reference is also copied when duplicating the MO, the new MO is incorrectly linked to the same purchase order.

opw-5873769