### PR TITLE
[IMP] mail: message preview in chatbubble and sidebar

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -12,7 +12,7 @@
             </t>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">
-            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" t-att-title="this.channel.description" class="text-muted text-truncate smaller" t-out="this.channel.description"/>
+            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" class="text-muted text-truncate smaller" t-out="this.channel.description"/>
         </xpath>
     </t>
     <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
@@ -22,6 +22,16 @@
                 <CountryFlag t-if="this.channel.showCorrespondentCountry" country="this.channel.correspondentCountry" class="'o-mail-DiscussSidebarChannel-country my-auto'"/>
                 <span t-if="this.channel.livechat_lang_id" t-out="this.channel.livechat_lang_id.name" class="fw-normal small"/>
             </div>
+        </xpath>
+    </t>
+
+    <t t-inherit="mail.ThreadPreview" t-inherit-mode="extension">
+        <xpath expr="//*[hasclass('o-mail-ThreadPreview')]/div[1]" position="after">
+            <div
+                t-if="this.props.channel.livechat_status === 'need_help' and this.props.channel.description"
+                class="o-mail-ThreadPreview-livechatTopic mx-2 px-1 text-muted fst-italic o-xsmaller"
+                t-out="this.props.channel.description"
+            />
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -12,16 +12,26 @@
             </t>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">
-            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" t-att-title="this.channel.description" class="text-muted text-truncate smaller" t-out="this.channel.description"/>
+            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" class="text-muted text-truncate smaller" t-out="this.channel.description"/>
         </xpath>
     </t>
     <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-floatingName')]" position="after">
-            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" t-att-title="this.channel.description" class="text-muted text-truncate smaller px-2 pb-1" t-out="this.channel.description"/>
+            <div t-if="this.channel.livechat_status === 'need_help' and this.channel.description" class="text-muted text-truncate smaller px-2 pb-1" t-out="this.channel.description"/>
             <div class="d-flex align-items-baseline gap-1 px-2 pb-2">
                 <CountryFlag t-if="this.channel.showCorrespondentCountry" country="this.channel.correspondentCountry" class="'o-mail-DiscussSidebarChannel-country my-auto'"/>
                 <span t-if="this.channel.livechat_lang_id" t-out="this.channel.livechat_lang_id.name" class="fw-normal small"/>
             </div>
+        </xpath>
+    </t>
+
+    <t t-inherit="mail.ThreadPreview" t-inherit-mode="extension">
+        <xpath expr="//*[hasclass('o-mail-ThreadPreview')]/div[1]" position="after">
+            <div
+                t-if="this.props.channel.livechat_status === 'need_help' and this.props.channel.description"
+                class="o-mail-ThreadPreview-livechatTopic mx-2 px-1 text-muted fst-italic o-xsmaller"
+                t-out="this.props.channel.description"
+            />
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,6 +1,6 @@
 import { useRef, useSubEnv } from "@web/owl2/utils";
 import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
-import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
+import { ThreadPreview } from "@mail/core/common/thread_preview";
 
 import { Component, computed, signal, useEffect } from "@odoo/owl";
 
@@ -10,22 +10,6 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
-
-class ChatBubblePreview extends Component {
-    static components = { MessageSeenIndicator };
-    static props = ["chatWindow", "close"];
-    static template = "mail.ChatBubblePreview";
-
-    /** @returns {import("models").DiscussChannel} */
-    get channel() {
-        return this.props.chatWindow.channel;
-    }
-
-    get previewText() {
-        const lastMessage = this.channel.newestPersistentOfAllMessage;
-        return lastMessage?.previewText || _t("This is the start of your conversation");
-    }
-}
 
 /**
  * @typedef {Object} Props
@@ -42,7 +26,7 @@ export class ChatBubble extends Component {
         const popoverRef = useChildRef();
         this.isMobileOS = isMobileOS();
         this.isPopoverOpen = signal(false);
-        this.popover = usePopover(ChatBubblePreview, {
+        this.popover = usePopover(ThreadPreview, {
             animation: false,
             onClose: () => this.isPopoverOpen.set(false),
             position: "left-middle",
@@ -59,7 +43,10 @@ export class ChatBubble extends Component {
         this.hover = useHover(["root", popoverRef], {
             onHover: () => {
                 this.env.bus.trigger("ChatBubble:preview-will-open", this);
-                this.popover.open(this.rootRef.el, { chatWindow: this.props.chatWindow });
+                this.popover.open(this.rootRef.el, {
+                    channel: this.channel,
+                    className: "o-mail-ChatBubble-preview",
+                });
                 this.isPopoverOpen.set(true);
             },
             onAway: () => this.popover.close(),

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, useSubEnv } from "@web/owl2/utils";
 import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
-import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
+import { ThreadPreview } from "@mail/core/common/thread_preview";
 
 import { Component } from "@odoo/owl";
 
@@ -9,25 +9,6 @@ import { useHover } from "@mail/utils/common/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { isMobileOS } from "@web/core/browser/feature_detection";
-
-class ChatBubblePreview extends Component {
-    static components = { MessageSeenIndicator };
-    static props = ["chatWindow", "close"];
-    static template = "mail.ChatBubblePreview";
-
-    /** @returns {import("models").DiscussChannel} */
-    get channel() {
-        return this.props.chatWindow.channel;
-    }
-
-    get previewText() {
-        const lastMessage = this.channel.newestPersistentOfAllMessage;
-        if (!lastMessage) {
-            return false;
-        }
-        return lastMessage.previewText;
-    }
-}
 
 /**
  * @typedef {Object} Props
@@ -43,7 +24,7 @@ export class ChatBubble extends Component {
         this.store = useService("mail.store");
         const popoverRef = useChildRef();
         this.isMobileOS = isMobileOS();
-        this.popover = usePopover(ChatBubblePreview, {
+        this.popover = usePopover(ThreadPreview, {
             animation: false,
             onClose: () => (this.state.isPopoverOpen = false),
             position: "left-middle",
@@ -60,7 +41,10 @@ export class ChatBubble extends Component {
         this.hover = useHover(["root", popoverRef], {
             onHover: () => {
                 this.env.bus.trigger("ChatBubble:preview-will-open", this);
-                this.popover.open(this.rootRef.el, { chatWindow: this.props.chatWindow });
+                this.popover.open(this.rootRef.el, {
+                    channel: this.channel,
+                    className: "o-mail-ChatBubble-preview",
+                });
                 this.state.isPopoverOpen = true;
             },
             onAway: () => this.popover.close(),

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -12,15 +12,4 @@
         </div>
     </t>
 
-    <t t-name="mail.ChatBubblePreview">
-        <div t-if="this.props.chatWindow?.channel" class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
-            <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-out="this.props.chatWindow.channel.displayName"/>
-            <t t-set="message" t-value="this.channel.newestPersistentOfAllMessage" />
-            <div class="text-truncate small mx-2 px-1 text-muted">
-                <MessageSeenIndicator t-if="message?.showSeenIndicator(this.channel.thread)" message="message"/>
-                <t t-out="this.previewText" />
-            </div>
-        </div>
-    </t>
-
 </templates>

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -12,15 +12,4 @@
         </div>
     </t>
 
-    <t t-name="mail.ChatBubblePreview">
-        <div t-if="this.props.chatWindow?.channel" class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
-            <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-out="this.props.chatWindow.channel.displayName"/>
-            <t t-set="message" t-value="this.channel.newestPersistentOfAllMessage" />
-            <div t-if="this.previewText" class="text-truncate small mx-2 px-1 text-muted">
-                <MessageSeenIndicator t-if="message.showSeenIndicator(this.channel.thread)" message="message"/>
-                <t t-out="message.previewText" />
-            </div>
-        </div>
-    </t>
-
 </templates>

--- a/addons/mail/static/src/core/common/thread_preview.js
+++ b/addons/mail/static/src/core/common/thread_preview.js
@@ -1,0 +1,20 @@
+import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
+
+import { Component } from "@odoo/owl";
+
+export class ThreadPreview extends Component {
+    static components = { MessageSeenIndicator };
+    static props = ["channel", "className?", "close"];
+    static defaultProps = {
+        className: "",
+    };
+    static template = "mail.ThreadPreview";
+
+    get message() {
+        return this.props.channel?.newestPersistentOfAllMessage;
+    }
+
+    get previewText() {
+        return this.message?.previewText;
+    }
+}

--- a/addons/mail/static/src/core/common/thread_preview.scss
+++ b/addons/mail/static/src/core/common/thread_preview.scss
@@ -1,0 +1,10 @@
+.o-mail-ThreadPreview {
+    max-width: 225px;
+}
+
+.o-mail-ThreadPreview-text {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+}

--- a/addons/mail/static/src/core/common/thread_preview.xml
+++ b/addons/mail/static/src/core/common/thread_preview.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.ThreadPreview">
+        <div t-if="this.props.channel" class="o-mail-ThreadPreview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble" t-att-class="this.props.className">
+            <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-out="this.props.channel.displayName"/>
+            <div t-if="this.previewText" class="small mx-2 px-1 text-muted d-flex align-items-start gap-1">
+                <div class="o-mail-ThreadPreview-text min-w-0">
+                    <MessageSeenIndicator t-if="this.message.showSeenIndicator(this.props.channel.thread)" message="this.message"/>
+                    <t t-out="this.previewText" />
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -1,16 +1,18 @@
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
+import { ThreadPreview } from "@mail/core/common/thread_preview";
 import { DiscussSidebarChannelActions } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel_actions";
 import { DiscussSidebarSubchannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/subchannel";
 import { useHover, UseHoverOverlay } from "@mail/utils/common/hooks";
 
-import { useService } from "@web/core/utils/hooks";
+import { useChildRef, useService } from "@web/core/utils/hooks";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { markEventHandled } from "@web/core/utils/misc";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 
 export const discussSidebarChannelIndicatorsRegistry = registry.category(
@@ -32,18 +34,42 @@ export class DiscussSidebarChannel extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.hover = useHover(["root"], {
+        this.rootRef = useRef("root");
+        const popoverRef = useChildRef();
+        this.popover = usePopover(ThreadPreview, {
+            animation: false,
+            position: "right-middle",
+            popoverClass:
+                "dropdown-menu bg-view border-0 p-0 overflow-visible o-rounded-bubble mx-1",
+            ref: popoverRef,
+        });
+        this.env.bus.addEventListener("DiscussSidebar:preview-will-open", ({ detail }) => {
+            if (detail === this) {
+                return;
+            }
+            this.popover.close();
+        });
+        this.hover = useHover(["root", popoverRef], {
             onHover: () => {
+                if (this.showingActions?.isOpen) {
+                    this.popover.close();
+                    return;
+                }
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = true;
+                    return;
                 }
+                this.env.bus.trigger("DiscussSidebar:preview-will-open", this);
+                this.popover.open(this.rootRef.el, { channel: this.channel });
             },
             onAway: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = false;
+                    return;
                 }
+                this.popover.close();
             },
-            stateObserver: () => [this.floating?.isOpen],
+            stateObserver: () => [this.floating?.isOpen, this.showingActions?.isOpen],
         });
         this.floating = useDropdownState();
         this.showingActions = useDropdownState();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.scss
@@ -65,3 +65,18 @@
 .o-mail-DiscussSidebarChannel-subChannelList {
     gap: 1px;
 }
+
+// ThreadPreview popover opened from the discuss sidebar (arrow points left)
+.o-mail-DiscussSidebar-item + .popover-arrow {
+    z-index: 1 !important;
+
+    &::before {
+        border-right-color: $o-gray-300 !important;
+        left: 1px !important;
+    }
+
+    &::after {
+        border-right-color: $gray-100 !important;
+        left: 2px !important;
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -30,7 +30,7 @@
             t-on-click="(ev) => this.openChannel(ev, this.channel)"
             t-custom-ref="root"
         >
-            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': this.store.discuss.isSidebarCompact, 'overflow-hidden': !this.store.discuss.isSidebarCompact }" t-att-title="this.store.discuss.isSidebarCompact ? undefined : this.channel.displayName">
+            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': this.store.discuss.isSidebarCompact, 'overflow-hidden': !this.store.discuss.isSidebarCompact }">
                 <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !this.store.discuss.isSidebarCompact }">
                     <DiscussAvatar record="this.channel" size="26"/>
                 </div>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -30,7 +30,7 @@
             t-on-click="(ev) => this.openChannel(ev, this.channel)"
             t-custom-ref="root"
         >
-            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': this.store.discuss.isSidebarCompact, 'overflow-hidden': !this.store.discuss.isSidebarCompact }" t-att-title="this.store.discuss.isSidebarCompact ? undefined : this.channel.displayName">
+            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': this.store.discuss.isSidebarCompact, 'overflow-hidden': !this.store.discuss.isSidebarCompact }">
                 <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !this.store.discuss.isSidebarCompact }">
                     <DiscussAvatar channel="this.channel" size="26"/>
                 </div>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.js
@@ -1,7 +1,9 @@
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
+import { ThreadPreview } from "@mail/core/common/thread_preview";
 import { DiscussSidebarChannelActions } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel_actions";
 import { useHover, UseHoverOverlay } from "@mail/utils/common/hooks";
-import { useService } from "@web/core/utils/hooks";
+import { useChildRef, useService } from "@web/core/utils/hooks";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
 import { markEventHandled } from "@web/core/utils/misc";
@@ -15,18 +17,42 @@ export class DiscussSidebarSubchannel extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.hover = useHover(["root"], {
+        this.rootRef = useRef("root");
+        const popoverRef = useChildRef();
+        this.popover = usePopover(ThreadPreview, {
+            animation: false,
+            position: "right-middle",
+            popoverClass:
+                "dropdown-menu bg-view border-0 p-0 overflow-visible o-rounded-bubble mx-1",
+            ref: popoverRef,
+        });
+        this.env.bus.addEventListener("DiscussSidebar:preview-will-open", ({ detail }) => {
+            if (detail === this) {
+                return;
+            }
+            this.popover.close();
+        });
+        this.hover = useHover(["root", popoverRef], {
             onHover: () => {
+                if (this.showingActions?.isOpen) {
+                    this.popover.close();
+                    return;
+                }
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = true;
+                    return;
                 }
+                this.env.bus.trigger("DiscussSidebar:preview-will-open", this);
+                this.popover.open(this.rootRef.el, { channel: this.channel });
             },
             onAway: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = false;
+                    return;
                 }
+                this.popover.close();
             },
-            stateObserver: () => [this.floating?.isOpen],
+            stateObserver: () => [this.floating?.isOpen, this.showingActions?.isOpen],
         });
         this.floating = useDropdownState();
         this.showingActions = useDropdownState();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
@@ -27,7 +27,7 @@
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
             </t>
-            <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded-2 text-start text-truncate align-items-center" t-att-title="this.store.discuss.isSidebarCompact ? undefined : this.channel.displayName" t-on-click="(ev) => this.openChannel(ev, this.channel)" t-att-class="{
+            <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded-2 text-start text-truncate align-items-center" t-on-click="(ev) => this.openChannel(ev, this.channel)" t-att-class="{
                 'o-active': this.channel.discussAppAsThread,
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': this.store.discuss.isSidebarCompact,
                 'o-nonCompact me-1 pe-0 ps-1 o-py-0_5': !this.store.discuss.isSidebarCompact,


### PR DESCRIPTION
Currently, hovering on a chat bubble in the chat hub displays a message preview. However, it is quite short and the name of the author takes most of the space.

This commit allows to have a maximum of 3 lines of preview, so that more content of the message can be displayed.

In addition, the same message preview is now also available when hovering a channel in the sidebar, allowing to have a quick glance on the last message of the channel without having to open it.

task-6042545

<img width="355" height="162" alt="image" src="https://github.com/user-attachments/assets/c82b5941-6d54-4fbb-a107-98b6ecc34d67" />

<img width="547" height="425" alt="image" src="https://github.com/user-attachments/assets/eab2ff34-41a1-42c0-97e3-bc71c22c9303" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
