### PR TITLE
[FIX] html_editor, *: remove form tags from collaborative

### DIFF
--- a/addons/html_editor/static/src/core/dom_observer_plugin.js
+++ b/addons/html_editor/static/src/core/dom_observer_plugin.js
@@ -1053,9 +1053,10 @@ export class DomObserverPlugin extends Plugin {
     applyAddMutation(mutation) {
         const { nodeId, serializedNode, parentNodeId, nextNodeId, previousNodeId } = mutation;
 
-        const toAdd =
+        let toAdd =
             this.dependencies.domReferenceMap.getNodeById(nodeId) ||
             this.dependencies.domReferenceMap.unserializeNode(serializedNode);
+        toAdd = this.processThrough("add_node_mutation_processors", toAdd);
         if (!toAdd) {
             return;
         }

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1499,7 +1499,8 @@ export class HistoryPlugin extends Plugin {
     applyAddMutation(mutation) {
         const { nodeId, serializedNode, parentNodeId, nextNodeId, previousNodeId } = mutation;
 
-        const toAdd = this.nodeMap.getNode(nodeId) || this.unserializeNode(serializedNode);
+        let toAdd = this.nodeMap.getNode(nodeId) || this.unserializeNode(serializedNode);
+        toAdd = this.processThrough("add_node_mutation_processors", toAdd);
         if (!toAdd) {
             return;
         }
@@ -1831,7 +1832,7 @@ export class HistoryPlugin extends Plugin {
         }
         const fakeNode = this.document.createElement("fake-el");
         fakeNode.appendChild(unserializedNode);
-        this.dependencies.sanitize.sanitize(fakeNode, { IN_PLACE: true });
+        this.dependencies.sanitize.sanitize(fakeNode);
         unserializedNode = fakeNode.firstChild;
         if (!unserializedNode) {
             return null;

--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -28,7 +28,7 @@ export class SanitizePlugin extends Plugin {
      * @param {HTMLElement} elem
      * @returns {HTMLElement} the element itself
      */
-    sanitize(elem) {
+    sanitize(elem, config = {}) {
         for (const cb of this.getResource("before_sanitize_processors")) {
             elem = cb(elem);
         }
@@ -36,6 +36,7 @@ export class SanitizePlugin extends Plugin {
             IN_PLACE: true,
             ADD_TAGS: ["#document-fragment", "fake-el", "t"],
             ADD_ATTR: ["contenteditable", "t-field", "t-out", "t-esc"],
+            ...config,
         });
         for (const cb of this.getResource("after_sanitize_processors")) {
             elem = cb(elem);

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -406,7 +406,10 @@ export class Editor {
             warnOfNamingConvention("processThrough", resourceId, { suffix: "processors" });
         }
         this.getResource(resourceId).forEach((processor) => {
-            item = processor(item, ...args) || item;
+            const newValue = processor(item, ...args);
+            if (newValue !== undefined) {
+                item = newValue;
+            }
         });
         return item;
     }

--- a/addons/html_editor/static/src/main/translate/translate_dialog.js
+++ b/addons/html_editor/static/src/main/translate/translate_dialog.js
@@ -106,7 +106,7 @@ export class TranslateDialog extends Component {
         const fragment = POSTPROCESS_GENERATED_CONTENT(content, this.props.baseContainer);
         let result = "";
         for (const child of fragment.children) {
-            this.props.sanitize(child, { IN_PLACE: true });
+            this.props.sanitize(child);
             result += child.outerHTML;
         }
         return markup(result);
@@ -173,7 +173,7 @@ export class TranslateDialog extends Component {
                 translatedText || "",
                 this.props.baseContainer
             );
-            this.props.sanitize(fragment, { IN_PLACE: true });
+            this.props.sanitize(fragment);
             this.props.insert(fragment);
         } catch (e) {
             this.props.close();

--- a/addons/html_editor/static/src/main/translate/translate_dialog.js
+++ b/addons/html_editor/static/src/main/translate/translate_dialog.js
@@ -100,7 +100,7 @@ export class TranslateDialog extends Component {
         const fragment = POSTPROCESS_GENERATED_CONTENT(content, this.props.baseContainer);
         let result = "";
         for (const child of fragment.children) {
-            this.props.sanitize(child, { IN_PLACE: true });
+            this.props.sanitize(child);
             result += child.outerHTML;
         }
         return markup(result);
@@ -167,7 +167,7 @@ export class TranslateDialog extends Component {
                 translatedText || "",
                 this.props.baseContainer
             );
-            this.props.sanitize(fragment, { IN_PLACE: true });
+            this.props.sanitize(fragment);
             this.props.insert(fragment);
         } catch (e) {
             this.props.close();

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -46,6 +46,7 @@ export class CollaborationPlugin extends Plugin {
                 return false;
             }
         },
+        add_node_mutation_processors: this.sanitizeNode.bind(this),
     };
     static shared = [
         "getBranchIds",
@@ -118,6 +119,15 @@ export class CollaborationPlugin extends Plugin {
             node.setAttribute(attributeName, clone.getAttribute(attributeName));
         } else {
             node.removeAttribute(attributeName);
+        }
+    }
+
+    sanitizeNode(node) {
+        if (node) {
+            const fakeNode = this.document.createElement("fake-el");
+            fakeNode.appendChild(node);
+            this.dependencies.sanitize.sanitize(fakeNode, { FORBID_TAGS: ["form", "input"] });
+            return fakeNode.firstChild;
         }
     }
 

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -45,6 +45,7 @@ export class CollaborationPlugin extends Plugin {
                 return false;
             }
         },
+        add_node_mutation_processors: this.sanitizeNode.bind(this),
     };
     static shared = [
         "getBranchIds",
@@ -117,6 +118,15 @@ export class CollaborationPlugin extends Plugin {
             node.setAttribute(attributeName, clone.getAttribute(attributeName));
         } else {
             node.removeAttribute(attributeName);
+        }
+    }
+
+    sanitizeNode(node) {
+        if (node) {
+            const fakeNode = this.document.createElement("fake-el");
+            fakeNode.appendChild(node);
+            this.dependencies.sanitize.sanitize(fakeNode, { FORBID_TAGS: ["form", "input"] });
+            return fakeNode.firstChild;
         }
     }
 

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -509,6 +509,27 @@ describe("sanitize", () => {
             },
         });
     });
+    test("should sanitize form tag when adding a node", async () => {
+        await testMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: "<p>abc[c1}{c1][c2}{c2]</p>",
+            afterCreate: (peerInfos) => {
+                const document = peerInfos.c1.editor.document;
+                const div = document.createElement("div");
+                div.innerHTML = 'test<form><input type="text"/></form>';
+                peerInfos.c1.editor.editable.append(div);
+                commit(peerInfos.c1.editor);
+                peerInfos.c2.collaborationPlugin.insertRemoteHistoryCommits([
+                    peerInfos.c1.historyPlugin.commits[1],
+                ]);
+            },
+            afterCursorInserted: (peerInfos) => {
+                expect(peerInfos.c2.editor.editable).toHaveInnerHTML(
+                    '<p>abc[c1}{c1][c2}{c2]</p><div class="o-paragraph">test</div>'
+                );
+            },
+        });
+    });
     test("should not sanitize contenteditable attribute (check DOMPurify DEFAULT_ALLOWED_ATTR)", async () => {
         await testMultiEditor({
             peerIds: ["c1"],

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -514,6 +514,27 @@ describe("sanitize", () => {
             },
         });
     });
+    test("should sanitize form tag when adding a node", async () => {
+        await testMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: "<p>abc[c1}{c1][c2}{c2]</p>",
+            afterCreate: (peerInfos) => {
+                const document = peerInfos.c1.editor.document;
+                const div = document.createElement("div");
+                div.innerHTML = 'test<form><input type="text"/></form>';
+                peerInfos.c1.editor.editable.append(div);
+                addStep(peerInfos.c1.editor);
+                peerInfos.c2.collaborationPlugin.onExternalHistorySteps([
+                    peerInfos.c1.historyPlugin.steps[1],
+                ]);
+            },
+            afterCursorInserted: (peerInfos) => {
+                expect(peerInfos.c2.editor.editable).toHaveInnerHTML(
+                    '<p>abc[c1}{c1][c2}{c2]</p><div class="o-paragraph">test</div>'
+                );
+            },
+        });
+    });
     test("should not sanitize contenteditable attribute (check DOMPurify DEFAULT_ALLOWED_ATTR)", async () => {
         await testMultiEditor({
             peerIds: ["c1"],


### PR DESCRIPTION
*: html_builder, website, mail, mass_mailing, website_forum, website_mass_mailing, website_sale

Supporting form tags in a collaborative environment is challenging. It is not worth supporting it properly because it is never actually used in practice. This PR automatically removes form tags during collaborative edition since they are not properly supported anyway.

This PR also modifies `processThrough` to allow processors to return falsy values.

Previously, processThrough used `|| item` to fall back to original value if a processor returned a falsy value. This prevented processors from intentionally returning falsy values (e.g. null, undefined).

Now each processor is responsible for returning a value explicitly:

- Return the transformed value if processing occurred.
- Return the original item if no processing is needed or processing is in place.
- Return null/undefined to intentionally pass a falsy value.

Enterprise PR: https://github.com/odoo/enterprise/pull/119999

task-6030633





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
