### PR TITLE
[18.0][FIX] mail: handle None mail_message in assertNoMail

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -750,7 +750,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         else:
             raise AssertionError('mail.mail exists for message %s / recipients %s but should not exist' % (mail_message, recipients.ids))
         finally:
-            self.assertNotSentEmail(recipients=recipients, message_id=mail_message.message_id)
+            self.assertNotSentEmail(recipients=recipients, message_id=mail_message.message_id if mail_message else None)
 
     def assertNotSentEmail(self, recipients=None, message_id=None):
         """Check no email was generated during gateway mock.


### PR DESCRIPTION
This changes https://github.com/odoo/odoo/pull/230766/changes cause the issue.
I fix `AttributeError` when `mail_message` is None in `assertNoMail` method. The method was accessing `mail_message.message_id `without checking if `mail_message` is `None` first, causing a potential crash in test cases.

Added a conditional check to safely handle None values before accessing the message_id attribute.

@qrtl