### PR TITLE
[18.0][IMP] html_editor / web_editor / website : peertube integration

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -317,11 +317,11 @@ class HTML_Editor(http.Controller):
     @http.route(['/web_editor/video_url/data', '/html_editor/video_url/data'], type='json', auth='user', website=True)
     def video_url_data(self, video_url, autoplay=False, loop=False,
                        hide_controls=False, hide_fullscreen=False,
-                       hide_dm_logo=False, hide_dm_share=False):
+                       hide_dm_logo=False, hide_dm_share=False, peer_to_peer=False):
         return get_video_url_data(
             video_url, autoplay=autoplay, loop=loop,
             hide_controls=hide_controls, hide_fullscreen=hide_fullscreen,
-            hide_dm_logo=hide_dm_logo, hide_dm_share=hide_dm_share
+            hide_dm_logo=hide_dm_logo, hide_dm_share=hide_dm_share, peer_to_peer=peer_to_peer
         )
 
     @http.route(['/web_editor/attachment/add_data', '/html_editor/attachment/add_data'], type='json', auth='user', methods=['POST'], website=True)

--- a/addons/html_editor/tools.py
+++ b/addons/html_editor/tools.py
@@ -18,6 +18,7 @@ player_regexes = {
     'vimeo': r'//(player.)?vimeo.com/([a-z]*/)*([0-9]{6,11})[?]?.*',
     'dailymotion': r'(https?://|//)?(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
+    'peertube': r'(https?://|//)(?P<base_url>.*)/(videos\/embed|w)/(?P<video_id>[a-zA-Z0-9-_]*)',
 }
 
 
@@ -41,10 +42,13 @@ def get_video_source_data(video_url):
         instagram_match = re.search(player_regexes['instagram'], video_url)
         if instagram_match:
             return ('instagram', instagram_match[2], instagram_match)
+        peertube_match = re.search(player_regexes['peertube'], video_url)
+        if peertube_match:
+            return ('peertube', peertube_match.group("video_id"), peertube_match)
     return None
 
 
-def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=False, hide_fullscreen=False, hide_dm_logo=False, hide_dm_share=False):
+def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=False, hide_fullscreen=False, hide_dm_logo=False, hide_dm_share=False, peer_to_peer=False):
     """ Computes the platform name, the embed_url, the video id and the video params of the given URL
         (or error message in case of invalid URL).
     """
@@ -91,6 +95,16 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
         embed_url = f'//www.dailymotion.com/embed/video/{video_id}'
     elif platform == 'instagram':
         embed_url = f'//www.instagram.com/p/{video_id}/embed/'
+    elif platform == 'peertube':
+        params['autoplay'] = autoplay and 1 or 0
+        params['p2p'] = peer_to_peer and 1 or 0
+        if autoplay:
+            params['muted'] = 1
+        if hide_controls:
+            params['controls'] = 0
+        if loop:
+            params['loop'] = 1
+        embed_url = f'//{platform_match.group('base_url')}/videos/embed/{video_id}'
 
     if params:
         embed_url = f'{embed_url}?{url_encode(params)}'

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -54,23 +54,29 @@ export class VideoSelector extends Component {
             youtube: 'youtube',
             dailymotion: 'dailymotion',
             vimeo: 'vimeo',
+            peertube: 'peertube',
         };
 
         this.OPTIONS = {
             autoplay: {
                 label: _t("Autoplay"),
                 description: _t("Videos are muted when autoplay is enabled"),
-                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo, this.PLATFORMS.peertube],
                 urlParameter: 'autoplay=1',
             },
             loop: {
                 label: _t("Loop"),
-                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo, this.PLATFORMS.peertube],
                 urlParameter: 'loop=1',
+            },
+            peer_to_peer: {
+                label: _t("Peer To Peer"),
+                platforms: [this.PLATFORMS.peertube],
+                urlParameter: 'p2p=1',
             },
             hide_controls: {
                 label: _t("Hide player controls"),
-                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo, this.PLATFORMS.peertube],
                 urlParameter: 'controls=0',
             },
             hide_fullscreen: {

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.xml
@@ -29,7 +29,7 @@
                     <b>Video code </b>(URL or Embed)
                 </label>
                 <div class="text-start">
-                    <small class="text-muted">Accepts <b><i>Youtube</i></b>, <b><i>Vimeo</i></b>, <b><i>Dailymotion</i></b> and <b><i>Instagram</i></b> videos</small>
+                    <small class="text-muted">Accepts <b><i>Youtube</i></b>, <b><i>Vimeo</i></b>, <b><i>Dailymotion</i></b>, <b><i>Instagram</i></b> and <b><i>Peertube</i></b> videos</small>
                 </div>
                 <textarea t-ref="autofocus" t-model="state.urlInput" class="form-control" id="o_video_text" placeholder="Copy-paste your URL or embed code here" t-on-input="onChangeUrl" t-att-class="{ 'is-valid': state.urlInput and !this.state.errorMessage, 'is-invalid': state.urlInput and this.state.errorMessage }"/>
             </div>

--- a/addons/web_editor/tests/test_tools.py
+++ b/addons/web_editor/tests/test_tools.py
@@ -25,6 +25,8 @@ class TestVideoUtils(common.BaseCase):
         'dai.ly': 'https://dai.ly/x578has',
         'dailymotion_embed': 'https://www.dailymotion.com/embed/video/x578has?autoplay=1',
         'dailymotion_video_extra': 'https://www.dailymotion.com/video/x2jvvep_hakan-yukur-klip_sport',
+        'peertube_infothema_net': 'https://infothema.net/w/6EeX6iZnkUPshrXnqLC75D',
+        'peertube_media_zat_im': 'https://media.zat.im/w/35badfed-5322-48ac-b5c1-71b1ad88262e',
     }
 
     def test_player_regexes(self):
@@ -41,6 +43,9 @@ class TestVideoUtils(common.BaseCase):
         self.assertIsNotNone(re.search(tools.player_regexes['dailymotion'], TestVideoUtils.urls['dailymotion']))
         #instagram
         self.assertIsNotNone(re.search(tools.player_regexes['instagram'], TestVideoUtils.urls['instagram']))
+        #peertube
+        self.assertIsNotNone(re.search(tools.player_regexes['peertube'], TestVideoUtils.urls['peertube_infothema_net']))
+        self.assertIsNotNone(re.search(tools.player_regexes['peertube'], TestVideoUtils.urls['peertube_media_zat_im']))
 
     def test_get_video_source_data(self):
         self.assertEqual(3, len(tools.get_video_source_data(TestVideoUtils.urls['youtube'])))
@@ -77,6 +82,12 @@ class TestVideoUtils(common.BaseCase):
         #instagram
         self.assertEqual('instagram', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[0])
         self.assertEqual('B6dXGTxggTG', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[1])
+        #peertube
+        self.assertEqual('peertube', tools.get_video_source_data(TestVideoUtils.urls['peertube_infothema_net'])[0])
+        self.assertEqual('6EeX6iZnkUPshrXnqLC75D', tools.get_video_source_data(TestVideoUtils.urls['peertube_infothema_net'])[1])
+        self.assertEqual('peertube', tools.get_video_source_data(TestVideoUtils.urls['peertube_media_zat_im'])[0])
+        self.assertEqual('35badfed-5322-48ac-b5c1-71b1ad88262e', tools.get_video_source_data(TestVideoUtils.urls['peertube_media_zat_im'])[1])
+
 
     def test_get_video_url_data(self):
         self.assertEqual(4, len(tools.get_video_url_data(TestVideoUtils.urls['youtube'])))

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -28,6 +28,8 @@ player_regexes = {
     'vimeo_player': r'^(?:(?:https?:)?//)?player\.vimeo\.com\/video\/(?P<id>[^/\?]+)(?:\?(?P<params>[^\s]+))?$',
     'dailymotion': r'(https?://|//)?(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
+    'peertube': r'(https?://|//)(?P<base_url>.*)/(videos\/embed|w)/(?P<video_id>[a-zA-Z0-9-_]*)',
+
 }
 
 
@@ -53,10 +55,13 @@ def get_video_source_data(video_url):
         instagram_match = re.search(player_regexes['instagram'], video_url)
         if instagram_match:
             return ('instagram', instagram_match[2], instagram_match)
+        peertube_match = re.search(player_regexes['peertube'], video_url)
+        if peertube_match:
+            return ('peertube', peertube_match.group("video_id"), peertube_match)
     return None
 
 
-def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=False, hide_fullscreen=False, hide_dm_logo=False, hide_dm_share=False):
+def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=False, hide_fullscreen=False, hide_dm_logo=False, hide_dm_share=False, peer_to_peer=False):
     """ Computes the platform name, the embed_url, the video id and the video params of the given URL
         (or error message in case of invalid URL).
     """
@@ -111,6 +116,16 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
         embed_url = f'//www.dailymotion.com/embed/video/{video_id}'
     elif platform == 'instagram':
         embed_url = f'//www.instagram.com/p/{video_id}/embed/'
+    elif platform == 'peertube':
+        params['autoplay'] = autoplay and 1 or 0
+        params['p2p'] = peer_to_peer and 1 or 0
+        if autoplay:
+            params['muted'] = 1
+        if hide_controls:
+            params['controls'] = 0
+        if loop:
+            params['loop'] = 1
+        embed_url = f'//{platform_match.group('base_url')}/videos/embed/{video_id}'
 
     if params:
         embed_url = f'{embed_url}?{url_encode(params)}'
@@ -134,6 +149,7 @@ def get_video_embed_code(video_url):
         'loop': 'loop',
         'hide_controls': 'controls',
         'hide_fullscreen': 'fs',
+        'peer_to_peer': 'p2p',
         'hide_dm_logo': 'ui-logo',
         'hide_dm_share': 'sharing-enable',
     }

--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -1,15 +1,6 @@
 import { ObservingCookieWidgetMixin } from "@website/snippets/observing_cookie_mixin";
 const { _manageIframeSrc } = ObservingCookieWidgetMixin;
 
-const SUPPORTED_DOMAINS = [
-    "youtu.be",
-    "youtube.com",
-    "youtube-nocookie.com",
-    "instagram.com",
-    "player.vimeo.com",
-    "vimeo.com",
-    "dailymotion.com",
-];
 
 /**
  * Builds a video iframe for a saved `src` and appends it to the DOM.
@@ -36,11 +27,6 @@ export function generateVideoIframe(parentEl) {
     const m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);
     if (!m) {
         // Unsupported protocol or wrong URL format, don't inject iframe
-        return;
-    }
-    const domain = m[1].replace(/^www\./, "");
-    if (!SUPPORTED_DOMAINS.includes(domain)) {
-        // Unsupported domain, don't inject iframe
         return;
     }
     const iframeEl = document.createElement("iframe");


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Have the possibility to integrate Peertube videos in Odoo.

<img width="1127" height="525" alt="image" src="https://github.com/user-attachments/assets/dc6496fb-e3fc-4a06-a079-c98555df6dd7" />


**Commit 1 :** 

    [IMP] web_editor/html_editor: implement Peertube videos integration
    - Add parser to parse peertube URL. As the base_url is not know
      we put the check as the last 'elif', as a fallback, if other more
      simple matches failed.
    - Add a new option 'peer_to_peer', available only for 'peertube' videos.
      It provides the possibility to enable or not specific p2p feature,
      that generates a warning, if enabled.
      ('Watching this video may reveal your IP address to others').

**Commit 2 :** 

    [REM] website: remove supported domain check before inserting iframe.
    
    Rational: That is required to have the possibility to integrate
    peertube video as the base url is not the same.

    Also, putting Alphabet (Youtube) or Meta (Instagram) as 'secure' is quite weird,
    regarding the long list of scandals these companies have faced:
    
    - PRISM program (see Edward Snowden’s revelations in 2013)
    - Cambridge Analytica scandal (2018)
    - ...
