### PR TITLE
[FIX] account_edi_ubl_cii: Allow only invoices can be grouped

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -59,6 +59,9 @@ class AccountMove(models.Model):
         Group lines by tax, based on the invoice lines
         """
         self.ensure_one()
+        if not self.is_invoice(include_receipts=True):
+            raise UserError(_("You can only group lines of an invoice"))
+
         line_vals = self._get_line_vals_group_by_tax(self.partner_id, fields.Date.to_string(self.date))
         self.invoice_line_ids = [Command.clear()]
         self.invoice_line_ids = line_vals


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: Allow only invoices can be grouped

Before this commit, no check was done on the document type at line grouping. This commit adds the check `is_invoice` so that we cannot group (e.g.) a journal entry type move

no-task
