### PR TITLE
[IMP] setup: support OpenRouter in bwrap-claude

### DIFF
--- a/setup/sandboxing/README.md
+++ b/setup/sandboxing/README.md
@@ -112,6 +112,40 @@ If VSCode is started, it should appear in the Claude CLI output.
 
 See the script header for the full sandbox layout.
 
+#### Using OpenRouter
+
+To use [OpenRouter](https://openrouter.ai/) as a proxy for Claude API calls, set the
+`OPENROUTER_API_KEY` environment variable and pass the `--openrouter` flag.
+
+Add the following to your shell configuration (e.g. `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`):
+
+```sh
+export OPENROUTER_API_KEY="sk-or-xxx"
+```
+
+Reload your shell configuration (e.g. `source ~/.bashrc`, `source ~/.zshrc`, or `source ~/.config/fish/config.fish`).
+Then launch the sandboxed Claude with:
+
+```sh
+bwrap-claude.sh --openrouter
+```
+
+The following environment variables are passed to the sandbox with sensible defaults:
+
+| Variable                         | Default                     |
+| -------------------------------- | --------------------------- |
+| `ANTHROPIC_BASE_URL`             | `https://openrouter.ai/api` |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`  | `z-ai/glm-4.7-flash`        |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `z-ai/glm-5-turbo`          |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`   | `z-ai/glm-5`                |
+
+Override any default by exporting the corresponding environment variable:
+
+```sh
+export ANTHROPIC_DEFAULT_OPUS_MODEL="minimax/minimax-m2.7"
+bwrap-claude.sh --openrouter
+```
+
 ### Example: Running Odoo tests
 
 Here is an example of prompt to run the CRM tests (Python and JavaScript tours):

--- a/setup/sandboxing/bwrap/bwrap-claude.sh
+++ b/setup/sandboxing/bwrap/bwrap-claude.sh
@@ -21,7 +21,7 @@
 #   - Odoo filestore (~/.local/share/Odoo)
 #
 # USAGE
-#   bwrap-claude.sh [--add-dir <path> ...] [claude args...]
+#   bwrap-claude.sh [--add-dir <path> ...] [--openrouter] [claude args...]
 #
 # OPTIONS
 #   --add-dir <path>
@@ -29,6 +29,19 @@
 #       pre-configured Odoo directories. Also passed to Claude as --add-dir
 #       so its internal tool access matches the sandbox. All other arguments
 #       are forwarded to Claude.
+#
+#   --openrouter
+#       Configure Claude to use OpenRouter as a proxy for Anthropic API calls.
+#       Requires OPENROUTER_API_KEY to be set in the host environment.
+#       The following environment variables are passed to the sandbox:
+#         - ANTHROPIC_BASE_URL (default: https://openrouter.ai/api)
+#         - ANTHROPIC_AUTH_TOKEN (set to OPENROUTER_API_KEY)
+#         - ANTHROPIC_API_KEY (empty, required for OpenRouter)
+#         - ANTHROPIC_DEFAULT_HAIKU_MODEL (default: z-ai/glm-4.7-flash)
+#         - ANTHROPIC_DEFAULT_SONNET_MODEL (default: z-ai/glm-5-turbo)
+#         - ANTHROPIC_DEFAULT_OPUS_MODEL (default: z-ai/glm-5)
+#       All defaults can be overridden by setting the corresponding host
+#       environment variables.
 #
 # ENVIRONMENT
 #   ODOO_BASE     Path to the Odoo workspace (default: ~/src/odoo)
@@ -124,10 +137,14 @@ ODOO_BASE="${ODOO_BASE:-$HOME/src/odoo}"
 # Collect allowed dirs from args; intercept --add-dir from args for bwrap binding
 ALLOW_DIRS=("$ODOO_BASE")
 CLAUDE_ARGS=()
+USE_OPENROUTER=false
 while [[ $# -gt 0 ]]; do
   if [[ "$1" == "--add-dir" ]]; then
     shift
     ALLOW_DIRS+=("$(cd "$1" && pwd)")
+    shift
+  elif [[ "$1" == "--openrouter" ]]; then
+    USE_OPENROUTER=true
     shift
   else
     CLAUDE_ARGS+=("$1")
@@ -209,5 +226,25 @@ for d in "${ALLOW_DIRS[@]}"; do
 done
 CLAUDE_CMD+=( "${CLAUDE_ARGS[@]}" )
 
-echo "Running: bwrap ${BRAP[@]} -- $CLAUDE_BIN ${CLAUDE_CMD[@]}" >&2
-exec bwrap "${BRAP[@]}" -- "$CLAUDE_BIN" "${CLAUDE_CMD[@]}"
+# Build bwrap environment variable arguments
+BWRAP_ENV=()
+if [[ "$USE_OPENROUTER" == true ]]; then
+  # Validate required API key
+  if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+    echo "Error: --openrouter requires OPENROUTER_API_KEY to be set" >&2
+    exit 1
+  fi
+  # Set environment variables for OpenRouter
+  BWRAP_ENV+=(
+    --setenv OPENROUTER_API_KEY "$OPENROUTER_API_KEY"
+    --setenv ANTHROPIC_BASE_URL "${ANTHROPIC_BASE_URL:-https://openrouter.ai/api}"
+    --setenv ANTHROPIC_AUTH_TOKEN "$OPENROUTER_API_KEY"
+    --setenv ANTHROPIC_API_KEY ""
+    --setenv ANTHROPIC_DEFAULT_HAIKU_MODEL "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-z-ai/glm-4.7-flash}"
+    --setenv ANTHROPIC_DEFAULT_SONNET_MODEL "${ANTHROPIC_DEFAULT_SONNET_MODEL:-z-ai/glm-5-turbo}"
+    --setenv ANTHROPIC_DEFAULT_OPUS_MODEL "${ANTHROPIC_DEFAULT_OPUS_MODEL:-z-ai/glm-5}"
+  )
+fi
+
+echo "Running: bwrap ${BRAP[@]} ${BWRAP_ENV[@]} -- $CLAUDE_BIN ${CLAUDE_CMD[@]}" >&2
+exec bwrap "${BRAP[@]}" "${BWRAP_ENV[@]}" -- "$CLAUDE_BIN" "${CLAUDE_CMD[@]}"


### PR DESCRIPTION
Add --openrouter option to configure Claude Code to use OpenRouter as a proxy for Anthropic API calls. When enabled, passes the required environment variables to the sandbox:

- OPENROUTER_API_KEY (required, from host environment)
- ANTHROPIC_BASE_URL (default: https://openrouter.ai/api)
- ANTHROPIC_DEFAULT_*_MODEL (configurable model defaults)
- ANTHROPIC_AUTH_TOKEN, ANTHROPIC_API_KEY (for authentication)

All default values can be overridden via host environment variables.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
