### PR TITLE
[FIX] snailmail: fix access error when accessing IAP account company

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -230,7 +230,7 @@ class SnailmailLetter(models.Model):
             }
         }
         """
-        account_token = self.env['iap.account'].get('snailmail').sudo().account_token
+        account_token = self.env['iap.account'].sudo().get('snailmail').account_token
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
         documents = []
 


### PR DESCRIPTION
Issue:
Before this commit, when sending a follow up report by post, an access error is thrown if the user doesn't have enough access to read from res.company model

Fix:
Access the IAP account as sudo

opw-6050041