### PR TITLE
[PERF] stock_account: ensure dates are compared with the right timezone

### DIFF
--- a/addons/stock_account/report/stock_valuation_report.py
+++ b/addons/stock_account/report/stock_valuation_report.py
@@ -30,7 +30,7 @@ class StockValuationReport(models.AbstractModel):
         # Check if date is a string instance
         if isinstance(date, str):
             date = fields.Date.from_string(date)
-        if date == fields.Date.today():
+        if date == fields.Date.context_today(self):
             date = False
         if not date:
             inventory_data = company.stock_value()


### PR DESCRIPTION
When accessing the Inventory Valuation report, we check if the selected date correspond to the current day:

https://github.com/odoo/odoo/blob/3610d16ae47e53860e6e047b98de6a60733a5408/addons/stock_account/report/stock_valuation_report.py#L33-L34

If the date is today, the method _run_average_batch() simply computes the value as qty_available * standard_price. But if it is not, it will replay the whole AVCO history which can be heavy.

https://github.com/odoo/odoo/blob/3610d16ae47e53860e6e047b98de6a60733a5408/addons/stock_account/models/product.py#L394-L397

The "date" variable used in the comparison is the local date obtained from the browser while fields.Date.today() returns the UTC date. In certain case, when the local timezone is not on the same day as UTC anymore, this causes the report to be very slow to load because it replays the full history when it should not.

We propose to use the context_today() method instead to get the date from the user's timezone.

Benchmark:

| No AVCO Products | Before PR | After PR |
|------------------|-----------|----------|
|            12000 |    > 40 s |      3 s |

opw-6050007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr