### PR TITLE
[FIX] website_sale: filmstrip height with no image

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -158,11 +158,13 @@
 
         // Filmstrip design variations ->
         &.o_wsale_filmstrip_default {
+            --o-wsale-filmstrip-item-min-height: 3.5rem;
             --o-wsale-filmstrip-item-color: #{color-contrast($light)};
             --o-wsale-filmstrip-item-bg-hover: #{if(lightness($light) > .5, darken($light, 8%), lighten($light, 8%))};
         }
 
         &.o_wsale_filmstrip_bordered {
+            --o-wsale-filmstrip-item-min-height: 3.5rem;
             --o-wsale-filmstrip-item-border-width: #{$border-width};
             --o-wsale-filmstrip-item-bg: transparent;
             --o-wsale-filmstrip-item-image-bg: #{$gray-100};

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -1198,9 +1198,6 @@
         <div id="o_wsale_categories_filmstrip" position="attributes">
             <attribute name="class" add="o_wsale_filmstrip_images" remove="o_wsale_filmstrip_default" separator=" "/>
         </div>
-        <div name="o_wsale_filmstrip_placeholder" position="attributes">
-            <attribute name="t-if">not c.has_published_products</attribute>
-        </div>
     </template>
     <template
         id="website_sale.filmstrip_categories_grid"


### PR DESCRIPTION
This commit fixes two issues regarding the filmstrip in the /shop page :

- Adding a minimum height to the elements of the `default` and `bordered` designs, so that their heights remain consistent whether they contain an image or not.
- Display a placeholder image for the `images` filmstrip if empty.

task-5491550

| Before | After |
|--------|--------|
| <img width="613" height="103" alt="image" src="https://github.com/user-attachments/assets/852ef2ce-6265-4622-9e30-4e8112bbf264" /> | <img width="618" height="114" alt="image" src="https://github.com/user-attachments/assets/0933c0c2-a669-4236-9148-a25226214ce6" /> |
| <img width="718" height="164" alt="image" src="https://github.com/user-attachments/assets/ac1b8d91-44fa-4ce0-8ddb-beba271a2423" /> | <img width="718" height="164" alt="image" src="https://github.com/user-attachments/assets/8676e9f9-074b-40e9-a75b-76561437c081" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
