### PR TITLE
[FIX] web_editor: fix language direction in convert inline

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -890,6 +890,17 @@ export async function toInline(element, cssRules) {
         node.removeAttribute("contenteditable")
     );
 
+    // Ensure language direction is applied
+    if (editable.hasAttribute('dir')) {
+        const dir = editable.getAttribute('dir');
+        if (dir === 'ltr' || dir === 'rtl') {
+            Array.from(editable.children).forEach(child => {
+                child.style.setProperty('direction', dir);
+            });
+        }
+        editable.removeAttribute('dir');
+    }
+
     // Hide replaced cells on Outlook
     element.querySelectorAll(".mso-hide").forEach(_hideForOutlook);
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -796,6 +796,17 @@ export async function toInline($editable, options) {
     // Remove contenteditable attributes
     [editable, ...editable.querySelectorAll('[contenteditable]')].forEach(node => node.removeAttribute('contenteditable'));
 
+    // Ensure language direction is applied
+    if (editable.hasAttribute('dir')) {
+        const dir = editable.getAttribute('dir');
+        if (dir === 'ltr' || dir === 'rtl') {
+            Array.from(editable.children).forEach(child => {
+                child.style.setProperty('direction', dir);
+            });
+        }
+        editable.removeAttribute('dir');
+    }
+
     // Hide replaced cells on Outlook
     editable.querySelectorAll('.mso-hide').forEach(_hideForOutlook);
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Mail Marketing app
- Change user language to a RTL language (such as Arabic)
- Create a marketing campaign with RTL content
- Send it
- Mail received changes from RTL to LTR

**Issue:**
Conversion doesn't seem to take into account the `dir` top-level attribute when creating the inline styling. This keeps the mails in the default format ('ltr').

**Fix:**
Check if the top-level element has such attributes, and manually add the `direction` style instead (style is applied on all direct children to ensure it's taken into account when taking the `innerHTML`).

opw-5982854