### PR TITLE
[FIX] partner_autocomplete: validate returned VAT

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -141,7 +141,18 @@ class ResPartner(models.Model):
                 'error': True,
                 'error_message': error
             })
-        return result
+        return self._validate_partner_autocomplete_response(result)
+
+    @api.model
+    def _validate_partner_autocomplete_response(self, autocomplete_response):
+        if (
+            self.env['ir.module.module']._get('base_vat').state == 'installed'
+            and (vat_number := autocomplete_response.get('vat'))
+            and (enriched_company := self.env.context.get('enriched_company_data'))
+            ):
+            country = self.env['res.country'].browse(enriched_company['country_id']['id']).exists()
+            autocomplete_response['vat'] = self._run_vat_checks(country, vat_number, validation='setnull')[0]
+        return autocomplete_response
 
     @api.model
     def enrich_by_duns(self, duns, timeout=15):

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -73,10 +73,14 @@ export function usePartnerAutocomplete() {
      * @private
      */
     function enrichCompany(company) {
+        const context = { 
+            'enriched_company_data': company,
+        };
+
         if (isGSTNumber(company.query)){
             return orm.call('res.partner', 'enrich_by_gst', [company.query]);
         }
-        return orm.call('res.partner', 'enrich_by_duns', [company.duns]);
+        return orm.call('res.partner', 'enrich_by_duns', [company.duns], { context: context });
     }
 
     function removeUselessFields(company, fieldsToKeep) {

--- a/addons/partner_autocomplete/tests/test_res_company.py
+++ b/addons/partner_autocomplete/tests/test_res_company.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from odoo.tests import common, tagged
 from odoo.addons.partner_autocomplete.tests.common import MockIAPPartnerAutocomplete
 
@@ -59,3 +60,34 @@ class TestResCompany(common.TransactionCase, MockIAPPartnerAutocomplete):
 
         company_1.website = "http://www.cwi.nl:80/%7Eguido/Python.html"
         self.assertEqual(company_1._get_company_domain(), "cwi.nl")
+
+    def test_enrich_by_duns_with_incorrect_vat(self):
+        """
+        Ensure the VAT number is removed when the partner autocomplete return an incorrect VAT number
+        """
+        if self.env['ir.module.module']._get('base_vat').state != 'installed':
+            self.skipTest("The module base vat is required to run this test.")
+
+        # Mock the company details from the JS call `enrichCompany(company)`
+        be_company_data = {
+            'city': 'Brussels',
+            'duns': 'BE1234567',
+            'name': 'Test BE Company',
+            'country_id': {
+                'id': 20, 'display_name': 'Belgium'
+            },
+            'query': 'BE Comp',
+            'description': 'Belgium'
+        }
+
+        original_method = self.env.registry['iap.autocomplete.api']._request_partner_autocomplete
+
+        def patched_request(self_api, endpoint, params, timeout=15):
+            response, error = original_method(self_api, endpoint, params, timeout=timeout)
+
+            response = {'request_code': 200, 'total_cost': 0, 'credit_error': True, 'data': {'vat': 'BE1234567'}}
+            return response, error
+
+        with patch.object(self.env.registry['iap.autocomplete.api'], '_request_partner_autocomplete', patched_request):
+            result = self.env['res.partner'].with_context(enriched_company_data=be_company_data).enrich_by_duns('BE1234567')
+            self.assertEqual(result.get('vat'), '')


### PR DESCRIPTION
### Issue:
When autocompleting some partners, the returned VAT could be in an invalid format, leading to a validation error
You need `base_vat` installed to get the issue

### Cause:
The partner autocomplete feature relies on IAP credits for full data retrieval
When no credits are available, only the VAT is returned if it was already fetched before

In some cases, this VAT value is incorrectly formatted, which triggers a validation error when applied to the partner

### Fix:
Invalid VAT values returned by the autocomplete are now ignored to prevent errors
Since the correct VAT cannot be retrieved without IAP credits, the value is simply removed

### Steps to reproduce:
- Install `l10n_cy` (we need a localization to enable base_vat)
- Create a new partner from an invoice
- Enter TONYO 360 and select the autocomplete suggestion
Before the fix: The VAT field is filled with an invalid value, causing a validation error

opw-6030164