### PR TITLE
[FIX] website: fixup preview dynamic content of custom snippet

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -147,7 +147,7 @@ export class DynamicSnippet extends Interaction {
     }
 
     render() {
-        if (!this.isConfigComplete()) {
+        if (this.el.querySelector(".s_dialog_preview")) {
             return;
         }
         if (this.data.length > 0 || this.withSample) {


### PR DESCRIPTION
The commit 0327a6d37fe3274d59c158eaacb153a43121df0f added the interaction to fetch content of dynamic snippet in the iframe of the dialog to preview snippets. To avoid emptying dynamic snippets filled with fake data, it skipped rendering in certain condition.

This commit changes that condition to better match the intent to not remove preview data.

task-5427353