### PR TITLE
[FIX] web: record_selectors, relational_utils: selectCreateDialog nic…

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -100,8 +100,12 @@ export class RecordAutocomplete extends Component {
             : undefined;
         // fine for now but we don't like this kind of dependence of core to views
         const SelectCreateDialog = registry.category("dialogs").get("select_create");
+        let title = _t("Search");
+        if (fieldString && fieldString.trim()) {
+            title = _t("Search: %s", fieldString);
+        }
         this.addDialog(SelectCreateDialog, {
-            title: _t("Search: %s", fieldString),
+            title,
             dynamicFilters,
             domain: this.getDomain(),
             resModel,

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -577,8 +577,10 @@ export class Many2XAutocomplete extends Component {
                 },
             ];
         }
-
-        const title = _t("Search: %s", fieldString);
+        let title = _t("Search");
+        if (fieldString && fieldString.trim()) {
+            title = _t("Search: %s", fieldString);
+        }
         this.selectCreate({
             domain,
             context,


### PR DESCRIPTION
…e title

When opening a selectCreateDialog from a record selector or a relational field, when no (or empty) fieldString was passed to form the dialog's title , an ugly `Search: undefined` was set as the title

After this commit, if we don't receive the right props, we simply set the title to `Search`

part-of-task-5932652

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
