### PR TITLE
[IMP] mail, *: improve portal chatter copywriting

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -214,7 +214,6 @@
                     </div>
                     <!-- chatter -->
                     <div id="invoice_communication" class="mt-4">
-                        <h3>Communication history</h3>
                         <t t-call="portal.message_thread"/>
                     </div>
                 </div>

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -214,7 +214,7 @@
                     </div>
                     <!-- chatter -->
                     <div id="invoice_communication" class="mt-4">
-                        <h3>Communication history</h3>
+                        <h3>Communication History</h3>
                         <t t-call="portal.message_thread"/>
                     </div>
                 </div>

--- a/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
+++ b/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
@@ -142,7 +142,7 @@ test("portal_invoice_page_payment is started with #portal_pay", async () => {
                                     <iframe id="invoice_html" class="position-relative my-2" width="100%" height="100%" frameborder="0" scrolling="no" data-oe-model="ir.ui.view" data-oe-id="789" data-oe-field="arch" data-oe-xpath="/data/xpath/div/div[1]/div[1]/iframe[1]" src="/my/invoices/2?access_token=48b81433-0b2f-4ebd-847b-980120176bb6&amp;report_type=html" style="height: 0px;"></iframe>
                                 </div>
                                 <div id="invoice_communication" class="mt-4">
-                                    <h3 data-oe-model="ir.ui.view" data-oe-id="789" data-oe-field="arch" data-oe-xpath="/data/xpath/div/div[1]/div[2]/h3[1]">Communication history</h3>
+                                    <h3 data-oe-model="ir.ui.view" data-oe-id="789" data-oe-field="arch" data-oe-xpath="/data/xpath/div/div[1]/div[2]/h3[1]">Communication History</h3>
                                     <div id="discussion" data-anchor="true" class="d-print-none o_portal_chatter o_not_editable p-0" data-oe-model="ir.ui.view" data-oe-id="559" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]" data-token="48b81433-0b2f-4ebd-847b-980120176bb6" data-res_model="account.move" data-res_id="2" data-pager_step="10" data-allow_composer="1" data-two_columns="false">
                                         <div id="chatterRoot"></div>
                                     </div>

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -14,6 +14,11 @@ class MessageReactionController(ThreadController):
         if not message_sudo:
             raise NotFound()
         thread_model = message_sudo.model and request.env[message_sudo.model]
+        if (
+            not request.env.user._is_internal() and
+            not getattr(thread_model, "_reactions_in_portal_chatter", False)
+        ):
+            raise NotFound()
         msg_mode = getattr(thread_model, "_mail_message_reaction_access", "create")
         message = self._get_message_with_access(int(message_id), mode=msg_mode, **kwargs)
         if not message:

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -52,6 +52,7 @@ class DiscussChannel(models.Model):
     _mail_flat_thread = False
     _mail_post_access = 'read'
     _mail_message_reaction_access = "read"
+    _reactions_in_portal_chatter = True
     _inherit = ["mail.thread", "bus.sync.mixin"]
 
     MAX_BOUNCE_LIMIT = 10

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -100,6 +100,7 @@ export class Composer extends Component {
         sidebar: true,
         showFullComposer: true,
         allowUpload: true,
+        autofocus: 0,
     };
     static props = [
         "composer",

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -37,7 +37,7 @@ registerMessageAction("reaction", {
         messageActive: owner.isActive,
     }),
     componentCondition: ({ owner }) => !isMobileOS() && !owner.isMessageContextMenu,
-    condition: ({ message, thread }) => message.canAddReaction(thread),
+    condition: ({ owner, message, thread }) => message.canAddReaction({ owner, thread }),
     icon: "oi oi-smile-add",
     name: _t("Add a Reaction"),
     onSelected({ owner }) {
@@ -104,7 +104,8 @@ registerMessageAction("reply-to", {
         thread?.eq(store.inbox) || message.isSelfAuthored ? 55 : 20,
 });
 registerMessageAction("add-bookmark", {
-    condition: ({ message }) => message.canToggleBookmark && !message.is_bookmarked,
+    condition: ({ message, owner }) =>
+        message.canToggleBookmark && !message.is_bookmarked && !owner.env.inFrontendPortalChatter,
     icon: "fa fa-bookmark-o",
     name: _t("Bookmark"),
     onSelected: ({ message }) => message.addBookmark(),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -507,9 +507,9 @@ export class Message extends Record {
     get canToggleBookmark() {
         return Boolean(
             !this.is_transient &&
-            !this.isPending &&
-            this.store.self_user?.share === false &&
-            this.persistent
+                !this.isPending &&
+                this.store.self_user?.share === false &&
+                this.persistent
         );
     }
 
@@ -589,13 +589,13 @@ export class Message extends Record {
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
-    canAddReaction(thread) {
+    canAddReaction({ owner, thread } = {}) {
         return Boolean(
             !this.is_transient &&
-            !this.isPending &&
-            this.thread?.can_react &&
-            !this.thread.isTransient &&
-            this.thread.has_mail_thread
+                !this.isPending &&
+                this.thread?.can_react &&
+                !this.thread.isTransient &&
+                this.thread.has_mail_thread
         );
     }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -59,7 +59,7 @@
                         <t t-if="this.showStartMessage" t-call="mail.Thread.startMessage"/>
                         <div t-else="" class="d-flex flex-column align-items-center">
                             <span class="fs-1" style="filter: grayscale(1);">😶</span>
-                            <span>The conversation is empty.</span>
+                            <span>No messages yet.</span>
                         </div>
                     </t>
                 </t>

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -278,7 +278,7 @@ test("should not display user notification messages in chatter", async () => {
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await contains(".o-mail-Thread:has(:text('The conversation is empty.'))");
+    await contains(".o-mail-Thread:has(:text('No messages yet.'))");
     await contains(".o-mail-Message", { count: 0 });
 });
 

--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -105,6 +105,8 @@ class PortalWebClientController(WebclientController):
         }
 
         def can_react(thread):
+            if not getattr(thread, "_reactions_in_portal_chatter", False):
+                return False
             thread_mode = False
             # sudo: mail.thread - can read thread to build _mail_get_operation_for_mail_message_operation
             for domain, operation in thread.sudo()._mail_get_operation_for_mail_message_operation(
@@ -127,6 +129,7 @@ class PortalWebClientController(WebclientController):
             return bool(has_access)
 
         res.attr("can_react", can_react)
+        res.attr("display_name")
         res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
         res.one(
             "portal_partner",

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -124,24 +124,25 @@ class MailMessage(models.Model):
             if 'published_date_str' in properties_names:
                 values['published_date_str'] = format_datetime(self.env, values['date']) if values.get('date') else ''
             reaction_groups = []
-            for content, reactions in groupby(message.sudo().reaction_ids, lambda r: r.content):
-                reactions = self.env["mail.message.reaction"].union(reactions)
-                reaction_groups.append(
-                    {
-                        "content": content,
-                        "count": len(reactions),
-                        "guests": [
-                            {"id": guest.id, "name": guest.name}
-                            for guest in reactions.guest_id
-                        ],
-                        "message": message.id,
-                        "partners": [
-                            # sudo: res.partner - reading partners of reaction on accessible message is allowed
-                            {"id": partner.id, "name": partner.name}
-                            for partner in reactions.partner_id.sudo()
-                        ],
-                    },
-                )
+            if getattr(self.env[values["model"]], "_reactions_in_portal_chatter", False):
+                for content, reactions in groupby(message.sudo().reaction_ids, lambda r: r.content):
+                    reactions = self.env["mail.message.reaction"].union(reactions)
+                    reaction_groups.append(
+                        {
+                            "content": content,
+                            "count": len(reactions),
+                            "guests": [
+                                {"id": guest.id, "name": guest.name}
+                                for guest in reactions.guest_id
+                            ],
+                            "message": message.id,
+                            "partners": [
+                                # sudo: res.partner - reading partners of reaction on accessible message is allowed
+                                {"id": partner.id, "name": partner.name}
+                                for partner in reactions.partner_id.sudo()
+                            ],
+                        },
+                    )
             values.update(
                 {
                     "reactions": reaction_groups,
@@ -177,6 +178,8 @@ class MailMessage(models.Model):
             else attachment_values["mimetype"])
         attachment = self.env['ir.attachment'].browse(attachment_values['id'])
         attachment_values["raw_access_token"] = attachment._get_raw_access_token()
+        attachment_values["has_thumbnail"] = attachment.has_thumbnail
+        attachment_values["thumbnail_access_token"] = attachment._get_thumbnail_token()
         if self.is_current_user_or_guest_author:
             attachment_values["ownership_token"] = attachment._get_ownership_token()
         return attachment_values

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -664,10 +664,12 @@
                      the message will be posted with the identity of the partner_id of the object
             :hash : signed token with the partner_id using `_sign_token` method (on mail.thread)
             :pid : identifier of the partner signing the token
+            :hide_header bool (optional) : hide the chatter header
 
         NOTE: for standard portal flows, _get_page_view_values should be used to properly setup the template parameters
     -->
     <template id="message_thread">
+        <h3 t-if="not hide_header">Communication History</h3>
         <div id="discussion" data-anchor="true"
             class="d-print-none o_portal_chatter o_not_editable p-0"
             t-att-data-token="token"

--- a/addons/project/static/src/project_sharing/chatter/message_model_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/message_model_patch.js
@@ -5,4 +5,7 @@ patch(Message.prototype, {
     shouldHideFromMessageListOnDelete(env) {
         return env.projectSharingId || super.shouldHideFromMessageListOnDelete(...arguments);
     },
+    canAddReaction({ owner, thread }){
+        return super.canAddReaction(...arguments) && !owner.env.projectSharingId;
+    },
 });

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -211,20 +211,6 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
     ],
 });
 
-registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message_reactions", {
-    steps: () => [
-        {
-            trigger: "table > tbody > tr a:has(span:contains(Project Sharing))",
-            run: "click",
-            expectUnloadPage: true,
-        },
-        { trigger: ".o_project_sharing" },
-        { trigger: ".o_kanban_record:contains('Test Task with messages')", run: "click" },
-        { trigger: ".o-mail-Message" },
-        { trigger: ".o-mail-Message .o-mail-MessageReaction:contains('👀')" },
-    ],
-});
-
 registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_users", {
     steps: () => [
         {

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -130,43 +130,6 @@ class TestProjectSharingUi(HttpCase):
         })
         self.start_tour("/my/projects", 'portal_project_sharing_tour_with_disallowed_milestones', login='georges1')
 
-    def test_04_project_sharing_chatter_message_reactions(self):
-        # portal users can load chatter messages containing partner reactions
-        self.env['project.share.wizard'].create({
-            'res_model': 'project.project',
-            'res_id': self.project_portal.id,
-            'collaborator_ids': [
-                Command.create({'partner_id': self.partner_portal.id, 'access_mode': 'edit'}),
-            ],
-        })
-        user_john = self.env["res.users"].create({
-            'name': 'John',
-            'login': 'john',
-            'password': 'john1234',
-            'email': 'john@example.com',
-            'group_ids': [Command.set([
-                self.env.ref('base.group_user').id,
-                self.env.ref('project.group_project_user').id
-            ])]
-        })
-        task = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
-            'name': 'Test Task with messages',
-            'project_id': self.project_portal.id,
-        })
-        self.authenticate("georges1", "georges1")
-        message = task.message_post(
-            body='TestingMessage',
-            message_type="comment",
-            subtype_id=self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
-        )
-        self.authenticate("john", "john")
-        self.project_portal.message_subscribe(partner_ids=[user_john.partner_id.id])
-        self.make_jsonrpc_request(
-            route="/mail/message/reaction",
-            params={"action": "add", "content": "👀", "message_id": message.id},
-        )
-        self.start_tour("/my/projects", 'test_04_project_sharing_chatter_message_reactions', login='georges1')
-
     def test_05_project_sharing_chatter_mention_users(self):
         self.env["project.share.wizard"].create(
             {

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -300,7 +300,6 @@
 
                     <hr/>
                     <div id="task_chat" data-anchor="true">
-                        <h3>Communication history</h3>
                         <t t-call="portal.message_thread" token="task.access_token"/>
                     </div>
                 </div>

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -300,7 +300,7 @@
 
                     <hr/>
                     <div id="task_chat" data-anchor="true">
-                        <h3>Communication history</h3>
+                        <h3>Communication History</h3>
                         <t t-call="portal.message_thread" token="task.access_token"/>
                     </div>
                 </div>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -175,7 +175,6 @@
                   <!-- chatter -->
                   <hr/>
                   <div id="purchase_order_communication">
-                      <h3>Communication history</h3>
                       <t t-call="portal.message_thread"/>
                   </div>
               </div><!-- // #quote_content -->

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -175,7 +175,7 @@
                   <!-- chatter -->
                   <hr/>
                   <div id="purchase_order_communication">
-                      <h3>Communication history</h3>
+                      <h3>Communication History</h3>
                       <t t-call="portal.message_thread"/>
                   </div>
               </div><!-- // #quote_content -->

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -378,7 +378,6 @@
                     <!-- chatter -->
                     <hr/>
                     <div id="sale_order_communication">
-                        <h3>Communication history</h3>
                         <t t-call="portal.message_thread"/>
                     </div>
                 </div><!-- // #quote_content -->

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -371,7 +371,7 @@
                     <!-- chatter -->
                     <hr/>
                     <div id="sale_order_communication">
-                        <h3>Communication history</h3>
+                        <h3>Communication History</h3>
                         <t t-call="portal.message_thread"/>
                     </div>
                 </div><!-- // #quote_content -->

--- a/addons/test_discuss_full/static/tests/tours/im_livechat_session_open_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/im_livechat_session_open_tour.js
@@ -11,7 +11,7 @@ registry.category("web_tour.tours").add("im_livechat_session_open", {
             run: "click",
         },
         {
-            trigger: ".o-mail-Thread:contains('The conversation is empty.')",
+            trigger: ".o-mail-Thread:contains('No messages yet.')",
         },
     ],
 });

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -13,6 +13,7 @@ class MailTestPortal(models.Model):
         'portal.mixin',
         'mail.thread',
     ]
+    _reactions_in_portal_chatter = True
 
     name = fields.Char('Name')
     partner_id = fields.Many2one('res.partner', 'Customer')
@@ -32,6 +33,7 @@ class MailTestPortalNoPartner(models.Model):
         'mail.thread',
         'portal.mixin',
     ]
+    _reactions_in_portal_chatter = True
 
     name = fields.Char()
 

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -1,18 +1,5 @@
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("bookmark_message_tour", {
-    steps: () => [
-        {
-            trigger:
-                "#chatterRoot:shadow .o-mail-Message:not([data-bookmarked]):contains(Test Message)",
-            run: "hover && click #chatterRoot:shadow [title='Bookmark']",
-        },
-        {
-            trigger: "#chatterRoot:shadow .o-mail-Message[data-bookmarked]:contains(Test Message)",
-        },
-    ],
-});
-
 registry.category("web_tour.tours").add("message_actions_tour", {
     steps: () => [
         {

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -247,21 +247,25 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                     {
                         'checksum': message.attachment_ids[0].checksum,
                         'filename': 'Test file 1',
+                        'has_thumbnail': False,
                         'id': message.attachment_ids[0].id,
                         'mimetype': 'text/plain',
                         'name': 'Test file 1',
                         'raw_access_token': message.attachment_ids[0]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
+                        'thumbnail_access_token': message.attachment_ids[0]._get_thumbnail_token(),
                     }, {
                         'checksum': message.attachment_ids[1].checksum,
                         'filename': 'Test file 0',
+                        'has_thumbnail': False,
                         'id': message.attachment_ids[1].id,
                         'mimetype': 'text/plain',
                         'name': 'Test file 0',
                         'raw_access_token': message.attachment_ids[1]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
+                        'thumbnail_access_token': message.attachment_ids[1]._get_thumbnail_token(),
                     }
                 ]
             )

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -22,13 +22,6 @@ class TestUIPortal(TestPortal):
             }
         )
 
-    def test_bookmark_message(self):
-        self.start_tour(
-            f"/my/test_portal_records/{self.record_portal.id}",
-            "bookmark_message_tour",
-            login=self.user_employee.login,
-        )
-
     def test_no_copy_link_for_non_readable_portal_record(self):
         # mail.test.portal has read access only for base.group_user
         self.start_tour(

--- a/addons/test_mail_full/views/test_portal_template.xml
+++ b/addons/test_mail_full/views/test_portal_template.xml
@@ -5,7 +5,6 @@
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <!-- chatter -->
             <div>
-                <h3>Communication history</h3>
                 <t t-call="portal.message_thread"/>
             </div>
         </xpath>

--- a/addons/test_mail_full/views/test_portal_template.xml
+++ b/addons/test_mail_full/views/test_portal_template.xml
@@ -5,7 +5,7 @@
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <!-- chatter -->
             <div>
-                <h3>Communication history</h3>
+                <h3>Communication History</h3>
                 <t t-call="portal.message_thread"/>
             </div>
         </xpath>

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -173,6 +173,7 @@ class BlogPost(models.Model):
         'website.cover_properties.mixin', 'website.searchable.mixin']
     _order = 'id DESC'
     _mail_post_access = 'read'
+    _reactions_in_portal_chatter = True
 
     def _compute_website_url(self):
         super(BlogPost, self)._compute_website_url()

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -312,7 +312,7 @@ list of filtered posts (by date or tag).
                     <div groups="base.group_public" class="small mb-4">
                         <a t-attf-href="/web/login?redirect=/blog/{{slug(blog_post.blog_id)}}/{{slug(blog_post)}}#discussion" class="btn btn-sm btn-primary"><b>Sign in</b></a> to leave a comment
                     </div>
-                    <t t-call="portal.message_thread" object="blog_post"/>
+                    <t t-call="portal.message_thread" object="blog_post" hide_header="True"/>
                 </div>
             </div>
         </div>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -528,7 +528,6 @@
             </div>
             <hr/>
             <div>
-                <h3>Communication history</h3>
                 <div>
                     <t t-call="portal.message_thread" object="lead"/>
                 </div>
@@ -821,7 +820,6 @@
             <hr/>
 
             <div>
-                <h3>Communication history</h3>
                 <div>
                     <t t-call="portal.message_thread" object="opportunity"/>
                 </div>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -526,7 +526,7 @@
             </div>
             <hr/>
             <div>
-                <h3>Communication history</h3>
+                <h3>Communication History</h3>
                 <div>
                     <t t-call="portal.message_thread" object="lead"/>
                 </div>
@@ -823,7 +823,7 @@
             <hr/>
 
             <div>
-                <h3>Communication history</h3>
+                <h3>Communication History</h3>
                 <div>
                     <t t-call="portal.message_thread" object="opportunity"/>
                 </div>

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -42,6 +42,7 @@ class ProductTemplate(models.Model):
         "website.searchable.mixin",
     ]
     _mail_post_access = "read"
+    _reactions_in_portal_chatter = True
     _check_company_auto = True
 
     # === DEFAULT METHODS ===#

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -858,6 +858,7 @@
                         <t t-call="portal.message_thread"
                             object="product"
                             display_rating="True"
+                            hide_header="True"
                             message_per_page="5"
                             two_columns="true"/>
                     </div>

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -32,6 +32,7 @@ class SlideChannel(models.Model):
     ]
     _order = 'sequence, id'
     _partner_unfollow_enabled = True
+    _reactions_in_portal_chatter = True
 
     _CUSTOMER_HEADERS_LIMIT_COUNT = 0  # never use X-Msg-To headers
 

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -30,6 +30,7 @@ class SlideSlide(models.Model):
     ]
     _description = 'Slide'
     _mail_post_access = 'read'
+    _reactions_in_portal_chatter = True
     _order_by_strategy = {
         'sequence': 'sequence asc, id asc',
         'most_viewed': 'total_views desc',

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -56,7 +56,7 @@ registry.category("web_tour.tours").add("course_review_modification", {
                 "#chatterRoot:shadow .o-mail-Chatter:not(:has(.o_website_rating_card_container))",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Thread:contains(The conversation is empty.)",
+            trigger: "#chatterRoot:shadow .o-mail-Thread:contains(No messages yet.)",
         },
         {
             trigger: ".o_wslides_course_header .o_website_rating_static[title='0 stars on 5']",

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             // If it fails here, it means that the portal chatter has fetched the notes.
-            trigger: "#chatterRoot:shadow .o-mail-Chatter:has(:text(The conversation is empty.))",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter:has(:text(No messages yet.))",
         },
         {
             // If it fails here, it means the log note is considered as a review

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -221,6 +221,7 @@
                                         object="channel"
                                         hash="message_post_hash"
                                         pid="message_post_pid"
+                                        hide_header="True"
                                         display_rating="True"
                                         disable_composer="True"/>
                                 </div>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -367,6 +367,7 @@
                 </t>
                 <t t-if="enable_slide_comments" t-call="portal.message_thread"
                     object="slide"
+                    hide_header="True"
                     disable_composer="not (slide.channel_id.can_comment and slide.channel_id.allow_comment)"
                     display_rating="False"/>
             </div>


### PR DESCRIPTION
* = account{_payment}, project, purchase, sale, test_discuss_full, test_mail_full, website_crm_partner_assign, website_slides

Enterprise PR: https://github.com/odoo/enterprise/pull/117246

This commit improves the portal chatter UX by:
- Adapting the copywriting of the empty conversation message.
- Adapting the capitalization of the chatter header.

task-6041769