### PR TITLE
[IMP] website, website_sale: improve configurator

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -338,7 +338,10 @@
                 }
 
                 height: var(--ConfiguratorPreview-height);
-                box-shadow: $box-shadow-sm;
+
+                img {
+                    box-shadow: $box-shadow-sm;
+                }
 
                 @include media-breakpoint-up(lg) {
                     &:hover {
@@ -352,7 +355,10 @@
 
                 &:hover {
                     border-color: map-get($theme-colors, primary)!important;
-                    box-shadow: $box-shadow;
+
+                    img {
+                        box-shadow: $box-shadow;
+                    }
 
                     .theme_preview_tip {
                         transform: translate3d(0,-120%,0);

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -125,7 +125,7 @@ SHOP_PAGE_STYLE_MAPPING = {
         },
     },
     "chips_contained": {
-        "title": _lt("Chips Contained"),
+        "title": _lt("Minimal Cards"),
         "img_src": "/website_sale/static/src/img/configurator/shop/chips_contained.jpg",
         "views": {
             "enable": [
@@ -205,7 +205,7 @@ SHOP_PAGE_STYLE_MAPPING = {
         },
     },
     "cards": {
-        "title": _lt("Cards"),
+        "title": _lt("Visual Cards"),
         "img_src": "/website_sale/static/src/img/configurator/shop/cards.jpg",
         "views": {
             "enable": [
@@ -264,7 +264,7 @@ PRODUCT_PAGE_STYLE_MAPPING = {
         },
     },
     "large_grid": {
-        "title": _lt("Large Grid"),
+        "title": _lt("Showcase Grid"),
         "img_src": "/website_sale/static/src/img/configurator/product/large_grid.jpg",
         "views": {
             "enable": [

--- a/addons/website_sale/static/src/js/client_actions/configurator/productPageSelectionScreen.xml
+++ b/addons/website_sale/static/src/js/client_actions/configurator/productPageSelectionScreen.xml
@@ -6,15 +6,13 @@
             <div class="o_configurator_screen_content pb-5">
                 <div class="container-fluid px-3 px-xl-5">
                     <div class="o_configurator_typing_text text-center pt-3 mb-4">
-                        Choose your favorite <b class="text-info">Product Page</b>
+                        Choose your <b class="text-info">Product Page Template</b>
                     </div>
                     <div class="row row-cols-1 row-cols-lg-3 row-cols-sm-2 g-2 g-sm-3 g-lg-4">
                         <t t-foreach="this.productPageStyles" t-as="style" t-key="style_index">
                             <div class="col">
-                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2">
-                                    <h6 class="theme_preview_tip text-center text-muted d-none d-lg-block">
-                                        Click to select
-                                    </h6>
+                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2 text-center">
+                                    <h6 t-esc="style.title" class="badge border rounded-pill fs-6"/>
                                     <div class="ratio" style="--aspect-ratio: 66%;">
                                         <img
                                             t-attf-src="{{style.img_src}}"

--- a/addons/website_sale/static/src/js/client_actions/configurator/shopPageSelectionScreen.xml
+++ b/addons/website_sale/static/src/js/client_actions/configurator/shopPageSelectionScreen.xml
@@ -6,15 +6,13 @@
             <div class="o_configurator_screen_content pb-5">
                 <div class="container-fluid px-3 px-xl-5">
                     <div class="o_configurator_typing_text text-center pt-3 mb-4">
-                        Choose your favorite <b class="text-info">Online catalog</b>
+                        Choose your <b class="text-info">Online Catalog Template</b>
                     </div>
                     <div class="row row-cols-1 row-cols-lg-3 row-cols-sm-2 g-2 g-sm-3 g-lg-4">
                         <t t-foreach="this.shopPageStyles" t-as="style" t-key="style_index">
                             <div class="col">
-                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2">
-                                    <h6 class="theme_preview_tip text-center text-muted d-none d-lg-block">
-                                        Click to select
-                                    </h6>
+                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2 text-center">
+                                    <h6 t-esc="style.title" class="badge border rounded-pill fs-6"/>
                                     <div class="ratio" style="--aspect-ratio: 66%;">
                                         <img
                                             t-attf-src="{{style.img_src}}"


### PR DESCRIPTION
Before this PR, the catalog template configurator lead the user to choose the template based on the image. Now, by adding a description the user can understand that each template matches certain scenarios depending on their visual features.

**shopPageSelectionScreen**
| Before | After |
|--------|--------|
| <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 25" src="https://github.com/user-attachments/assets/16db6ec7-22a6-4444-94f1-cceb99f183da" /> | <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 01" src="https://github.com/user-attachments/assets/07497f3b-7283-410f-bd67-60f9f3bce937" /> |
| <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 33" src="https://github.com/user-attachments/assets/0a8efb45-b82d-4fe2-85d2-038718e59033" /> | <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 47" src="https://github.com/user-attachments/assets/5845a348-0aee-49b1-bf34-823a830cb0cf" /> | 

**productPageSelectionScreen**
| Before | After |
|--------|--------|
| <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 25 12" src="https://github.com/user-attachments/assets/e56a5521-e1b6-4610-ae87-5756a0d6b91c" /> | <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 55" src="https://github.com/user-attachments/assets/55acde91-a4d0-4957-8ec5-de67ad80f715" /> |
| <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 25 20" src="https://github.com/user-attachments/assets/d4a6e554-1f3a-45c2-a565-5dd6d5029ff4" /> | <img width="1683" height="1046" alt="Screenshot 2026-03-25 at 10 24 58" src="https://github.com/user-attachments/assets/f51e06c1-f6ab-47c8-a51b-96f5f695c4e4" /> | 

task-5906246

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
