### PR TITLE
[FIX] analytic: set analytic account by default

### DIFF
--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -133,6 +133,15 @@ class AccountAnalyticLine(models.Model):
         return arch, view
 
     @api.model
+    def default_get(self, fields_list):
+        defaults = super().default_get(fields_list)
+        account_id = self.env.context.get('default_auto_account_id')
+        account = self.env['account.analytic.account'].browse(account_id).exists()
+        if account:
+            defaults[account.plan_id._column_name()] = account.id
+        return defaults
+
+    @api.model
     def fields_get(self, allfields=None, attributes=None):
         fields = super().fields_get(allfields, attributes)
         if not self._context.get("studio") and self.env['account.analytic.plan'].check_access_rights('read', raise_exception=False):

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -38,7 +38,7 @@
     </record>
 
     <record model="ir.actions.act_window" id="account_analytic_line_action">
-        <field name="context">{'search_default_group_date': 1}</field>
+        <field name="context">{'search_default_group_date': 1, 'default_auto_account_id': active_id}</field>
         <field name="domain">[('auto_account_id','=', active_id)]</field>
         <field name="name">Gross Margin</field>
         <field name="res_model">account.analytic.line</field>


### PR DESCRIPTION
When accessing analytic items from the gross margin smart button on an analytic account, creating a new record does not pre-fill the analytic account field.

This happens because the context does not set `default_account_id` for the active analytic account, leading to newly created lines not being linked at creation time.

This commit ensures the analytic account is correctly passed through the context, so it is automatically set when creating a new analytic line from this flow.

Steps to reproduce:
- Open an analytic account
- Click on the gross margin smart button
- Create a new analytic item

Before: analytic account not set by default
After: analytic account is pre-filled via context

task-3909624