### PR TITLE
[FIX] mail: fix activity state is shared accross tabs

### DIFF
--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -202,7 +202,7 @@ export class Activity extends Record {
             [[this.id]],
             { feedback: this.feedback }
         );
-        this.activityBroadcastChannel?.postMessage({
+        this.store.activityBroadcastChannel?.postMessage({
             type: "RELOAD_CHATTER",
             payload: { id: this.res_id, model: this.res_model },
         });
@@ -210,9 +210,12 @@ export class Activity extends Record {
     }
 
     remove({ broadcast = true } = {}) {
+        if (!this.exists()) {
+            return;
+        }
         this.delete();
         if (broadcast) {
-            this.activityBroadcastChannel?.postMessage({
+            this.store.activityBroadcastChannel?.postMessage({
                 type: "DELETE",
                 payload: { id: this.id },
             });

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -6,14 +6,24 @@ import {
     contains,
     defineMailModels,
     inputFiles,
+    insertText,
     openFormView,
     start,
     startServer,
     step,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { MailActivity } from "@mail/../tests/mock_server/mock_models/mail_activity";
+
 import { advanceTime, mockDate } from "@odoo/hoot-mock";
-import { mockService, onRpc, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
+import {
+    getService,
+    mockService,
+    onRpc,
+    patchWithCleanup,
+    serverState,
+} from "@web/../tests/web_test_helpers";
 import { deserializeDateTime, serializeDate, today } from "@web/core/l10n/dates";
 import { getOrigin } from "@web/core/utils/urls";
 
@@ -616,4 +626,93 @@ test("activity with a channel mention", async () => {
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Activity-note a", { text: "#Channel" });
     await contains(".o-mail-ChatWindow-header", { text: "Channel" });
+});
+
+test("activity updates are shared between tabs", async () => {
+    const pyEnv = await startServer();
+    MailActivity._views.form = "<form><field name='summary'/></form>";
+    const unpatch = patchWithCleanup(BroadcastChannel.prototype, {
+        postMessage({ type, payload }) {
+            if (type === "INSERT") {
+                if (payload.summary) {
+                    expect.step(`${type} - ${payload.summary}`);
+                }
+                return;
+            }
+            if (type === "DELETE") {
+                expect.step(`${type} - ${payload.id}`);
+                return;
+            }
+            expect.step(type);
+        },
+    });
+    const [firstActivityId] = pyEnv["mail.activity"].create([
+        {
+            can_write: true,
+            res_id: serverState.partnerId,
+            res_model: "res.partner",
+            summary: "Send an email to Marc",
+        },
+        {
+            can_write: true,
+            res_id: serverState.partnerId,
+            res_model: "res.partner",
+            summary: "Say hello to Bob",
+        },
+    ]);
+    await start();
+    await openFormView("res.partner", serverState.partnerId);
+    // Ensure state updates are corectly sent.
+    await expect.waitForSteps(["INSERT - Send an email to Marc", "INSERT - Say hello to Bob"]);
+    await contains(".o-mail-Activity", { count: 2 });
+    await contains(".o-mail-Activity-info:has(:text(“Send an email to Marc”))");
+    await click(".o-mail-Activity-edit:eq(0)");
+    await insertText("[name='summary'] input", "Send an email to Jane", { replace: true });
+    await click("button:text(Save)");
+    // Every insert triggers a broadcast, what matter is that the last value is correctly sent.
+    await expect.waitForSteps([
+        "INSERT - Send an email to Marc",
+        "INSERT - Say hello to Bob",
+        "INSERT - Send an email to Jane",
+        "INSERT - Say hello to Bob",
+    ]);
+    await click(".o-mail-Activity:eq(0) button:text(Cancel)");
+    await expect.waitForSteps([`DELETE - ${firstActivityId}`]);
+    await contains(".o-mail-Activity-info:has(:text(“Say hello to Bob”))");
+    await click(".o-mail-Activity-markDone");
+    await click(".o-mail-ActivityMarkAsDone button:text(Done)");
+    await expect.waitForSteps([
+        "INSERT - Say hello to Bob",
+        "INSERT - Say hello to Bob",
+        "RELOAD_CHATTER",
+    ]);
+    const newActivityId = pyEnv["mail.activity"].create({
+        res_id: serverState.partnerId,
+        res_model: "res.partner",
+        summary: "Send another email",
+    });
+    unpatch();
+    // Ensure state update are properly received.
+    const store = getService("mail.store");
+    store.activityBroadcastChannel.onmessage({
+        data: {
+            type: "INSERT",
+            payload: new mailDataHelpers.Store(
+                pyEnv["mail.activity"].browse(newActivityId)
+            ).get_result(),
+        },
+    });
+    await contains(".o-mail-Activity-info:has(:text(“Send another email”))");
+    store.activityBroadcastChannel.onmessage({
+        data: { type: "DELETE", payload: { id: newActivityId } },
+    });
+    await contains(".o-mail-Activity-info:has(:text(“Send another email”))", { count: 0 });
+    onRpc("/mail/thread/messages", () => expect.step("/mail/thread/messages"));
+    store.activityBroadcastChannel.onmessage({
+        data: {
+            type: "RELOAD_CHATTER",
+            payload: { id: serverState.partnerId, model: "res.partner" },
+        },
+    });
+    await expect.waitForSteps(["/mail/thread/messages"]);
 });


### PR DESCRIPTION
Since [1], the activity state, which is supposed to be shared accross tab through a broadcast channel, isn't anymore.

This PR fixes the responsible typo.

[1]: #161286

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
