### PR TITLE
[FIX] account: Remove payment QR code on mobile

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -302,7 +302,7 @@
                                         invisible="not show_partner_bank_account or payment_type == 'outbound'"
                                         required="require_partner_bank_account"/>
                             </group>
-                            <group>
+                            <group class="d-none d-md-block">
                                 <field name="qr_code" invisible="1"/>
                                 <div invisible="not qr_code" colspan="2" class="text-center">
                                     <field name="qr_code" widget="html"/>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -136,7 +136,7 @@
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
                         </group>
                         <field name="qr_code" invisible="1"/>
-                        <div invisible="not qr_code" colspan="2" class="text-center">
+                        <div invisible="not qr_code" colspan="2" class="text-center d-none d-md-block">
                             <field name="qr_code"/>
                         </div>
                     </group>


### PR DESCRIPTION
When a payment meets few conditions, we display a qr code to invite
the user to scan it with his bank app. But in mobile it doesn't make sens.

We would like to implement a link instead, so the user can open his
bank app directly from odoo, but it doesn't seems doable for free
without any providers.

We will hide the qr code on mobile displays for now.

task-4563391

Linked:https://github.com/odoo/enterprise/pull/111756