### PR TITLE
[FIX] point_of_sale: fix pricelist price when POS uses a different currency

### DIFF
--- a/addons/point_of_sale/models/product_pricelist.py
+++ b/addons/point_of_sale/models/product_pricelist.py
@@ -9,11 +9,17 @@ class ProductPricelist(models.Model):
     @api.model
     def _load_pos_data_domain(self, data, config):
         pricelist_ids = [preset['pricelist_id'] for preset in data['pos.preset']]
-        return [('id', 'in', config._get_available_pricelists().ids + pricelist_ids)]
+        all_ids = config._get_available_pricelists().ids + pricelist_ids
+        referenced_base_pricelist_ids = self.env['product.pricelist.item'].search([
+            ('pricelist_id', 'in', all_ids),
+            ('base', '=', 'pricelist'),
+            ('base_pricelist_id', '!=', False),
+        ]).base_pricelist_id.ids
+        return [('id', 'in', list(set(all_ids + referenced_base_pricelist_ids)))]
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['id', 'name', 'display_name', 'item_ids']
+        return ['id', 'name', 'display_name', 'currency_id', 'item_ids']
 
 
 class ProductPricelistItem(models.Model):

--- a/addons/point_of_sale/models/res_currency.py
+++ b/addons/point_of_sale/models/res_currency.py
@@ -7,11 +7,9 @@ class ResCurrency(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        company_currency_id = config.company_id.currency_id.id
-        config_currency_id = config.currency_id.id
-        if company_currency_id != config_currency_id:
-            return [('id', 'in', [company_currency_id, config_currency_id])]
-        return [('id', '=', config_currency_id)]
+        currency_ids = {config.company_id.currency_id.id, config.currency_id.id}
+        currency_ids.update(pricelist['currency_id'] for pricelist in data['product.pricelist'])
+        return [('id', 'in', list(currency_ids))]
 
     @api.model
     def _load_pos_data_fields(self, config):

--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -134,6 +134,15 @@ export class ProductTemplateAccounting extends Base {
             price = standardPrice;
         }
 
+        const posCurrency = this.models["pos.config"].getFirst().currency_id;
+        const pricelistCurrency = pricelist.currency_id;
+        const needsCurrencyConversion =
+            pricelistCurrency && posCurrency && pricelistCurrency.id !== posCurrency.id;
+
+        if (needsCurrencyConversion) {
+            price *= pricelistCurrency.rate / posCurrency.rate;
+        }
+
         if (rule.compute_price === "fixed") {
             price = rule.fixed_price;
         } else if (rule.compute_price === "percentage") {
@@ -153,6 +162,10 @@ export class ProductTemplateAccounting extends Base {
             if (rule.price_max_margin) {
                 price = Math.min(price, price_limit + rule.price_max_margin);
             }
+        }
+
+        if (needsCurrencyConversion) {
+            price *= posCurrency.rate / pricelistCurrency.rate;
         }
 
         // This return value has to be rounded with round_di before

--- a/addons/point_of_sale/static/tests/unit/accounting/pricelist.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/pricelist.test.js
@@ -148,3 +148,63 @@ test("Pricelist: Nested Pricelists (Pricelist of Pricelist)", async () => {
     // Calculation: (100 - 10%) + 5 = 90 + 5 = 95
     expect(product.getPrice(nestedPricelist, 1, 0, false, product)).toBe(95);
 });
+
+test("Nested Pricelists with different currencies", async () => {
+    const store = await setupPosEnv();
+
+    const mxn = store.models["res.currency"].create({
+        name: "MXN",
+        symbol: "MX$",
+        position: "before",
+        rounding: 0.01,
+        rate: 2.0,
+        decimal_places: 2,
+    });
+
+    // POS uses MXN
+    const config = store.models["pos.config"].getFirst();
+    config.update({ currency_id: mxn });
+
+    // Base pricelist in USD: +10 USD surcharge on list_price
+    const usd = store.models["res.currency"].get(1);
+    const basePricelist = store.models["product.pricelist"].create({
+        name: "USD Pricelist",
+        currency_id: usd,
+    });
+    const baseRule = store.models["product.pricelist.item"].create({
+        pricelist_id: basePricelist,
+        compute_price: "formula",
+        base: "list_price",
+        price_surcharge: 10,
+    });
+    basePricelist.update({ item_ids: [baseRule] });
+    basePricelist.computeRuleIndexes();
+
+    // POS pricelist in MXN: based on USD pricelist + 25% discount
+    const posPricelist = store.models["product.pricelist"].create({
+        name: "MXN Pricelist",
+        currency_id: mxn,
+    });
+    const posRule = store.models["product.pricelist.item"].create({
+        pricelist_id: posPricelist,
+        compute_price: "percentage",
+        percent_price: 25,
+        base: "pricelist",
+        base_pricelist_id: basePricelist,
+    });
+    posPricelist.update({ item_ids: [posRule] });
+    posPricelist.computeRuleIndexes();
+
+    const productTemplate = store.models["product.template"].create({
+        name: "Test Product",
+        list_price: 100,
+    });
+    const product = store.models["product.product"].create({
+        product_tmpl_id: productTemplate,
+        lst_price: 100,
+    });
+
+    // 100 MXN → 50 USD, + 10 surcharge = 60 USD → 120 MXN
+    // 120 MXN - 25% = 90 MXN
+    expect(product.getPrice(posPricelist, 1, 0, false, product)).toBe(90);
+});

--- a/addons/point_of_sale/static/tests/unit/data/product_pricelist.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/product_pricelist.data.js
@@ -4,7 +4,7 @@ export class ProductPricelist extends models.ServerModel {
     _name = "product.pricelist";
 
     _load_pos_data_fields() {
-        return ["id", "name", "display_name", "item_ids"];
+        return ["id", "name", "display_name", "currency_id", "item_ids"];
     }
 
     _records = [

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -302,8 +302,8 @@ class PosConfig(models.Model):
 
     def _load_self_data_models(self):
         return ['pos.session', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.partner',
-            'res.currency', 'pos.printer', 'pos.category', 'product.template', 'product.product', 'product.combo', 'product.combo.item', 'res.company', 'account.tax',
-            'account.tax.group', 'res.country', 'product.category', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position',
+            'pos.printer', 'pos.category', 'product.template', 'product.product', 'product.combo', 'product.combo.item', 'res.company', 'account.tax',
+            'account.tax.group', 'res.country', 'product.category', 'product.pricelist', 'product.pricelist.item', 'res.currency', 'account.fiscal.position',
             'res.lang', 'product.attribute', 'product.attribute.custom.value', 'product.template.attribute.line', 'product.template.attribute.value', 'product.tag',
             'decimal.precision', 'uom.uom', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding',
             'res.country', 'res.country.state', 'mail.template']


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Set up a POS with a currency different from the company currency (e.g. company in USD, POS in SSP).
2. Create a USD pricelist with a surcharge rule (e.g. +10 USD on list_price).
3. Create an SSP pricelist that references the USD pricelist as its base (base = "pricelist"), with an additional discount rule.
4. Assign the SSP pricelist to the POS and add a product.

-> The displayed price ignores the currency conversion between the two pricelists: surcharges/discounts are applied as if both pricelists share the same currency.

What's happening:
-----------------
The POS pre-converts product prices from company currency to POS currency in `_load_pos_data_read`. However, `getPrice` in JS never converts between the POS currency and the pricelist's own currency before applying the rule's formula (surcharge, discount, etc.).

The fix:
--------
In `getPrice`, convert the price from POS currency to pricelist currency before applying the rule, then convert back afterward.

Note that we have changed the loading order of the models for `pos_self_order`, such as 'res.currency' records are loaded after 'product.pricelist' ones, because now the loaded currencies depend on the loaded pricelists.

opw-6013513