### PR TITLE
[FIX] mail: prevent duplicate close button in ActionPanel

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -19,7 +19,7 @@
                 <i t-if="props.icon" class="text-muted fa-fw" t-att-class="props.icon"/>
                 <p t-if="props.title" class="fw-bold text-uppercase m-0 flex-grow-1" t-esc="props.title"/>
                 <t t-slot="header-extra"/>
-                <button t-if="props.close and !env.inChatWindow" class="btn p-1 opacity-75 opacity-100-hover ms-auto" title="Close panel" t-on-click.stop="() => props.close({ closeAll: true })">
+                <button t-if="props.close and env.inMeetingView" class="btn p-1 opacity-75 opacity-100-hover ms-auto" title="Close panel" t-on-click.stop="() => props.close({ closeAll: true })">
                     <i class="oi oi-close fa-fw"/>
                 </button>
             </div>


### PR DESCRIPTION
ActionPanel components (e.g. invitation panel, delete thread dialog) displayed an extra close (X) button in Discuss. The close button was shown when not in a chat window, causing duplication with the existing close button.

This commit restricts the button visibility to the meeting view only, preventing the extra close button.

Task-[6054963](https://www.odoo.com/odoo/project/1519/tasks/6054963)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
