### PR TITLE
[FIX] pos_restaurant: fix floor plan table positions in RTL languages

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_plan/floor_plan.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_plan/floor_plan.xml
@@ -19,7 +19,7 @@
                 </div>
             </t>
             <t t-else="">
-                <div t-ref="canvas" class="o_fp_canvas_inner position-relative" t-attf-style="{{getCanvasStyles()}}">
+                <div t-ref="canvas" class="o_fp_canvas_inner position-relative" dir="ltr" t-attf-style="{{getCanvasStyles()}}">
                       <t t-foreach="getFloorDecorElements()" t-as="element" t-key="element.uuid">
                          <t t-call="pos_restaurant.floor_screen_element"/>
                      </t>

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_plan_editor/floor_plan_editor.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_plan_editor/floor_plan_editor.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.floor_plan_editor">
         <div t-ref="container" class="o_fp_canvas w-100 h-100 overflow-auto position-relative" t-attf-style="{{getScrollContainerStyles()}}" t-on-click="onCanvasClick" >
-             <div t-ref="canvas" class="o_fp_canvas_inner position-relative" t-attf-style="{{getCanvasStyles()}}">
+             <div t-ref="canvas" class="o_fp_canvas_inner position-relative" dir="ltr" t-attf-style="{{getCanvasStyles()}}">
                  <svg class="o_fp_snap_guides position-absolute w-100 h-100 top-0 start-0" t-ref="snapGuides" />
                  <Handles floorElement="floorPlanStore.selectedElement" canvasRef="canvasRef" onStartResize="startResize" onStartMove="startDrag" onStartRotate="startRotate"
                           onEdit="onEdit" actions="handlesActions" actionMenuPosition="state.actionMenuPosition" />


### PR DESCRIPTION
In RTL languages (e.g. Arabic), `position: absolute` elements anchor to the top-right corner of their containing block instead of top-left. Since floor plan elements are positioned via
`transform: translate(left, top)` using pixel coordinates stored from a top-left origin, all tables and decor elements were rendered at wrong positions when the UI direction was RTL.

opw-6040855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
