### PR TITLE
[IMP] {test_}mail,cloud_storage_azure: make attachment links impossible to miss

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import re
 import requests
 
 from datetime import datetime, timezone, timedelta
@@ -215,6 +216,9 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
 
     def test_cloud_storage_attachments(self):
         """Cloud attachments should be converted to links in outgoing emails."""
+        def normalize_html(html):
+            return re.sub(r'(?=<)', '\n',
+                          " ".join(line.strip() for line in html.strip().splitlines() if line.strip()))
 
         thread_model = self.env["res.partner"].create({"name": "Cloud Test Partner", "email": "cloud@test.com"})
         cloud_attachment = self.env["ir.attachment"].create({
@@ -246,7 +250,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         self.assertEqual(len(self._mails), 2, "Two emails should be sent.")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -283,7 +288,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
                 "Only text attachment should be sent in the message")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": cloud_attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(cloud_attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -321,13 +327,11 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         with self.mock_mail_gateway(mail_unlink_sent=False):
             composer._action_send_mail()
 
-        for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            cloud_attachment_present = body.count(cloud_attachment.access_token) == body.count(cloud_attachment.name) == 1
-            cloud_attachment2_present = body.count(cloud_attachment2.access_token) == body.count(cloud_attachment2.name) == 1
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": large_attachment}))
-            self.assertTrue(body.count(large_attachment_link) == 1 and cloud_attachment_present and cloud_attachment2_present,
-                "Two cloud and one large attachments should be converted and sent as links in the outgoing email.",
-            )
+        self.assertEqual(len(self._new_mails.attachment_ids), 3)
+        for body in [m["body"] for m in self._mails]:
+            self.assertIn(cloud_attachment.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(cloud_attachment2.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(large_attachment.access_token, body, "large attachment should be converted as link")
 
     def test_uninstall_fail(self):
         with self.assertRaises(UserError, msg="Don't uninstall the module if there are Azure attachments in use"):

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -2,9 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
+import contextlib
 import datetime
 import json
 import logging
+import lxml
+import markupsafe
 import psycopg2
 import pytz
 import re
@@ -393,6 +396,96 @@ class MailMail(models.Model):
             body = re.sub(_UNFOLLOW_REGEX, '', body)
         return body
 
+    @api.model
+    def _render_attachments_links(self, attachments):
+        """ Temporary replacement for the mail.mail_attachment_links template in stable. """
+        rendered_attachments = [markupsafe.Markup("""
+        <div style="display: inline" data-attachment-id="%(attachment_id)s">
+            <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content">
+                <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+                    <a href="%(attachment_base_url)s/web/content/%(attachment_id)s?download=1&amp;access_token=%(attachment_access_token)s"
+                        style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%%; color:#008f8c; vertical-align: middle; font-size: 15px;"
+                        width="100%%" target="_blank">
+                         &#11015; %(attachment_name)s
+                    </a>
+                </div>
+            </div>
+        </div>
+        """) % {
+            'attachment_id': a.id,
+            'attachment_access_token': a.access_token,
+            'attachment_name': a.name,
+            'attachment_base_url': a.get_base_url(),
+        }
+                                for a in attachments]
+        return markupsafe.Markup(
+            """<div class="o-attachments-container" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%%;">
+                %(attachments)s
+            </div>""") % {'attachments': markupsafe.Markup('').join(rendered_attachments)}
+
+    @api.model
+    def _render_attachment_links_in_body(self, body, attachments, force=False, append=False):
+        """ Render the attachment container in the email body with download links when required.
+
+        :param str body: the original email body (HTML).
+        :param recordset attachments: attachments to render as links.
+        :param bool force: skip size estimation and always add links.
+        :param bool append: whether to replace existing links container or append just after it (if present).
+        :return: the modified body with the inserted download links
+            or False if the links should not be inserted (force == False and estimate size below limits).
+        :rtype: str | False
+        """
+        try:
+            root = lxml.html.fromstring(body or '')
+            container = root.xpath('//div[hasclass("o-attachments-container")][not(ancestor::*[@data-oe-version])]')
+        except lxml.etree.ParserError:
+            root = None
+            container = []
+
+        # Remove attachments handled outside the "o-attachments-container" (added through the html editor directly)
+        outside_attachments = set()
+        if root is not None:
+            path_all_ids = '//*[@data-attachment-id][not(ancestor::*[@data-oe-version])]/@data-attachment-id'
+            path_container_ids = '//div[hasclass("o-attachments-container")][not(ancestor::*[@data-oe-version])]//*[@data-attachment-id]/@data-attachment-id'
+            with contextlib.suppress(ValueError, TypeError):
+                outside_attachments = (
+                        {int(el) for el in root.xpath(path_all_ids)} -
+                        {int(el) for el in root.xpath(path_container_ids)})
+        attachments -= self.env['ir.attachment'].browse(list(outside_attachments))
+
+        if not force:
+            max_email_size_bytes = (self.env['ir.mail_server']).sudo()._get_max_email_size() * 1024 * 1024
+            default_estimated_header_size = 5000
+            estimated_email_size_bytes = self._estimate_email_size(
+                {}, body, [a.file_size for a in attachments.sudo()]) + default_estimated_header_size
+            if estimated_email_size_bytes <= max_email_size_bytes:
+                if len(container) > 0:
+                    container[0].getparent().remove(container[0])
+                    return lxml.html.tostring(root, pretty_print=True).decode()
+                return False
+
+        attachments.generate_access_token()
+        attachments_node = lxml.html.fragment_fromstring(self._render_attachments_links(attachments))
+        if len(container) == 0:
+            if root is None:
+                # We just add it at the end as the parsing of the body has failed
+                return tools.mail.append_content_to_html(
+                    body or '', lxml.html.tostring(attachments_node).decode(), plaintext=False)
+            elif len(signature_container := root.xpath('//div[hasclass("o-signature-container")][not(ancestor::*[@data-oe-version])]')):
+                signature_container[0].addprevious(attachments_node)
+            elif len(body_node := root.findall('body')):
+                body_node[0].append(attachments_node)
+            elif len(html_node := root.findall('html')):
+                html_node[0].append(attachments_node)
+            else:
+                root.append(attachments_node)
+        elif append:
+            # Add a second container just after the existing one
+            container[0].addnext(attachments_node)
+        else:
+            container[0].getparent().replace(container[0], attachments_node)
+        return lxml.html.tostring(root).decode()
+
     def _prepare_outgoing_list(self, mail_server=False, recipients_follower_status=None):
         """ Return a list of emails to send based on current mail.mail. Each
         is a dictionary for specific email values, depending on a partner, or
@@ -483,13 +576,9 @@ class MailMail(models.Model):
                 attachments = attachments - self.env['ir.attachment'].browse(list(link_ids))
 
         # Convert URL-only attachments (e.g. cloud or plain external links) into email links
-        url_attachments = attachments.sudo().filtered(
+        attachments_to_links = attachments.sudo().filtered(
             lambda a: a.url and not a.file_size and a.url.startswith(('http://', 'https://', 'ftp://')))
-        if url_attachments:
-            url_attachments.sudo().generate_access_token()
-            attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links', {'attachments': url_attachments})
-            body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
-            attachments -= url_attachments
+        attachments -= attachments_to_links
 
         # Turn remaining attachments into links if they are too heavy and
         # their ownership are business models (i.e. something != mail.message,
@@ -501,12 +590,15 @@ class MailMail(models.Model):
             max_email_size_bytes = (mail_server or self.env['ir.mail_server']
                                     ).sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
-                # Remove attachments and prepare downloadable links to be added in the body
-                record_owned_attachments.sudo().generate_access_token()
-                attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links',
-                                                                {'attachments': record_owned_attachments})
-                body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+                attachments_to_links |= record_owned_attachments
                 attachments -= record_owned_attachments
+
+        if attachments_to_links:
+            # force = True as we already have determined that the attachments must be turned into links
+            # append = True as an attachment link container could already have been added by the client in the body,
+            # and all attachment corresponding to a link in the body are removed above.
+            body = self._render_attachment_links_in_body(body, attachments_to_links, force=True, append=True)
+
         # Prepare the remaining attachment (those not embedded as link)
         # load attachment binary data with a separate read(), as prefetching all
         # `datas` (binary field) could bloat the browse cache, triggering

--- a/addons/mail/tests/test_mail_mail.py
+++ b/addons/mail/tests/test_mail_mail.py
@@ -1,3 +1,6 @@
+import base64
+from itertools import product
+
 from odoo.tests import TransactionCase
 from unittest import mock
 import smtplib
@@ -33,3 +36,102 @@ class MailCase(TransactionCase):
             "Error without exception. Probably due to sending "
             "an email without computed recipients."
         )
+
+    def check_render_attachment_links_in_body(self, body, attachments_to_render, check_attachments, expected_in):
+        """Check the default and forced rendering of the attachment links.
+
+        :param str body : The raw body that will be processed.
+        :param recordset attachments_to_render: The attachments that will be processed.
+        :param recordset check_attachments: Attachments that are expected to appear in the rendered output.
+        :param str expected_in: A snippet that must be present in the rendered output.
+        """
+        MailMail = self.env['mail.mail']
+        rendered = MailMail._render_attachment_links_in_body(body, attachments_to_render)
+        if len(check_attachments) > 1:
+            self.assertEqual(
+                rendered.count('o-attachments-container'), 1,
+                "With 2 attachments, the limit is reached and the attachments links must be added")
+            for idx, attachment in enumerate(check_attachments):
+                self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+                self.assertIn(attachment.access_token, rendered, f'attachment {idx} must be present')
+        else:
+            # The limit is not reached, the attachment links must not be added
+            if 'o-attachments-container' in (body or ''):
+                # If the container was present, it is removed
+                self.assertEqual(rendered.count('o-attachments-container'), 0)
+            else:
+                self.assertFalse(rendered)
+
+        # Check that forcing the rendering always render all attachments
+        rendered_force = MailMail._render_attachment_links_in_body(body, attachments_to_render, force=True)
+        self.assertEqual(rendered_force.count('o-attachments-container'), 1)
+        self.assertIn(expected_in, rendered_force)
+        for idx, attachment in enumerate(check_attachments):
+            self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+            self.assertIn(attachment.access_token, rendered_force, f'attachment {idx} must be present')
+
+        # Check appending
+        rendered_force = MailMail._render_attachment_links_in_body(
+            body, attachments_to_render, force=True, append=True)
+        self.assertEqual(rendered_force.count('o-attachments-container'),
+                         1 + (body or '').count('o-attachments-container'))
+        self.assertIn(expected_in, rendered_force)
+        for idx, attachment in enumerate(check_attachments):
+            self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+            self.assertIn(attachment.access_token, rendered_force, f'attachment {idx} must be present')
+
+    def test_render_attachment_links_in_body(self):
+        """Test attachment link rendering over various body formats and attachment counts."""
+        # size of header ({}), overhead from _estimate_email_size, overhead from _render_attachment_links_in_body
+        default_overhead_size = 2 + 10 * 1024 + 5000
+        no_attachments = self.env['ir.attachment']
+        content = b'TEST'
+        content_len = len(base64.b64encode(content))
+        all_attachments = self.env['ir.attachment'].create(
+            [{'name': name, 'raw': content}
+             for name in ['test1.txt', 'test2.txt', 'outside.txt']])
+        outside_attachment = all_attachments[2]
+        outside_attachment.generate_access_token()
+        for attachments, (body, expected_in) in product(
+                (
+                        no_attachments,
+                        all_attachments[0],
+                        all_attachments[:2],
+                ),
+                (
+                        (False, '<div class="o-attachments-container"'),
+                        ('', '<div class="o-attachments-container"'),
+                        ('OUTSIDE only text', 'only text<div class="o-attachments-container"'),
+                        ('<html>OUTSIDE <p>broken html</p></htm>', 'broken html</p><div class="o-attachments-container"'),
+                        ('<root>OUTSIDE broken html</root>', 'broken html<div class="o-attachments-container"'),
+                        ('<html>OUTSIDE <p>fine html</p></html>', 'fine html</p><div class="o-attachments-container"'),
+                        ('<html><body>OUTSIDE correct html</body></html>', 'correct html<div class="o-attachments-container"'),
+                        ('<html><body>OUTSIDE Hello, <div class="o-signature-container">Signature</div></body></html>',
+                         'Hello, <div class="o-attachments-container"'),
+                        (('<html><body>OUTSIDE Hello <div class="o-attachments-container">can be replaced</div>..., '
+                          '<div class="o-signature-container">Signature</div></body></html>'),
+                         'Hello <div class="o-attachments-container"'),
+                ),
+        ):
+            # Setup limit to be reach with the second attachment only
+            self.env['ir.config_parameter'].sudo().set_param(
+                'base.default_max_email_size',
+                (default_overhead_size + (len(body) if body else 0) + content_len + 1) / 1024.0 / 1024.0)
+            with self.subTest(test='without outside attachment', body=body, attachments=attachments):
+                self.check_render_attachment_links_in_body(
+                    body, attachments, check_attachments=attachments, expected_in=expected_in)
+
+            if body:
+                attachments_outside = attachments | outside_attachment
+                self.assertEqual(len(attachments_outside), len(attachments) + 1)
+                body_outside = body.replace(
+                    'OUTSIDE', (f'<a data-attachment-id="{outside_attachment.id}" '
+                                f'href="http://localhost:8069/web/content/{outside_attachment.id}?download=1'
+                                f'&amp;access_token={outside_attachment.access_token}">outside.txt</a>'))
+                self.env['ir.config_parameter'].sudo().set_param(
+                    'base.default_max_email_size',
+                    (default_overhead_size + (len(body_outside) if body else 0) + content_len + 1) / 1024.0 / 1024.0)
+                self.assertIn(outside_attachment.access_token, body_outside)
+                with self.subTest(test='with outside attachment', body=body_outside, attachments=attachments_outside):
+                    self.check_render_attachment_links_in_body(
+                        body_outside, attachments_outside, check_attachments=attachments, expected_in=expected_in)

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -643,6 +643,12 @@ class MailComposer(models.TransientModel):
             return super(MailComposer, self.with_context(prefetch_fields=False))._compute_field_value(field)
         return super()._compute_field_value(field)
 
+    @api.onchange('attachment_ids')
+    def _onchange_attachment_ids(self):
+        new_body = self.env['mail.mail']._render_attachment_links_in_body(self.body, self.attachment_ids._origin)
+        if new_body is not False:
+            self.body = new_body
+
     # ------------------------------------------------------------
     # CRUD / ORM
     # ------------------------------------------------------------

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -422,7 +422,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=10, employee=10):  # tm 8/8
+        with self.assertQueryCount(admin=19, employee=19):  # tm 18/18
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',


### PR DESCRIPTION
When an email is too big the server turns attachments into links but often recipients don't see the links as they are appended at the end of the email. To avoid that, we turn the attachments into links directly in the composer when the attachments are added so the sender is aware that the attachments are converted into links.

We keep the server mechanism that turns attachments into links as a fallback as we only support the convertion into link in the composer for now but we improve the rendering of the attachments with the same layout as in the composer.

In both case, we try to append the attachments links just before the signature to make them more visible.

Note that we had to increase the number of queries for the test test_mail_composer_form_attachments because _onchange_attachment_ids is called multiple time during it. And each time, a query to load the attachment to compute the total size is performed.

Notes:
- as the changes are done in stable, we haven't removed the max email size configuration per mail server. That specific configuration is ignored when turning attachments into links in the composer (using the default max email size). But it is not ignored when turning attachments into link when sending the mail which could lead to some inconsistencies (attachments turned into links while it shouldn't when the server max email size is greater than the default).
- to lay out the links, we don’t use flex because "flex-wrap: wrap;" is removed by the html editor. Instead, we just use a div with "display: inline" to simulate it.

Task-5912830