### PR TITLE
[IMP] html_editor: multi-cell support for removal/clear table operations

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -379,13 +379,22 @@ export class TablePlugin extends Plugin {
      */
     removeColumn(cell) {
         const table = closestElement(cell, "table");
-        const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
-        const index = cells.findIndex((td) => td === cell);
-        const siblingCell = cells[index - 1] || cells[index + 1];
-        table
-            .querySelectorAll(`tr :is(td, th):nth-of-type(${index + 1})`)
-            .forEach((td) => td.remove());
-        // not sure we should move the cursor?
+        const selectedTds = table.querySelectorAll(".o_selected_td");
+        let startColumnIndex, endColumnIndex;
+        if (selectedTds.length) {
+            startColumnIndex = getColumnIndex(selectedTds[0]);
+            endColumnIndex = getColumnIndex(selectedTds[selectedTds.length - 1]);
+        } else {
+            startColumnIndex = endColumnIndex = getColumnIndex(cell);
+        }
+        const siblingCell =
+            cell.parentElement.children[startColumnIndex - 1] ||
+            cell.parentElement.children[endColumnIndex + 1];
+        for (const row of table.rows) {
+            for (let columnIndex = endColumnIndex; columnIndex >= startColumnIndex; columnIndex--) {
+                row.cells[columnIndex].remove();
+            }
+        }
         siblingCell
             ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingCell))
             : this.deleteTable(table);
@@ -395,8 +404,18 @@ export class TablePlugin extends Plugin {
      */
     removeRow(row) {
         const table = closestElement(row, "table");
-        const siblingRow = row.previousElementSibling || row.nextElementSibling;
-        row.remove();
+        const selectedTds = table.querySelectorAll(".o_selected_td");
+        let startRowIndex, endRowIndex;
+        if (selectedTds.length) {
+            startRowIndex = getRowIndex(selectedTds[0]);
+            endRowIndex = getRowIndex(selectedTds[selectedTds.length - 1]);
+        } else {
+            startRowIndex = endRowIndex = getRowIndex(row);
+        }
+        const siblingRow = table.rows[startRowIndex - 1] || table.rows[endRowIndex + 1];
+        for (let rowIndex = endRowIndex; rowIndex >= startRowIndex; rowIndex--) {
+            table.rows[rowIndex].remove();
+        }
         siblingRow
             ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingRow.cells[0]))
             : this.deleteTable(table);
@@ -605,23 +624,29 @@ export class TablePlugin extends Plugin {
      */
     clearColumnContent(cell) {
         const table = closestElement(cell, "table");
-        const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
-        const index = cells.findIndex((td) => td === cell);
-        table.querySelectorAll(`tr :is(td, th):nth-of-type(${index + 1})`).forEach((td) => {
+        const selectedTds = table.querySelectorAll(".o_selected_td");
+        const index = getColumnIndex(cell);
+        const tds = selectedTds.length
+            ? selectedTds
+            : [...table.rows].map((row) => row.cells[index]);
+        for (const td of tds) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             fillEmpty(baseContainer);
             td.replaceChildren(baseContainer);
-        });
+        }
     }
     /**
      * @param {HTMLTableRowElement} row
      */
     clearRowContent(row) {
-        row.querySelectorAll("td, th").forEach((td) => {
+        const table = closestElement(row, "table");
+        const selectedTds = table.querySelectorAll(".o_selected_td");
+        const tds = selectedTds.length ? selectedTds : row.cells;
+        for (const td of tds) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             fillEmpty(baseContainer);
             td.replaceChildren(baseContainer);
-        });
+        }
     }
     deleteTable(table) {
         table =
@@ -669,16 +694,12 @@ export class TablePlugin extends Plugin {
             firstCellColumnIndex === 0 && lastCellColumnIndex === firstRowCells.length - 1;
 
         if (areFullColumnsSelected) {
-            for (let index = firstCellColumnIndex; index <= lastCellColumnIndex; index++) {
-                this.removeColumn(firstRowCells[index]);
-            }
+            this.removeColumn(firstRowCells[firstCellColumnIndex]);
             return;
         }
 
         if (areFullRowsSelected) {
-            for (let index = firstCellRowIndex; index <= lastCellRowIndex; index++) {
-                this.removeRow(rows[index]);
-            }
+            this.removeRow(rows[firstCellRowIndex]);
             return;
         }
 

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -70,6 +70,26 @@ function removeColumn(cell) {
     };
 }
 
+function clearRowContent(row) {
+    return (editor) => {
+        if (!row) {
+            const selection = editor.shared.selection.getEditableSelection();
+            row = findInSelection(selection, "tr");
+        }
+        editor.shared.table.clearRowContent(row);
+    };
+}
+
+function clearColumnContent(cell) {
+    return (editor) => {
+        if (!cell) {
+            const selection = editor.shared.selection.getEditableSelection();
+            cell = findInSelection(selection, "td");
+        }
+        editor.shared.table.clearColumnContent(cell);
+    };
+}
+
 describe("row", () => {
     describe("convert", () => {
         test("should convert the first row to table header", async () => {
@@ -426,6 +446,236 @@ describe("row", () => {
                 contentAfter: "<p>[]<br></p>",
             });
         });
+        test("should remove rows where all cells are selected", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">gh</td>
+                                <td class="o_selected_td">ij</td>
+                                <td class="o_selected_td">kl</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">mn</td>
+                                <td class="o_selected_td">op</td>
+                                <td class="o_selected_td">qr</td>
+                            </tr>
+                            <tr>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: removeRow(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab[]</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should remove rows with partial cell selection", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">gh</td>
+                                <td class="o_selected_td">ij</td>
+                                <td>kl</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">mn</td>
+                                <td class="o_selected_td">op</td>
+                                <td>qr</td>
+                            </tr>
+                            <tr>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: removeRow(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab[]</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+    });
+
+    describe("clear content", () => {
+        test("should clear content of a single row based on selection", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>gh</td>
+                                <td>ij</td>
+                                <td>kl</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearRowContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td>gh</td>
+                                <td>ij</td>
+                                <td>kl</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+
+        test("should clear content of all fully selected rows", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">[]gh</td>
+                                <td class="o_selected_td">ij</td>
+                                <td class="o_selected_td">kl</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">mn</td>
+                                <td class="o_selected_td">op</td>
+                                <td class="o_selected_td">qr</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearRowContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td">[]<p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+
+        test("should clear partially selected cells across rows", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>gh</td>
+                                <td class="o_selected_td">[]ij</td>
+                                <td class="o_selected_td">kl</td>
+                            </tr>
+                            <tr>
+                                <td>mn</td>
+                                <td class="o_selected_td">op</td>
+                                <td class="o_selected_td">qr</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearRowContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>gh</td>
+                                <td class="o_selected_td">[]<p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td>mn</td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
     });
 });
 
@@ -723,6 +973,248 @@ describe("column", () => {
                 ),
                 stepFunction: removeColumn(),
                 contentAfter: "<p>[]<br></p>",
+            });
+        });
+        test("should remove columns where all cells are selected", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">cd</td>
+                                <td class="o_selected_td">ef</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td">kl</td>
+                                <td class="o_selected_td">mn</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td class="o_selected_td">st</td>
+                                <td class="o_selected_td">uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: removeColumn(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab[]</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should remove columns with partial cell selection", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">[]cd</td>
+                                <td class="o_selected_td">ef</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td">kl</td>
+                                <td class="o_selected_td">mn</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: removeColumn(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab[]</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+    });
+
+    describe("clear content", () => {
+        test("should clear content of a single column based on selection", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td>gh</td>
+                                <td>ij</td>
+                                <td>kl</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearColumnContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<p><br></p></td>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td>ij</td>
+                                <td>kl</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+
+        test("should clear content of all fully selected columns", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">[]cd</td>
+                                <td class="o_selected_td">ef</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td">kl</td>
+                                <td class="o_selected_td">mn</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td class="o_selected_td">st</td>
+                                <td class="o_selected_td">uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearColumnContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">[]<p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+
+        test("should clear content of partially selected cells across columns", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">[]cd</td>
+                                <td class="o_selected_td">ef</td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td">kl</td>
+                                <td class="o_selected_td">mn</td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: clearColumnContent(),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>ab</td>
+                                <td class="o_selected_td">[]<p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td>gh</td>
+                            </tr>
+                            <tr>
+                                <td>ij</td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td class="o_selected_td"><p><br></p></td>
+                                <td>op</td>
+                            </tr>
+                            <tr>
+                                <td>qr</td>
+                                <td>st</td>
+                                <td>uv</td>
+                                <td>wx</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
             });
         });
     });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Row/column removal and clear content only handled a single cell, requiring repeated actions and ignoring partial selections.

### Desired behavior after PR is merged:

- These operations support multi-cell selection:
    - removal applies to all rows/columns in the selected range.
    - clear content applies only to selected cells.

task-6026229

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
