### PR TITLE
[FIX] mass_mailing: fix language direction for convert inline

### DIFF
--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -1348,6 +1348,7 @@ describe("Convert classes to inline styles", () => {
             body {
                 background-color: red;
                 color: white;
+                direction: rtl;
                 font-size: 50px;
                 div {
                     border-color: ${borderColor} !important;
@@ -1356,10 +1357,10 @@ describe("Convert classes to inline styles", () => {
         `,
             0
         );
-        iframeEditable.innerHTML = `<div class="o_layout" style="padding: 50px;"></div>`;
+        iframeEditable.innerHTML = `<div class="o_layout" style="padding: 50px;">Test</div>`;
         classToStyle(iframeEditable, getCSSRules(iframeEditable.ownerDocument));
         expect(iframeEditable).toHaveInnerHTML(
-            `<div class="o_layout" style="border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;border-left-color:${borderColor};border-bottom-color:${borderColor};border-right-color:${borderColor};border-top-color:${borderColor};border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;border-left-color:${borderColor};border-bottom-color:${borderColor};border-right-color:${borderColor};border-top-color:${borderColor};border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;font-size:50px;direction:rtl;color:white;background-color:red;padding: 50px;">Test</div>`,
             { message: "should have given all styles of body to .o_layout" }
         );
         styleSheet.deleteRule(0);

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -72,3 +72,9 @@ html:has(.o_layout) {
         outline-offset: -2px;
     }
 }
+
+body {
+    // Set frontend direction that will be flipped with
+    // rtlcss for right-to-left text direction.
+    direction: ltr;
+}


### PR DESCRIPTION
**Steps to reproduce:**
- Install Mail Marketing app
- Change user language to a RTL language (such as Arabic)
- Create a marketing campaign with RTL content
- Send it
- Mail received changes from RTL to LTR

**Issue:**
Conversion doesn't take into account the current
language direction anymore when creating the inline
styling. This keeps the mails in the default format ('ltr').

Previously the inline conversion was using the `/portal/static/src/scss/portal.scss`
to set the html body text direction using the `rtlcss` library:
```css
 // Frontend general
body {
    // Set frontend direction that will be flipped with
    // rtlcss for right-to-left text direction.
    direction: ltr;
}
```
It was used during the inline conversion in a `CSSStyleRule`
after loading the doc sheets, and added with the `.o_layout` selector:
```js
if (selector === "body") {
    // The top element of a mailing has the class
    // 'o_layout'. Give it the body's styles so they can
    // trickle down.
    cssRules.push({
        selector: ".o_layout",
        rawRule: subRule,
        specificity: 1,
    });
}
```
But recent refactor reworked the styling assets used by
this process, which removed this behavior.

**Fix:**
Keep style `direction` (instead of `dir` attribute) like
before, to avoid compatibility issues in mail engines.
This is done by reapplying the body rule on the
mass_mailing iframe styling, but it could also be manually
added to the fragment itself using the editor current config
or localization.

related: https://github.com/odoo/odoo/commit/354b8f60dbabcfac690d90bf657592e1347e4f86

opw-5982854