### PR TITLE
[FIX] product, hr_expense, point_of_sale: enable zoom on product images

### DIFF
--- a/addons/hr_expense/views/product_product_views.xml
+++ b/addons/hr_expense/views/product_product_views.xml
@@ -37,7 +37,7 @@
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <field name='product_variant_count' invisible='1'/>
                         <field name="id" invisible="1"/>
-                        <field name="image_1920" widget="image" class="oe_avatar" options="{'image_preview': 'image_128'}"/>
+                        <field name="image_1920" widget="image" class="oe_avatar" options="{'zoom': True, 'image_preview': 'image_128'}"/>
                         <field name="type" invisible="1"/>
                         <div class="oe_title px-3">
                             <label for="name" string="Product Name"/>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -193,7 +193,7 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
+                    <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'zoom': True, 'convert_to_webp': True, 'preview_image': 'image_128'}"/>
                     <group name="name">
                             <field name="name" class="oe_inline" placeholder="e.g. Cheese Burger" string="Product Name"/>
                             <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -29,7 +29,7 @@
                         name="image_1920"
                         widget="image"
                         class="oe_avatar"
-                        options="{'convert_to_webp': True, 'preview_image': 'image_128'}"
+                        options="{'convert_to_webp': True, 'preview_image': 'image_128', 'zoom': True}"
                     />
                     <div class="oe_title">
                         <label for="name" string="Product"/>
@@ -333,7 +333,7 @@
                         <field name="active" invisible="1"/>
                         <field name="id" invisible="1"/>
                         <field name="company_id" invisible="1"/>
-                        <field name="image_1920" widget="image" class="oe_avatar" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
+                        <field name="image_1920" widget="image" class="oe_avatar" options="{'zoom': True, 'convert_to_webp': True, 'preview_image': 'image_128'}"/>
                         <div class="oe_title">
                             <label for="name" string="Product Name"/>
                             <h1><field name="name" readonly="1" placeholder="e.g. Odoo Enterprise Subscription"/></h1>
@@ -533,7 +533,7 @@
             <field name="arch" type="xml">
                 <form>
                     <sheet>
-                        <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
+                        <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'zoom': True, 'convert_to_webp': True, 'preview_image': 'image_128'}"/>
                         <group name="name">
                                 <field name="company_id" invisible="1"/>
                                 <field name="currency_id" invisible="1"/>


### PR DESCRIPTION
This PR enables the zoom feature for product images across the **Product**, **Expenses**, and **Point of Sale** modules.

Currently, some product views display images without the zoom capability. This makes it difficult for users to inspect smaller details of a product. Enabling the `zoom` option on the `image_1920` widget provides a more consistent UI.

### **Changes**

Added zoom to the following modules: **hr_expense** (product variant), **point_of_sale** (product view), and **product** (template and variant views).

**Task ID: 6003499**