### PR TITLE
[FIX] mrp: auto pick only raw move component

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -471,6 +471,13 @@ class StockMove(models.Model):
                 self = other_move + updated_product_move
         if self.env.context.get('force_manual_consumption'):
             vals['manual_consumption'] = True
+        if (
+            not self.env.context.get("auto_conso")
+            and any(cmd[0] == Command.CREATE for cmd in vals.get("move_line_ids", []))
+            and all(move.raw_material_production_id for move in self)
+        ):
+            vals['manual_consumption'] = True
+            vals['picked'] = True
         if 'product_uom_qty' in vals and 'move_line_ids' in vals:
             # first update lines then product_uom_qty as the later will unreserve
             # so possibly unlink lines

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -464,6 +464,38 @@ class TestConsumeComponent(TestConsumeComponentCommon):
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
         ])
 
+    def test_multi_lot_component_consumption(self):
+        """
+        Check that indicated lot on raw move lines are conserved even if the first
+        lot has enough quantity on hand
+        """
+        self.bom_serial_lines[0].unlink()
+        self.bom_serial_lines[2].unlink()
+
+        quants = self.create_quant(self.raw_lot, 2)
+        quants |= self.create_quant(self.raw_lot, 2, offset=1)
+        quants.action_apply_inventory()
+
+        mo = self.create_mo(self.mo_serial_tmpl, 1)
+        mo.action_confirm()
+        mo.move_raw_line_ids.quantity = 1
+        mo.move_raw_ids.write({
+            'move_line_ids': [
+                Command.create({
+                    'quantity': 1,
+                    'product_id': self.raw_lot.id,
+                    'product_uom_id': self.raw_lot.uom_id.id,
+                    'lot_id': quants[1].lot_id.id
+                })
+            ]
+        })
+        mo.button_mark_done()
+        mo.invalidate_recordset()
+        self.assertRecordValues(mo.move_raw_line_ids, [
+            {'quantity': 1.0},
+            {'quantity': 1.0},
+        ])
+
     def test_no_component_consumption_on_lot_removal(self):
         """
         If we have a manufacturing order (MO) for a product tracked by lot, and we assign a lot number

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -2768,6 +2768,62 @@ class TestStockFlowPostInstall(TestStockCommon):
         picking.picking_type_id = picking_type_1
         self.assertEqual(picking.name, "PT1/00002")
 
+    def test_reservation_method_for_outgoing(self):
+        """ Test the functional flow when the reservation method for outgoing picking types is set to 'manual' """
+        outgoing_picking_type = self.warehouse_1.out_type_id
+
+        outgoing_picking_type.reservation_method = 'manual'
+
+        quant_none = self.create_quant(self.raw_none, 3)
+        quant_lot = self.create_quant(self.raw_lot, 2)
+        (quant_none + quant_lot).action_apply_inventory()
+
+        with Form(self.env['stock.picking']) as picking_form:
+            picking_form.picking_type_id = outgoing_picking_type
+
+            with picking_form.move_ids_without_package.new() as move_form:
+                move_form.product_id = self.raw_none
+                move_form.product_uom_qty = 3
+
+            with picking_form.move_ids_without_package.new() as move_form:
+                move_form.product_id = self.raw_lot
+                move_form.product_uom_qty = 2
+
+        picking = picking_form.save()
+
+        self.assertEqual(len(picking.move_ids), 2)
+        picking.action_confirm()
+
+        move_track_none, move_track_lot = picking.move_ids
+
+        self.assertEqual(move_track_none.quantity, 0)
+        self.assertEqual(move_track_lot.quantity, 0)
+
+        move_track_none.quantity = 3
+
+        # Simulate the form view of the burger button (detail of a move) for serial/lot tracking
+        with (
+            Form(move_track_lot, self.env.ref('stock.view_stock_move_operations')) as move_form,
+            move_form.move_line_ids.new() as move_line_form,
+        ):
+            move_line_form.quantity = 2
+            move_line_form.lot_id = quant_lot.lot_id
+
+        # Check stock move lines creation for each move
+        self.assertEqual(len(move_track_none.move_line_ids), 1)
+        self.assertEqual(move_track_none.move_line_ids.quantity, 3)
+
+        self.assertEqual(len(move_track_lot.move_line_ids), 1)
+        self.assertEqual(move_track_lot.move_line_ids.quantity, 2)
+        self.assertTrue(move_track_lot.move_line_ids.lot_id)
+
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+
+        # Check quantity available in stock for each product
+        self.assertEqual(self.raw_none.qty_available, 0)
+        self.assertEqual(self.raw_lot.qty_available, 0)
+
     def test_name_create_location(self):
         """
         e.g., from .csv/.xlsx import:


### PR DESCRIPTION
Commit https://github.com/odoo-dev/odoo/commit/63e44737fe469ab56b8e8e96c1ad47205ead1094 force `picked` to `True` when editing the stock
move line in mrp module. The issue is, having Manufacturing installed,
writing on any stock move (even in a picking) will go throughout this
code and mark the move as picked. This commit adds a contrains to only
update raw component moves.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
