### PR TITLE
[IMP] l10n_ro: actualizează rapoartele de TVA pentru România

### DIFF
--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -289,13 +289,13 @@
                     </record>
                     <record id="account_tax_report_ro_baza_rd12" model="account.report.line">
                         <field name="name">12 - TAX BASE - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge) , of which:</field>
-                        <field name="name@ro">12 - BAZĂ FISCALĂ - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
+                        <field name="name@ro">12 - BAZĂ FISCALĂ - Achiziții de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
                         <field name="code">tax_ro_baza_rd12</field>
                         <field name="aggregation_formula">tax_ro_baza_rd121.balance + tax_ro_baza_rd122.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd121" model="account.report.line">
                                 <field name="name">12.1 - TAX BASE - Purchases of goods and services, taxable at 21% rate</field>
-                                <field name="name@ro">12.1 - BAZĂ FISCALĂ - Achizitii de bunuri si servicii, taxabile cu cota 21%</field>
+                                <field name="name@ro">12.1 - BAZĂ FISCALĂ - Achiziții de bunuri și servicii, taxabile cu cota 21%</field>
                                 <field name="code">tax_ro_baza_rd121</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd121_tag" model="account.report.expression">
@@ -437,7 +437,7 @@
                     </record>
                     <record id="account_tax_report_ro_tva_rd12" model="account.report.line">
                         <field name="name">12 - VAT - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge) , of which:</field>
-                        <field name="name@ro">12 - TVA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
+                        <field name="name@ro">12 - TVA - Achiziții de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
                         <field name="code">tax_ro_tva_rd12</field>
                         <field name="aggregation_formula">tax_ro_tva_rd121.balance + tax_ro_tva_rd122.balance</field>
                         <field name="children_ids">
@@ -689,11 +689,11 @@
                 <field name="name">TAX BASE ON DOMESTIC PURCHASES OF GOODS/SERVICES AND IMPORTS, EXEMPT OR NON-TAXABLE INTRA-COMMUNITY PURCHASES</field>
                 <field name="name@ro">BAZĂ DE IMPOZITARE PE CUMPĂRĂRI INTERNE DE MĂRFURI, SERVICII ȘI IMPORTURI, CUMPĂRĂRI INTRACOMUNITARE SCURTATE SAU NEIMPOZABILE</field>
                 <field name="code">tax_ro_baza_achiz</field>
-                <field name="aggregation_formula">tax_ro_baza_rd24.balance + tax_ro_baza_rd25.balance + tax_ro_baza_rd27.balance + tax_ro_baza_rd30.balance</field>
+                <field name="aggregation_formula">tax_ro_baza_rd24.balance + tax_ro_baza_rd25.balance + tax_ro_baza_rd27.balance + tax_ro_baza_rd29.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd24" model="account.report.line">
                         <field name="name">24 - TAX BASE - Purchases of goods and services taxable at 21%, other than those under heading 27</field>
-                        <field name="name@ro">24 - BAZĂ FISCALĂ - Achiziţii de bunuri şi servicii taxabile cu cota de 21%, altele decât cele de la rd.27</field>
+                        <field name="name@ro">24 - BAZĂ FISCALĂ - Achiziții de bunuri şi servicii taxabile cu cota de 21%, altele decât cele de la rd.27</field>
                         <field name="code">tax_ro_baza_rd24</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd24_tag" model="account.report.expression">
@@ -705,7 +705,7 @@
                     </record>
                     <record id="account_tax_report_ro_baza_rd25" model="account.report.line">
                         <field name="name">25 - TAX BASE - Purchases of goods and services taxable at 11% rate</field>
-                        <field name="name@ro">25 - BAZĂ FISCALĂ - Achiziţii de bunuri şi servicii taxabile cu cota de 11%</field>
+                        <field name="name@ro">25 - BAZĂ FISCALĂ - Achiziții de bunuri şi servicii taxabile cu cota de 11%</field>
                         <field name="code">tax_ro_baza_rd25</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd25_tag" model="account.report.expression">
@@ -717,13 +717,13 @@
                     </record>
                     <record id="account_tax_report_ro_baza_rd27" model="account.report.line">
                         <field name="name">26 - TAX BASE - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge), of which</field>
-                        <field name="name@ro">26 - BAZĂ FISCALĂ - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă ), din care:</field>
+                        <field name="name@ro">26 - BAZĂ FISCALĂ - Achiziții de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă ), din care:</field>
                         <field name="code">tax_ro_baza_rd27</field>
                         <field name="aggregation_formula">tax_ro_baza_rd271.balance + tax_ro_baza_rd272.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd271" model="account.report.line">
                                 <field name="name">26.1 - TAX BASE - Purchases of goods, taxable at 21%</field>
-                                <field name="name@ro">26.1 - BAZĂ FISCALĂ - Achiziţii de bunuri si servicii, taxabile cu cota 21%</field>
+                                <field name="name@ro">26.1 - BAZĂ FISCALĂ - Achiziții de bunuri si servicii, taxabile cu cota 21%</field>
                                 <field name="code">tax_ro_baza_rd271</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd271_tag" model="account.report.expression">
@@ -735,7 +735,7 @@
                             </record>
                             <record id="account_tax_report_ro_baza_rd272" model="account.report.line">
                                 <field name="name">26.2 - TAX BASE - Purchases of goods, taxable at 11%</field>
-                                <field name="name@ro">26.2 - BAZĂ FISCALĂ - Achiziţii de bunuri, taxabile cu cota 11%</field>
+                                <field name="name@ro">26.2 - BAZĂ FISCALĂ - Achiziții de bunuri, taxabile cu cota 11%</field>
                                 <field name="code">tax_ro_baza_rd272</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd272_tag" model="account.report.expression">
@@ -747,24 +747,24 @@
                             </record>
                         </field>
                     </record>
-                    <record id="account_tax_report_ro_baza_rd30" model="account.report.line">
+            <record id="account_tax_report_ro_baza_rd29" model="account.report.line">
                         <field name="name">29 - TAX BASE - Purchases of tax-exempt or non-taxable goods and services, of which:</field>
-                        <field name="name@ro">29 - BAZĂ FISCALĂ -Achiziţii de bunuri şi servicii scutite de taxă  sau neimpozabile, din care :</field>
-                        <field name="code">tax_ro_baza_rd30</field>
+                        <field name="name@ro">29 - BAZĂ FISCALĂ -Achiziții de bunuri şi servicii scutite de taxă  sau neimpozabile, din care :</field>
+                        <field name="code">tax_ro_baza_rd29</field>
                         <field name="expression_ids">
-                            <record id="account_tax_report_ro_baza_rd30_tag" model="account.report.expression">
+                            <record id="account_tax_report_ro_baza_rd29_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">29 - TAX BASE</field>
                             </record>
                         </field>
                         <field name="children_ids">
-                            <record id="account_tax_report_ro_baza_rd301" model="account.report.line">
+                            <record id="account_tax_report_ro_baza_rd291" model="account.report.line">
                                 <field name="name">29.1 - TAX BASE - Tax-exempt intra-Community purchases of services (not completed under the simplified method)</field>
-                                <field name="name@ro">29.1 - BAZĂ FISCALĂ - Achiziţii de servicii intracomunitare scutite de taxă</field>
-                                <field name="code">tax_ro_baza_rd301</field>
+                                <field name="name@ro">29.1 - BAZĂ FISCALĂ - Achiziții de servicii intracomunitare scutite de taxă</field>
+                                <field name="code">tax_ro_baza_rd291</field>
                                 <field name="expression_ids">
-                                    <record id="account_tax_report_ro_baza_rd301_tag" model="account.report.expression">
+                                    <record id="account_tax_report_ro_baza_rd291_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">29_1 - TAX BASE</field>
@@ -779,11 +779,11 @@
                 <field name="name">VAT ON DOMESTIC PURCHASES OF GOODS/SERVICES AND IMPORTS, EXEMPT OR NON-TAXABLE INTRA-COMMUNITY PURCHASES</field>
                 <field name="name@ro">TVA LA ACHIZIȚIILE INTERNE DE BUNURI/SERVICII ȘI IMPORTURI, CUMPĂRĂRI INTRACOMUNITARE SCURTATE SAU NEIMPOZABILE</field>
                 <field name="code">tax_ro_tva_achiz</field>
-                <field name="aggregation_formula">tax_ro_tva_rd24.balance + tax_ro_tva_rd25.balance + tax_ro_tva_rd27.balance + tax_ro_tva_rd28.balance + tax_ro_tva_rd29.balance</field>
+                <field name="aggregation_formula">tax_ro_tva_rd24.balance + tax_ro_tva_rd25.balance + tax_ro_tva_rd27.balance + tax_ro_tva_rd28.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd24" model="account.report.line">
                         <field name="name">24 - VAT - Purchases of goods and services taxable at 21%, other than those under heading 27</field>
-                        <field name="name@ro">24 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 21%, altele decât cele de la rd.27</field>
+                        <field name="name@ro">24 - TVA - Achiziții de bunuri şi servicii taxabile cu cota de 21%, altele decât cele de la rd.27</field>
                         <field name="code">tax_ro_tva_rd24</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd24_tag" model="account.report.expression">
@@ -795,7 +795,7 @@
                     </record>
                     <record id="account_tax_report_ro_tva_rd25" model="account.report.line">
                         <field name="name">25 - VAT - Purchases of goods and services taxable at 11%</field>
-                        <field name="name@ro">25 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 11%</field>
+                        <field name="name@ro">25 - TVA - Achiziții de bunuri şi servicii taxabile cu cota de 11%</field>
                         <field name="code">tax_ro_tva_rd25</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd25_tag" model="account.report.expression">
@@ -805,30 +805,30 @@
                             </record>
                         </field>
                     </record>
-                    <record id="account_tax_report_ro_tva_rd27" model="account.report.line">
+                    <record id="account_tax_report_ro_tva_rd26" model="account.report.line">
                         <field name="name">26 - VAT - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge), of which</field>
-                        <field name="name@ro">26 - TVA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă ), din care:</field>
-                        <field name="code">tax_ro_tva_rd27</field>
-                        <field name="aggregation_formula">tax_ro_tva_rd271.balance + tax_ro_tva_rd272.balance</field>
+                        <field name="name@ro">26 - TVA - Achiziții de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă ), din care:</field>
+                        <field name="code">tax_ro_tva_rd26</field>
+                        <field name="aggregation_formula">tax_ro_tva_rd261.balance + tax_ro_tva_rd262.balance</field>
                         <field name="children_ids">
-                            <record id="account_tax_report_ro_tva_rd271" model="account.report.line">
+                            <record id="account_tax_report_ro_tva_rd261" model="account.report.line">
                                 <field name="name">26.1 - VAT - Purchases of goods, taxable at 21%</field>
-                                <field name="name@ro">26.1 - TVA - Achiziţii de bunuri si servicii, taxabile cu cota 21%</field>
-                                <field name="code">tax_ro_tva_rd271</field>
+                                <field name="name@ro">26.1 - TVA - Achiziții de bunuri si servicii, taxabile cu cota 21%</field>
+                                <field name="code">tax_ro_tva_rd261</field>
                                 <field name="expression_ids">
-                                    <record id="account_tax_report_ro_tva_rd271_tag" model="account.report.expression">
+                                    <record id="account_tax_report_ro_tva_rd261_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">26_1 - VAT</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="account_tax_report_ro_tva_rd272" model="account.report.line">
+                            <record id="account_tax_report_ro_tva_rd262" model="account.report.line">
                                 <field name="name">26.2 - VAT - Purchases of goods, taxable at 11%</field>
-                                <field name="name@ro">26.2 - TVA - Achiziţii de bunuri, taxabile cu cota 11%</field>
-                                <field name="code">tax_ro_tva_rd272</field>
+                                <field name="name@ro">26.2 - TVA - Achiziții de bunuri, taxabile cu cota 11%</field>
+                                <field name="code">tax_ro_tva_rd262</field>
                                 <field name="expression_ids">
-                                    <record id="account_tax_report_ro_tva_rd272_tag" model="account.report.expression">
+                                    <record id="account_tax_report_ro_tva_rd262_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">26_2 - VAT</field>
@@ -837,24 +837,24 @@
                             </record>
                         </field>
                     </record>
-                    <record id="account_tax_report_ro_tva_rd28" model="account.report.line">
+                    <record id="account_tax_report_ro_tva_rd27" model="account.report.line">
                         <field name="name">27 - VAT - Flat-rate compensation for purchases of agricultural products and services from suppliers applying the special scheme for farmers</field>
                         <field name="name@ro">27 - TVA - Compensația în cotă forfetară pentru achiziții de produse și servicii agricole de la furnizori care aplică regimul special pentru agricultori</field>
-                        <field name="code">tax_ro_tva_rd28</field>
+                        <field name="code">tax_ro_tva_rd27</field>
                         <field name="expression_ids">
-                            <record id="account_tax_report_ro_tva_rd28_tag" model="account.report.expression">
+                            <record id="account_tax_report_ro_tva_rd27_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">27 - VAT</field>
                             </record>
                         </field>
                     </record>
-                    <record id="account_tax_report_ro_tva_rd29" model="account.report.line">
+                    <record id="account_tax_report_ro_tva_rd28" model="account.report.line">
                         <field name="name">28 - VAT - Flat-rate compensation adjustments</field>
                         <field name="name@ro">28 - TVA - Regularizări privind  compensația în cotă forfetară</field>
-                        <field name="code">tax_ro_tva_rd29</field>
+                        <field name="code">tax_ro_tva_rd28</field>
                         <field name="expression_ids">
-                            <record id="account_tax_report_ro_tva_rd29_tag" model="account.report.expression">
+                            <record id="account_tax_report_ro_tva_rd28_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">28 - VAT</field>
@@ -863,96 +863,95 @@
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_baza_total_rd31" model="account.report.line">
+            <record id="account_tax_report_ro_baza_total_rd30" model="account.report.line">
                 <field name="name">30 - TAX BASE - TOTAL DEDUCTIBLE TAX (amount from row 20 to row 28, except row 20.1, 22.1, 26.1, 26.2)</field>
-                <field name="name@ro">30 - BAZĂ FISCALĂ - TOTAL TAXĂ DEDUCTIBILĂ (sumă de la rd.20  până la rd.28, cu excepţia celor de la rd. 20.1, 22.1, 26.1, 26.2 ) </field>
-                <field name="code">tax_ro_baza_total_rd31</field>
+                <field name="name@ro">30 - BAZĂ FISCALĂ - TOTAL TAXĂ DEDUCTIBILĂ (sumă de la rd.20  până la rd.28, cu excepția celor de la rd. 20.1, 22.1, 26.1, 26.2 ) </field>
+                <field name="code">tax_ro_baza_total_rd30</field>
                 <field name="aggregation_formula">tax_ro_baza_intracom_eu_a.balance + tax_ro_baza_achiz.balance</field>
             </record>
-            <record id="account_tax_report_ro_tva_total_rd31" model="account.report.line">
+            <record id="account_tax_report_ro_tva_total_rd30" model="account.report.line">
                 <field name="name">30 - VAT - TOTAL DEDUCTIBLE TAX (amount from row 20 to row 28, except row 20.1, 22.1, 26.1, 26.2)</field>
-                <field name="name@ro">30 - TVA - TOTAL TAXĂ DEDUCTIBILĂ (sumă de la rd.20  până la rd.28, cu excepţia celor de la rd. 20.1, 22.1, 26.1, 26.2 ) </field>
-                <field name="code">tax_ro_tva_total_rd31</field>
-                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
+                <field name="name@ro">30 - TVA - TOTAL TAXĂ DEDUCTIBILĂ (sumă de la rd.20  până la rd.28, cu excepția celor de la rd. 20.1, 22.1, 26.1, 26.2 ) </field>
+                <field name="code">tax_ro_tva_total_rd30</field>
+                 <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
             </record>
-            <record id="account_tax_report_ro_tva_rd32" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd31" model="account.report.line">
                 <field name="name">31 - VAT - SUB-TOTAL TAX DEDUCTED PURSUANT TO ARTICLE 297 AND ARTICLE 298 OR ARTICLE 300 AND ARTICLE 298</field>
                 <field name="name@ro">31 - TVA - SUB-TOTAL TAXĂ DEDUSĂ CONFORM ART. 297 ŞI ART. 298  SAU ART. 300 ŞI ART. 298 DIN CODUL FISCAL ȘI COMPENSAȚIE ÎN COTĂ FORFETARĂ</field>
-                <field name="code">tax_ro_tva_rd32</field>
-                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
-            </record>
-            <record id="account_tax_report_ro_tva_rd33" model="account.report.line">
+                <field name="code">tax_ro_tva_rd31</field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>            </record>
+            <record id="account_tax_report_ro_tva_rd32" model="account.report.line">
                 <field name="name">32 - VAT - VAT actually refunded to foreign purchasers, including commission to authorised establishments</field>
-                <field name="name@ro">32 - TVA - TVA efectiv restituită cumpărătorilor străini, inclusiv comisionul unităţilor autorizate</field>
-                <field name="code">tax_ro_tva_rd33</field>
+                <field name="name@ro">32 - TVA - TVA efectiv restituită cumpărătorilor străini, inclusiv comisionul unităților autorizate</field>
+                <field name="code">tax_ro_tva_rd32</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd33_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_tva_rd32_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">32 - VAT</field>
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_baza_rd34" model="account.report.line">
+            <record id="account_tax_report_ro_baza_rd33" model="account.report.line">
                 <field name="name">33 - TAX BASE - Deducted tax adjustments</field>
                 <field name="name@ro">33 - BAZĂ FISCALĂ - Regularizări taxă dedusă</field>
-                <field name="code">tax_ro_baza_rd34</field>
+                <field name="code">tax_ro_baza_rd33</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_rd34_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_baza_rd33_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">33 - TAX BASE</field>
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_tva_rd34" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd33" model="account.report.line">
                 <field name="name">33 - VAT - Deducted tax adjustments</field>
                 <field name="name@ro">33 - TVA - Regularizări taxă dedusă</field>
-                <field name="code">tax_ro_tva_rd34</field>
+                <field name="code">tax_ro_tva_rd33</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd34_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_tva_rd33_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">33 - VAT</field>
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_tva_rd35" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd34" model="account.report.line">
                 <field name="name">34 - VAT - Pro-rata adjustments / adjustments for capital goods</field>
                 <field name="name@ro">34 - TVA - Ajustări conform pro-rata / ajustări de taxă</field>
-                <field name="code">tax_ro_tva_rd35</field>
+                <field name="code">tax_ro_tva_rd34</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd35_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_tva_rd34_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">34 - VAT</field>
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_tva_rd36" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd35" model="account.report.line">
                 <field name="name">35 - VAT - TOTAL TAX DEDUCTED (row 31 + row 32 + row 33 + row 34)</field>
                 <field name="name@ro">35 - TVA - TOTAL TAXĂ DEDUSĂ (rd.31+rd.32+rd.33+rd.34)</field>
-                <field name="code">tax_ro_tva_rd36</field>
-                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance + tax_ro_tva_rd33.balance + tax_ro_tva_rd34.balance + tax_ro_tva_rd35.balance</field>
+                <field name="code">tax_ro_tva_rd35</field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance + tax_ro_tva_rd32.balance + tax_ro_tva_rd33.balance + tax_ro_tva_rd34.balance</field>
             </record>
-            <record id="account_tax_report_ro_tva_rd40" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd39" model="account.report.line">
                 <field name="name">39 - VAT - VAT differences to be paid established by the tax inspection authorities by means of a communicated decision and not paid by the date of submission of the VAT return</field>
-                <field name="name@ro">39 - TVA - Diferenţe de TVA de plată stabilite de organele fiscale prin decizie comunicată  şi neachitate până la data depunerii decontului de TVA</field>
-                <field name="code">tax_ro_tva_rd40</field>
+                <field name="name@ro">39 - TVA - Diferențe de TVA de plată stabilite de organele fiscale prin decizie comunicată  şi neachitate până la data depunerii decontului de TVA</field>
+                <field name="code">tax_ro_tva_rd39</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd40_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_tva_rd39_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">39 - VAT</field>
                     </record>
                 </field>
             </record>
-            <record id="account_tax_report_ro_tva_rd43" model="account.report.line">
+            <record id="account_tax_report_ro_tva_rd42" model="account.report.line">
                 <field name="name">42 - VAT - Negative VAT differences established by the tax inspection authorities by decision communicated by the date of submission of the VAT return</field>
-                <field name="name@ro">42 - TVA - Diferenţe negative de TVA stabilite de organele de inspecţie fiscală prin decizie comunicată până la data depunerii decontului de TVA </field>
-                <field name="code">tax_ro_tva_rd43</field>
+                <field name="name@ro">42 - TVA - Diferențe negative de TVA stabilite de organele de inspecție fiscală prin decizie comunicată până la data depunerii decontului de TVA </field>
+                <field name="code">tax_ro_tva_rd42</field>
                 <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd43_tag" model="account.report.expression">
+                    <record id="account_tax_report_ro_tva_rd42_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">42 - VAT</field>


### PR DESCRIPTION
Actualizate ID-urile și formulele din rapoartele de TVA pentru a reflecta corect structura și codurile utilizate în România. Aceasta asigură o aliniere mai clară cu cerințele de raportare și minimizează problemele de conformitate.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
