### PR TITLE
[FIX] im_livechat: fix runbot issue due to remove livechat-rating rel…

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -76,7 +76,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         store = Store().add(chatbot_message, "_store_message_fields")
         self.assertEqual(
             store.get_result()["mail.message"],
-            [
+            self._filter_messages_fields(
                 {
                     "attachment_ids": [],
                     "author_guest_id": False,
@@ -117,7 +117,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                     "trackingValues": [],
                     "write_date": fields.Datetime.to_string(chatbot_message.write_date),
                 }
-            ],
+            ),
         )
 
     @users('emp')


### PR DESCRIPTION
…ation

Before this commit, tests could fail depending on whether the rating module was installed or not.

Now, the values we check are dynamically added depending on what is installed.

fixes-runbot-242084

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
