### PR TITLE
[FIX] hr_attendance: checkout employee when archived

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -76,6 +76,15 @@ class HrEmployee(models.Model):
 
         return res
 
+    def action_archive(self):
+        super().action_archive()
+        self.env['hr.attendance'].search([
+            ('employee_id', 'in', self.ids),
+            ('check_out', '=', False),
+        ]).write({
+            'check_out': fields.Datetime.now(),
+        })
+
     @api.depends('overtime_ids.duration', 'attendance_ids')
     def _compute_total_overtime(self):
         for employee in self:

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -2,6 +2,7 @@
 
 import pytz
 from datetime import datetime
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
@@ -62,3 +63,15 @@ class TestHrAttendance(TransactionCase):
         # now = 2019/3/2 14:00 in the employee's timezone
         with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(pytz.utc).replace(tzinfo=None)):
             self.assertEqual(employee.hours_today, 5, "It should have counted 5 hours")
+
+    def test_attendance_checkout_while_employee_archived(self):
+        """An employee should be checked out by the system, if employee is getting archive."""
+        test_attendance = self.env['hr.attendance'].create({
+            'check_in': datetime(2024, 1, 1, 8, 0),
+            'employee_id': self.test_employee.id,
+        })
+
+        with freeze_time("2024-01-01 17:00:00"):
+            self.test_employee.action_archive()
+            self.assertEqual(test_attendance.check_out, fields.Datetime.now())
+            self.assertEqual(test_attendance.worked_hours, 8.0)


### PR DESCRIPTION
Before:
- When an employee was archived, their attendance was not updated.

After:
- When an employee is archived, if they are currently checked in, they will be automatically checked out at the current timestamp.

task-5916700

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
