### PR TITLE
[IMP] website_sale: preserve add-to-cart intent on configurator close

### DIFF
--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -60,7 +60,7 @@ export class ProductConfiguratorDialog extends Component {
 
     setup() {
         this.title = _t("Configure your product");
-        this.env.dialogData.dismiss = !this.props.edit && this.props.discard.bind(this);
+        this.env.dialogData.dismiss = !this.props.edit && this._onDialogDismiss.bind(this);
         this.state = useState({
             products: [],
             optionalProducts: [],
@@ -499,5 +499,18 @@ export class ProductConfiguratorDialog extends Component {
             this.props.discard(); // clear the line
         }
         this.props.close();
+    }
+
+    _onDialogDismiss() {
+        if (this.isPossibleConfiguration()) {
+            const mainProduct = this.state.products.find(
+                (product) => product.product_tmpl_id === this.env.mainProductTmplId
+            );
+            const optionalProducts = this.state.products.filter(
+                (product) => product.product_tmpl_id !== this.env.mainProductTmplId
+            );
+            return this.props.discard(mainProduct, optionalProducts);
+        }
+        return this.props.discard();
     }
 }

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -358,20 +358,21 @@ export class CartService {
                 options,
                 ...additionalData,
                 save: async (mainProduct, optionalProducts, options) => {
-                    const product = this._serializeProduct(mainProduct);
-                    resolve(this._makeRequest({
-                        productTemplateId: product.product_template_id,
-                        productId: product.product_id,
-                        quantity: product.quantity,
-                        uom_id: product.uom_id,
-                        productCustomAttributeValues: product.product_custom_attribute_values,
-                        noVariantAttributeValues: product.no_variant_attribute_value_ids,
-                        linked_products: optionalProducts.map(this._serializeProduct),
-                        shouldRedirectToCart: options.goToCart,
-                        ...additionalData,
-                    }));
+                    resolve(
+                        this._saveConfiguredProduct(
+                            mainProduct,
+                            optionalProducts,
+                            options.goToCart,
+                            additionalData,
+                        )
+                    );
                 },
-                discard: () => resolve(0),
+                discard: async (mainProduct, optionalProducts) => {
+                    if(mainProduct) {
+                        this._saveConfiguredProduct(mainProduct, optionalProducts, false)
+                    }
+                    resolve(0);
+                }
             });
         });
     }
@@ -414,6 +415,31 @@ export class CartService {
             .flatMap(ptal => ptal.selected_attribute_value_ids);
 
         return serializedProduct;
+    }
+
+    /**
+     * Save the configured product and its optional products by sending
+     * the serialized data to the backend.
+     *
+     * @param {Object} mainProduct - The main configured product.
+     * @param {Array<Object>} optionalProducts - List of optional products.
+     * @param {boolean} goToCart - Whether to redirect to the cart after saving.
+     *
+     * @returns {Promise} - Promise resolving the server request.
+     */
+    _saveConfiguredProduct(mainProduct, optionalProducts, goToCart, additionalData = {}) {
+        const product = this._serializeProduct(mainProduct);
+        return this._makeRequest({
+            productTemplateId: product.product_template_id,
+            productId: product.product_id,
+            quantity: product.quantity,
+            uom_id: product.uom_id,
+            productCustomAttributeValues: product.product_custom_attribute_values,
+            noVariantAttributeValues: product.no_variant_attribute_value_ids,
+            linked_products: optionalProducts.map(this._serializeProduct),
+            shouldRedirectToCart: goToCart,
+            ...additionalData,
+        });
     }
 
     /**


### PR DESCRIPTION
Previously, closing the product configurator dialog without confirming resulted in no products being added to the cart, even if the user had initiated an add-to-cart action.

This change ensures that both the main product and optional products are added to the cart when the dialog is closed, provided the configuration is valid.

task-6055551
