### PR TITLE
[FIX] core: handle `chrome_debug.log` missing

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1086,7 +1086,7 @@ class ChromeBrowser:
                 proc.wait()
         self._logger.warning(
             'Chrome headless failed to start:\n%s',
-            pathlib.Path(self.user_data_dir, "chrome_debug.log").read_text(encoding="utf-8"),
+            self.read_log().decode(),
         )
         # since the chrome never started, it's not going to be `stop`-ed so we
         # need to cleanup the directory here
@@ -1143,6 +1143,12 @@ class ChromeBrowser:
         except OSError:
             raise unittest.SkipTest("%s not found" % cmd[0])
         self._logger.info('Chrome pid: %s', self.chrome_pid)
+
+    def read_log(self) -> bytes:
+        try:
+            return pathlib.Path(self.user_data_dir, 'chrome_debug.log').read_bytes()
+        except FileNotFoundError:
+            return b''
 
     def _find_websocket(self):
         version = self._json_command('version')
@@ -1594,7 +1600,7 @@ which leads to stray network requests and inconsistencies."""
         save_log = functools.partial(
             save_test_file,
             self.test_class.__name__,
-            pathlib.Path(self.user_data_dir, "chrome_debug.log").read_bytes(),
+            self.read_log(),
             prefix='chrome_log_',
             extension='txt',
             document_type="Chrome Log",


### PR DESCRIPTION
Follow up to #255054

[Apparently][] on old versions of chrome `chrome_debug.log` may not exist if the verbosity is not at least 1 (or chrome otherwise has had things to write to the log). Thus handle the possibility of the file being missing instead of assuming it's present just because we've told chrome to generate one.

[Apparently]: https://github.com/odoo/odoo/pull/255054#pullrequestreview-4001460518
