### PR TITLE
[FIX] website: remove default value from radio buttons

### DIFF
--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -96,7 +96,7 @@ export function renderField(field, resetId = false) {
     if (!field.id) {
         field.id = generateHTMLId();
     }
-    if (field.records && (field.type === "many2one" || field.type === "selection")) {
+    if (field.records && field.type === "many2one") {
         const hasDefault =
             field.records[0]?.["display_name"] === "" ||
             field.records.some((value) => value.selected);


### PR DESCRIPTION
# How to reproduce
- Go to the website editor
- Add a Contact Form block
- Add a new field with the type "Radio Buttons"
- Do not set any value to default

# The issue
A default empty value appears in the form. The is value can be selected
by the user and will not trigger any validation warning even if the
field is set to required

# Cause
Commit [1] changed the way the default value is added for the
Selection field. It contains a small oversight as the type value for
"Selection" is not "selection" but many2one.

https://github.com/odoo/odoo/blob/f28c9f8dc5639ff8606b139ca9d384f115b003d3/addons/website/static/src/builder/plugins/form/form_option.xml#L96-L109

[1]: https://github.com/odoo/odoo/commit/34ddd5dd6a036792c44b865cb7a4671f4ca033cf

opw-6062186

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
