### PR TITLE
[FIX] pos_sale: skip line_subsection in settleSO

### DIFF
--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -133,7 +133,7 @@ patch(PosStore.prototype, {
                     },
                 ]),
             };
-            if (line.display_type === "line_section") {
+            if (["line_section", "line_subsection"].includes(line.display_type)) {
                 continue;
             }
             newLineValues.attribute_value_ids = (line.product_custom_attribute_value_ids || []).map(


### PR DESCRIPTION
`line_subsection` lines have no product, so calling `addLineToCurrentOrder` on them raised a TypeError trying to read `taxes_id` of undefined. Skip them early, the same way `line_section` is handled.

opw-5949585

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
