### PR TITLE
[FIX] packaging: Fix odoo 19 packages for Debian 13

### DIFF
--- a/doc/cla/individual/smortex.md
+++ b/doc/cla/individual/smortex.md
@@ -1,0 +1,11 @@
+French Polynesia, 2026-03-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Romain Tartière romain@blogreen.org https://github.com/smortex

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list
         'psycopg2 >= 2.2',
         'pyopenssl',
-        'PyPDF2',
+        'PyPDF2;python_version<"3.13"',
+        'PyPDF;python_version>="3.13"',
         'pyserial',
         'python-dateutil',
         'python-stdnum',


### PR DESCRIPTION
The Debian packages for odoo 19 available on the nightly repository cannot be installed on Debian 13 due to incorrect dependencies on python3-pypdf2 that does not exist anymore on recent versions of Debian.

In #233598, dependencies have been updated to use the new package python3-pypdf when using Python 3.13+, which should have fixed the packges on Debian 13, unfortunately the issue still exist as noted in multiple other issues (e.g. #233667, #247711).

Packaging depends on pybuild(1) from Debian's dh-python, which in turn depends on setup.py to determine dependencies, but this file has not been updated in #233598 to reflect the dependency on PyPDF with modern versions of Python and PyPDF2 with older versions of Python.

Adjust setup.py to match the way requirements.txt depends on PyPDF or PyPDF2 depending on the version of Python in use.

Fixes #233667
Fixes #247711
