### PR TITLE
[FIX] account: prevent tax recomputation for imported invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1640,7 +1640,19 @@ class AccountMove(models.Model):
             # The move is not stored yet so the only thing we have is the invoice lines.
             base_lines += self._prepare_epd_base_lines_for_taxes_computation_from_base_lines(base_amls)
             AccountTax._add_tax_details_in_base_lines(base_lines, self.company_id)
-            AccountTax._round_base_lines_tax_details(base_lines, self.company_id)
+            # For imported invoices, preserve origin tax lines to maintain rounding
+            origin_tax_lines = []
+            if self._origin.id and all(l.is_imported for l in base_amls):
+                origin_lines = self._origin.line_ids.filtered(lambda l: l.display_type == 'product')
+                if any(
+                    a.analytic_distribution != o.analytic_distribution
+                    for a, o in zip(base_amls, origin_lines)
+                ):
+                    origin_tax_amls = self._origin.line_ids.filtered('tax_repartition_line_id')
+                    origin_tax_lines = [self._prepare_tax_line_for_taxes_computation(tl) for tl in origin_tax_amls]
+
+            AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=origin_tax_lines)
+            tax_lines = origin_tax_lines
         return base_lines, tax_lines
 
     @api.depends_context('lang')
@@ -3030,6 +3042,15 @@ class AccountMove(models.Model):
                 # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
                 round_from_tax_lines = 'reapply_currency_rate'
             elif changed_lines := list(get_changed_lines(move_base_lines_values_before, base_lines)):
+                if all(line.is_imported for line in changed_lines):
+                    if not any(
+                        field_has_changed(move_base_lines_values_before, line, field)
+                        for line in changed_lines
+                        if line in move_base_lines_values_before
+                        for field in move_base_lines_values_before[line]
+                        if field != 'analytic_distribution'
+                    ):
+                        continue
                 # A base line has been modified.
                 round_from_tax_lines = (
                     # The changed lines don't affect the taxes.

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -934,3 +934,65 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         )
         self.assertEqual(results['value']['tax_totals']['base_amount'], 2000.0)
         self.assertEqual(results['value']['tax_totals']['total_amount'], 2600.0)
+
+    def test_imported_invoice_tax_preserved_on_analytic_change(self):
+        """
+        When a vendor bill is imported (is_imported=True on its lines), the tax amounts
+        may differ from what Odoo would compute (e.g. due to rounding at the source).
+        Changing only the analytic distribution in the UI triggers an onchange that
+        recomputes taxes, which must NOT alter the imported tax amounts.
+        """
+        tax_rep = self.percent_tax_1.invoice_repartition_line_ids.filtered(lambda l: l.repartition_type == 'tax')
+        move = self.env['account.move'].with_context(skip_invoice_sync=True).create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2024-01-01',
+            'line_ids': [
+                Command.create({
+                    'name': 'Imported line',
+                    'display_type': 'product',
+                    'price_unit': 82.64,
+                    'quantity': 1,
+                    'amount_currency': 82.64,
+                    'balance': 82.64,
+                    'account_id': self.company_data['default_account_expense'].id,
+                    'tax_ids': [Command.set(self.percent_tax_1.ids)],
+                    'is_imported': True,
+                }),
+                Command.create({
+                    'name': 'Tax 21%',
+                    'display_type': 'tax',
+                    'amount_currency': 17.36,
+                    'balance': 17.36,
+                    'account_id': self.company_data['default_account_expense'].id,
+                    'tax_repartition_line_id': tax_rep.id,
+                    'is_imported': True,
+                }),
+                Command.create({
+                    'display_type': 'payment_term',
+                    'amount_currency': -100.00,
+                    'balance': -100.00,
+                    'account_id': self.company_data['default_account_payable'].id,
+                }),
+            ],
+        })
+
+        analytic_plan = self.env['account.analytic.plan'].create({'name': 'Test Plan'})
+        analytic_account = self.env['account.analytic.account'].create({
+            'name': 'Test Analytic',
+            'plan_id': analytic_plan.id,
+        })
+
+        # Simulate the frontend onchange when assigning analytic distribution
+        res = move.onchange(
+            {'invoice_line_ids': [
+                Command.update(move.invoice_line_ids[0].id, {
+                    'analytic_distribution': {str(analytic_account.id): 100},
+                }),
+            ]},
+            ['invoice_line_ids'],
+            {"invoice_line_ids": {}, "tax_totals": {}},
+        )
+
+        tax_totals = res.get('value', {}).get('tax_totals')
+        self.assertIsNone(tax_totals)


### PR DESCRIPTION
When modifying the analytic distribution on an imported invoice line, the tax synchronization mechanism recalculate taxes from scratch, causing rounding discrepancies

Task id - [6030615](https://www.odoo.com/odoo/project/967/tasks/6030615)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
