### PR TITLE
[FIX] sale: ensure negative discounts are not displayed in reports

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -67,7 +67,7 @@
 
             <!-- Is there a discount on at least one line? -->
             <t t-set="lines_to_report" t-value="doc._get_order_lines_to_report()"/>
-            <t t-set="display_discount" t-value="any(l.discount for l in lines_to_report)"/>
+            <t t-set="display_discount" t-value="any(l.discount > 0 for l in lines_to_report)"/>
 
             <div class="oe_structure"></div>
             <table class="table table-sm o_main_table table-borderless mt-4">
@@ -105,10 +105,17 @@
                                     </span>
                                 </td>
                                 <td name="td_priceunit" class="text-end">
-                                    <span t-field="line.price_unit">3</span>
+                                    <span
+                                        t-if="line.discount &lt; 0"
+                                        t-out="(1 - line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                                    />
+                                    <span
+                                        t-else=""
+                                        t-field="line.price_unit"
+                                    />
                                 </td>
                                 <td t-if="display_discount" class="text-end">
-                                    <span t-field="line.discount">-</span>
+                                    <span t-if="line.discount > 0" t-field="line.discount">-</span>
                                 </td>
                                 <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
                                 <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">


### PR DESCRIPTION
Steps to produce:
---
- Install the `Sales` module.
- Enable discounts from settings.
- Create a Sale Order with a negative discount on an order line.
- Preview the Sale Order and click on the view details button.

Issue:
---
- Negative discount values are not shown in the preview (portal view), but they are displayed in the generated PDF.

Root cause:
---
- At [1], the portal template includes a condition to display discounts only when they are greater than 0, while the report templates lack this check, leading to inconsistent behavior.

Solution:
---
- Applied the same condition in the report templates to align the PDF output with the portal preview behavior.

Before:
---
<img width="787" height="136" alt="image" src="https://github.com/user-attachments/assets/d32311be-4aec-4d6f-b905-d5e52f712ba4" />

After:
---
<img width="775" height="139" alt="image" src="https://github.com/user-attachments/assets/2614a8ad-dca6-49ca-b720-5c234aa91cf6" />


[1]https://github.com/odoo/odoo/blob/0f463fd247d2f5da79d6ec2b6bec18774f6f600b/addons/sale/views/sale_portal_templates.xml#L539

Enterprise PR: https://github.com/odoo/enterprise/pull/111916

opw-6061568
