### PR TITLE
[IMP] project: remove duplicate action from project kanban view

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -495,7 +495,6 @@
 
                                         <a t-if="['portal', 'invited_users'].includes(record.privacy_visibility.raw_value) and !record.is_template.raw_value" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
-                                        <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
                                         <a class="dropdown-item" role="menuitem" type="open">Settings</a>
                                     </div>
                                     <div class="col-12 ps-0" groups="!project.group_project_manager">

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -473,7 +473,6 @@
 
                                         <a t-if="['portal', 'invited_users'].includes(record.privacy_visibility.raw_value) and !record.is_template.raw_value" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
-                                        <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
                                         <a class="dropdown-item" role="menuitem" type="open">Settings</a>
                                     </div>
                                     <div class="col-12 ps-0" groups="!project.group_project_manager">


### PR DESCRIPTION
Before:

- The project kanban card's dropdown menu included a `Duplicate` button. Because this button was placed where it could be easily clicked by accident, and because it instantly created a new project without any confirmation warning, users were unintentionally creating duplicate projects.

After:

- The `Duplicate` action link is removed from the `project.project.kanban` view menu template. This prevents accidental duplications from the kanban view.

task-6043499