### PR TITLE
[FIX] hr_holidays_attendance: fix employee access to overtime dashboard

### DIFF
--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -85,5 +85,38 @@
             <field name="perm_unlink" eval="0"/>
             <field name="perm_read" eval="1"/>
         </record>
+
+        <!-- Overtime Lines -->
+        <record id="hr_attendance_overtime_line_rule_employee_company" model="ir.rule">
+            <field name="name">Overtime Line multi company rule</field>
+            <field name="model_id" ref="model_hr_attendance_overtime_line"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">[('employee_id.company_id', 'in', company_ids)]</field>
+        </record>
+
+        <record id="hr_attendance_overtime_line_rule_admin" model="ir.rule">
+            <field name="name">Overtime Line Administrator: Full access</field>
+            <field name="model_id" ref="model_hr_attendance_overtime_line"/>
+            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
+        </record>
+
+        <record id="hr_attendance_overtime_line_rule_officer" model="ir.rule">
+            <field name="name">Overtime Line Officer: Restrict to managed employees</field>
+            <field name="model_id" ref="model_hr_attendance_overtime_line"/>
+            <field name="domain_force">[('employee_id.attendance_manager_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
+        </record>
+
+        <record id="hr_attendance_overtime_line_rule_own_reader" model="ir.rule">
+            <field name="name">Overtime Line base user: Read his own overtime lines</field>
+            <field name="model_id" ref="model_hr_attendance_overtime_line"/>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_own_reader'))]"/>
+            <field name="perm_create" eval="0"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_unlink" eval="0"/>
+            <field name="perm_read" eval="1"/>
+        </record>
     </data>
 </odoo>

--- a/addons/hr_attendance/security/ir.model.access.csv
+++ b/addons/hr_attendance/security/ir.model.access.csv
@@ -8,4 +8,5 @@ access_hr_attendance_overtime_ruleset_admin,hr.attendance.admin.overtime.ruleset
 access_hr_attendance_overtime_rule_user,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,hr.group_hr_manager,1,0,0,0
 access_hr_attendance_overtime_rule_officer,hr.attendance.officer.overtime.rule,model_hr_attendance_overtime_rule,group_hr_attendance_officer,1,0,0,0
 access_hr_attendance_overtime_line_officer,hr.attendance.officer.overtime.line,model_hr_attendance_overtime_line,group_hr_attendance_officer,1,1,1,1
+access_hr_attendance_overtime_line_own_reader,hr.attendance.overtime.line.own.reader,model_hr_attendance_overtime_line,group_hr_attendance_own_reader,1,0,0,0
 access_hr_attendance_overtime_ruleset_hr_manager,hr.attendance.admin.overtime.ruleset,model_hr_attendance_overtime_ruleset,hr.group_hr_manager,1,0,0,0

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1309,3 +1309,59 @@ class TestHrAttendanceOvertime(HttpCase):
         self.assertEqual(att.overtime_hours, -6)
         self.assertEqual(att.validated_overtime_hours, 10)
         self.assertEqual(att.expected_hours, 8)
+
+    def test_overtime_line_access_rules(self):
+        """Test ir.rules on hr.attendance.overtime.line per access level:
+        - own_reader (base user): can only read their own overtime lines.
+        - officer: can read overtime lines of managed employees and their own.
+        - admin (group_hr_attendance_user): can read all overtime lines.
+        """
+        officer_user = new_test_user(self.env, login='officer', groups='base.group_user,hr_attendance.group_hr_attendance_officer', company_id=self.company.id).with_company(self.company)
+        own_reader_user = new_test_user(self.env, login='own_reader', groups='hr_attendance.group_hr_attendance_own_reader', company_id=self.company.id).with_company(self.company)
+        officer_employee, own_reader_employee = self.env['hr.employee'].create([{
+            'name': 'Officer Employee',
+            'user_id': officer_user.id,
+            'company_id': self.company.id,
+            'tz': 'UTC',
+            'date_version': date(2020, 1, 1),
+            'contract_date_start': date(2020, 1, 1),
+            'resource_calendar_id': self.company.resource_calendar_id.id,
+            'ruleset_id': self.ruleset.id,
+        }, {
+            'name': 'Own Reader Employee',
+            'user_id': own_reader_user.id,
+            'company_id': self.company.id,
+            'tz': 'UTC',
+            'date_version': date(2020, 1, 1),
+            'contract_date_start': date(2020, 1, 1),
+            'resource_calendar_id': self.company.resource_calendar_id.id,
+            'ruleset_id': self.ruleset.id,
+        }])
+        self.other_employee.attendance_manager_id = officer_user.id
+        self.env['hr.attendance'].create([{
+            'employee_id': own_reader_employee.id,
+            'check_in': datetime(2021, 1, 4, 8, 0),
+            'check_out': datetime(2021, 1, 4, 20, 0),
+        }, {
+            'employee_id': officer_employee.id,
+            'check_in': datetime(2021, 1, 4, 8, 0),
+            'check_out': datetime(2021, 1, 4, 20, 0),
+        }, {
+            'employee_id': self.other_employee.id,
+            'check_in': datetime(2021, 1, 4, 8, 0),
+            'check_out': datetime(2021, 1, 4, 20, 0),
+        }])
+        overtime_line = self.env['hr.attendance.overtime.line']
+        all_lines = overtime_line.search([('employee_id', 'in', (own_reader_employee | officer_employee | self.other_employee).ids)])
+        self.assertEqual(len(all_lines.employee_id), 3)
+
+        own_reader_lines = overtime_line.with_user(own_reader_user).search([])
+        self.assertEqual(own_reader_lines.employee_id, own_reader_employee)
+
+        officer_lines = overtime_line.with_user(officer_user).search([])
+        self.assertEqual(officer_lines.mapped('employee_id'), officer_employee | self.other_employee)
+
+        admin_lines = overtime_line.with_user(self.user).search([])
+        self.assertIn(own_reader_employee, admin_lines.employee_id)
+        self.assertIn(officer_employee, admin_lines.employee_id)
+        self.assertIn(self.other_employee, admin_lines.employee_id)


### PR DESCRIPTION
Steps to reproduce:
1. Enable "Display Extra Hours" in Attendance settings.
2. Assign an overtime ruleset to an employee.
3. Ensure the employee does not have the "Officer: Manage attendances" group.
4. Create an attendance that generates extra hours for this employee.
5. Log in as the employee and open the Employees app to view Extra Hours.

Issue:
An Access Error is raised because `get_overtime_data_by_employee` in
`hr_holidays_attendance/models/hr_employee.py` performs a `_read_group`
on `hr.attendance.overtime.line`. In 19.0, the only ACL for this model
grants access to `group_hr_attendance_officer`:
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/hr_attendance/security/ir.model.access.csv#L1-L11

Users with `group_hr_attendance_own_reader` (implied by `base.group_user`,
i.e. all internal users) have no read access to `hr.attendance.overtime.line`.

In later versions, this was already fixed by adding a read-only ACL for
`group_hr_attendance_own_reader` on this model:
https://github.com/odoo/odoo/blob/ad4a2ec11fea2058445e4003099af3a5caa1ef22/addons/hr_attendance/security/ir.model.access.csv#L13

This is why forward-ports are not needed.

Solution:
Add the missing `access_hr_attendance_overtime_line_own_reader` ACL to
grant read-only access to `group_hr_attendance_own_reader` on
`hr.attendance.overtime.line`, matching the approach used in later versions.
This is preferred over using `.sudo()` as it properly grants the intended
access right rather than bypassing security checks entirely.

opw-6055081