### PR TITLE
[FIX] l10n_jo_edi, l10n_jo_edi_pos: handle division taxes

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -344,7 +344,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             return "O"
 
         def get_jo_tax_type(tax):
-            if tax.amount_type == 'percent':
+            if tax.amount_type in ('percent', 'division'):
                 return 'general'
             elif tax.amount_type == 'fixed':
                 return 'special'

--- a/addons/l10n_jo_edi_pos/models/pos_edi_ubl_21_jo.py
+++ b/addons/l10n_jo_edi_pos/models/pos_edi_ubl_21_jo.py
@@ -347,12 +347,13 @@ class PosEdiXmlUBL21Jo(models.AbstractModel):
 
     def _get_tax_category_node(self, vals):
         grouping_key = vals['grouping_key']
+        is_percentage_tax = grouping_key['amount_type'] in ('percent', 'division')
         return {
             'cbc:ID': {'_text': grouping_key['tax_category_code'], 'schemeAgencyID': 6, 'schemeID': 'UN/ECE 5305'},
-            'cbc:Percent': {'_text': grouping_key['amount']} if grouping_key['amount_type'] == 'percent' else None,
+            'cbc:Percent': {'_text': grouping_key['amount']},
             'cac:TaxScheme': {
                 'cbc:ID': {
-                    '_text': 'VAT' if grouping_key['amount_type'] == 'percent' else 'OTH',
+                    '_text': 'VAT' if is_percentage_tax else 'OTH',
                     'schemeAgencyID': 6,
                     'schemeID': 'UN/ECE 5153',
                 },


### PR DESCRIPTION
Taxes with `amount_type == 'division'` were treated as non-percentage types, causing `cbc:Percent` to be omitted from the generated XML and `TaxScheme/ID` to be set to `OTH` instead of `VAT`. JoFotara rejects invoices where `cbc:Percent` is absent, raising a NullPointerException on the receiver side.

opw-5919123

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
