### PR TITLE
[IMP] mail, various: cleanup of the attachment‑to‑link conversion improvement

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -218,7 +218,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         """Cloud attachments should be converted to links in outgoing emails."""
         def normalize_html(html):
             return re.sub(r'(?=<)', '\n',
-                          " ".join(line.strip() for line in html.strip().splitlines() if line.strip()))
+                          " ".join(line.strip() for line in html.strip().splitlines() if line.strip())
+                          ).replace('⬇', '&#11015;')
 
         thread_model = self.env["res.partner"].create({"name": "Cloud Test Partner", "email": "cloud@test.com"})
         cloud_attachment = self.env["ir.attachment"].create({
@@ -251,7 +252,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
             body = normalize_html(body)
-            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(attachment)))
+            large_attachment_link = normalize_html(str(
+                self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": attachment})))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -289,7 +291,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
             body = normalize_html(body)
-            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(cloud_attachment)))
+            large_attachment_link = normalize_html(str(
+                self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": cloud_attachment})))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import re
 import requests
 
 from datetime import datetime, timezone, timedelta
@@ -215,6 +216,9 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
 
     def test_cloud_storage_attachments(self):
         """Cloud attachments should be converted to links in outgoing emails."""
+        def normalize_html(html):
+            return re.sub(r'(?=<)', '\n',
+                          " ".join(line.strip() for line in html.strip().splitlines() if line.strip()))
 
         thread_model = self.env["res.partner"].create({"name": "Cloud Test Partner", "email": "cloud@test.com"})
         cloud_attachment = self.env["ir.attachment"].create({
@@ -246,7 +250,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         self.assertEqual(len(self._mails), 2, "Two emails should be sent.")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -283,7 +288,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
                 "Only text attachment should be sent in the message")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": cloud_attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(cloud_attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -321,13 +327,11 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         with self.mock_mail_gateway(mail_unlink_sent=False):
             composer._action_send_mail()
 
-        for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            cloud_attachment_present = body.count(cloud_attachment.access_token) == body.count(cloud_attachment.name) == 1
-            cloud_attachment2_present = body.count(cloud_attachment2.access_token) == body.count(cloud_attachment2.name) == 1
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": large_attachment}))
-            self.assertTrue(body.count(large_attachment_link) == 1 and cloud_attachment_present and cloud_attachment2_present,
-                "Two cloud and one large attachments should be converted and sent as links in the outgoing email.",
-            )
+        self.assertEqual(len(self._new_mails.attachment_ids), 3)
+        for body in [m["body"] for m in self._mails]:
+            self.assertIn(cloud_attachment.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(cloud_attachment2.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(large_attachment.access_token, body, "large attachment should be converted as link")
 
     def test_uninstall_fail(self):
         with self.assertRaises(UserError, msg="Don't uninstall the module if there are Azure attachments in use"):

--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -41,13 +41,17 @@
         </template>
 
         <template id="mail_attachment_links" name="Attachment links">
-<div style="max-width: 900px; width: 100%;">
-    <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 10px 0px;"/>
-    <div t-foreach="attachments" t-as="attachment">
-        <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
-           style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
-            &amp;#128229; <t t-out="attachment.name"/>
-        </a>
+<div class="o-attachments-container" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%;">
+    <div style="display: inline" t-foreach="attachments" t-as="attachment">
+        <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content" tattf-data-attachment-id="attachment.id">
+            <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+                <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
+                    style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%; color:#008f8c; vertical-align: middle; font-size: 15px;"
+                    width="100%" target="_blank">
+                     &amp;#11015; <t t-out="attachment.name"/>
+                </a>
+            </div>
+        </div>
     </div>
 </div>
         </template>

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -2,9 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
+import contextlib
 import datetime
 import json
 import logging
+import lxml
+import markupsafe
 import re
 import smtplib
 from collections import defaultdict
@@ -384,6 +387,96 @@ class MailMail(models.Model):
             body = re.sub(_UNFOLLOW_REGEX, '', body)
         return body
 
+    @api.model
+    def _render_attachments_links(self, attachments):
+        """ Temporary replacement for the mail.mail_attachment_links template in stable. """
+        rendered_attachments = [markupsafe.Markup("""
+            <div style="display: inline">
+                <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content" data-attachment-id="%(attachment_id)s">
+                    <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+                        <a href="%(attachment_base_url)s/web/content/%(attachment_id)s?download=1&amp;access_token=%(attachment_access_token)s"
+                            style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%%; color:#008f8c; vertical-align: middle; font-size: 15px;"
+                            width="100%%" target="_blank">
+                             &#11015; %(attachment_name)s
+                        </a>
+                    </div>
+                </div>
+            </div>
+            """) % {
+            'attachment_id': a.id,
+            'attachment_access_token': a.access_token,
+            'attachment_name': a.name,
+            'attachment_base_url': a.get_base_url(),
+        }
+                                for a in attachments]
+        return markupsafe.Markup(
+            """<div class="o-attachments-container" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%%;">
+                %(attachments)s
+            </div>""") % {'attachments': markupsafe.Markup('').join(rendered_attachments)}
+
+    @api.model
+    def _render_attachment_links_in_body(self, body, attachments, force=False, append=False):
+        """ Render the attachment container in the email body with download links when required.
+
+        :param str body: the original email body (HTML).
+        :param recordset attachments: attachments to render as links.
+        :param bool force: skip size estimation and always add links.
+        :param bool append: whether to replace existing links container or append just after it (if present).
+        :return: the modified body with the inserted download links
+            or False if the links should not be inserted (force == False and estimate size below limits).
+        :rtype: str | False
+        """
+        try:
+            root = lxml.html.fromstring(body or '')
+            container = root.find_class('o-attachments-container')
+        except lxml.etree.ParserError:
+            root = None
+            container = []
+
+        # Remove attachments handled outside the "o-attachments-container" (added through the html editor directly)
+        outside_attachments = set()
+        if root is not None:
+            path_all_ids = '//*[@data-attachment-id]/@data-attachment-id'
+            path_container_ids = '//div[@class="o-attachments-container"]//*[@data-attachment-id]/@data-attachment-id'
+            with contextlib.suppress(ValueError, TypeError):
+                outside_attachments = (
+                        {int(el) for el in root.xpath(path_all_ids)} -
+                        {int(el) for el in root.xpath(path_container_ids)})
+        attachments -= self.env['ir.attachment'].browse(list(outside_attachments))
+
+        if not force:
+            max_email_size_bytes = (self.env['ir.mail_server']).sudo()._get_max_email_size() * 1024 * 1024
+            default_estimated_header_size = 5000
+            estimated_email_size_bytes = self._estimate_email_size(
+                {}, body, [a.file_size for a in attachments.sudo()]) + default_estimated_header_size
+            if estimated_email_size_bytes <= max_email_size_bytes:
+                if len(container) > 0:
+                    container[0].getparent().remove(container[0])
+                    return lxml.html.tostring(root, pretty_print=True).decode()
+                return False
+
+        attachments.generate_access_token()
+        attachments_node = lxml.html.fragment_fromstring(self._render_attachments_links(attachments))
+        if len(container) == 0:
+            if root is None:
+                # We just add it at the end as the parsing of the body has failed
+                return tools.mail.append_content_to_html(
+                    body or '', lxml.html.tostring(attachments_node).decode(), plaintext=False)
+            elif len(signature_container := root.find_class('o-signature-container')):
+                signature_container[0].addprevious(attachments_node)
+            elif len(body_node := root.findall('body')):
+                body_node[0].append(attachments_node)
+            elif len(html_node := root.findall('html')):
+                html_node[0].append(attachments_node)
+            else:
+                root.append(attachments_node)
+        elif append:
+            # Add a second container just after the existing one
+            container[0].addnext(attachments_node)
+        else:
+            container[0].getparent().replace(container[0], attachments_node)
+        return lxml.html.tostring(root).decode()
+
     def _prepare_outgoing_list(self, mail_server=False, doc_to_followers=None):
         """ Return a list of emails to send based on current mail.mail. Each
         is a dictionary for specific email values, depending on a partner, or
@@ -475,13 +568,9 @@ class MailMail(models.Model):
                 attachments = attachments - self.env['ir.attachment'].browse(list(link_ids))
 
         # Convert URL-only attachments (e.g. cloud or plain external links) into email links
-        url_attachments = attachments.sudo().filtered(
+        attachments_to_links = attachments.sudo().filtered(
             lambda a: a.url and not a.file_size and a.url.startswith(('http://', 'https://', 'ftp://')))
-        if url_attachments:
-            url_attachments.sudo().generate_access_token()
-            attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links', {'attachments': url_attachments})
-            body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
-            attachments -= url_attachments
+        attachments -= attachments_to_links
 
         # Turn remaining attachments into links if they are too heavy and
         # their ownership are business models (i.e. something != mail.message,
@@ -493,12 +582,15 @@ class MailMail(models.Model):
             max_email_size_bytes = (mail_server or self.env['ir.mail_server']
                                     ).sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
-                # Remove attachments and prepare downloadable links to be added in the body
-                record_owned_attachments.sudo().generate_access_token()
-                attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links',
-                                                                {'attachments': record_owned_attachments})
-                body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+                attachments_to_links |= record_owned_attachments
                 attachments -= record_owned_attachments
+
+        if attachments_to_links:
+            # force = True as we already have determined that the attachments must be turned into links
+            # append = True as an attachment link container could already have been added by the client in the body,
+            # and all attachment corresponding to a link in the body are removed above.
+            body = self._render_attachment_links_in_body(body, attachments_to_links, force=True, append=True)
+
         # attachments sorted by increasing ID to match front-end and upload ordering
         attachments.sudo().fetch(['name', 'raw', 'mimetype'])
         email_attachments = [

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -579,8 +579,7 @@ class MailMail(models.Model):
                 lambda a: a.res_model and a.res_id and a.res_model != 'mail.message'):
             estimated_email_size_bytes = self._estimate_email_size(
                 headers, body, [a.file_size for a in attachments.sudo()])
-            max_email_size_bytes = (mail_server or self.env['ir.mail_server']
-                                    ).sudo()._get_max_email_size() * 1024 * 1024
+            max_email_size_bytes = self.env['ir.mail_server'].sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
                 attachments_to_links |= record_owned_attachments
                 attachments -= record_owned_attachments

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -7,7 +7,6 @@ import datetime
 import json
 import logging
 import lxml
-import markupsafe
 import re
 import smtplib
 from collections import defaultdict
@@ -388,33 +387,6 @@ class MailMail(models.Model):
         return body
 
     @api.model
-    def _render_attachments_links(self, attachments):
-        """ Temporary replacement for the mail.mail_attachment_links template in stable. """
-        rendered_attachments = [markupsafe.Markup("""
-            <div style="display: inline">
-                <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content" data-attachment-id="%(attachment_id)s">
-                    <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
-                        <a href="%(attachment_base_url)s/web/content/%(attachment_id)s?download=1&amp;access_token=%(attachment_access_token)s"
-                            style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%%; color:#008f8c; vertical-align: middle; font-size: 15px;"
-                            width="100%%" target="_blank">
-                             &#11015; %(attachment_name)s
-                        </a>
-                    </div>
-                </div>
-            </div>
-            """) % {
-            'attachment_id': a.id,
-            'attachment_access_token': a.access_token,
-            'attachment_name': a.name,
-            'attachment_base_url': a.get_base_url(),
-        }
-                                for a in attachments]
-        return markupsafe.Markup(
-            """<div class="o-attachments-container" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%%;">
-                %(attachments)s
-            </div>""") % {'attachments': markupsafe.Markup('').join(rendered_attachments)}
-
-    @api.model
     def _render_attachment_links_in_body(self, body, attachments, force=False, append=False):
         """ Render the attachment container in the email body with download links when required.
 
@@ -456,7 +428,8 @@ class MailMail(models.Model):
                 return False
 
         attachments.generate_access_token()
-        attachments_node = lxml.html.fragment_fromstring(self._render_attachments_links(attachments))
+        attachments_node = lxml.html.fragment_fromstring(
+            self.env['ir.qweb']._render('mail.mail_attachment_links', {'attachments': attachments}))
         if len(container) == 0:
             if root is None:
                 # We just add it at the end as the parsing of the body has failed

--- a/addons/mail/tests/test_mail_mail.py
+++ b/addons/mail/tests/test_mail_mail.py
@@ -1,3 +1,6 @@
+import base64
+from itertools import product
+
 from odoo.tests import tagged, TransactionCase
 from unittest import mock
 import smtplib
@@ -46,3 +49,104 @@ class MailCase(TransactionCase):
             with self.subTest(field=field_name):
                 msg.invalidate_model()
                 mail[field_name]
+
+    def check_render_attachment_links_in_body(self, body, attachments_to_render, check_attachments, expected_in):
+        """Check the default and forced rendering of the attachment links.
+
+        :param str body : The raw body that will be processed.
+        :param recordset attachments_to_render: The attachments that will be processed.
+        :param recordset check_attachments: Attachments that are expected to appear in the rendered output.
+        :param str expected_in: A snippet that must be present in the rendered output.
+        """
+        MailMail = self.env['mail.mail']
+        rendered = MailMail._render_attachment_links_in_body(body, attachments_to_render)
+        if len(check_attachments) > 1:
+            self.assertEqual(
+                rendered.count('o-attachments-container'), 1,
+                "With 2 attachments, the limit is reached and the attachments links must be added")
+            for idx, attachment in enumerate(check_attachments):
+                self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+                self.assertIn(attachment.access_token, rendered, f'attachment {idx} must be present')
+        else:
+            # The limit is not reached, the attachment links must not be added
+            if 'o-attachments-container' in (body or ''):
+                # If the container was present, it is removed
+                self.assertEqual(rendered.count('o-attachments-container'), 0)
+            else:
+                self.assertFalse(rendered)
+
+        # Check that forcing the rendering always render all attachments
+        rendered_force = MailMail._render_attachment_links_in_body(body, attachments_to_render, force=True)
+        self.assertEqual(rendered_force.count('o-attachments-container'), 1)
+        self.assertIn(expected_in, rendered_force)
+        for idx, attachment in enumerate(check_attachments):
+            self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+            self.assertIn(attachment.access_token, rendered_force, f'attachment {idx} must be present')
+
+        # Check appending
+        rendered_force = MailMail._render_attachment_links_in_body(
+            body, attachments_to_render, force=True, append=True)
+        self.assertEqual(rendered_force.count('o-attachments-container'),
+                         1 + (body or '').count('o-attachments-container'))
+        self.assertIn(expected_in, rendered_force)
+        for idx, attachment in enumerate(check_attachments):
+            self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+            self.assertIn(attachment.access_token, rendered_force, f'attachment {idx} must be present')
+
+    def test_render_attachment_links_in_body(self):
+        """Test attachment link rendering over various body formats and attachment counts."""
+        # size of header ({}), overhead from _estimate_email_size, overhead from _render_attachment_links_in_body
+        default_overhead_size = 2 + 10 * 1024 + 5000
+        no_attachments = self.env['ir.attachment']
+        content = b'TEST'
+        content_len = len(base64.b64encode(content))
+        all_attachments = self.env['ir.attachment'].create(
+            [{'name': name, 'raw': content}
+             for name in ['test1.txt', 'test2.txt', 'outside.txt']])
+        outside_attachment = all_attachments[2]
+        outside_attachment.generate_access_token()
+        for attachments, (body, expected_in) in product(
+                (
+                        no_attachments,
+                        all_attachments[0],
+                        all_attachments[:2],
+                ),
+                (
+                        (False, '<div class="o-attachments-container"'),
+                        ('', '<div class="o-attachments-container"'),
+                        ('OUTSIDE only text', 'only text<div class="o-attachments-container"'),
+                        ('<html>OUTSIDE <p>broken html</p></htm>',
+                         'broken html</p><div class="o-attachments-container"'),
+                        ('<root>OUTSIDE broken html</root>', 'broken html<div class="o-attachments-container"'),
+                        ('<html>OUTSIDE <p>fine html</p></html>', 'fine html</p><div class="o-attachments-container"'),
+                        ('<html><body>OUTSIDE correct html</body></html>',
+                         'correct html<div class="o-attachments-container"'),
+                        ('<html><body>OUTSIDE Hello, <div class="o-signature-container">Signature</div></body></html>',
+                         'Hello, <div class="o-attachments-container"'),
+                        (('<html><body>OUTSIDE Hello <div class="o-attachments-container">can be replaced</div>..., '
+                          '<div class="o-signature-container">Signature</div></body></html>'),
+                         'Hello <div class="o-attachments-container"'),
+                ),
+        ):
+            # Setup limit to be reach with the second attachment only
+            self.env['ir.config_parameter'].sudo().set_float(
+                'base.default_max_email_size',
+                (default_overhead_size + (len(body) if body else 0) + content_len + 1) / 1024.0 / 1024.0)
+            with self.subTest(test='without outside attachment', body=body, attachments=attachments):
+                self.check_render_attachment_links_in_body(
+                    body, attachments, check_attachments=attachments, expected_in=expected_in)
+
+            if body:
+                attachments_outside = attachments | outside_attachment
+                self.assertEqual(len(attachments_outside), len(attachments) + 1)
+                body_outside = body.replace(
+                    'OUTSIDE', (f'<a data-attachment-id="{outside_attachment.id}" '
+                                f'href="http://localhost:8069/web/content/{outside_attachment.id}?download=1'
+                                f'&amp;access_token={outside_attachment.access_token}">outside.txt</a>'))
+                self.env['ir.config_parameter'].sudo().set_float(
+                    'base.default_max_email_size',
+                    (default_overhead_size + (len(body_outside) if body else 0) + content_len + 1) / 1024.0 / 1024.0)
+                self.assertIn(outside_attachment.access_token, body_outside)
+                with self.subTest(test='with outside attachment', body=body_outside, attachments=attachments_outside):
+                    self.check_render_attachment_links_in_body(
+                        body_outside, attachments_outside, check_attachments=attachments, expected_in=expected_in)

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -685,6 +685,12 @@ class MailComposeMessage(models.TransientModel):
             return super(MailComposeMessage, self.with_context(prefetch_fields=False))._compute_field_value(field)
         return super()._compute_field_value(field)
 
+    @api.onchange('attachment_ids')
+    def _onchange_attachment_ids(self):
+        new_body = self.env['mail.mail']._render_attachment_links_in_body(self.body, self.attachment_ids._origin)
+        if new_body is not False:
+            self.body = new_body
+
     # ------------------------------------------------------------
     # CRUD / ORM
     # ------------------------------------------------------------

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -1024,7 +1024,7 @@ class TestMailMailServer(MailCommon):
         email content.
 
         The feature is tested in the following conditions:
-        - using a specified server or the default one (to test command ICP parameter)
+        - using a specified server or the default one
         - in batch mode
         - with mail that exceed (with one or more attachments) or not the limit
         - with attachment owned by a business record or not: attachments not owned by a
@@ -1053,7 +1053,7 @@ class TestMailMailServer(MailCommon):
                 (3, self.env['ir.mail_server'], True, True),
                 # 1 attachment: exceed max size
                 (1, self.env['ir.mail_server'], True, True),
-                # Same as above with a specific server. Note that the default and server max_email size are reversed.
+                # Same as above with a specific server as the max_email_size is global
                 (1, test_mail_server, True, False),
                 (3, test_mail_server, True, True),
                 (1, test_mail_server, True, True),
@@ -1064,15 +1064,9 @@ class TestMailMailServer(MailCommon):
             # Setup max email size to check that the right maximum is used (default or mail server one)
             if expected_is_links:
                 max_size_test_succeed = max_size_always_exceed * n_attachment
-                max_size_test_fail = max_size_never_exceed
             else:
                 max_size_test_succeed = max_size_never_exceed
-                max_size_test_fail = max_size_always_exceed * n_attachment
-            if mail_server:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_fail)
-                mail_server.max_email_size = max_size_test_succeed
-            else:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
+            self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
 
             attachments = self.env['ir.attachment'].sudo().create([{
                 'name': f'attachment{idx_attachment}',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -463,7 +463,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=18, employee=18):  # tm 17/17
+        with self.assertQueryCount(admin=27, employee=27):  # tm 26/26
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -272,10 +272,9 @@ class IrMail_Server(models.Model):
         """
         return dict()
 
+    @api.model
     def _get_max_email_size(self):
-        if self.max_email_size:
-            return self.max_email_size
-        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size') or 10
+        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size') or 20
 
     def _get_test_email_from(self):
         self.ensure_one()
@@ -297,16 +296,13 @@ class IrMail_Server(models.Model):
     def _get_test_email_to(self):
         return "noreply@odoo.com"
 
-    def test_smtp_connection(self, autodetect_max_email_size=False):
-        """Test the connection and if autodetect_max_email_size, set auto-detected max email size.
+    def test_smtp_connection(self):
+        """Test the connection.
 
-        :param bool autodetect_max_email_size: whether to autodetect the max email size
-        :return: client action to notify the user of the result of the operation (connection test or
-            auto-detection successful depending on the ``autodetect_max_email_size`` parameter)
+        :return: client action to notify the user of the result of the operation
         :rtype: dict
 
-        :raises UserError: if the connection fails and if ``autodetect_max_email_size`` and
-            the server doesn't support the auto-detection of email max size
+        :raises UserError: if the connection fails
         """
         for server in self:
             smtp = False
@@ -329,12 +325,6 @@ class IrMail_Server(models.Model):
                 (code, repl) = smtp.getreply()
                 if code != 354:
                     raise UserError(_('The server refused the test connection with error %(repl)s', repl=repl))  # noqa: TRY301
-                if autodetect_max_email_size:
-                    max_size = smtp.esmtp_features.get('size')
-                    if not max_size:
-                        raise UserError(_('The server "%(server_name)s" doesn\'t return the maximum email size.',
-                                          server_name=server.name))
-                    server.max_email_size = float(max_size) / (1024 ** 2)
             except (UnicodeError, idna.core.InvalidCodepoint) as e:
                 raise UserError(_("Invalid server name!\n %s", e)) from e
             except (gaierror, timeout) as e:
@@ -363,27 +353,16 @@ class IrMail_Server(models.Model):
                 except Exception:
                     # ignored, just a consequence of the previous exception
                     pass
-
-        if autodetect_max_email_size:
-            message = _(
-                'Email maximum size updated (%(details)s).',
-                details=', '.join(f'{server.name}: {human_size(server.max_email_size * 1024 ** 2)}' for server in self))
-        else:
-            message = _('Connection Test Successful!')
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'message': message,
+                'message': _('Connection Test Successful!'),
                 'type': 'success',
                 'sticky': False,
                 'next': {'type': 'ir.actions.act_window_close'},  # force a form reload
             },
         }
-
-    def action_retrieve_max_email_size(self):
-        self.ensure_one()
-        return self.test_smtp_connection(autodetect_max_email_size=True)
 
     @classmethod
     def _disable_send(cls):

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -19,17 +19,6 @@
                             </group>
                             <group>
                                 <field name="sequence"/>
-                                <div colspan="2" class="d-flex justify-content-between">
-                                    <div>
-                                        <label for="max_email_size"
-                                               string="Convert attachments to links for emails over"/>
-                                        <field name="max_email_size" class="oe_inline mx-1"/>
-                                        <span class="o_form_label">MB</span>
-                                    </div>
-                                    <button class="btn btn-link pt-0" type="object" name="action_retrieve_max_email_size">
-                                        <i class="fa fa-gear"/> Detect Max Limit
-                                    </button>
-                                </div>
                             </group>
                         </group>
                         <group>


### PR DESCRIPTION
This PR finalises the improvement of the attachment‑to‑link conversion that was introduced in the version 18.0 with:

[IMP] base, {test_}mail: remove the "per server" maximum email size setting

We remove the "per server" max email size setting in favor of the existing max email size global setting. We also change that global setting from 10MB to 20MB.

[IMP] mail, cloud_storage_azure: restore attachment links template

To improve the rendering of the mail attachment links in stable, we have added a method to render them in python: mail_mail._render_attachments_links.

We remove that method and use an updated version of the template mail.mail_attachment_links instead.

Task-5912830

Note: the commit of the fix from version 18.0 is temporary included in this branch for testing and will be removed when it is merged.