### PR TITLE
[FIX] html_builder: unblock ui on reloadable operation error

### DIFF
--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -628,15 +628,18 @@ function useOperationWithReload(callApply, reload) {
     return async (...args) => {
         const { editingElement } = args[0][0];
         env.services.ui.block();
-        const applyResults = await callApply(...args);
-        if (!applyResults.includes(BuilderAction.cancelReload)) {
-            env.editor.shared.history.addStep();
-            await env.editor.shared.savePlugin.save();
-            const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
-            const url = reload.getReloadUrl?.();
-            await env.editor.config.reloadEditor({ target, url });
+        try {
+            const applyResults = await callApply(...args);
+            if (!applyResults.includes(BuilderAction.cancelReload)) {
+                env.editor.shared.history.addStep();
+                await env.editor.shared.savePlugin.save();
+                const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
+                const url = reload.getReloadUrl?.();
+                await env.editor.config.reloadEditor({ target, url });
+            }
+        } finally {
+            env.services.ui.unblock();
         }
-        env.services.ui.unblock();
     };
 }
 

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -268,3 +268,37 @@ test("Shouldn't reload(save, etc) when a reload is canceled", async () => {
     expect(".o_blockUI").toHaveCount(0);
     expect.verifySteps(["save"]);
 });
+
+test("UI is unblocked when getting an error on a reloadable operation", async () => {
+    expect.errors(1);
+    const { promise, resolve } = Promise.withResolvers();
+    addBuilderAction({
+        TestAction: class extends BuilderAction {
+            static id = "testAction";
+            setup() {
+                this.reload = {};
+            }
+            async apply({ editingElement }) {
+                await promise;
+                throw new Error("Apply failed!");
+            }
+        },
+    });
+
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderButton action="'testAction'">Click</BuilderButton>`;
+        }
+    );
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `<div class="test-options-target">Target</div>`
+    );
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container [data-action-id='testAction']").click();
+    expect(".o_blockUI").toHaveCount(1);
+    resolve();
+    await waitSidebarUpdated();
+    expect(".o_blockUI").toHaveCount(0);
+    expect.verifyErrors(["Apply failed!"]);
+});


### PR DESCRIPTION
Since commit [1], the UI is blocked during a reloadable operation, but an early exit on error prevented unblock() from being called.

This commit fixes it by wrapping it in a try/finally to ensure the UI is always unblocked.

[1]: https://github.com/odoo/odoo/commit/453b7eb8e038ee8e8a54de16fc1a45fb2fab573a
