### PR TITLE
[FIX] stock: update picking shipping_weight with pack type

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -889,7 +889,10 @@ class StockPicking(models.Model):
         for picking in self:
             picking.weight_bulk = picking_weights[picking.id]
 
-    @api.depends('move_line_ids.result_package_id', 'move_line_ids.result_package_id.shipping_weight', 'move_line_ids.result_package_id.outermost_package_id.shipping_weight', 'weight_bulk')
+    @api.depends(
+        'move_line_ids.result_package_id', 'move_line_ids.result_package_id.package_type_id', 'move_line_ids.result_package_id.shipping_weight',
+        'move_line_ids.result_package_id.outermost_package_id', 'move_line_ids.result_package_id.outermost_package_id.package_type_id', 'move_line_ids.result_package_id.outermost_package_id.shipping_weight',
+        'weight_bulk')
     def _compute_shipping_weight(self):
         for picking in self:
             # if shipping weight is not assigned => default to calculated product weight

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -2069,6 +2069,16 @@ class TestPackagePropagation(TestPackingCommon):
         self.assertEqual(delivery.shipping_weight, 31)
         self.assertEqual(delivery2.shipping_weight, 17)
 
+        # Changing the package type should update the weight
+        delivery2.move_line_ids.result_package_id.package_type_id = self.pack_type_pallet
+        self.assertEqual(delivery2.shipping_weight, 22)
+        # Weight should also update when doing pack-ception shenanigans
+        delivery2.action_put_in_pack()
+        delivery2.move_line_ids.result_package_id.outermost_package_id.package_type_id = self.pack_type_pallet
+        self.assertEqual(delivery2.shipping_weight, 32)
+        delivery2.move_line_ids.result_package_id.outermost_package_id.package_type_id = self.pack_type_box
+        self.assertEqual(delivery2.shipping_weight, 27)
+
     def test_package_removal(self):
         """ Checks that the button 'Remove' in the package view in pickings behaves as expected:
             - Only removes related move/move lines from the picking if it was only added through an entire pack


### PR DESCRIPTION
Issue
-----
Doing `action_put_in_pack` then changing the pack type to one with a base weight doesn't correctly update the picking's `shipping_weight`.

Steps to reproduce
-----
- Enable packages
- Create package types:
	- Big box with base weight of 5kg
	- Huge box with base weight of 15kg
- Create a product AAA with weight of 10kg
- Create a delivery for 1 unit of AAA
- Confirm delivery
- Put in pack
- Update the pack type to "Big box"

> shipping_weight is still 10kg instead of 15kg

- Put in pack again
- Update the pack type to "Huge box"

> shipping_weight is still 10kg instead of 30kg

Cause
-----
Changing the package type doesn't change its' `shipping_weight`, so we don't trigger the picking's `_compute_shipping_weight`.

-----
Ticket:
opw-5975689