### PR TITLE
[FIX] account_edi_ubl_cii: allow VAT without country prefix for Peppol

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -230,6 +230,10 @@ EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES = {
     'IS', 'LI', 'NO',
 }
 
+VAT_PREFIX_EXCEPTION_COUNTRIES = {
+    'HU', 'IS'
+}
+
 # -------------------------------------------------------------------------
 # SUPPORTED FILE TYPES FOR IMPORT
 # -------------------------------------------------------------------------

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -4,7 +4,7 @@ from odoo import _, models, Command
 from odoo.tools import html2plaintext
 from odoo.tools.float_utils import float_is_zero, float_round
 from odoo.addons.account.tools import dict_to_xml
-from odoo.addons.account_edi_ubl_cii.models.account_edi_common import FloatFmt
+from odoo.addons.account_edi_ubl_cii.models.account_edi_common import FloatFmt, VAT_PREFIX_EXCEPTION_COUNTRIES
 from odoo.addons.account_edi_ubl_cii.tools import Invoice, CreditNote, DebitNote
 from odoo.addons.account_edi_ubl_cii.tools.ubl_20_optional_fields import PEPPOL_INVOICE_OPTIONAL_FIELDS, PEPPOL_INVOICE_OPTIONAL_LINE_FIELDS, PEPPOL_CREDIT_NOTE_OPTIONAL_FIELDS, PEPPOL_CREDIT_NOTE_OPTIONAL_LINE_FIELDS
 
@@ -635,6 +635,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         """ Generic helper to generate the Party node for a res.partner. """
         partner = vals['partner']
         commercial_partner = partner.commercial_partner_id
+        vat = commercial_partner.vat
+        country_code = commercial_partner.country_id.code
+        if country_code in VAT_PREFIX_EXCEPTION_COUNTRIES and not vat.upper().startswith(country_code):
+            vat = country_code + vat
         party_node = {
             'cbc:EndpointID': {
                 '_text': None,
@@ -649,7 +653,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'cac:PostalAddress': self._get_address_node(vals),
             'cac:PartyLegalEntity': {
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
-                'cbc:CompanyID': {'_text': commercial_partner.vat},
+                'cbc:CompanyID': {'_text': vat},
                 'cac:RegistrationAddress': self._get_address_node({**vals, 'partner': commercial_partner}),
             },
             'cac:Contact': {
@@ -662,15 +666,15 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if partner.vat and partner.vat != '/':
             party_node['cac:PartyTaxScheme'] = {
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
-                'cbc:CompanyID': {'_text': commercial_partner.vat},
+                'cbc:CompanyID': {'_text': vat},
                 'cac:RegistrationAddress': self._get_address_node({**vals, 'partner': commercial_partner}),
                 'cac:TaxScheme': {
                     'cbc:ID': {
                         '_text': (
                             'NOT_EU_VAT'
                             if commercial_partner.country_id
-                            and commercial_partner.vat
-                            and not commercial_partner.vat[:2].isalpha()
+                            and vat
+                            and not vat[:2].isalpha()
                             else 'VAT'
                         )
                     }

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -10,6 +10,7 @@ from odoo.addons.account_edi_ubl_cii.models.account_edi_common import (
     FloatFmt,
     GST_COUNTRY_CODES,
     EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES,
+    VAT_PREFIX_EXCEPTION_COUNTRIES
 )
 from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
 
@@ -669,8 +670,8 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             else:
                 tax_scheme_id = 'VAT'
 
-            if country_code == 'HU' and not vat.upper().startswith('HU'):
-                vat = 'HU' + vat[:8]
+            if country_code in VAT_PREFIX_EXCEPTION_COUNTRIES and not vat.upper().startswith(country_code):
+                vat = country_code + vat
 
             nodes.append({
                 'cbc:CompanyID': {'_text': vat},
@@ -746,10 +747,14 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
                 },
             })
         elif commercial_partner.vat and commercial_partner.vat != '/':
+            vat = commercial_partner.vat
+            country_code = commercial_partner.country_id.code
+            if country_code in VAT_PREFIX_EXCEPTION_COUNTRIES and not vat.upper().startswith(country_code):
+                vat = country_code + vat
             nodes.append({
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
                 'cbc:CompanyID': {
-                    '_text': commercial_partner.vat,
+                    '_text': vat,
                     'schemeID': None,
                 },
             })


### PR DESCRIPTION
Current behavior before PR:
- There was a restriction that VAT must start with the country code.
- But for some countries (like Iceland), VAT does not include the country code.
- Because of this, Peppol validation failed (Schematron error) and users could not 
  send invoices.

Desired behavior after PR is merged:
- Users can now send invoices through Peppol even if the VAT does not start with
  the country code.

Changes implemented:
- If VAT does not start with the country code, the prefix is added during export.

task-6050791


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
