### PR TITLE
[FIX] point_of_sale: prevent redundant company info on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -135,7 +135,7 @@
                     <div>
                         <div t-if="company.vat" t-out="vatText"/>
                         <div t-if="company.phone">
-                            Tel: <t t-out="company.phone"/>
+                            Tel: <span dir="ltr"><t t-out="company.phone"/></span>
                         </div>
                         <div t-if="company.email" t-out="company.email"/>
                         <div t-if="company.website" t-out="company.website"/>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -12,16 +12,6 @@
         </div>
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
-                <!-- contact address -->
-                <div t-if="order.company?.name" t-esc="order.company.name" />
-                <t t-if="order.company.phone">
-                    <div>Tel:<span dir="ltr"><t t-esc="order.company.phone" /></span></div>
-                </t>
-                <t t-if="order.company.vat">
-                    <div t-esc="vatText"/>
-                </t>
-                <div t-if="order.company.email" t-esc="order.company.email" />
-                <div t-if="order.company.website" t-esc="order.company.website" />
                 <div t-if="order.config.receipt_header" style="white-space:pre-line" t-esc="order.config.receipt_header" />
                 <div t-if="order?.getCashierName()" class="cashier">
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>


### PR DESCRIPTION
Before this commit, the receipt was showing the company information twice. It happened after the commit https://github.com/odoo/odoo/commit/dca40d16481ba504d608cc65d82e7821e01c5932.

opw-6053013

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
