### PR TITLE
[FIX] bus: more resilient websocket kick_all

### DIFF
--- a/addons/bus/tests/test_close_websocket_after_tour.py
+++ b/addons/bus/tests/test_close_websocket_after_tour.py
@@ -1,8 +1,10 @@
 import gc
+import threading
 from unittest.mock import patch
 from weakref import WeakSet
 
 from odoo.tests import tagged
+
 from .. import websocket as websocket_module
 from .common import WebsocketCase
 
@@ -29,9 +31,20 @@ class TestCloseWebsocketAfterTour(WebsocketCase):
         # Open a socket that won't be closed when calling browser.close()
         mocked_brower_class.return_value.navigate_to.side_effect = navigate_to_side_effect
 
-        with patch.object(websocket_module, "_websocket_instances", WeakSet()):
+        og_disconnect = websocket_module.Websocket._disconnect
+        disconnect_called_ev = threading.Event()
+
+        def _disconnect(ws, code, reason):
+            og_disconnect(ws, code, reason)
+            disconnect_called_ev.set()
+
+        with (
+            patch.object(websocket_module, "_websocket_instances", WeakSet()),
+            patch.object(websocket_module.Websocket, "_disconnect", _disconnect),
+        ):
             self.browser_js("/odoo", "")
             self.assertTrue(websocket_created)
+            disconnect_called_ev.wait()
             # serve_forever_patch prevent websocket instances from being collected. Stop it now.
             self._serve_forever_patch.stop()
             gc.collect()

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -44,6 +44,7 @@ from .session_helpers import check_session, new_env
 from .tools import orjson
 
 _logger = logging.getLogger(__name__)
+_stopping = threading.Event()
 
 
 MAX_TRY_ON_POOL_ERROR = 10
@@ -74,6 +75,7 @@ def acquire_cursor(db):
 # ------------------------------------------------------
 # EXCEPTIONS
 # ------------------------------------------------------
+
 
 class UpgradeRequired(HTTPException):
     code = 426
@@ -1005,6 +1007,8 @@ class WebsocketConnectionHandler:
         """
         if not cls.websocket_allowed(request):
             raise ServiceUnavailable("Websocket is disabled in test mode")
+        if _stopping.is_set():
+            raise ServiceUnavailable("Websocket is shutting down")
         public_session = cls._handle_public_configuration(request)
         try:
             response = cls._get_handshake_response(request.httprequest.headers)
@@ -1141,17 +1145,38 @@ class WebsocketConnectionHandler:
 
 def _kick_all(code=CloseCode.GOING_AWAY):
     """ Disconnect all the websocket instances. """
-    _logger.info('disconnecting %s websockets', len(_websocket_instances))
-    count = 0
-    wait_threshold = max(odoo.sql_db._Pool._maxconn // 8, 8) if odoo.sql_db._Pool else 32
-    for websocket in _websocket_instances:
-        if websocket.state is ConnectionState.OPEN:
-            websocket.close(code)
-            count += 1
-            if count % wait_threshold == 0:
-                time.sleep(0.5)
-                _logger.debug('kicking websockets %s/%s ...', count, len(_websocket_instances))
-    _logger.debug('kicking websockets %s/%s done', count, len(_websocket_instances))
+    _stopping.set()  # refuse new connections
+    try:
+        _logger.info("Disconnecting %s websockets", len(_websocket_instances))
+        count = 0
+        wait_threshold = max(odoo.sql_db._Pool._maxconn // 8, 8) if odoo.sql_db._Pool else 32
+        for websocket in _websocket_instances:
+            if websocket.state is ConnectionState.OPEN:
+                websocket.close(code)
+                count += 1
+                if count % wait_threshold == 0:
+                    time.sleep(0.5)
+                    _logger.debug("signaling websockets to shutdown %s/%s ...", count, len(_websocket_instances))
+        _logger.debug("signaling websockets to shutdown %s/%s done", count, len(_websocket_instances))
+
+        # Every websocket has been signaled to shut down, but the
+        # closing handshake might not be complete yet, wait up to
+        # TIMEOUT/10 seconds for all handshaked to be done.
+        for _ in range(int(TimeoutManager.TIMEOUT)):
+            if all(
+                websocket.state is ConnectionState.CLOSED
+                for websocket in _websocket_instances
+            ):
+                break
+            time.sleep(.1)
+        else:
+            _logger.warning("There remain %s closing websockets", sum(
+                1
+                for websocket in _websocket_instances
+                if websocket.state is not ConnectionState.CLOSED
+            ))
+    finally:
+        _stopping.clear()
 
 
 CommonServer.on_stop(_kick_all)


### PR DESCRIPTION
The kick-all function signals all websockets to shutdown, but there are two shortcommings:

1. The server is still accepting new connections.
2. The kick-all function doesn't wait for the websockets to actually be closed.

The first problem is solved by introducing a new `is_stopping` event that is checked when one access the /websocket route. The connection is rejected with status code 503 - Service Unavailable[^1] when the event is set.

The second problem is solved by polling all the signaled websockets and make sure they all are closed, when not sleep a bit and poll again, for a maximum of TIMEOUT/10 seconds (1.5 seconds by default).

[^1]: https://http.cat/status/503
