### PR TITLE
[FIX] website: add overlap in bold 19 shape

### DIFF
--- a/addons/html_builder/static/shapes/Bold/19.svg
+++ b/addons/html_builder/static/shapes/Bold/19.svg
@@ -1,5 +1,5 @@
 <svg fill="#383E45" xmlns="http://www.w3.org/2000/svg">
-    <rect width="calc(50% - 660px)" height="192px" x="0%"/>
+    <rect width="calc(51% - 660px)" height="192px" x="0%"/>
     <rect width="100%" height="64px" x="1320"/>
     <svg viewBox="0 0 1320 192" preserveAspectRatio="xMidYMin meet" height="192">
         <path d="M581.426 64H1320V0H0V192H428.574C436.53 192 444.161 188.839 449.787 183.213L560.213 72.7868C565.839 67.1607 573.47 64 581.426 64Z"/>


### PR DESCRIPTION
Steps to reproduce the issue:
1. Enter website edit mode
2. Create a "Banner connected" block
3. Select the 10th option under "Bold" as the shape

Issue:
A thin line appears at certain resolutions or zoom levels

Cause:
This is due to inaccuracies with the svg's calculated style.

Solution:
This commit brings it in line with what's done for the Bold 20 shape, by creating a bit of overlap, which fixes the line.

(Open images in fullscreen to see the difference!)
Current behavior before PR:
<img width="1919" height="861" alt="image" src="https://github.com/user-attachments/assets/f9ac02e6-9e89-4bf1-8f60-acdac8014e0f" />


Desired behavior after PR is merged:
<img width="1918" height="847" alt="image" src="https://github.com/user-attachments/assets/a6808f48-e39f-41ec-8f6c-5738214ca412" />


Commit where these shapes were added, for reference: https://github.com/odoo/odoo/commit/81a2ff6d816bd6a279f6ce8fb5f935abc44f6518