### PR TITLE
[IMP] account_accountant: for bank rec allow contacts from branches as well

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -59,7 +59,7 @@ class AccountBankStatementLine(models.Model):
         comodel_name='res.partner',
         string='Partner', ondelete='restrict',
         domain="['|', ('parent_id','=', False), ('is_company','=',True)]",
-        check_company=True)
+    )
 
     # Technical field used to store the bank account number before its creation, upon the line's processing
     account_number = fields.Char(string='Bank Account Number')


### PR DESCRIPTION
Before this commit:
- When a user from the parent company wants to reconcile a bank statement, they
  cannot select a partner that belongs strictly to a branch.
- This prevents the manual creation of operations or the proper matching of
  invoices issued by the branch.

After this commit:
- Now, for the bank reconciliation operations, we are allowing the partners
  having parent_id set to False or is_company set to True.

Task-5949437