### PR TITLE
[IMP] l10n_ca: set the appropriate domestic_fiscal_position_id

### DIFF
--- a/addons/l10n_ca/models/res_company.py
+++ b/addons/l10n_ca/models/res_company.py
@@ -6,6 +6,22 @@ class ResCompany(models.Model):
 
     l10n_ca_pst = fields.Char(related='partner_id.l10n_ca_pst', string='PST Number', store=False, readonly=False)
 
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get('state_id'):
+            self._update_l10n_ca_fiscal_position()
+        return res
+
+    def _update_l10n_ca_fiscal_position(self):
+        """ Put the local fiscal position first, so that domestic_fiscal_position_id is set right. """
+        for company in self.filtered(lambda c: c.root_id.chart_template == 'ca_2023'):
+            local_fp = self.env['account.fiscal.position'].with_company(company).search([('state_ids', 'in', company.state_id.id)], limit=1)
+            if not local_fp:
+                continue
+
+            ca_fps = company.fiscal_position_ids.filtered(lambda fp: fp.country_id.code == 'CA')
+            local_fp.sequence = min(ca_fps.mapped('sequence')) - 1
+
 
 class BaseDocumentLayout(models.TransientModel):
     _inherit = 'base.document.layout'

--- a/addons/l10n_ca/models/template_ca.py
+++ b/addons/l10n_ca/models/template_ca.py
@@ -55,6 +55,14 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
+    @template('ca_2023', 'account.fiscal.position')
+    def _get_ca_account_fiscal_position(self):
+        """ Ensure the appropriate domestic_fiscal_position_id gets set. """
+        code = (self.env.company.state_id.code or '').lower()
+        if code in ('ab', 'bc', 'mb', 'nb', 'nl', 'ns', 'nt', 'nu', 'on', 'pe', 'qc', 'sk', 'yt'):
+            return {f'fiscal_position_template_{code}': {'sequence': 1}}
+        return {}
+
     def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
         accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
         if company.account_fiscal_country_id.code == 'CA':

--- a/addons/l10n_ca/tests/__init__.py
+++ b/addons/l10n_ca/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_fiscal_position

--- a/addons/l10n_ca/tests/test_fiscal_position.py
+++ b/addons/l10n_ca/tests/test_fiscal_position.py
@@ -1,0 +1,21 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestFiscalPosition(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('ca')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.company_data['company']
+
+    def test_domestic_fiscal_position_updates_on_state_change(self):
+        ChartTemplate = self.env['account.chart.template'].with_company(self.company)
+
+        self.company.state_id = self.env.ref('base.state_ca_on')
+        self.assertEqual(self.company.domestic_fiscal_position_id, ChartTemplate.ref('fiscal_position_template_on'))
+
+        self.company.state_id = self.env.ref('base.state_ca_qc')
+        self.assertEqual(self.company.domestic_fiscal_position_id, ChartTemplate.ref('fiscal_position_template_qc'))


### PR DESCRIPTION
Currently it's always the Alberta one for Canada. Inspired by the approach for AE [1].

On top of setting it during the loading of the chart template, we also move the local fiscal position first when the state of the company changes (sort of similar to l10n_in, although less complex). Companies don't typically move between states, but when a new database is created, the state field will be empty and is set manually by the user afterward.

[1] https://github.com/odoo/odoo/pull/230708

task-5467315