### PR TITLE
[FIX] hr_attendance: filter out approved/refused entries

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -317,6 +317,7 @@ class HrAttendance(models.Model):
         overtime_vals_list = []
         for ruleset_sudo, ruleset_attendances in attendances_by_ruleset.items():
             attendances_dates = list(chain(*ruleset_attendances._get_dates().values()))
+            ruleset_attendances = ruleset_attendances.filtered_domain([('overtime_status', 'not in', ['approved', 'refused'])])
             overtime_vals_list.extend([
                 {
                     **val,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Issue: If you create an overtime request to be approved and then approve it and create another one within the same week, the already-approved entry will request approval again. Same thing with if it's refused.

Solution: We filter out ruleset_attendances in 'approved' or 'refused' states so that they will not be added into overtime_vals_list.

Current behavior before PR: When a new attendance is created, the system triggers a full weekly recalculation that deletes all existing overtime records. Because the "Approved" or "Refused" status is not preserved during this process, the system recreates these entries with a default "To Approve" status. This forces managers to repeatedly re-approve the same hours every time an employee logs a new shift.

Desired behavior after PR is merged: The system should respect finalized manager decisions during weekly recalculations. By filtering out attendances that are already in an "Approved" or "Refused" state, the generator will skip those days and prevent the creation of redundant approval requests. This ensures that a manager only has to process a specific overtime entry once.

opw-6054497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
