### PR TITLE
[IMP] hr: add spacing after avatar

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -4,7 +4,7 @@
     <t t-name="hr.KanbanMany2OneAvatarEmployeeField">
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="false" displayName="displayName"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">


### PR DESCRIPTION
Before this PR, a spacing was missing between
the employee image and the employee name. It was
added by switching the noSpacing to false.

| Before | After |
|--------|--------|
| <img width="567" height="142" alt="Screenshot 2026-03-25 at 13 35 42" src="https://github.com/user-attachments/assets/e513600c-7019-490d-bc2f-da9819ccce89" /> | <img width="567" height="142" alt="Screenshot 2026-03-25 at 13 35 31" src="https://github.com/user-attachments/assets/744f36f6-52e3-4ad3-91cc-135071c9e0c9" /> |

task-5960515

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
