### PR TITLE
[FIX] delivery, website_sale: bypass express checkout state match

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -66,7 +66,8 @@ class DeliveryCarrier(models.Model):
     )
 
     country_ids = fields.Many2many('res.country', 'delivery_carrier_country_rel', 'carrier_id', 'country_id', 'Countries')
-    state_ids = fields.Many2many('res.country.state', 'delivery_carrier_state_rel', 'carrier_id', 'state_id', 'States')
+    state_ids = fields.Many2many('res.country.state', 'delivery_carrier_state_rel', 'carrier_id', 'state_id', 'States',
+        help="States that this carrier applies to. Note that in some countries, state filtering won't work when using express checkout.")
     zip_prefix_ids = fields.Many2many(
         'delivery.zip.prefix', 'delivery_zip_prefix_rel', 'carrier_id', 'zip_prefix_id', 'Zip Prefixes',
         help="Prefixes of zip codes that this carrier applies to. Note that regular expressions can be used to support countries with varying zip code lengths, i.e. '$' can be added to end of prefix to match the exact zip (e.g. '100$' will only match '100' and not '1000')")
@@ -193,7 +194,8 @@ class DeliveryCarrier(models.Model):
         self.ensure_one()
         if self.country_ids and partner.country_id not in self.country_ids:
             return False
-        if self.state_ids and partner.state_id not in self.state_ids:
+        if ((not self.env.context.get('is_express_checkout_flow') or partner.state_id) and
+            self.state_ids and partner.state_id not in self.state_ids):
             return False
         if self.zip_prefix_ids:
             regex = re.compile('|'.join(['^' + zip_prefix for zip_prefix in self.zip_prefix_ids.mapped('name')]))

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -236,7 +236,7 @@ class Delivery(WebsiteSale):
                  value.
         """
         res = {}
-        for dm in order_sudo._get_delivery_methods():
+        for dm in order_sudo.with_context(is_express_checkout_flow=True)._get_delivery_methods():
             rate = Delivery._get_rate(dm, order_sudo, is_express_checkout_flow=True)
             if rate['success']:
                 fname = f'{dm.delivery_type}_use_locations'


### PR DESCRIPTION
Issue:
---
Using express checkout, delivery state filter doesn't work in all countries.

Steps to reproduce:
1- Setup stripe apple/google express checkout.
2- In standard delivery, filter `county/states` to `BE/Wallonia`.
3- Using a phone, open cart and try express checkout.
4- Add an address in Wallonia.

Outcome: You will see and invalid address error.

Cause:
---
In the apple/google express checkout, the state field is not provided in all countries. The flow works correctly in USA, which the state is provided as `region`:
https://github.com/odoo/odoo/blob/b7f13d70cb49f767082f36ba409cfc609c5349a7/addons/payment_stripe/static/src/interactions/express_checkout.js#L172-L176

However, this doesn't work in counries such as Belgium and UAE as the state is not provided as region. As a result the `_match_address` would never match.

Fix:
---
We could change the behavior so in express checkout, if the state is not provided in the address, we always match the state. A helper would let the clients knows of this limitation on express checkout.

opw-6040166
