### PR TITLE
[IMP] l10n_pe_pos:  Display Positive Amounts for Credit Notes in POS receipt

### DIFF
--- a/addons/l10n_pe_pos/__init__.py
+++ b/addons/l10n_pe_pos/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
+from . import receipt

--- a/addons/l10n_pe_pos/receipt/__init__.py
+++ b/addons/l10n_pe_pos/receipt/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order_receipt

--- a/addons/l10n_pe_pos/receipt/pos_order_receipt.py
+++ b/addons/l10n_pe_pos/receipt/pos_order_receipt.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class PosOrderReceipt(models.AbstractModel):
+    _inherit = 'pos.order.receipt'
+    _description = 'Point of Sale Order Receipt Generator'
+
+    def _order_receipt_generate_line_data(self):
+        lines = super()._order_receipt_generate_line_data()
+        if self.company_id.country_code == 'PE' and self.is_refund:
+            # Invert values for refund (reverse sign)
+            for line in lines:
+                line['qty'] *= -1
+        return lines
+
+    def _order_receipt_generate_payment_data(self):
+        payments = super()._order_receipt_generate_payment_data()
+        if self.company_id.country_code == 'PE' and self.is_refund:
+            # Invert values for refund (reverse sign)
+            for i, line in enumerate(self.payment_ids):
+                payments[i]['amount'] = self._order_receipt_format_currency(line.amount * -1)
+        return payments

--- a/addons/l10n_pe_pos/static/src/app/utils/generate_printer_data.js
+++ b/addons/l10n_pe_pos/static/src/app/utils/generate_printer_data.js
@@ -1,0 +1,52 @@
+import { patch } from "@web/core/utils/patch";
+import { GeneratePrinterData } from "@point_of_sale/app/utils/printer/generate_printer_data";
+
+patch(GeneratePrinterData.prototype, {
+    generateTaxData() {
+        if (this.company.country_id.code !== "PE") {
+            return super.generateTaxData(...arguments);
+        }
+        const data = this.order._constructPriceData();
+        const discount = this.order.getTotalDiscount();
+        const rounding = this.order.appliedRounding;
+        const sign = this.order.orderSign; // Invert values for refund (reverse sign)
+
+        return {
+            same_tax_base: data.taxDetails.same_tax_base,
+            discount_amount: discount ? this.formatCurrency(discount * sign) : false,
+            rounding_amount: rounding ? this.formatCurrency(rounding * sign) : false,
+            tax_amount: this.formatCurrency(data.taxDetails.tax_amount * sign),
+            total_amount: this.formatCurrency(data.taxDetails.total_amount * sign),
+            subtotal_amount: this.formatCurrency(data.taxDetails.base_amount_currency * sign),
+            taxes: data.taxDetails.subtotals[0]?.tax_groups?.map((tax) => ({
+                name: tax.group_name,
+                amount: this.formatCurrency(tax.tax_amount * sign),
+                amount_base: this.formatCurrency(tax.base_amount_currency * sign),
+            })),
+        };
+    },
+
+    generateLineData() {
+        const lines = super.generateLineData(...arguments);
+        if (this.company.country_id.code !== "PE") {
+            return lines;
+        }
+        const sign = this.order.orderSign;
+        return lines.map((line) => ({
+            ...line,
+            qty: line.qty * sign,
+        }));
+    },
+
+    generatePaymentData() {
+        const data = super.generatePaymentData(...arguments);
+        if (this.company.country_id.code !== "PE") {
+            return data;
+        }
+        const sign = this.order.orderSign;
+        return this.order.payment_ids.map((line, index) => ({
+            ...data[index],
+            amount: this.formatCurrency(line.amount * sign),
+        }));
+    },
+});


### PR DESCRIPTION
- In the Peruvian localization, credit notes (Nota de Crédito Electrónica) are legal documents where amounts must be represented in positive values, since The document itself already implies a reversal in accounting terms.
- This discrepancy creates confusion in the printed ticket when using the POS as the official electronic document representation.

In this commit:
- We print the positive value of the amount and the product quantity in the POS refund receipt.

task-6061747
