### PR TITLE
[PERF] mail: optimize recordset concatenation for group by mail message operation

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -86,10 +86,15 @@ class Base(models.AbstractModel):
         """ Globally reverse result of '_mail_get_operation_for_mail_message_operation'
         aka return documents for a given access to check on them. """
         document_operations = self._mail_get_operation_for_mail_message_operation(message_operation)
+        operation_documents_ids = defaultdict(set)
         operation_documents = defaultdict(lambda: self.env[self._name])
         for record, record_operation in document_operations.items():
-            operation_documents[record_operation] += record
-        # force prefetch in a post-loop as recordset concatenation may lose it
+            operation_documents_ids[record_operation].add(record.id)
+
+        for record_operation, record_ids in operation_documents_ids.items():
+            operation_documents[record_operation] = self.browse(record_ids)
+
+        # force prefetch in a post-loop asacco recordset concatenation may lose it
         for operation, records in operation_documents.items():
             records = records.with_prefetch(self.ids)
         return operation_documents


### PR DESCRIPTION
Related Ticket: https://www.odoo.com/odoo/project/49/tasks/6037414

### Description of the issue/feature this PR addresses:
This PR addresses a performance bottleneck caused by inefficient recordset concatenation during mail message operations.

### Current behavior before PR:
The previous implementation used the += operator to iteratively append records to a recordset inside a loop. This behavior of recordset concatenation creates a completely new recordset in memory and evaluates each record sequentially for every addition.

### Desired behavior after PR is merged:
To resolve this performance bottleneck, the records are now first grouped by operation using their integer IDs in a standard Python set. Once the loop completes, a single `self.browse(record_ids)` is called for each operation group. This eliminates the repetitive overhead of continuous recordset instantiation and speeds up the overall process.

### Benchmark:
The function `mail_group_by_operation_for_mail_message_operation()` is running with a total invoice count of ~172,000 invoices. 

Speed:
|# Input Data | Before Fix | After Fix |
|---|---|---|
| 172,000 | 23.62s | 1.06s |

### Reference

opw-6037414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
