### PR TITLE
[FIX] pos_hr: avoid unnecessary employee creation

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -24,6 +24,7 @@ class PosConfig(models.Model):
         group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
             lambda u: self.company_id in u.company_ids
         )
+        group_users.invalidate_recordset(['employee_id'])
         allowed_employees = group_users.sudo().mapped('employee_id')
         if not allowed_employees and group_users:
             target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_id)[0]


### PR DESCRIPTION
In version 19.1, an error occurs when inviting a new user via General Settings and then clicking Manage Users:
"The operation cannot be completed: A user cannot be linked to multiple employees in the same company."

This happens even when logged in as an admin user with an existing linked employee. The issue stems from the `employee_id` field in the `res_users` model being a context-dependent computed field.

The `self.env.cache` lacks the employee data,
specifically `'res.users.employee_id': {(1, (2, True)): {2: None}}`.

To resolve this, i've used invalidate_recordset for proper clean the cache,
and again get the value of employee_id.

Clicking directly on "Manage Users" sometimes we cannot face an error, possibly a caching issue.
Inviting a user before accessing "Manage Users" results in an error,

<img width="1885" height="964" alt="2026-03-25_16-21" src="https://github.com/user-attachments/assets/8cd7d094-b0ce-42ca-a43f-1081de7ddc70" />

[opw-6041866](https://www.odoo.com/odoo/project/70/tasks/6041866)
[upg-4031096](https://upgrade.odoo.com/odoo/request/4031096)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
