### PR TITLE
[FIX] portal, website_sale: show validation error in so update address

### DIFF
--- a/addons/portal/static/src/interactions/address.js
+++ b/addons/portal/static/src/interactions/address.js
@@ -149,7 +149,7 @@ export class CustomerAddress extends Interaction {
                     element.classList.remove('is-invalid');
                 }
             })
-            result.invalid_fields.forEach(
+            result?.invalid_fields?.forEach(
                 fieldName => this.addressForm[fieldName].classList.add('is-invalid')
             );
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1242,7 +1242,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
             if use_delivery_as_billing:
                 partner_fnames.add('partner_invoice_id')
 
-        order_sudo._update_address(partner_sudo.id, partner_fnames)
+        try:
+            order_sudo._update_address(partner_sudo.id, partner_fnames)
+        except ValidationError as e:
+            feedback_dict.pop('redirectUrl', None)
+            feedback_dict['messages'] = list(e.args)
+            self.env.cr.rollback()
+            return json.dumps(feedback_dict)
 
         if order_sudo._is_anonymous_cart():
             # Unsubscribe the public partner if the cart was previously anonymous.


### PR DESCRIPTION
Issue:
---
BR public users are facing unresponsive address confirm issue.

Steps to reproduce:
1- Install `l10n_br_avatax_sale`, `website_sale`
2- Using a public user, add a product to cart and got to checkout.
3- In the address form, use `CPF` identification type.

Outcome:
The confrim button is unresponsive.

Cause:
---
This issue is introduced after odoo/enterprise#101579. After that change `_recompute_taxes` calls external tax computation, which is failing in `CPF` address type due to avatax missconfiguration. However, currently there is no validation error handling for `so._update_address` inside `/shop/address/submit` route, resulting in non-responsive confirm button.

Fix:
---
We can handle the validation error by returning the error in feedback_dict.

opw-6005767
