### PR TITLE
[FIX] sale_project: Ignore archived tasks in project dashboard

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -390,7 +390,7 @@ class ProjectProject(models.Model):
         project_sql = project_query.select(f'{self._table}.id ', f'{self._table}.sale_line_id')
 
         Task = self.env['project.task']
-        task_domain = [('project_id', 'in', self.ids), ('sale_line_id', '!=', False)]
+        task_domain = [('project_id', 'in', self.ids), ('sale_line_id', '!=', False), ('active', '=', True)]
         if Task._name in domain_per_model:
             task_domain = expression.AND([
                 domain_per_model[Task._name],


### PR DESCRIPTION
Archived tasks are hidden by default. However, sale order lines on archived tasks are still included in the project dashboard display.

Video example: https://drive.google.com/file/d/1FMG-eEuyO5cJS0UwHpdIwBaVUMUCyGUt/view?usp=sharing

This can make it difficult to determine where the excess revenue is coming from.

This commit ensures that sale order lines set on archived tasks are ignored in the dashboard's revenue calculations.

opw-5922894
Link to ticket: https://www.odoo.com/odoo/project.task/5922894

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr