### PR TITLE
[FIX] l10n_cl: restore custom header on invoices

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -131,7 +131,7 @@
 
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
 
-        <t t-set="o" position="after">
+        <t t-call="web.external_layout" position="before">
             <t t-set="custom_header" t-value="'l10n_cl.custom_header'"/>
         </t>
 


### PR DESCRIPTION
### Issue:
In 19.2, the custom header defined by `l10n_cl`
was not displayed on invoices
The standard layout was used instead

### Cause:
This change:
https://github.com/odoo/odoo/commit/eb6e88a25050fff2bd09317739dd51ba451450df modified the `t-call` behavior to ignore `t-set` inside the call

Since the `o` variable is defined within the `t-call` in the invoice report: https://github.com/odoo/odoo/blob/a08e84e84aa26e86a291ef0de5bdd4ac20f6274e/addons/account/views/report_invoice.xml#L110-L115 the custom parameter header was ignored

### Steps to reproduce:
- Install `l10n_cl` and switch to the CL company
- Create and confirm an invoice
- Open the preview

### Before the fix:
The default header is used

### After the fix:
The custom header are correctly applied (as in 19.1)

opw-6057122