### PR TITLE
[IMP] core: disallow PYTHONOPTIMIZE

### DIFF
--- a/odoo/init.py
+++ b/odoo/init.py
@@ -6,6 +6,13 @@
 import gc
 import sys
 from .release import MIN_PY_VERSION
+
+
+if sys.flags.optimize:
+    raise RuntimeError(
+        "Running odoo with Python optimization enabled (-O/-OO/PYTHONOPTIMIZE) is not supported"
+    )
+
 assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Odoo requires Python >= {'.'.join(map(str, MIN_PY_VERSION))} to run."
 
 # ----------------------------------------------------------


### PR DESCRIPTION
Odoo does not support being run with PYTHONOPTIMIZE set to anything > 0

-O removes assert statements, which Odoo heavily relies upon for ensuring business logic as well as runtime security. -OO also discards docstrings, which are also relied upon (e.g. in `ir.model` or `api_doc`).