### PR TITLE
[FIX] web: hide kanban record menu when read-only

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -20,7 +20,7 @@
     </t>
 
     <t t-name="web.KanbanRecordMenu">
-        <div t-if="this.showMenu" class="o_dropdown_kanban bg-transparent position-absolute end-0 top-0 w-auto">
+        <div t-if="this.showMenu and !this.props.readonly" class="o_dropdown_kanban bg-transparent position-absolute end-0 top-0 w-auto">
             <Dropdown menuClass="'o-dropdown--kanban-record-menu'" position="'bottom-end'">
                 <button class="btn o-no-caret rounded-0 px-1" title="Dropdown menu">
                     <span class="oi oi-ellipsis-v"/>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5242,7 +5242,7 @@ test("edit the kanban color with translated colors resulting in the same terms",
     expect(getKanbanRecord({ index: 0 })).toHaveClass("o_kanban_color_9");
 });
 
-test("colorpicker doesn't appear when missing access rights", async () => {
+test("dropdown menu doesn't appear when missing access rights", async () => {
     await mountView({
         type: "kanban",
         resModel: "category",
@@ -5259,8 +5259,9 @@ test("colorpicker doesn't appear when missing access rights", async () => {
             </kanban>`,
     });
 
-    await toggleKanbanRecordDropdown(0);
-    expect(".o_kanban_colorpicker").toHaveCount(0);
+    // When the Kanban record is read-only (e.g., edit='0'), the dropdown menu and its toggle
+    // are not rendered to prevent displaying empty dropdowns
+    expect(`.o_kanban_record:eq(0) .o_dropdown_kanban .dropdown-toggle`).toHaveCount(0);
 });
 
 test("load more records in column", async () => {


### PR DESCRIPTION
**Purpose**
Currently, the Kanban record menu (the ellipsis dropdown) is displayed even when the Kanban view is in read-only mode. This occurs frequently in `SelectCreateDialog` or when specific conditions on the menu items result in an empty dropdown.

This leads to a poor UX where users see "extra dots" that either do nothing or show actions that are restricted in the current context.

**Specification**
- Modified `KanbanRecordMenu` to check for `props.readonly`.
- The menu will now only be rendered if `showMenu` is true AND the view is not in readonly mode.
- This ensures that in selection dialogs or read-only kanban views, the unnecessary UI element is removed.

**Task-6026033**