### PR TITLE
feat: claude-agents als Submodul einbinden (Commands + Skills)

### DIFF
--- a/.claude/agents/claude-md-learner.md
+++ b/.claude/agents/claude-md-learner.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/claude-md-learner.md

--- a/.claude/agents/doc-watcher.md
+++ b/.claude/agents/doc-watcher.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/doc-watcher.md

--- a/.claude/agents/live-auditor.md
+++ b/.claude/agents/live-auditor.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/live-auditor.md

--- a/.claude/agents/odoo-reviewer.md
+++ b/.claude/agents/odoo-reviewer.md
@@ -1,0 +1,1 @@
+../../.claude-agents/odoo/agents/odoo-reviewer.md

--- a/.claude/agents/parallel-fixer.md
+++ b/.claude/agents/parallel-fixer.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/parallel-fixer.md

--- a/.claude/agents/repo-auditor.md
+++ b/.claude/agents/repo-auditor.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/repo-auditor.md

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/security-reviewer.md

--- a/.claude/agents/skills-extractor.md
+++ b/.claude/agents/skills-extractor.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/skills-extractor.md

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/agents/test-runner.md

--- a/.claude/commands/create-skills.md
+++ b/.claude/commands/create-skills.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/create-skills.md

--- a/.claude/commands/doc-sync.md
+++ b/.claude/commands/doc-sync.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/doc-sync.md

--- a/.claude/commands/extract-skills.md
+++ b/.claude/commands/extract-skills.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/extract-skills.md

--- a/.claude/commands/fix-parallel.md
+++ b/.claude/commands/fix-parallel.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/fix-parallel.md

--- a/.claude/commands/full-audit.md
+++ b/.claude/commands/full-audit.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/full-audit.md

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/learn.md

--- a/.claude/commands/live-audit.md
+++ b/.claude/commands/live-audit.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/live-audit.md

--- a/.claude/commands/odoo-audit.md
+++ b/.claude/commands/odoo-audit.md
@@ -1,0 +1,1 @@
+../../.claude-agents/odoo/commands/odoo-audit.md

--- a/.claude/commands/repo-audit.md
+++ b/.claude/commands/repo-audit.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/repo-audit.md

--- a/.claude/commands/request-review.md
+++ b/.claude/commands/request-review.md
@@ -1,0 +1,1 @@
+../../.claude-agents/team/commands/request-review.md

--- a/.claude/commands/summarize-session.md
+++ b/.claude/commands/summarize-session.md
@@ -1,0 +1,1 @@
+../../.claude-agents/team/commands/summarize-session.md

--- a/.claude/commands/use-skill.md
+++ b/.claude/commands/use-skill.md
@@ -1,0 +1,1 @@
+../../.claude-agents/core/commands/use-skill.md

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.claude-agents/skills/.claude/skills

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".claude-agents"]
+	path = .claude-agents
+	url = https://github.com/BERNHARD-KRENN-R-D/claude-agents.git


### PR DESCRIPTION
## Zusammenfassung

- `.claude-agents/` Submodul eingebunden (claude-agents inkl. claude-skills)
- `.claude/commands/` — Symlinks zu allen Slash-Commands (/repo-audit, /live-audit, /use-skill, etc.)
- `.claude/agents/` — Symlinks zu allen Sub-Agenten
- `.claude/skills/` — Symlink zu 13 Skills (odoo/, security/, ubuntu/, macos/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)