### PR TITLE
[FIX] project: reset web.base.url in order to control link

### DIFF
--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -144,6 +144,7 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
                 task.write({field: dummy_value(field)})
 
     def test_wizard_confirm(self):
+        self.env['ir.config_parameter'].set_str('web.base.url', "gopher://example.org")
         partner_portal_no_user = self.env['res.partner'].create({
             'name': 'NoUser portal',
             'email': 'no@user.portal',
@@ -167,5 +168,5 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
         project_share_wizard_confirmation.action_send_mail()
         mail_partner = self.env['mail.message'].search([('partner_ids', '=', partner_portal_no_user.id)], limit=1)
         self.assertTrue(mail_partner, 'A mail should have been sent to the non portal user')
-        self.assertIn(f'href="http://localhost:{config["http_port"]}/web/signup', str(mail_partner.body), 'The message link should contain the url to register to the portal')
+        self.assertIn('href="gopher://example.org/web/signup', str(mail_partner.body), 'The message link should contain the url to register to the portal')
         self.assertIn('token=', str(mail_partner.body), 'The message link should contain a personalized token to register to the portal')


### PR DESCRIPTION
When running odoo, port 0 can be used to delegate port assignment to the kernel.

Since #254216, the port selected by the kernel is written back to the config.

This becomes an issue when using port 0 to install a database, and then separately to run `post_install` tests: database installation will write one port to `web.base.url`, then the post_install run will be using a different port which doesn't match (or since `test_wizard_confirm` isn't an `HttpCase` it might still be configured with port 0 if no test before it was an `HttpCase`).

Fix this test at least, by overwriting the web.base.url with one we control and checking for that exact value afterwards.
