### PR TITLE
[FIX] sale: ensure hide prices and composition work correctly for subsections

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -138,6 +138,7 @@
                         </t>
 
                         <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+                        <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
 
                         <t t-if="not line.collapse_composition">
                             <tr
@@ -145,7 +146,6 @@
                                 name="tr_section"
                                 t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                             >
-                                <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
                                 <t
                                     t-set="section_name_colspan"
                                     t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
@@ -267,6 +267,7 @@
                                 </td>
                                 <td name="td_section_group_priceunit" class="text-end text-nowrap">
                                     <span
+                                        t-if="show_section_total"
                                         name="price_subtotal_section_grouped"
                                         t-out="section_line['price_subtotal']"
                                         t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
@@ -290,6 +291,7 @@
                                 </td>
                                 <td name="td_section_group_total" class="text-end o_price_total">
                                     <span
+                                        t-if="show_section_total"
                                         t-out="section_line[price_field]"
                                         t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
                                     >

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -773,6 +773,7 @@
                                 </t>
 
                                 <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+                                <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
 
                                 <t t-if="not line.collapse_composition">
                                     <tr
@@ -780,7 +781,6 @@
                                         name="tr_section"
                                         t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                                     >
-                                        <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
                                         <t
                                             t-set="section_name_colspan"
                                             t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
@@ -948,6 +948,7 @@
                                         </td>
                                         <td name="td_section_group_priceunit" class="d-none d-sm-table-cell text-end text-nowrap">
                                             <span
+                                                t-if="show_section_total"
                                                 t-out="section_line['price_subtotal']"
                                                 t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
                                             />
@@ -964,6 +965,7 @@
                                         </td>
                                         <td name="td_section_group_total" class="text-end o_price_total">
                                             <span
+                                                t-if="show_section_total"
                                                 name="price_subtotal_section_grouped"
                                                 t-out="section_line[price_field]"
                                                 t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"


### PR DESCRIPTION
Steps to reproduce:
---
- Install `Sales` module.
- Create a Sale Order.
- Add a section with products.
- Add a subsection under it with products.
- Enable `Hide Prices` on the section.
- Enable `Hide Composition` on the subsection.
- Preview the Sale Order.

Issue:
---
- Prices are still visible in the subsection (grouped view) even though `Hide Prices` is enabled on the parent section.

Root cause:
---
- The variable `show_section_total` was defined only within the main rendering block and not reused in the grouped (`t-else`) block.
- The grouped section summary (used when `collapse_composition=True`) did not respect the parent section's `collapse_prices` setting, causing prices to be displayed.

Solution:
---
- Moved `show_section_total` definition outside the main conditional block so it can be reused in both rendering paths.
- Applied `t-if="show_section_total"` to price fields in the grouped section summary to ensure consistency with the parent section's price visibility.

Before:
---
<img width="1030" height="232" alt="image" src="https://github.com/user-attachments/assets/1ac05e5e-6841-420f-909f-994690656cc0" />

After:
---
<img width="1023" height="232" alt="image" src="https://github.com/user-attachments/assets/921ae337-4d53-433a-a42b-bdc437181889" />



opw-5979807
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
