### PR TITLE
[FIX] web: avoid missing freshly generated /web/assets on replica

### DIFF
--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -94,9 +94,9 @@ class Binary(http.Controller):
         assets_params = assets_params or {}
         assert isinstance(assets_params, dict)
         debug_assets = unique == 'debug'
+        stream = None
         if unique in ('any', '%'):
             unique = ANY_UNIQUE
-        attachment = None
         if unique != 'debug':
             url = env['ir.asset']._get_asset_bundle_url(filename, unique, assets_params)
             assert not '%' in url
@@ -109,7 +109,9 @@ class Binary(http.Controller):
                 ('create_uid', '=', SUPERUSER_ID),
             ]
             attachment = env['ir.attachment'].sudo().search(domain, limit=1)
-        if not attachment:
+            if attachment:
+                stream = env['ir.binary']._get_stream_from(attachment, 'raw', filename)
+        if stream is None:
             # try to generate one
             if env.cr.readonly:
                 env.cr.rollback()  # reset state to detect newly generated assets
@@ -137,16 +139,18 @@ class Binary(http.Controller):
                     # check if the version matches. If not, redirect to the last version
                     if not debug_assets and unique != ANY_UNIQUE and unique != bundle.get_version(asset_type):
                         return request.redirect(bundle.get_link(asset_type))
+                    attachment = None
                     if css and bundle.stylesheets:
-                        attachment = env['ir.attachment'].sudo().browse(bundle.css().id)
+                        attachment = bundle.css()
                     elif js and bundle.javascripts:
-                        attachment = env['ir.attachment'].sudo().browse(bundle.js().id)
+                        attachment = bundle.js()
+                    if attachment:
+                        stream = rw_env['ir.binary']._get_stream_from(attachment, 'raw', filename)
                 except ValueError as e:
                     _logger.warning("Parsing asset bundle %s has failed: %s", filename, e)
                     raise request.not_found() from e
-        if not attachment:
+        if stream is None:
             raise request.not_found()
-        stream = env['ir.binary']._get_stream_from(attachment, 'raw', filename)
         send_file_kwargs = {'as_attachment': False, 'content_security_policy': None}
         if unique and unique != 'debug':
             send_file_kwargs['immutable'] = True

--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -192,3 +192,31 @@ class TestWebAssetsCursors(HttpCase):
             ],
             'Only one readwrite cursor should be used to generate assets without replica',
         )
+
+    def test_web_binary_streams_generated_asset_from_rw_cursor(self):
+        """
+        When a readonly asset request has to generate a fresh bundle, the response should
+        not reread that freshly created attachment from the readonly cursor.
+        """
+        generated_attachment_ids = set()
+        original_save_attachment = odoo.addons.base.models.assetsbundle.AssetsBundle.save_attachment
+        original_get_stream_from = odoo.addons.base.models.ir_binary.IrBinary._get_stream_from
+
+        def save_attachment(bundle, extension, content):
+            attachment = original_save_attachment(bundle, extension, content)
+            generated_attachment_ids.update(attachment.ids)
+            return attachment
+
+        def get_stream_from(binary, record, *args, **kwargs):
+            if (
+                binary.env.cr.readonly
+                and record._name == 'ir.attachment'
+                and record.id in generated_attachment_ids
+            ):
+                raise AssertionError("Freshly generated assets should not be streamed from a readonly cursor")
+            return original_get_stream_from(binary, record, *args, **kwargs)
+
+        with patch('odoo.addons.base.models.assetsbundle.AssetsBundle.save_attachment', autospec=True, side_effect=save_attachment):
+            with patch('odoo.addons.base.models.ir_binary.IrBinary._get_stream_from', autospec=True, side_effect=get_stream_from):
+                response = self.url_open(f'/web/assets/{self.bundle_version}/{self.bundle_name}.min.css', allow_redirects=False)
+                self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
When `/web/assets/...` is requested on a readonly route and the bundle is missing, Odoo regenerates it on the primary using a RW cursor. It can then still try to read the freshly created `ir.attachment` through the original RO/replica env.

In a primary/replica setup, replication may not have caught up yet, so the new attachment is not visible on the replica. As a result, readonly `/web/assets/...` requests can fail right after asset regeneration when fetching the freshly generated bundle.

Steps to reproduce:
1. Configure Odoo with a PostgreSQL primary/replica setup.
2. Open a website in edit mode.
3. Trigger an asset regeneration (for example by changing a theme color).
4. Let the resulting readonly `/web/assets/...` request fetch the freshly generated bundle.

Build the response stream from the RW env after regeneration instead of rereading the fresh attachment through the RO/replica env.

opw-6034833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
