### PR TITLE
[FIX] hr_attendance: fix expected hours calculation for attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -93,7 +93,8 @@ class HrAttendance(models.Model):
     @api.depends("worked_hours", "overtime_hours")
     def _compute_expected_hours(self):
         for attendance in self:
-            attendance.expected_hours = attendance.worked_hours - attendance.overtime_hours
+            calendar = attendance._get_employee_calendar()
+            attendance.expected_hours = attendance.worked_hours - attendance.overtime_hours if attendance.overtime_hours else calendar.hours_per_day
 
     def _compute_color(self):
         for attendance in self:

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -108,6 +108,17 @@ class TestHrAttendance(TransactionCase):
         with self.assertRaises(AssertionError):
             attendance_form.save()
 
+    def test_expected_hours_with_standard_calendar(self):
+        """Test that expected_hours equals calendar's hours_per_day when no overtime"""
+
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': datetime(2025, 1, 15, 10, 0),
+            'check_out': datetime(2025, 1, 15, 18, 0),
+        })
+        # Standard 40h/week calendar has 8 hours per day
+        self.assertEqual(attendance.expected_hours, 8)
+
     # @freeze_time("2024-02-1")
     # def test_change_in_out_mode_when_manual_modification(self):
     #     TODO naja: cron should work eventually when the adjustment feature is back


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------------
1. Install the Attendance module
2. Create an employee with a Standard 40h/week working schedule
3. Create its attendance:
    * Check in at 10:00 AM.
    * Check out at 06:00 PM (total 7 hours)
4. Navigate to Attendance > Reporting > Attendances

Observation:
-----------------------------------------
The Expected Hours column shows 7 hours, matching the worked hours, instead of the expected 8 hours based on the working schedule

Issue:
 -----------------------------------------
In `_compute_expected_hours`, when no overtime is recorded (worked hours < scheduled hours), the expected hours are incorrectly set equal to the worked hours

Solution:
 -----------------------------------------
Ensure that when no overtime is recorded, the expected hours are computed based on the employee's working schedule instead of the worked hours

opw-5253946