### PR TITLE
[FIX] stock_picking_batch: prevent crash if sequence prefix contains '/'

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -415,7 +415,8 @@ class StockPickingBatch(models.Model):
     # -------------------------------------------------------------------------
     @api.model
     def _prepare_name(self, picking_type, sequence_code, company_id):
-        sequence_prefix, sequence_number = (self.env['ir.sequence'].with_company(company_id).next_by_code(sequence_code) or '/').split('/')
+        sequence = self.env['ir.sequence'].with_company(company_id).next_by_code(sequence_code) or '/'
+        sequence_prefix, sequence_number = sequence.rsplit('/', 1)
         return f"{sequence_prefix}/{picking_type.sequence_code}/{sequence_number}"
 
     def _sanity_check(self):

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -1193,6 +1193,20 @@ class TestBatchPicking02(TransactionCase):
         self.assertEqual(batch.state, 'done')
         self.assertFalse(pickings[1].batch_id)
 
+    def test_batch_name_with_complex_prefix(self):
+        """Check that batch name is correctly generated with a complex prefix."""
+        # Fetch an existing sequence and update its prefix
+        sequence = self.env['ir.sequence'].search([('code', '=', 'picking.batch')], limit=1)
+        self.assertTrue(sequence, "Sequence with code 'picking.batch' should exist.")
+        sequence.prefix = 'BATCH/test/2026/'
+        # Create an empty batch with a picking type
+        batch = self.env['stock.picking.batch'].create({
+            'picking_type_id': self.picking_type_internal.id,
+            'company_id': self.env.company.id,
+        })
+        # Assert the generated name starts with the complex prefix and contains the picking_type code
+        self.assertTrue(batch.name.startswith('BATCH/test/2026/'))
+        self.assertIn(self.picking_type_internal.sequence_code, batch.name)
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
next_by_code() can return a sequence with multiple '/' in the prefix (e.g. "BATCH/test/00002" or "batch/test/2026/00002"). Using split('/') causes a ValueError: too many values to unpack.

Use rsplit('/', 1) to always split on the last '/' and correctly extract the sequence prefix and number.

Steps to reproduce the bug:
- Go to settings > technical > sequences & identifiers > sequence:
    - batch transfer: - prefix: BATCH/test/

- Create a new batch:
    - operation type: delivery orders
    - Try to save

Problem:
a traceback is triggered:
```ValueError: too many values to unpack (expected 2)```

opw-6043880
