### PR TITLE
[FIX] base, account: allow record and co-records in the same company in _check_company

### DIFF
--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -163,3 +163,92 @@ class TestAccountPartner(AccountTestInvoicingCommon):
         self.env.user.group_ids -= self.env.ref('account.group_validate_bank_account')
         with self.assertRaisesRegex(UserError, "You do not have the rights to trust"), self.cr.savepoint():
             account.write({'allow_out_payment': True})
+
+    def test_partner_creation_multicompany(self):
+        """ Test the creation of 'res.partner' records in a multi-company environment.
+            The test is focused on 3 company-dependent fields:
+            - Receivable account (property_account_receivable_id): mandatory with 'company_ids' props
+            - Payable account (property_account_payable_id): mandatory with 'company_ids' props
+            - Fiscal position (property_account_position_id): not mandatory with 'company_id' props
+
+            Here is the list of the tested cases:
+            1. The record (res.partner) doesn't belong to any company:
+               a) Fiscal position in the current company => OK
+               b) Fiscal position in a different company than the current one => ERROR
+            2. The record belongs to a different company than the current one:
+               a) Receivable/Payable account and fiscal position belong to the same company => OK
+               b) Receivable/Payable account (company_ids) belong to the current company => ERROR
+               c) Fiscal position (company_id) belongs to the current company => ERROR
+        """
+        company_b = self.setup_other_company(name='Company B')['company']
+
+        # props in current company (i.e. "company_1_data")
+        receivable_a = self.company_data['default_account_receivable']
+        payable_a = self.company_data['default_account_receivable']
+        fiscal_position_a = self.fiscal_pos_a
+
+        # props in "Company B"
+        fiscal_position_b = self.env['account.fiscal.position'].create({
+            'name': 'Fiscal postion B',
+            'company_id': company_b.id,
+        })
+        receivable_b = self.env['account.account'].create({
+            'name': 'Receivable Account B',
+            'code': '1234',
+            'account_type': 'asset_receivable',
+            'company_ids': [Command.set(company_b.ids)],
+        })
+        payable_b = self.env['account.account'].create({
+            'name': 'Payable Account B',
+            'code': '4321',
+            'account_type': 'liability_payable',
+            'company_ids': [Command.set(company_b.ids)],
+        })
+
+        ############################################
+        # The record doesn't belong to any company #
+        ############################################
+
+        # The co-record belongs to the current company => OK
+        self.env['res.partner'].create({
+            'name': 'Partner XYZ',
+            'property_account_position_id': fiscal_position_a.id,
+            'company_id': False,
+        })
+        # The co-record doesn't belong to the current company => ERROR
+        with self.assertRaises(UserError):
+            self.env['res.partner'].create({
+                'name': 'Partner XYZ',
+                'property_account_position_id': fiscal_position_b.id,
+                'company_id': False,
+            })
+
+        ##################################################################
+        # The record belongs to a different company than the current one #
+        ##################################################################
+
+        # All co-records belong to the same company than the record => OK
+        self.env['res.partner'].create({
+            'name': 'Partner XYZ',
+            'property_account_position_id': fiscal_position_b.id,
+            'property_account_receivable_id': receivable_b.id,
+            'property_account_payable_id': payable_b.id,
+            'company_id': company_b.id,
+        })
+        # Receivable and payable accounts belong to the current company => ERROR
+        with self.assertRaises(UserError):
+            self.env['res.partner'].create({
+                'name': 'Partner XYZ',
+                'property_account_receivable_id': receivable_a.id,
+                'property_account_payable_id': payable_a.id,
+                'company_id': company_b.id,
+            })
+        # Fiscal postion belongs to the current company => ERROR
+        with self.assertRaises(UserError):
+            self.env['res.partner'].create({
+                'name': 'Partner XYZ',
+                'property_account_position_id': fiscal_position_a.id,
+                'property_account_receivable_id': receivable_b.id,
+                'property_account_payable_id': payable_b.id,
+                'company_id': company_b.id,
+            })

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4064,11 +4064,16 @@ class BaseModel(metaclass=MetaModel):
             # linked via those relation fields are compatible with the company that owns the property value, i.e.
             # the company for which the value is being assigned, i.e:
             #      `self.property_account_payable_id.company_id == self.env.company
-            company = self.env.company
+            if 'company_id' in record and record.company_id:
+                companies = record.company_id
+            elif 'company_ids' in record and record.company_ids:
+                companies = record.company_ids
+            else:
+                companies = self.env.company
             for name in property_fields:
                 corecords = record.sudo()[name]
                 if corecords:
-                    domain = corecords._check_company_domain(company)
+                    domain = corecords._check_company_domain(companies)
                     if domain and corecords != corecords.with_context(active_test=False).filtered_domain(domain):
                         inconsistencies.append((record, name, corecords))
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install contacts and account
- Create a second company
- Stay in the first company

- Create a new contact:
  * Company: [the second company]
  * Account Receivable: [create a new one in the second company]
  * Account Payable: [create a new one in the second company]
- Save

**Issue:**
A UserError is raised because "Account Receivable" and "Account Payable" don't belong to the current company.

**Cause:**
Those fields are company-dependent.
As their value is registered for the current company, they are forced in that company, even if the linked record belongs to another one.
It would be weird for a company-dependent field to belong to another company than the one it is defined in.
However, it is also weird to create a record that belongs to a company and that have fields belonging to another company.

**Solution:**
In "_check_company" method, verify that the company set on the company-dependent co-records is the same than the company of the record when it is set.

opw-5409503



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
