### PR TITLE
[FIX] website_sale: replace undefined variables

### DIFF
--- a/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
+++ b/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
@@ -13,7 +13,7 @@
                 t-attf-class="d-flex align-items-center gap-3 btn btn-light mb-2 me-3"
             >
                 <i class="fa fa-image fs-2 opacity-25" role="img"/>
-                <div class="placeholder opacity-25" t-att-style="`width: ${(c % 3) + 4}rem`"/>
+                <div class="placeholder opacity-25" t-att-style="`width: ${(category_placeholder_index % 3) + 4}rem`"/>
             </div>
         </div>
     </div>
@@ -33,7 +33,7 @@
                     t-foreach="[...Array(10).keys()]"
                     t-as="category_placeholder"
                     t-key="category_placeholder"
-                    t-attf-class="d-block placeholder placeholder-xs opacity-25 col-{{(p % 4) + 4}}"
+                    t-attf-class="d-block placeholder placeholder-xs opacity-25 col-{{(category_placeholder_index % 4) + 4}}"
                 />
             </div>
             <hr class="my-4"/>
@@ -43,7 +43,7 @@
                     t-foreach="[...Array(9).keys()]"
                     t-as="category_placeholder"
                     t-key="category_placeholder"
-                    t-attf-class="d-block placeholder placeholder-xs opacity-25 col-{{(p % 3) + 6}}"
+                    t-attf-class="d-block placeholder placeholder-xs opacity-25 col-{{(category_placeholder_index % 3) + 6}}"
                 />
             </div>
         </div>


### PR DESCRIPTION
The editor previews are not having the expected design due to the `c`
and `p` variables being undefined.

Steps to reproduce for eg. filmstrip:
- Disable the `categories_opt_top` (Categories: top)
- Hover the "Top" editor button
- See the filmstrip is missing it's placeholder rectangle "text" due to
the width style not being applied.

task-6047816



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
