### PR TITLE
[IMP] point_of_sale: loopback support for LNA TargetAddressSpace

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -94,6 +94,8 @@
             # for the render_service.test.js
             'point_of_sale/static/src/app/utils/html-to-image.js',
             'point_of_sale/static/src/app/printer/render_service.js',
+            # for lna.test.js
+            'point_of_sale/static/src/app/utils/init_lna.js',
         ],
 
         # PoS assets

--- a/addons/point_of_sale/static/src/app/utils/init_lna.js
+++ b/addons/point_of_sale/static/src/app/utils/init_lna.js
@@ -30,3 +30,16 @@ export const initLNA = async (notificationService) => {
         notificationService.add(message, { type: "warning" });
     }
 };
+
+export function getLNATargetAddressSpace(url) {
+    let hostname;
+    try {
+        hostname = new URL(url).hostname;
+    } catch {
+        hostname = url;
+    }
+    if (hostname === "localhost" || hostname === "127.0.0.1") {
+        return "loopback";
+    }
+    return "local";
+}

--- a/addons/point_of_sale/static/tests/unit/lna.test.js
+++ b/addons/point_of_sale/static/tests/unit/lna.test.js
@@ -1,0 +1,20 @@
+import { expect, test } from "@odoo/hoot";
+import { getLNATargetAddressSpace } from "@point_of_sale/app/utils/init_lna";
+
+test("targetAddressSpace local", () => {
+    expect(getLNATargetAddressSpace("http://192.168.1.1")).toBe("local");
+    expect(getLNATargetAddressSpace("http://192.168.1.1:8008")).toBe("local");
+    expect(getLNATargetAddressSpace("http://192.168.1.1:8080/demo")).toBe("local");
+
+    expect(getLNATargetAddressSpace("invalidurl")).toBe("local");
+});
+
+test("targetAddressSpace loopback", () => {
+    expect(getLNATargetAddressSpace("http://localhost")).toBe("loopback");
+    expect(getLNATargetAddressSpace("http://localhost:1234/demo")).toBe("loopback");
+    expect(getLNATargetAddressSpace("http://localhost/demo")).toBe("loopback");
+
+    expect(getLNATargetAddressSpace("http://127.0.0.1")).toBe("loopback");
+    expect(getLNATargetAddressSpace("http://127.0.0.1:1234/demo")).toBe("loopback");
+    expect(getLNATargetAddressSpace("http://127.0.0.1/demo")).toBe("loopback");
+});

--- a/addons/pos_epson_printer/static/src/app/epson_printer.js
+++ b/addons/pos_epson_printer/static/src/app/epson_printer.js
@@ -2,6 +2,7 @@ import { BasePrinter } from "@point_of_sale/app/printer/base_printer";
 import { _t } from "@web/core/l10n/translation";
 import { getTemplate } from "@web/core/templates";
 import { createElement, append, createTextNode } from "@web/core/utils/xml";
+import { getLNATargetAddressSpace } from "@point_of_sale/app/utils/init_lna";
 
 function ePOSPrint(children) {
     let ePOSLayout = getTemplate("pos_epson_printer.ePOSLayout");
@@ -26,6 +27,9 @@ export class EpsonPrinter extends BasePrinter {
         const protocol = odoo.use_lna ? "http:" : window.location.protocol;
         this.url = protocol + "//" + ip;
         this.address = this.url + "/cgi-bin/epos/service.cgi?devid=local_printer";
+        if (odoo.use_lna) {
+            this.lnaTargetAddressSpace = getLNATargetAddressSpace(this.address);
+        }
     }
 
     /**
@@ -66,8 +70,8 @@ export class EpsonPrinter extends BasePrinter {
             body: img,
         };
 
-        if (odoo.use_lna) {
-            params.targetAddressSpace = "local";
+        if (this.lnaTargetAddressSpace) {
+            params.targetAddressSpace = this.lnaTargetAddressSpace;
         }
 
         const res = await fetch(this.address, params);


### PR DESCRIPTION
This commit backports support for loopback TargetAddressSpace from 19.0.

Before:
LNA requests to localhost (127.0.0.1) used "local" TargetAddressSpace,
which caused communication issues (CORS/PNA restrictions).

After:
Requests to localhost now correctly use "loopback" TargetAddressSpace,
allowing proper communication with locally running devices.

Impact:
Enables stable communication with USB/network printers running on
localhost without requiring IoT devices.

Reference:
https://github.com/odoo/odoo/pull/250972

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
