### PR TITLE
[FIX] account: uninstall prevent error with audit log

### DIFF
--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -179,7 +179,7 @@ class MailMessage(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _except_audit_log(self):
-        if self.env.context.get('bypass_audit') is bypass_token:
+        if self.env.context.get('bypass_audit') is bypass_token or 'account' in self.pool.uninstalling_modules:
             return
         for message in self:
             if message.account_audit_log_move_id and not message.account_audit_log_move_id.posted_before:


### PR DESCRIPTION
Due to this commit: https://github.com/odoo/odoo/commit/dd753ce538cb48b49e1e331f634e262447ff772d

During the uninstall, the table of the model used in _search_account_audit_log_restricted has been removed and it causes a crash. To avoid that, the except audit log is not performed anymore when account is in the pool of uninstalling module.

runbot-104970737




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
