### PR TITLE
[IMP] mrp: split mo by serial

### DIFF
--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -695,6 +695,25 @@ class TestTraceability(TestMrpCommon):
         third_serials_wizard = Form.from_action(self.env, third_mo.action_generate_serial())
         self.assertEqual(third_serials_wizard.lot_name, 'TEST0000006')
 
+    def test_split_and_assign_serials(self):
+        """ Confirm a MO for 3 serial numbers. generate 3 serial number and split the mo"""
+        mo, _, _, _, _ = self.generate_mo(tracking_final='serial', qty_final=3)
+        mo.action_confirm()
+
+        wizard = self.env['mrp.production.serials'].with_context(active_id=mo.id).create({
+            'production_id': mo.id,
+            'serial_numbers': 'SN001\nSN002\nSN003',
+        })
+        wizard.action_split_and_assign_serials()
+
+        split_mos = self.env['mrp.production'].search([('production_group_id', '=', mo.production_group_id.id)])
+        self.assertEqual(len(split_mos), 3)
+
+        serials = ['SN001', 'SN002', 'SN003']
+        for smo in split_mos:
+            self.assertIn(smo.lot_producing_ids.name, serials)
+            self.assertNotEqual(smo.state, 'done')
+
     @freeze_time('2024-02-03')
     def test_interpolation_in_batch_serials(self):
         """

--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.fields import Command
 from odoo.exceptions import UserError
 
 
@@ -49,34 +50,28 @@ class MrpProductionSerials(models.TransientModel):
         action['res_id'] = self.id
         return action
 
+    def action_split_and_assign_serials(self):
+        self.ensure_one()
+        lots = self._parse_serial_numbers()
+
+        split_amounts = {self.production_id: [1] * len(lots)}
+        mos = self.production_id._split_productions(amounts=split_amounts)
+        for mo, serial in zip(mos, lots):
+            mo.lot_producing_ids = [Command.link(serial.id)]
+        return self._closing_action(mos)
+
     def action_apply(self):
         self.ensure_one()
-        if not self.serial_numbers:
-            raise UserError(self.env._("There is no serial numbers to apply."))
-        lots = list(filter(lambda serial_number: len(serial_number.strip()) > 0, self.serial_numbers.split('\n'))) if self.serial_numbers else []
-        existing_lots = self.env['stock.lot'].search([
-            '|', ('company_id', '=', False), ('company_id', '=', self.production_id.company_id.id),
-            ('product_id', '=', self.production_id.product_id.id),
-            ('name', 'in', lots),
-        ])
-        existing_lot_names = existing_lots.mapped('name')
-        new_lots = []
-        sequence = self.production_id.product_id.lot_sequence_id
-        for lot_name in sorted(lots):
-            if lot_name in existing_lot_names:
-                continue
-            if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
-                sequence.sudo().number_next_actual += 1
-            new_lots.append({
-                'name': lot_name,
-                'product_id': self.production_id.product_id.id
-            })
-        self.production_id.lot_producing_ids = existing_lots + self.env['stock.lot'].create(new_lots)
+        lots = self._parse_serial_numbers()
+        self.production_id.lot_producing_ids = lots
         if self.production_id.qty_producing != len(self.production_id.lot_producing_ids):
             self.production_id.qty_producing = len(self.production_id.lot_producing_ids)
         (self.workorder_id or self.production_id).set_qty_producing()
+        return self._closing_action()
 
-        print_actions = self.production_id._autoprint_mass_generated_lots()
+    def _closing_action(self, mos=False):
+        mos = mos or self.production_id
+        print_actions = mos._autoprint_mass_generated_lots()
         if print_actions:
             return {
                 'type': 'ir.actions.client',
@@ -86,3 +81,31 @@ class MrpProductionSerials(models.TransientModel):
                     'reports': print_actions,
                 }
             }
+        return {'type': 'ir.actions.act_window_close'}
+
+    def _parse_serial_numbers(self):
+        self.ensure_one()
+        if not self.serial_numbers:
+            raise UserError(self.env._("There is no serial numbers to apply."))
+        lots = list(filter(lambda serial_number: len(serial_number.strip()) > 0, self.serial_numbers.split('\n'))) if self.serial_numbers else []
+        if not lots:
+            raise UserError(self.env._("No valid serial numbers provided."))
+        existing_lots = self.env['stock.lot'].search([
+            '|', ('company_id', '=', False), ('company_id', '=', self.production_id.company_id.id),
+            ('product_id', '=', self.production_id.product_id.id),
+            ('name', 'in', lots),
+        ])
+        existing_lot_names = existing_lots.mapped('name')
+        new_lots_vals = []
+        sequence = self.production_id.product_id.lot_sequence_id
+        for lot_name in sorted(lots):
+            if lot_name in existing_lot_names:
+                continue
+            if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
+                sequence.sudo().number_next_actual += 1
+            new_lots_vals.append({
+                'name': lot_name,
+                'product_id': self.production_id.product_id.id,
+            })
+        new_lots = self.env['stock.lot'].create(new_lots_vals)
+        return existing_lots + new_lots

--- a/addons/mrp/wizard/mrp_production_serial_numbers.xml
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.xml
@@ -25,6 +25,7 @@
                 <field name="serial_numbers" nolabel="1" placeholder="copy paste a list and/or use Generate"/>
                 <footer>
                     <button name="action_apply" string="Apply" type="object" class="btn-primary"/>
+                    <button name="action_split_and_assign_serials" string="Prepare MO" type="object" class="btn-secondary"/>
                     <button string="Discard" class="btn-secondary" special="cancel" />
                 </footer>
             </form>


### PR DESCRIPTION
Since 4bb4e08066449, producing multiple serial that have been generated is only doable on one mo. We can split mo. we can generate serial number but we cannot do both at the same time. This commit adds a new button into the generate serial wizard to split the main mo into the number of serial wanted and attribute one for each sub mo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
