### PR TITLE
### [FIX] spreadsheet: disable pivot grouping for unsupported field type

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -9,7 +9,8 @@ import { LOADING_ERROR } from "@spreadsheet/data_sources/data_source";
 import { omit } from "@web/core/utils/objects";
 import { OdooPivotLoader } from "./odoo_pivot_loader";
 
-const { pivotRegistry, supportedPivotPositionalFormulaRegistry } = registries;
+const { pivotRegistry, supportedPivotPositionalFormulaRegistry, pivotNormalizationValueRegistry } =
+    registries;
 const { pivotTimeAdapter, toString, areDomainArgsFieldsValid, toNormalizedPivotValue, deepEquals } =
     helpers;
 
@@ -631,7 +632,7 @@ pivotRegistry.add("ODOO", {
         ((MEASURES_TYPES.includes(field.type) && field.aggregator) || field.type === "many2one") &&
         field.name !== "id" &&
         field.store,
-    isGroupable: (field) => field.groupable,
+    isGroupable: (field) => field.groupable && pivotNormalizationValueRegistry.contains(field.type),
 });
 
 supportedPivotPositionalFormulaRegistry.add("ODOO", true);

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -43,6 +43,7 @@ import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 import { Partner, Product } from "../../helpers/data";
 const { toZone } = spreadsheet.helpers;
+const { pivotRegistry, pivotNormalizationValueRegistry } = spreadsheet.registries;
 
 describe.current.tags("headless");
 defineSpreadsheetModels();
@@ -2448,4 +2449,54 @@ test("Pivot headers day of week are still correct after updating the locale's we
     });
     await waitForDataLoaded(model);
     expect(getEvaluatedGrid(model, "A22:A24")).toEqual([["Monday"], ["Thursday"], ["Friday"]]);
+});
+
+test("Groupable fields in pivot", async function () {
+    const groupableFieldTypes = [
+        "boolean",
+        "integer",
+        "float",
+        "monetary",
+        "char",
+        "text",
+        "date",
+        "datetime",
+        "selection",
+        "reference",
+        "many2one",
+        "many2many",
+        "many2one_reference",
+    ];
+    const { model, pivotId } = await createSpreadsheetWithPivot({});
+    expect(pivotId).toBe(model.getters.getPivotId("1"));
+    const pivot = model.getters.getPivot(pivotId);
+    let mockField = Object.values(pivot.getFields())[0];
+
+    for (const fieldType of groupableFieldTypes) {
+        mockField = { ...mockField, type: fieldType, groupable: true };
+        expect(pivotRegistry.get(pivot.type).isGroupable(mockField)).toBe(true, {
+            message: `Field ${fieldType} should be groupable`,
+        });
+        expect(pivotNormalizationValueRegistry.contains(fieldType)).toBe(true, {
+            message: `Field ${fieldType} should be normalizable`,
+        });
+    }
+
+    const nonGroupableFieldTypes = [
+        "html",
+        "binary",
+        "json",
+        "properties",
+        "properties_definition",
+        "one2many",
+    ];
+    for (const fieldType of nonGroupableFieldTypes) {
+        mockField = { ...mockField, type: fieldType, groupable: true };
+        expect(pivotRegistry.get(pivot.type).isGroupable(mockField)).toBe(false, {
+            message: `Field ${fieldType} should not be groupable`,
+        });
+        expect(pivotNormalizationValueRegistry.contains(fieldType)).toBe(false, {
+            message: `Field ${fieldType} should not be normalizable`,
+        });
+    }
 });


### PR DESCRIPTION

Spreadsheet pivots only do not support all field types. But we were
relying only on `field.groupable` to determine if a field could be
grouped, which is wrong (eg. JSON fields can be groupable but are not
supported). It leads to crashes for fields that were groupable,
but didn't have an entry in `pivotNormalizationValueRegistry`.

Added a test for all of the field types to ensure we have a correct
behavior.

Task: 6036075
Task: [6036075](https://www.odoo.com/odoo/2328/tasks/6036075)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
