### PR TITLE
[FIX] website: fix `test_29`

### DIFF
--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -528,7 +528,8 @@ class TestUi(HttpCaseWithWebsiteUser):
             'parent_id': menu_root.id,
             'action': 'ir.actions.act_window,%d' % (self.env.ref('base.open_module_tree').id,),
         })
-        self.env.ref('base.user_admin').action_id = self.env.ref('base.menu_administration').id
+        self.env.ref('base.user_admin').action_id = self.env['ir.actions.actions'].search([('name', '=', 'Settings')], limit=1)
+        self.assertTrue(self.env.ref('base.user_admin').action_id, 'The user should have an action (or the test/tour will not test anything).')
         self.assertFalse(menu_root.action, 'The top menu should not have an action (or the test/tour will not test anything).')
         self.start_tour('/', 'website_backend_menus_redirect', login='admin')
 


### PR DESCRIPTION
After the merge of [1], the test `TestUi.test_29_website_backend_menus_redirect` started
consistently failing.

**Problem**

The test contained an incorrect line that used the ID of an `ir.ui.menu` record as if it
were the ID of an `ir.actions.actions` record. Before [1], this did not raise any error
because, by coincidence, an `ir.actions.actions` record with the same ID already existed,
so the issue went unnoticed.

After [1], the way `ir.ui.menu` IDs are assigned changed, causing the test to fail.

The failure only occurs when the test is executed together with other tests that consume
`ir.actions.actions` IDs in such a way that, when test_29 is executed, the `ir.ui.menu`
ID does not correspond to any `ir.actions.actions` ID because such ID has already been
consumed during testing.

For example, the test does not fail locally if executed alone, but if fails if executed
with the test tag `:TestServerActions,.test_29_website_backend_menus_redirect` (only the
`website` module is required to reproduce).

**Fix**

The incorrect assignment between `ir.actions.action` and `ir.ui.menu` is replaced with a
correct one that maintains the original purpose of the test.

[1]:https://github.com/odoo/odoo/pull/248661

runbot-242044
