### PR TITLE
[FIX] point_of_sale: order report margin currency

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -89,7 +89,7 @@ class PosOrderReport(models.Model):
                 s.pricelist_id,
                 s.session_id,
                 s.account_move IS NOT NULL AS invoiced,
-                l.price_subtotal - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
+                (l.price_subtotal - COALESCE(l.total_cost,0)) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
                 pm.payment_method_id AS payment_method_id,
                 fpc.id AS pos_categ_id
 

--- a/addons/point_of_sale/tests/test_report_pos_order.py
+++ b/addons/point_of_sale/tests/test_report_pos_order.py
@@ -107,3 +107,36 @@ class TestReportPoSOrder(TestPoSCommon):
 
         self.assertEqual(reports[0].margin, 135)
         self.assertEqual(reports[0].price_total, 135)
+
+    def test_report_pos_order_margin_other_currency(self):
+        """Test that the currency_rate set on the order is correctly taken into account when generating the report"""
+
+        product1 = self.create_product('Product 1', self.categ_basic, 150)
+        self.open_new_session()
+        session = self.pos_session
+
+        self.env['pos.order'].create({
+         'session_id': session.id,
+            'lines': [
+                (0, 0, {
+                    'name': "OL/0001",
+                    'product_id': product1.id,
+                    'price_unit': 300,
+                    'discount': 0,
+                    'qty': 1.0,
+                    'price_subtotal': 300,
+                    'price_subtotal_incl': 300,
+                })
+            ],
+            'amount_total': 300.0,
+            'amount_tax': 0.0,
+            'amount_paid': 300.0,
+            'amount_return': 0.0,
+            'currency_rate': 2
+        })
+
+        reports = self.env['report.pos.order'].sudo().search([('product_id', '=', product1.id)], order='id')
+
+        self.assertEqual(reports[0].margin, 150)
+        self.assertEqual(reports[0].price_subtotal_excl, 150)
+        self.assertEqual(reports[0].price_total, 150)


### PR DESCRIPTION
When making a pos order in a PoS that uses a different currency, the margin in the pos order report would not take the currency into account

Steps to reproduce:
-------------------
* Create a product with a price of 100€ and cost 0€ (margin = 100€)
* Setup a PoS to use a different currency with a rate of 2 (so 1€=>0.5)
* Create a PoS order for this product and validate it
* Go to the pos order report and select the order you just made
> Observation: The value of the margin is 200 expressed in the different
  currency, when the rest of the report is using the company currency.

Why the fix:
------------
The currency was only applied on the product cost, we now apply it on the whole margin.

opw-5927473