### PR TITLE
[FIX] l10n_ar{_stock,}: restore custom header and footer on invoices

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -75,7 +75,7 @@
 
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
       <!-- custom header and footer -->
-        <t t-set="o" position="after">
+        <t t-call="web.external_layout" position="before">
             <t t-set="custom_header" t-value="'l10n_ar.custom_header'"/>
             <t t-set="report_date" t-value="o.invoice_date"/>
             <t t-set="report_number" t-value="o.l10n_latam_document_number"/>

--- a/addons/l10n_ar_stock/views/report_delivery_guide.xml
+++ b/addons/l10n_ar_stock/views/report_delivery_guide.xml
@@ -23,6 +23,28 @@
                     <t t-set="report_name" t-value="stock_doc_type.report_name"/>
                 </t>
                 <t t-set="custom_header" t-value="'l10n_ar_stock.custom_header'"/>
+                <t t-set="custom_footer">
+                    <div class="row">
+                        <div name="footer_left_column" class="col-6 text-start">
+                            <div name="pager" t-if="report_type == 'pdf'">
+                                Page: <span class="page"/> / <span class="topage"/>
+                            </div>
+                            <div name="sequence_range" t-if="o.l10n_ar_cai_data">
+                                Sequence from <t t-out="o.l10n_ar_cai_data['sequence_number_start']"/> to <t t-out="o.l10n_ar_cai_data['sequence_number_end']"/>
+                            </div>
+                        </div>
+                        <div name="footer_right_column" class="col-6 text-end" t-if="o.l10n_ar_cai_data">
+                            <div name="cai_number">
+                                CAI: <t t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
+                            </div>
+                            <div name="cai_expiration_date">
+                                CAI Expiration Date: <t t-out="o.l10n_ar_cai_data['cai_expiration_date']" t-options='{"widget": "date"}'/>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </xpath>
+            <xpath expr="//div[hasclass('page')]" position="before">
                 <div id="informations">
                     <t><strong>Customer: </strong></t>
                     <span t-field="o.partner_id.commercial_partner_id.name"/>
@@ -44,26 +66,6 @@
                         <span t-else="" t-out="o.partner_id.vat"/>
                     </t>
                 </div>
-                <t t-set="custom_footer">
-                    <div class="row">
-                        <div name="footer_left_column" class="col-6 text-start">
-                            <div name="pager" t-if="report_type == 'pdf'">
-                                Page: <span class="page"/> / <span class="topage"/>
-                            </div>
-                            <div name="sequence_range" t-if="o.l10n_ar_cai_data">
-                                Sequence from <t t-out="o.l10n_ar_cai_data['sequence_number_start']"/> to <t t-out="o.l10n_ar_cai_data['sequence_number_end']"/>
-                            </div>
-                        </div>
-                        <div name="footer_right_column" class="col-6 text-end" t-if="o.l10n_ar_cai_data">
-                            <div name="cai_number">
-                                CAI: <t t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
-                            </div>
-                            <div name="cai_expiration_date">
-                                CAI Expiration Date: <t t-out="o.l10n_ar_cai_data['cai_expiration_date']" t-options='{"widget": "date"}'/>
-                            </div>
-                        </div>
-                    </div>
-                </t>
             </xpath>
             <xpath expr="//t[@t-set='address']" position="replace"/>
             <xpath expr="//t[@t-set='information_block']" position="replace"/>


### PR DESCRIPTION
### Issue:
In 19.2, the custom header and footer defined by `l10n_ar` were not displayed on invoices
The standard layout was used instead

### Cause:
This change:
https://github.com/odoo/odoo/commit/eb6e88a25050fff2bd09317739dd51ba451450df modified the `t-call` behavior to ignore `t-set` inside the call

Since the `o` variable is defined within the `t-call` in the invoice report: https://github.com/odoo/odoo/blob/a08e84e84aa26e86a291ef0de5bdd4ac20f6274e/addons/account/views/report_invoice.xml#L110-L115 the custom parameters (header and footer) were ignored

### Steps to reproduce:
- Install `l10n_ar` and switch to the AR company
- Create an invoice
- Open the preview

### Before the fix:
The default header and footer are used

### After the fix:
The custom header and footer are correctly applied (as in 19.1)

### Fix:
This PR also fix the delivery guide document

opw-6046454