### PR TITLE
[FIX] stock_account: correct stock interim accounting for inter-company returns

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -781,9 +781,23 @@ class StockMove(models.Model):
     def _is_returned(self, valued_type):
         self.ensure_one()
         if valued_type == 'in':
-            return self.location_id and self.location_id.usage == 'customer'   # goods returned from customer
+            return self.location_id and (
+                self.location_id.usage == 'customer'
+                or (
+                    self.location_id.usage == 'transit'
+                    and self.origin_returned_move_id
+                    and not self.origin_returned_move_id._is_returned('out')
+                )
+            )  # goods returned from customer or inter-company return
         if valued_type == 'out':
-            return self.location_dest_id and self.location_dest_id.usage == 'supplier'   # goods returned to supplier
+            return self.location_dest_id and (
+                self.location_dest_id.usage == 'supplier'
+                or (
+                    self.location_dest_id.usage == 'transit'
+                    and self.origin_returned_move_id
+                    and not self.origin_returned_move_id._is_returned('in')
+                )
+            )  # goods returned to supplier or inter-company return
 
     def _get_all_related_aml(self):
         return self.account_move_ids.line_ids

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -474,3 +474,105 @@ class TestAccountMove(TestAccountMoveStockCommon):
                 'taxes_id': {'fields': {'name': {}}},
             }
             product.web_read(specification)
+
+    def test_return_inter_company_delivery(self):
+        stock_location = self.env['stock.warehouse'].search([
+            ('company_id', '=', self.env.company.id),
+        ], limit=1).lot_stock_id
+        transit_loc = self.env.ref('stock.stock_location_inter_company')
+
+        # Provide stock in the source location so returns and their reservations work correctly
+        self.env['stock.quant']._update_available_quantity(self.product_A, stock_location, 1.0)
+
+        delivery = self.env['stock.picking'].create({
+            'location_id': stock_location.id,
+            'location_dest_id': transit_loc.id,
+            'partner_id': self.branch_a['company'].partner_id.id,
+            'picking_type_id': stock_location.warehouse_id.out_type_id.id,
+            'move_ids': [Command.create({
+                'name': self.product_A.name,
+                'product_id': self.product_A.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_A.uom_id.id,
+                'location_id': stock_location.id,
+                'location_dest_id': transit_loc.id,
+            })]
+        })
+        delivery.action_confirm()
+        delivery.move_ids.quantity = 1
+        delivery.button_validate()
+        stock_output_lines = delivery.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_output_account)
+
+        self.assertTrue(stock_output_lines, "Inter-company delivery was not accounted to output account")
+
+        return_wizard = self.env['stock.return.picking'].with_context(active_id=delivery.id, active_model='stock.picking').create({})
+        res = return_wizard.action_create_returns_all()
+        return_picking = self.env['stock.picking'].browse(res['res_id'])
+        return_picking.button_validate()
+        return_stock_output_lines = return_picking.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_output_account)
+
+        self.assertTrue(return_stock_output_lines, "Inter-company delivery return was not accounted to output account")
+        self.assertEqual(
+            stock_output_lines.full_reconcile_id,
+            return_stock_output_lines.full_reconcile_id,
+            "Inter-company delivery return accounting was not reconciled against the original delivery",
+        )
+
+        return_return_wizard = self.env['stock.return.picking'].with_context(active_id=return_picking.id, active_model='stock.picking').create({})
+        res = return_return_wizard.action_create_returns_all()
+        return_return_picking = self.env['stock.picking'].browse(res['res_id'])
+        return_return_picking.button_validate()
+        return_return_stock_output_lines = return_return_picking.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_output_account)
+
+        self.assertTrue(return_return_stock_output_lines, "Inter-company delivery return return (a delivery) was not accounted to the output account")
+
+    def test_return_inter_company_receipt(self):
+        stock_location = self.env['stock.warehouse'].search([
+            ('company_id', '=', self.env.company.id),
+        ], limit=1).lot_stock_id
+        transit_loc = self.env.ref('stock.stock_location_inter_company')
+
+        # Provide stock in the source location so returns and their reservations work correctly
+        self.env['stock.quant']._update_available_quantity(self.product_A, transit_loc, 1.0)
+
+        receipt = self.env['stock.picking'].create({
+            'location_id': transit_loc.id,
+            'location_dest_id': stock_location.id,
+            'partner_id': self.branch_a['company'].partner_id.id,
+            'picking_type_id': stock_location.warehouse_id.in_type_id.id,
+            'move_ids': [Command.create({
+                'name': self.product_A.name,
+                'product_id': self.product_A.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_A.uom_id.id,
+                'location_id': transit_loc.id,
+                'location_dest_id': stock_location.id,
+            })]
+        })
+        receipt.action_confirm()
+        receipt.move_ids.quantity = 1
+        receipt.button_validate()
+        stock_input_lines = receipt.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_input_account)
+
+        self.assertTrue(stock_input_lines, "Inter-company receipt was not accounted to input account")
+
+        return_wizard = self.env['stock.return.picking'].with_context(active_id=receipt.id, active_model='stock.picking').create({})
+        res = return_wizard.action_create_returns_all()
+        return_picking = self.env['stock.picking'].browse(res["res_id"])
+        return_picking.button_validate()
+        return_stock_input_lines = return_picking.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_input_account)
+
+        self.assertTrue(return_stock_input_lines, "Inter-company receipt return was not accounted to input account")
+        self.assertEqual(
+            stock_input_lines.full_reconcile_id,
+            return_stock_input_lines.full_reconcile_id,
+            "Inter-company receipt return accounting was not reconciled against the original receipt",
+        )
+
+        return_return_wizard = self.env['stock.return.picking'].with_context(active_id=return_picking.id, active_model='stock.picking').create({})
+        res = return_return_wizard.action_create_returns_all()
+        return_return_picking = self.env['stock.picking'].browse(res['res_id'])
+        return_return_picking.button_validate()
+        return_return_stock_input_lines = return_return_picking.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.account_id == self.stock_input_account)
+
+        self.assertTrue(return_return_stock_input_lines, "Inter-company receipt return return (a receipt) was not accounted to the input account")


### PR DESCRIPTION
### Problem:
When returning a delivery or receipt for an inter-company transaction, the journal entry created for the return will account on the opposite stock interim account. That is, a delivery to another company will debit the stock output account, but returning the delivery will create an account move that credits the stock input account. Compare this to normal return behavior which will credit the stock output account to reverse the original delivery's entry.

### Solution:
When deciding whether a stock move is a return, we will include transit locations as valid locations.

### Steps to reproduce (Runbot v18)
- Automatic accounting
1. Create a SO for the automatically accounted product, selling to another company in the system
2. Validate the delivery, check the valuation and note there is a debit on the stock output account
3. Create a return for the delivery and validate it, check the valuation and note the credit on the stock input account

To clarify, this differs from when the customer on the SO is anything other than a res.company, where we will see a credit on the stock output account when the return is validated.
Also, this flow is the same for POs, and the same bug is addressed by this fix.

### Before
<table>
	<th>Move type</th>
	<th>Account</th>
	<th>Debit</th>
	<th>Credit</th>
	<tr>
		<td>Delivery</td>
		<td>Stock output</td>
		<td>100</td>
		<td>0</td>
	</tr>
	<tr>
		<td>Delivery Return</td>
		<td style="{color: red}">Stock input</td>
		<td>0</td>
		<td>100</td>
	</tr>
</table>

### After
(Or normal behavior without inter-company transfer)
<table>
	<th>Move type</th>
	<th>Account</th>
	<th>Debit</th>
	<th>Credit</th>
	<tr>
		<td>Delivery</td>
		<td>Stock output</td>
		<td>100</td>
		<td>0</td>
	</tr>
	<tr>
		<td>Delivery Return</td>
		<td>Stock output</td>
		<td>0</td>
		<td>100</td>
	</tr>
</table>

opw-5993147
