### PR TITLE
[FIX] sale: Simplify behavior of packaging quantity on so line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1242,6 +1242,10 @@ class SaleOrderLine(models.Model):
                     },
                 }
 
+    @api.onchange('product_packaging_qty')
+    def _onchange_product_packaging_qty(self):
+        self.env.remove_to_compute(self._fields['product_packaging_id'], self)
+
     #=== CRUD METHODS ===#
 
     @api.model_create_multi

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -288,6 +288,48 @@ class TestSaleOrder(SaleCommon):
         self.assertEqual(so2.order_line.product_packaging_id, company2_pack_of_10)
         self.assertEqual(so2.order_line.product_packaging_qty, 1.0)
 
+    def test_compute_packaging_02(self):
+        """Create a SO and use packaging. Check product_qty and product_packaging
+        are correctly calculated when packaging_qty is manually changed.
+        """
+        # Required for `product_packaging_qty` to be visible in the view
+        self.env.user.groups_id += self.env.ref('product.group_stock_packaging')
+        packaging_one, packaging_four = self.env['product.packaging'].create([{
+            'name': "One pack",
+            'product_id': self.product.id,
+            'qty': 1.0,
+        }, {
+            'name': "Four pack",
+            'product_id': self.product.id,
+            'qty': 4.0,
+        }])
+
+        so = self.empty_order
+        so_form = Form(so)
+        with so_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_uom_qty = 1.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+        self.assertEqual(so.order_line.product_packaging_qty, 1.0)
+        with so_form.order_line.edit(0) as line:
+            line.product_packaging_qty = 4.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_uom_qty, 4.0)
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+
+        with so_form.order_line.edit(0) as line:
+            line.product_packaging_qty = 5.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_one)
+        self.assertEqual(so.order_line.product_packaging_qty, 5.0)
+
+        with so_form.order_line.edit(0) as line:
+            line.product_uom_qty = 4.0
+        so_form.save()
+        self.assertEqual(so.order_line.product_packaging_id, packaging_four)
+        self.assertEqual(so.order_line.product_packaging_qty, 1.0)
+
     def _create_sale_order(self):
         """Create dummy sale order (without lines)"""
         return self.env['sale.order'].with_context(


### PR DESCRIPTION
Setup: A product with a packaging of 1 unit and a box of 4 units Usecase1:
- Add a line (by default it suggest the 1 unit packaging)
- Increase the quantity to 4 (it remains on unit packaging)
- Increase it to 5

It switch the packaging to Box of 4 and the quantity to 20.

Usecase2:
- Add a line of 1 unit
- Swith the packaging to box (the packaging quantity switch to 0.25)
- Set the packaging quantity to 4 (I want 4 boxes)

It switch everything back to unit.

We had to choose between:
- The packaging is computed base on the quantity to delivery in order to suggest a packaging or
- The user choose the packaging and the quantity of packaging to drive the quantity to deliver.

This commit modify the behavior, in order to let the user choose its packaging and drive the quantity to deliver base on that.

opw-6019088