### PR TITLE
[FIX] test_discuss_full: invalidate im_status cache for operator test

### DIFF
--- a/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
+++ b/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
@@ -28,6 +28,8 @@ class TestLivechatHrHolidays(MailCommon):
                 "state": "validate",
             }
         )
+        # necessary due to missing dependecies in im_status compute overrides
+        cls.user_employee.invalidate_recordset(["im_status"])
 
     def test_operator_available_on_leave(self):
         """Test operator is available on leave when they are online."""


### PR DESCRIPTION
 After sending a presence notification, `_send_status_updated_notification` leaves `im_status` cached on the user/guest record.
If a related model that affects `im_status` (such as `hr.leave`) is modified afterwards in the same transaction, the ORM has no declared dependency on it and will not invalidate the cache.
Subsequent reads then return the stale value.

breaking PR: https://github.com/odoo/odoo/pull/249314

runbot-242076