### PR TITLE
[FIX] spreadsheet: strip json before extending it

### DIFF
--- a/addons/spreadsheet/tests/test_utils.py
+++ b/addons/spreadsheet/tests/test_utils.py
@@ -37,3 +37,7 @@ class TestSpreadsheetUtils(TransactionCase):
             extend_serialized_json('{}', [('key1', '1'), ('key2', '2')]),
             '{"key1":1,"key2":2}'
         )
+        self.assertEqual(
+            extend_serialized_json('\n{}\n', [('key1', '1'), ('key2', '2')]),
+            '{"key1":1,"key2":2}'
+        )

--- a/addons/spreadsheet/utils/json.py
+++ b/addons/spreadsheet/utils/json.py
@@ -5,6 +5,7 @@ def extend_serialized_json(json: str, key_value_pairs: list) -> str:
     Add key-value pairs to a serialized JSON object string.
     value should be already serialized.
     """
+    json = json.strip()
     # avoid copying strings as much as possible for performance reasons
     parts = [json.removesuffix('}')]
     if json != '{}':


### PR DESCRIPTION
Steps to reproduce:
- Share the Sales Commission spreadsheet
- Open the shared link ⮕ traceback

This was caused by the trailing line break in the json, so the last character was not a `}`.

Task: 6064328

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
