### PR TITLE
[FIX] account_edi_ubl_cii: fix unit price rounding issue in peppol

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3769,6 +3769,93 @@ class AccountTax(models.Model):
             base_line['tax_details'][raw_field] += amount_to_distribute
 
     @api.model
+    def _get_gross_total_without_tax(self, base_line, company, in_foreign_currency=True, account_discount_base_lines=False, precision_digits=None):
+        """ Infer the gross total without tax from the base line.
+
+        :param base_line:                   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param company:                     The company owning the base line.
+        :param in_foreign_currency:         True if to be applied on amounts expressed in foreign currency,
+                                            False for amounts expressed in company currency.
+        :param account_discount_base_lines: Account the distributed global discount in 'discount_base_lines'
+                                            using '_dispatch_global_discount_lines' in 'raw_discount_amount'.
+        :param precision_digits:            The precision to be used to round.
+        :return:                            The gross total without tax.
+        """
+        suffix = '_currency' if in_foreign_currency else ''
+
+        tax_details = base_line['tax_details']
+        raw_total_excluded = tax_details[f'raw_total_excluded{suffix}']
+
+        discount_factor = 1 - (base_line['discount'] / 100.0)
+        if discount_factor:
+            raw_gross_total_excluded = raw_total_excluded / discount_factor
+        elif in_foreign_currency:
+            raw_gross_total_excluded = base_line['price_unit'] * base_line['quantity']
+        elif base_line['rate']:
+            raw_gross_total_excluded = base_line['price_unit'] * base_line['quantity'] / base_line['rate']
+        else:
+            raw_gross_total_excluded = 0.0
+        if account_discount_base_lines:
+            raw_gross_total_excluded -= sum(
+                discount_base_line['tax_details'][f'raw_total_excluded{suffix}']
+                for discount_base_line in base_line.get('discount_base_lines', [])
+            )
+
+        if precision_digits is not None:
+            raw_gross_total_excluded = float_round(raw_gross_total_excluded, precision_digits=precision_digits)
+        return raw_gross_total_excluded
+
+    @api.model
+    def _get_price_unit_without_tax(self, base_line, company, raw_gross_total_excluded, in_foreign_currency=True, precision_digits=None):
+        """ Infer the gross price unit without tax from the base line.
+
+        :param base_line:                   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param company:                     The company owning the base line.
+        :param raw_gross_total_excluded:    The gross total without tax.
+        :param in_foreign_currency:         True if to be applied on amounts expressed in foreign currency,
+                                            False for amounts expressed in company currency.
+        :param precision_digits:            The precision to be used to round.
+        :return:                            The gross price unit without tax.
+        """
+        if (
+            (precision_digits and float_is_zero(raw_gross_total_excluded, precision_digits=precision_digits))
+            or not raw_gross_total_excluded
+        ):
+            if in_foreign_currency:
+                raw_gross_price_unit = base_line['price_unit']
+            elif base_line['rate']:
+                raw_gross_price_unit = base_line['price_unit'] / base_line['rate']
+            else:
+                raw_gross_price_unit = 0.0
+        elif not base_line['quantity']:
+            raw_gross_price_unit = raw_gross_total_excluded
+        else:
+            raw_gross_price_unit = raw_gross_total_excluded / base_line['quantity']
+
+        if precision_digits is not None:
+            raw_gross_price_unit = float_round(raw_gross_price_unit, precision_digits=precision_digits)
+        return raw_gross_price_unit
+
+    @api.model
+    def _get_discount_amount_without_tax(self, base_line, company, raw_gross_total_excluded, in_foreign_currency=True, precision_digits=None):
+        """ Infer the discount amount without tax from the base line.
+
+        :param base_line:                   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param company:                     The company owning the base line.
+        :param raw_gross_total_excluded:    The gross total without tax.
+        :param in_foreign_currency:         True if to be applied on amounts expressed in foreign currency,
+                                            False for amounts expressed in company currency.
+        :param precision_digits:            The precision to be used to round.
+        :return:                            The discount amount without tax.
+        """
+        suffix = '_currency' if in_foreign_currency else ''
+        raw_discount_amount = raw_gross_total_excluded - base_line['tax_details'][f'raw_total_excluded{suffix}']
+
+        if precision_digits is not None:
+            raw_discount_amount = float_round(raw_discount_amount, precision_digits=precision_digits)
+        return raw_discount_amount
+
+    @api.model
     def _add_and_round_raw_gross_total_excluded_and_discount(
         self,
         base_lines,
@@ -3799,45 +3886,38 @@ class AccountTax(models.Model):
 
         suffix_currency = base_lines[0]['currency_id'] if in_foreign_currency else company.currency_id
         suffix = '_currency' if in_foreign_currency else ''
-        raw_field = f'raw_total_excluded{suffix}'
 
         for base_line in base_lines:
             tax_details = base_line['tax_details']
-            raw_total_excluded = tax_details[raw_field]
 
-            discount_factor = 1 - (base_line['discount'] / 100.0)
-            if discount_factor:
-                raw_gross_total_excluded = raw_total_excluded / discount_factor
-            elif suffix == '_currency':
-                raw_gross_total_excluded = base_line['price_unit'] * base_line['quantity']
-            elif base_line['rate']:
-                raw_gross_total_excluded = base_line['price_unit'] * base_line['quantity'] / base_line['rate']
-            else:
-                raw_gross_total_excluded = 0.0
-            if account_discount_base_lines:
-                raw_gross_total_excluded -= sum(
-                    discount_base_line['tax_details'][raw_field]
-                    for discount_base_line in base_line.get('discount_base_lines', [])
-                )
-            tax_details[f'raw_gross_total_excluded{suffix}'] = float_round(raw_gross_total_excluded, precision_digits=precision_digits)
+            raw_gross_total_excluded = self._get_gross_total_without_tax(
+                base_line=base_line,
+                company=company,
+                in_foreign_currency=in_foreign_currency,
+                account_discount_base_lines=account_discount_base_lines,
+                precision_digits=precision_digits,
+            )
+            tax_details[f'raw_gross_total_excluded{suffix}'] = raw_gross_total_excluded
 
             # Same as before but per unit.
-            if float_is_zero(raw_gross_total_excluded, precision_digits=precision_digits):
-                raw_gross_price_unit = base_line['price_unit']
-                if not suffix:
-                    if base_line['rate']:
-                        raw_gross_price_unit /= base_line['rate']
-                    else:
-                        raw_gross_price_unit = 0.0
-            elif not base_line['quantity']:
-                raw_gross_price_unit = raw_gross_total_excluded
-            else:
-                raw_gross_price_unit = raw_gross_total_excluded / base_line['quantity']
-            tax_details[f'raw_gross_price_unit{suffix}'] = float_round(raw_gross_price_unit, precision_digits=precision_digits)
+            raw_gross_price_unit = self._get_price_unit_without_tax(
+                base_line=base_line,
+                company=company,
+                raw_gross_total_excluded=raw_gross_total_excluded,
+                in_foreign_currency=in_foreign_currency,
+                precision_digits=precision_digits,
+            )
+            tax_details[f'raw_gross_price_unit{suffix}'] = raw_gross_price_unit
 
             # Compute the amount of the discount due to the 'discount' value set on 'base_line'.
-            raw_discount_amount = raw_gross_total_excluded - raw_total_excluded
-            tax_details[f'raw_discount_amount{suffix}'] = float_round(raw_discount_amount, precision_digits=precision_digits)
+            raw_discount_amount = self._get_discount_amount_without_tax(
+                base_line=base_line,
+                company=company,
+                raw_gross_total_excluded=raw_gross_total_excluded,
+                in_foreign_currency=in_foreign_currency,
+                precision_digits=precision_digits,
+            )
+            tax_details[f'raw_discount_amount{suffix}'] = raw_discount_amount
 
         # Tolerance.
         if not apply_strict_tolerance:

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from markupsafe import Markup
 
 from odoo import _, api, models
@@ -7,7 +8,6 @@ from odoo.tools import float_compare, float_is_zero, float_repr, format_list
 from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang, html_escape
 from odoo.tools.xml_utils import find_xml_value
-from datetime import datetime
 
 # -------------------------------------------------------------------------
 # UNIT OF MEASURE
@@ -148,39 +148,40 @@ class FloatFmt(float):
     """ A float with a given precision.
     The precision is used when formatting the float.
     """
-    def __new__(cls, value, min_dp=2, max_dp=None):
+    def __new__(cls, value, min_dp=None, max_dp=None):
         return super().__new__(cls, value)
 
-    def __init__(self, value, min_dp=2, max_dp=None):
+    def __init__(self, value, min_dp=None, max_dp=None):
+        if min_dp is None and max_dp is None:
+            self.min_dp = 2
+            self.max_dp = 2
+            return
+        if min_dp is None and max_dp is not None:
+            self.min_dp = self.max_dp = max_dp
+            return
+        if min_dp is not None and max_dp is None:
+            # Determine the most suitable max_dp.
+            # We want 180.74999999999997 to compute a max_dp of 2 but 0.01110515963896 to stay with the full number of decimals.
+            max_dp = max(len(str(float(value or 0.0)).split('.')[1]), min_dp)
+            while True:
+                if max_dp == min_dp:
+                    break
+                if not float_is_zero(round(value, max_dp - 1) - value, precision_digits=11):
+                    break
+                max_dp = max_dp - 1
+
         self.min_dp = min_dp
         self.max_dp = max_dp
 
     def __str__(self):
-        if not isinstance(self.min_dp, int) or (self.max_dp is not None and not isinstance(self.max_dp, int)):
-            return "<FloatFmt()>"
         self_float = float(self)
-        min_dp_int = int(self.min_dp)
-        if self.max_dp is None:
-            return float_repr(self_float, min_dp_int)
-        else:
-            # Format the float to between self.min_dp and self.max_dp decimal places.
-            # We start by formatting to self.max_dp, and then remove trailing zeros,
-            # but always keep at least self.min_dp decimal places.
-            max_dp_int = int(self.max_dp)
-            amount_max_dp = float_repr(self_float, max_dp_int)
-            num_trailing_zeros = len(amount_max_dp) - len(amount_max_dp.rstrip('0'))
-            return float_repr(self_float, max(max_dp_int - num_trailing_zeros, min_dp_int))
+        amount_str = float_repr(self_float, self.max_dp)
+        num_trailing_zeros = len(amount_str) - len(amount_str.rstrip('0'))
+        return float_repr(self_float, max(self.max_dp - num_trailing_zeros, self.min_dp))
 
     def __repr__(self):
-        if not isinstance(self.min_dp, int) or (self.max_dp is not None and not isinstance(self.max_dp, int)):
-            return "<FloatFmt()>"
         self_float = float(self)
-        min_dp_int = int(self.min_dp)
-        if self.max_dp is None:
-            return f"FloatFmt({self_float!r}, {min_dp_int!r})"
-        else:
-            max_dp_int = int(self.max_dp)
-            return f"FloatFmt({self_float!r}, {min_dp_int!r}, {max_dp_int!r})"
+        return f"FloatFmt({self_float!r}, {self.min_dp!r}, {self.max_dp!r})"
 
 
 class AccountEdiCommon(models.AbstractModel):

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -1017,12 +1017,23 @@ class AccountEdiUBL(models.AbstractModel):
     def _ubl_add_line_price_node(self, vals, in_foreign_currency=True):
         line_node = vals['line_node']
         base_line = vals['line_vals']['base_line']
-        suffix = '_currency' if in_foreign_currency else ''
         currency = base_line['currency_id'] if in_foreign_currency else vals['company_currency']
+
+        raw_gross_total_excluded = self.env['account.tax']._get_gross_total_without_tax(
+            base_line=base_line,
+            company=vals['company'],
+            in_foreign_currency=in_foreign_currency,
+        )
+        raw_gross_price_unit = self.env['account.tax']._get_price_unit_without_tax(
+            base_line=base_line,
+            company=vals['company'],
+            raw_gross_total_excluded=raw_gross_total_excluded,
+            in_foreign_currency=in_foreign_currency,
+        )
 
         line_node['cac:Price'] = {
             'cbc:PriceAmount': {
-                '_text': FloatFmt(base_line['tax_details'][f'raw_gross_price_unit{suffix}'], min_dp=1, max_dp=6),
+                '_text': FloatFmt(raw_gross_price_unit, min_dp=1),
                 'currencyID': currency.name,
             },
         }
@@ -1215,7 +1226,7 @@ class AccountEdiUBL(models.AbstractModel):
             gross_total_excluded += sign * allowance_charge_node['cbc:Amount']['_text']
 
         line_node['cbc:LineExtensionAmount'] = {
-            '_text': FloatFmt(gross_total_excluded, min_dp=currency.decimal_places),
+            '_text': FloatFmt(gross_total_excluded, max_dp=currency.decimal_places),
             'currencyID': currency.name,
         }
 
@@ -1680,11 +1691,11 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             '_currency': currency,
             'cbc:TaxableAmount': {
-                '_text': FloatFmt(tax_subtotal['base_amount'], min_dp=currency.decimal_places),
+                '_text': FloatFmt(tax_subtotal['base_amount'], max_dp=currency.decimal_places),
                 'currencyID': currency.name
             },
             'cbc:TaxAmount': {
-                '_text': FloatFmt(tax_subtotal['tax_amount'], min_dp=currency.decimal_places),
+                '_text': FloatFmt(tax_subtotal['tax_amount'], max_dp=currency.decimal_places),
                 'currencyID': currency.name
             },
             'cac:TaxCategory': [
@@ -1706,7 +1717,7 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             '_currency': currency,
             'cbc:TaxAmount': {
-                '_text': FloatFmt(tax_total['amount'], min_dp=currency.decimal_places),
+                '_text': FloatFmt(tax_total['amount'], max_dp=currency.decimal_places),
                 'currencyID': currency.name
             },
             'cac:TaxSubtotal': [
@@ -1883,7 +1894,7 @@ class AccountEdiUBL(models.AbstractModel):
             for line_node in vals['document_node'].get(line_key, [])
         )
         vals['legal_monetary_total_node']['cbc:LineExtensionAmount'] = {
-            '_text': FloatFmt(line_extension_amount, min_dp=currency.decimal_places),
+            '_text': FloatFmt(line_extension_amount, max_dp=currency.decimal_places),
             'currencyID': currency.name,
         }
 
@@ -1892,7 +1903,7 @@ class AccountEdiUBL(models.AbstractModel):
         node = vals['legal_monetary_total_node']
 
         node['cbc:TaxExclusiveAmount'] = {
-            '_text': FloatFmt(node['cbc:LineExtensionAmount']['_text'], min_dp=currency.decimal_places),
+            '_text': FloatFmt(node['cbc:LineExtensionAmount']['_text'], max_dp=currency.decimal_places),
             'currencyID': currency.name,
         }
 
@@ -1914,7 +1925,7 @@ class AccountEdiUBL(models.AbstractModel):
         node['cbc:TaxInclusiveAmount'] = {
             '_text': FloatFmt(
                 node['cbc:TaxExclusiveAmount']['_text'] + tax_amount,
-                min_dp=currency.decimal_places,
+                max_dp=currency.decimal_places,
             ),
             'currencyID': currency.name,
         }
@@ -1936,11 +1947,11 @@ class AccountEdiUBL(models.AbstractModel):
 
         node.update({
             'cbc:AllowanceTotalAmount': {
-                '_text': FloatFmt(total_allowance, min_dp=currency.decimal_places),
+                '_text': FloatFmt(total_allowance, max_dp=currency.decimal_places),
                 'currencyID': currency.name,
             } if total_allowance else None,
             'cbc:ChargeTotalAmount': {
-                '_text': FloatFmt(total_charge, min_dp=currency.decimal_places),
+                '_text': FloatFmt(total_charge, max_dp=currency.decimal_places),
                 'currencyID': currency.name,
             } if total_charge else None,
         })
@@ -1951,14 +1962,14 @@ class AccountEdiUBL(models.AbstractModel):
 
         payable_rounding_amount = (node['cbc:PayableRoundingAmount'] or {}).get('_text') or 0.0
         node['cbc:PrepaidAmount'] = {
-            '_text': FloatFmt(0.0, min_dp=currency.decimal_places),
+            '_text': FloatFmt(0.0, max_dp=currency.decimal_places),
             'currencyID': currency.name,
         }
         node['cbc:PayableAmount'] = {
             '_text': FloatFmt(
                 node['cbc:TaxInclusiveAmount']['_text']
                 + payable_rounding_amount,
-                min_dp=currency.decimal_places,
+                max_dp=currency.decimal_places,
             ),
             'currencyID': currency.name,
         }
@@ -1992,7 +2003,7 @@ class AccountEdiUBL(models.AbstractModel):
             }
         else:
             node['cbc:PayableRoundingAmount'] = {
-                '_text': FloatFmt(payable_rounding_amount, min_dp=currency.decimal_places),
+                '_text': FloatFmt(payable_rounding_amount, max_dp=currency.decimal_places),
                 'currencyID': currency.name,
             }
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -772,7 +772,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
         node['cbc:PayableAmount']['_text'] = FloatFmt(
             amount_residual,
-            min_dp=currency.decimal_places,
+            max_dp=currency.decimal_places,
         )
         node['cbc:PrepaidAmount']['_text'] = FloatFmt(
             amount_total
@@ -783,7 +783,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             # The super will compute a PrepaidAmount or 0.0 and a PayableAmount or 1000.
             # This extension is there to increase PrepaidAmount to 210 and PayableAmount to 1210.
             + vals['_ubl_values']['tax_withholding_amount'],
-            min_dp=currency.decimal_places,
+            max_dp=currency.decimal_places,
         )
 
     def _add_invoice_monetary_total_nodes(self, document_node, vals):
@@ -1582,7 +1582,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         ]
         if corresponding_line_node_amounts:
             node['cbc:TaxableAmount'] = {
-                '_text': FloatFmt(sum(corresponding_line_node_amounts), min_dp=currency.decimal_places),
+                '_text': FloatFmt(sum(corresponding_line_node_amounts), max_dp=currency.decimal_places),
                 'currencyID': currency.name,
             }
 

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_PEPPOL_EN16931_R120_line_extension_amount_huge_number_of_decimals.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_PEPPOL_EN16931_R120_line_extension_amount_huge_number_of_decimals.xml
@@ -104,21 +104,10 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">12.58</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">649.16</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">0.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
-			<cac:TaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>6.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:TaxCategory>
-		</cac:TaxSubtotal>
-		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">59.92</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">12.58</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">3091.26</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">649.16</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -129,37 +118,18 @@
 		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">59.92</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">59.92</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">72.50</cbc:TaxInclusiveAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">3091.26</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">3091.26</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">3740.42</cbc:TaxInclusiveAmount>
 		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="EUR">72.50</cbc:PayableAmount>
+		<cbc:PayableAmount currencyID="EUR">3740.42</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">20.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+		<cbc:InvoicedQuantity unitCode="C62">278362.5</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">3091.26</cbc:LineExtensionAmount>
 		<cac:Item>
-			<cbc:Description>Miel des Cabanes - 250gr</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>6.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.0</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">50.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">59.92</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Conditionnement spécial - pots de 50gr</cbc:Description>
+			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
@@ -170,7 +140,7 @@
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">1.1983471</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">0.01110515964</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -104,6 +104,22 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_CO_10_line_extension_amount_sum_lines')
 
+    def test_invoice_PEPPOL_EN16931_R120_line_extension_amount_huge_number_of_decimals(self):
+        """ [PEPPOL-EN16931-R120]-Invoice line net amount MUST equal (Invoiced quantity * (Item net price/item price base quantity)
+        + Sum of invoice line charge amount - sum of invoice line allowance amount
+        """
+        tax_21 = self.percent_tax(21.0)
+        product = self._create_product(lst_price=0.01110515963896, taxes_id=tax_21)
+        invoice = self._create_invoice_one_line(
+            product_id=product,
+            quantity=278362.5,
+            partner_id=self.partner_be,
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_PEPPOL_EN16931_R120_line_extension_amount_huge_number_of_decimals')
+
     def test_invoice_price_amount_rounding_precision_with_price_included_taxes(self):
         tax_21 = self.percent_tax(21.0, price_include_override='tax_included')
         product = self._create_product(lst_price=1039.99, taxes_id=tax_21)


### PR DESCRIPTION
**PROBLEM**
Previously, we rounded the unit price up to 6 digits in the generated xml for peppol. However, odoo compute the lineExtensionAmount with the raw unit price. The generated xml is invalid because `priceAmount*InvoicedQuantity != LineExtensionAmount`.

**STEP TO REPRODUCE**
1. Create an invoice with unit price of 0.01110515964, and quantity of 278362.5.
2. Generate an XML with peppol, and try validating the invoice. You should have the following error:
`[PEPPOL-EN16931-R120]-Invoice line net amount MUST equal (Invoiced quantity * (Item net price/item price base quantity) + Sum of invoice line charge amount - sum of invoice line allowance amount`

opw-6009771