### PR TITLE
[FIX] pos_sale: create move line with backend refund

### DIFF
--- a/addons/pos_sale/models/stock_picking.py
+++ b/addons/pos_sale/models/stock_picking.py
@@ -16,4 +16,9 @@ class StockPicking(models.Model):
                 continue
             lines_to_unreserve |= line
         lines_to_unreserve.sale_order_line_id.move_ids.filtered(lambda ml: ml.state not in ['cancel', 'done'])._do_unreserve()
-        return super()._create_move_from_pos_order_lines(lines.filtered(lambda l: not l.sale_order_line_id or (l.sale_order_line_id.has_valued_move_ids() or not l.sale_order_line_id.move_ids)))
+        lines_for_moves = lines.filtered(
+            lambda l: not l.sale_order_line_id
+            or (l.sale_order_line_id.has_valued_move_ids() or not l.sale_order_line_id.move_ids)
+            or (l.sale_order_line_id == l.refunded_orderline_id.sale_order_line_id)
+        )
+        return super()._create_move_from_pos_order_lines(lines_for_moves)

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1224,6 +1224,20 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.start_pos_tour('PoSSettleQuotation', login="accountman")
         self.assertEqual(order.order_line.qty_delivered, 1)
 
+        pos_order = self.main_pos_config.session_ids.order_ids
+        self.assertEqual(pos_order.picking_ids.move_line_ids.qty_done, 1)
+        refund_action = pos_order.refund()
+        refund_order = self.env['pos.order'].browse(refund_action['res_id'])
+
+        payment_context = {"active_ids": refund_order.ids, "active_id": refund_order.id}
+        refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': refund_order.amount_total,
+            'payment_method_id': self.bank_payment_method.id,
+        })
+        refund_payment.with_context(**payment_context).check()
+
+        self.assertEqual(refund_order.picking_ids.move_line_ids.qty_done, 1)
+
     def test_pos_order_and_invoice_amounts(self):
         payment_term = self.env['account.payment.term'].create({
             'name': "early_payment_term",


### PR DESCRIPTION
When creating a refund of a pos order linked to a SO the delivery is not created.

Steps to reproduce:
-------------------
* Create a product tracked by quantity
* Create a SO with the product and confirm it
* Open a session and settle the SO
* Go backend
* Refund the order & pay it
* See the delivery created
> Obsrevation: it has no move lines.
The pos order that settled the SO has move lines.

Why the fix:
------------
Version 18.0 is the only version that filters the lines when creating moves.
We notice the following commit: https://github.com/odoo/odoo/commit/e6678442ffe90e35a00e8b752e607d839920bee6

In the next version we're back with the original line as the logic was moved to a newly created module:
https://github.com/odoo/odoo/commit/42bcc2b49d46695c4afc518bb0f89254e24c12dc

Having a consistent code across version would solve this issue without triggering any issue on the test but the test was passing without the original fix.

So instead we'll add a specific fix here as well to keep the original logic.

A different behavior can be observed if we're refunding from the front or backend. When refunding from the front the refund order is not linked to the original SO thus `lines` don't get filtered. The difference with the backend comes from the fact that the refund is linked to the SO and thus the lines are filtered and we end up using no pos lines for creating move lines.

As this behavior is consistent across versions we don't want to modify it for only 1 version. Plus if we modify the front behavior we still have the issue anyway.

So not if the order has an origin SO id but is a refund of that original SO we don't filter it out for moves.

opw-5963829
