### PR TITLE
[FIX] l10n_ar_withholding: fix error when removing currency in payment register

### DIFF
--- a/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
+++ b/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.l10n_ar.tests.common import TestArCommon
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 from odoo import Command
 from datetime import datetime
 
@@ -435,3 +435,12 @@ class TestArWithholdingArRi(TestArCommon):
             # Receivable line:
             {'debit': 188865.27, 'credit': 0.0, 'currency_id': wizard.currency_id.id, 'amount_currency': 188865.27, 'reconciled': True}
         ])
+
+    def test_payment_register_without_currency(self):
+        "check computation of amount and adjustment warning without currency"
+        moves = self.in_invoice_wht_5('2-1')
+        taxes = [{'id': self.tax_wth_test_1.id, 'base_amount': sum(moves.mapped('amount_untaxed'))}]
+        wizard = Form(self.new_payment_register(moves, taxes))
+        wizard.currency_id = self.env['res.currency']
+        self.assertEqual(wizard.amount, 188865.27)
+        self.assertFalse(wizard.l10n_ar_adjustment_warning)

--- a/addons/l10n_ar_withholding/wizards/account_payment_register.py
+++ b/addons/l10n_ar_withholding/wizards/account_payment_register.py
@@ -24,7 +24,8 @@ class AccountPaymentRegister(models.TransientModel):
         for wizard in self:
             checks = wizard.l10n_latam_new_check_ids if wizard.filtered(lambda x: x._is_latam_check_payment(check_subtype='new_check')) else wizard.l10n_latam_move_check_ids
             checks_amount = sum(checks.mapped('amount'))
-            if not wizard.currency_id.is_zero(checks_amount) and wizard.currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0:
+            currency_id = wizard.currency_id or wizard.company_currency_id
+            if not currency_id.is_zero(checks_amount) and currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0:
                 if wizard.partner_type == 'supplier':
                     original_amount = wizard.amount
                     f_delta = checks_amount - wizard.l10n_ar_net_amount
@@ -38,10 +39,10 @@ class AccountPaymentRegister(models.TransientModel):
                     wizard._compute_l10n_ar_net_amount()
                     for i in range(201):
                         f_delta = checks_amount - wizard.l10n_ar_net_amount
-                        if wizard.currency_id.is_zero(f_delta):
+                        if currency_id.is_zero(f_delta):
                             break
                         der = ((wizard.l10n_ar_net_amount - f_previous) / d) if abs(d) >= 0.01 else 1.0
-                        if wizard.currency_id.is_zero(der):
+                        if currency_id.is_zero(der):
                             i = 200
                             break
                         d = max(f_delta / der, 0.01)
@@ -57,7 +58,8 @@ class AccountPaymentRegister(models.TransientModel):
         for wizard in self:
             checks = wizard.l10n_latam_new_check_ids if wizard.filtered(lambda x: x._is_latam_check_payment(check_subtype='new_check')) else wizard.l10n_latam_move_check_ids
             checks_amount = sum(checks.mapped('amount'))
-            wizard.l10n_ar_adjustment_warning = not wizard.currency_id.is_zero(checks_amount) and wizard.currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0
+            currency_id = wizard.currency_id or wizard.company_currency_id
+            wizard.l10n_ar_adjustment_warning = not currency_id.is_zero(checks_amount) and currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0
 
     @api.depends('amount', 'l10n_ar_withholding_ids.amount')
     def _compute_l10n_ar_net_amount(self):


### PR DESCRIPTION
When the user removes the currency from the payment register, a traceback is raised.

Steps to reproduce the error:
- Install ``l10n_ar_withholding`` module
- Switch to ``(AR) Exento`` company
- Create a new invoice > Confirm > Pay > Unset the currency

Traceback:
```py
ValueError: Expected singleton: res.currency()
```

https://github.com/odoo/odoo/blob/d98afdc08b46bf458eaa287ea882cc7663286a59/addons/l10n_ar_withholding/wizards/account_payment_register.py#L27
This line causes a traceback with an empty currency
when the user removes the currency from the payment register.

sentry-7362499567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
