### PR TITLE
[FIX] pos_online_payment: allow online payment when cash was mistakenly added first

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/receipt_screen_util.js
@@ -88,6 +88,15 @@ export function receiptAmountTotalIs(value) {
         },
     ];
 }
+export function receiptPaymentLineContains(paymentMethodName, amount) {
+    return [
+        {
+            isActive: ["desktop"],
+            content: `receipt payment line contains ${paymentMethodName} and ${amount}`,
+            trigger: `.receipt-screen .pos-receipt .paymentlines:contains("${paymentMethodName}"):contains("${amount}")`,
+        },
+    ];
+}
 export function receiptRoundingAmountIs(value) {
     return [
         {

--- a/addons/pos_online_payment/models/pos_order.py
+++ b/addons/pos_online_payment/models/pos_order.py
@@ -24,6 +24,17 @@ class PosOrder(models.Model):
         order_payments = self.env['pos.payment'].search(['&', ('pos_order_id', '=', self.id), ('online_account_payment_id', '=', False), ('payment_method_id.is_online_payment', '=', True)])
         order_payments.unlink()
 
+    def _clean_non_online_payment_lines(self):
+        self.ensure_one()
+        if self.state != 'draft':
+            return
+        non_online_payments = self.env['pos.payment'].search([
+            ('pos_order_id', '=', self.id),
+            ('payment_method_id.is_online_payment', '=', False),
+        ])
+        non_online_payments.unlink()
+        self.amount_paid = sum(self.payment_ids.mapped('amount'))
+
     def get_and_set_online_payments_data(self, next_online_payment_amount=False):
         """ Allows to update the amount to pay for the next online payment and
             get online payments already made and how much remains to be paid.
@@ -55,6 +66,16 @@ class PosOrder(models.Model):
                 return_data['deleted'] = True
             elif self._check_next_online_payment_amount(next_online_payment_amount):
                 self.next_online_payment_amount = next_online_payment_amount
+            elif (
+                tools.float_compare(next_online_payment_amount, 0.0, precision_rounding=self.currency_id.rounding) > 0
+                and tools.float_is_zero(self.get_amount_unpaid(), precision_rounding=self.currency_id.rounding)
+                and tools.float_compare(next_online_payment_amount, self._get_rounded_amount(self.amount_total), precision_rounding=self.currency_id.rounding) == 0
+                and not online_payments
+            ):  # There is a positive payment equal to the total order amount, the order has no unpaid balance, and no online payment record exists yet.
+                self.sudo()._clean_non_online_payment_lines()
+                return_data['amount_unpaid'] = self.get_amount_unpaid()
+                if self._check_next_online_payment_amount(next_online_payment_amount):
+                    self.next_online_payment_amount = next_online_payment_amount
 
         return return_data
 

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -71,6 +71,31 @@ patch(PaymentScreen.prototype, {
 
         const onlinePaymentLines = this.getRemainingOnlinePaymentLines();
         if (onlinePaymentLines.length > 0) {
+            const nonOnlineTotal = this.paymentLines
+                .filter(
+                    (l) =>
+                        !l.payment_method_id.is_online_payment || l.get_payment_status() === "done"
+                )
+                .reduce((sum, l) => sum + l.get_amount(), 0);
+            const orderTotal = this.currentOrder.amount_total;
+            const remainingForOnline = orderTotal - nonOnlineTotal;
+            const nonOnlineFullyCovers =
+                !this.env.utils.floatIsZero(orderTotal) &&
+                (this.env.utils.floatIsZero(Math.max(0, remainingForOnline)) ||
+                    remainingForOnline < 0);
+            if (nonOnlineFullyCovers) {
+                for (const line of [...this.paymentLines].filter(
+                    (l) => !l.payment_method_id.is_online_payment
+                )) {
+                    this.currentOrder.remove_paymentline(line);
+                }
+                for (const line of onlinePaymentLines) {
+                    if (this.env.utils.floatIsZero(line.get_amount())) {
+                        line.set_amount(orderTotal);
+                    }
+                }
+            }
+
             if (!this.currentOrder.id) {
                 this.cancelOnlinePayment(this.currentOrder);
                 this.dialog.add(AlertDialog, {

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -1,7 +1,9 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as OnlinePayment from "./utils/patch_online_payment_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
@@ -76,5 +78,29 @@ registry.category("web_tour.tours").add("test_selected_customer_after_adding_pay
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
             Dialog.is("Scan to Pay"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_switch_from_cash_to_online_payment_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "1"),
+            ProductScreen.selectedOrderlineHas("Letter Tray", "1.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("4.8"),
+            PaymentScreen.emptyPaymentlines("4.8"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.selectedPaymentlineHas("Cash", "4.8"),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.enterPaymentLineAmount("Online payment", "4.8"),
+            PaymentScreen.selectedPaymentlineHas("Online payment", "4.8"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            OnlinePayment.patchAndMockOnlinePayment(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.receiptAmountTotalIs("4.8"),
+            ReceiptScreen.receiptPaymentLineContains("Online payment", "4.8"),
         ].flat(),
 });

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -1,7 +1,9 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as OnlinePayment from "./utils/patch_online_payment_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
@@ -109,5 +111,29 @@ registry.category("web_tour.tours").add("test_selected_customer_after_adding_pay
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
             Dialog.is("Scan to Pay"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_switch_from_cash_to_online_payment_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "1"),
+            ProductScreen.selectedOrderlineHas("Letter Tray", "1.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("4.8"),
+            PaymentScreen.emptyPaymentlines("4.8"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.selectedPaymentlineHas("Cash", "4.8"),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.enterPaymentLineAmount("Online payment", "4.8"),
+            PaymentScreen.selectedPaymentlineHas("Online payment", "4.8"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            OnlinePayment.patchAndMockOnlinePayment(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.receiptAmountTotalIs("4.8"),
+            ReceiptScreen.receiptPaymentLineContains("Online payment", "4.8"),
         ].flat(),
 });

--- a/addons/pos_online_payment/static/tests/tours/utils/patch_online_payment_util.js
+++ b/addons/pos_online_payment/static/tests/tours/utils/patch_online_payment_util.js
@@ -1,0 +1,25 @@
+/* global posmodel */
+export function patchAndMockOnlinePayment() {
+    /** Client-side only mock for online payment confirmation. */
+    return [
+        {
+            content: "Mock online payment by patching the method used to confirm it",
+            trigger: "body",
+            run: function () {
+                posmodel.update_online_payments_data_with_server = async function (order) {
+                    const opData = {
+                        id: order.id,
+                        is_paid: true,
+                        paid_order: [
+                            {
+                                id: order.id,
+                                name: order.name,
+                            },
+                        ],
+                    };
+                    return posmodel.process_online_payments_data_from_server(order, opData);
+                };
+            },
+        },
+    ];
+}

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -339,6 +339,75 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
         self.assertEqual(order.state, "draft", "The order should still be in draft state.")
         self.assertEqual(len(order.payment_ids), 0, "There should be no payment line in the order.")
 
+    def test_switch_from_cash_to_online_payment(self):
+        """
+        Test that the server can switch to online payment if non-online payments lines
+        were added by mistake and the cashier wants to pay fully via online payment.
+        """
+        self.pos_config.with_user(self.pos_user).open_ui()
+        current_session = self.pos_config.current_session_id
+        current_session.set_opening_control(0, None)
+
+        product = self.letter_tray
+        order_uid = '00055-001-0002'
+        order_pos_reference = 'Order ' + order_uid
+        untax, atax = self.compute_tax(product, product.list_price)
+        order_total = untax + atax
+
+        # Simulate sync with CASH first
+        order_data = {
+            'uuid': order_uid,
+            'name': order_pos_reference,
+            'session_id': current_session.id,
+            'sequence_number': 2,
+            'state': 'draft',
+            'amount_paid': order_total,
+            'amount_return': 0,
+            'amount_tax': atax,
+            'amount_total': order_total,
+            'lines': [Command.create({
+                'product_id': product.id,
+                'qty': 1,
+                'price_unit': product.list_price,
+                'tax_ids': [(6, 0, product.taxes_id.ids)],
+                'price_subtotal': untax,
+                'price_subtotal_incl': order_total,
+            })],
+            'payment_ids': [Command.create({
+                'amount': order_total,
+                'payment_method_id': self.cash_payment_method.id,
+            })],
+        }
+
+        create_result = self.env['pos.order'].with_user(self.pos_user).sync_from_ui([order_data])
+        order_id = next(
+            r['id'] for r in create_result['pos.order']
+            if r['pos_reference'] == order_pos_reference
+        )
+        order = self.env['pos.order'].browse(order_id)
+
+        self.assertEqual(order.state, 'draft')
+        self.assertEqual(order.amount_paid, order_total)
+        self.assertEqual(order.get_amount_unpaid(), 0, "Cash should cover full order")
+
+        # Simulate the cashier removing the cash payment line and adding an online payment line
+        op_data = order.with_user(self.pos_user).get_and_set_online_payments_data(order_total)
+
+        self.assertEqual(op_data['id'], order.id)
+        self.assertNotIn('deleted', op_data)
+        self.assertEqual(
+            op_data['amount_unpaid'],
+            order_total,
+            "Server must clean non-online payments and return correct amount_unpaid",
+        )
+        self.assertEqual(order.next_online_payment_amount, order_total)
+        self.assertEqual(len(order.payment_ids), 0, "Stale cash payment must be removed")
+
+    def test_switch_from_cash_to_online_payment_tour(self):
+        """Tour: autofill cash, add online for full amount, validate, receipt."""
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_switch_from_cash_to_online_payment_tour", login="pos_user")
+
     @classmethod
     def tearDownClass(cls):
         # Restore company values after the tests

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -339,6 +339,75 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
         self.assertEqual(order.state, "draft", "The order should still be in draft state.")
         self.assertEqual(len(order.payment_ids), 0, "There should be no payment line in the order.")
 
+    def test_switch_from_cash_to_online_payment(self):
+        """
+        Test that the server can switch to online payment if non-online payments lines
+        were added by mistake and the cashier wants to pay fully via online payment.
+        """
+        self.pos_config.with_user(self.pos_user).open_ui()
+        current_session = self.pos_config.current_session_id
+        current_session.set_opening_control(0, None)
+
+        product = self.letter_tray
+        order_uid = '00055-001-0002'
+        order_pos_reference = 'Order ' + order_uid
+        untax, atax = self.compute_tax(product, product.list_price)
+        order_total = untax + atax
+
+        # Simulate sync with CASH first
+        order_data = {
+            'uuid': order_uid,
+            'name': order_pos_reference,
+            'session_id': current_session.id,
+            'sequence_number': 2,
+            'state': 'draft',
+            'amount_paid': order_total,
+            'amount_return': 0,
+            'amount_tax': atax,
+            'amount_total': order_total,
+            'lines': [Command.create({
+                'product_id': product.id,
+                'qty': 1,
+                'price_unit': product.list_price,
+                'tax_ids': [(6, 0, product.taxes_id.ids)],
+                'price_subtotal': untax,
+                'price_subtotal_incl': order_total,
+            })],
+            'payment_ids': [Command.create({
+                'amount': order_total,
+                'payment_method_id': self.cash_payment_method.id,
+            })],
+        }
+
+        create_result = self.env['pos.order'].with_user(self.pos_user).sync_from_ui([order_data])
+        order_id = next(
+            r['id'] for r in create_result['pos.order']
+            if r['pos_reference'] == order_pos_reference
+        )
+        order = self.env['pos.order'].browse(order_id)
+
+        self.assertEqual(order.state, 'draft')
+        self.assertEqual(order.amount_paid, order_total)
+        self.assertEqual(order.get_amount_unpaid(), 0, "Cash should cover full order")
+
+        # Simulate the cashier removing the cash payment line and adding an online payment line
+        op_data = order.with_user(self.pos_user).get_and_set_online_payments_data(order_total)
+
+        self.assertEqual(op_data['id'], order.id)
+        self.assertNotIn('deleted', op_data)
+        self.assertEqual(
+            op_data['amount_unpaid'],
+            order_total,
+            "Server must clean non-online payments and return correct amount_unpaid",
+        )
+        self.assertEqual(order.next_online_payment_amount, order_total)
+        self.assertEqual(len(order.payment_ids), 0, "Stale cash payment must be removed")
+
+    def test_switch_from_cash_to_online_payment_tour(self):
+        """Tour: autofill cash, add online for full amount, validate, receipt."""
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_switch_from_cash_to_online_payment_tour", login="pos_user")
+
     def test_online_payment_amount_updated_after_order_modification(self):
         self.pos_config.with_user(self.pos_admin).open_ui()
         self.start_pos_tour('test_online_payment_amount_updated_after_order_modification', login="pos_admin")


### PR DESCRIPTION
When adding online payment then cash (both covering the full order) (by mistake) and validating, we get "Invalid online payments"
then, we can't pay online anymore.
The order in the backend was covered by cash.

Steps to reproduce:
-------------------
* Add an online payment method to a PoS.
* In the PoS, create an order with a product and click Payment
* Add cash payment line (amount gets autofill)
* Add online payment line (input same amount)
* Click Validate

> Observation:
We get "Invalid online payments".
After that cash or card are acceptable and would change the payment method in the backend but online isn't possible anymore.

Why the fix:
------------
When an online payment method is involved, we handle it first because it can be cancelled easily and does not block like cash.

Implementation:
(1) Backend: _clean_non_online_payment_lines() removes stale non-online payments and updates amount_paid when the cashier requests online for the full amount.
(2) Frontend: remove non-online lines before sync when they fully cover the order, so sync does not re-add them.

opw-5917351