### PR TITLE
[FIX] l10n_us_account: link to direct deposit documentation

### DIFF
--- a/addons/l10n_us_account/views/res_config_settings_views.xml
+++ b/addons/l10n_us_account/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <setting id="sepa_payments" position="after">
                 <setting id="wise_payment_settings" string="U.S. Direct Deposit (via Wise)" company_dependent="1" help="Initiate payments in one-click using a Wise Business account"
-                    invisible="country_code != 'US'">
+                    invisible="country_code != 'US'" documentation="/applications/finance/fiscal_localizations/united_states.html#pay-by-direct-deposit">
                     <field name="module_l10n_us_direct_deposit" widget="upgrade_boolean"/>
                     <div id="wise_payment_content" class="content-group" invisible="not module_l10n_us_direct_deposit">
                         <div class="text-warning mt16 mb4">


### PR DESCRIPTION
When the Direct Deposit module was merged, there was no documentation created yet. Now that it has been merged we will add the link to the right documentation.

task-none