### PR TITLE
[PERF] account: avoid memory limit hit when computing cumulated_balance

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -719,14 +719,24 @@ class AccountMoveLine(models.Model):
         order_string = self.env.cr.mogrify(sql_order).decode()
         from_clause, where_clause, where_clause_params = query.get_sql()
         sql = """
-            SELECT account_move_line.id, SUM(account_move_line.balance) OVER (
-                ORDER BY %(order_by)s
-                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-            )
-            FROM %(from)s
-            WHERE %(where)s
-        """ % {'from': from_clause, 'where': where_clause or 'TRUE', 'order_by': order_string}
-        self.env.cr.execute(sql, where_clause_params)
+            SELECT aml.id, aml.cumulated_balance
+            FROM (
+                SELECT
+                    account_move_line.id,
+                    SUM(account_move_line.balance) OVER (
+                        ORDER BY %(order_by)s
+                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                    ) AS cumulated_balance
+                FROM %(from)s
+                WHERE %(where)s
+            ) aml
+            WHERE aml.id = ANY(%%s)
+        """ % {
+            'from': from_clause,
+            'where': where_clause or 'TRUE',
+            'order_by': order_string,
+        }
+        self.env.cr.execute(sql, where_clause_params + [self.ids])
         result = {r[0]: r[1] for r in self.env.cr.fetchall()}
         for record in self:
             record.cumulated_balance = result[record.id]


### PR DESCRIPTION
The _compute_cumulated_balance() method performs a query over every
existing move lines to get a dict associating the record id with
the cumulated sum at this point.

When there is a lot of move lines, the result returned by fetchall()
hits the memory limit and the server crashes.

We propose to encapsulate the original query to only return
the result for the account move lines present in self.

Benchmarks
---------------

The following benchmarks were generated with a customization of
the account.move.line list view to display the cumulated_balance
field.

Memory usage during the self.env.cr.execute and the dictionary
population:

|     Operation | Before the fix | After the fix |
|---------------|----------------|---------------|
| populate dict |         1.5 GB |       17.1 MB |
| execute query |         430 MB |        8.3 MB |

100 000 lines were displayed at the same time to get a significant
size.
So the number of records in self is more than 7 000 000 without
the fix and 100 000 with the fix.

Time spent in the _compute_cumulated_balance method:

| No of AML | Before the fix | After the fix |
|-----------|----------------|---------------|
| 7 000 000 |         10.4 s |         6.8 s |

opw-6053720

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
