### PR TITLE
[FIX] hr: set base company in demo activity plan

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -18,7 +18,7 @@
         <record id="onboarding_plan" model="mail.activity.plan">
             <field name="name">Onboarding</field>
             <field name="res_model">hr.employee</field>
-            <field name="company_id" eval="False"/>
+            <field name="company_id" ref="base.main_company"/>
         </record>
 
         <record id="onboarding_setup_it_materials" model="mail.activity.plan.template">
@@ -45,7 +45,7 @@
         <record id="offboarding_plan" model="mail.activity.plan">
             <field name="name">Offboarding</field>
             <field name="res_model">hr.employee</field>
-            <field name="company_id" eval="False"/>
+            <field name="company_id" ref="base.main_company"/>
         </record>
 
         <record id="offboarding_setup_compute_out_delais" model="mail.activity.plan.template">


### PR DESCRIPTION
# How to reproduce
- Be in a single company environment
- Employees app > Configuration > Activity Plan > Either demo plan (Onboarding or Offboarding)
- Try to select a department

# The problem
The dropdown is empty even if department exists. This can be check by creating a new plan and trying to assign departments to it.

# Cause
The demo data for thoses two plan explicitely sets the company_id to false :

https://github.com/odoo/odoo/blob/2c14ce9f655a1eea3d7b1cb0e0ce8108cf9da0df/addons/hr/data/hr_data.xml#L21 https://github.com/odoo/odoo/blob/2c14ce9f655a1eea3d7b1cb0e0ce8108cf9da0df/addons/hr/data/hr_data.xml#L48

But the department_id has check_company set to true :

https://github.com/odoo/odoo/blob/2c14ce9f655a1eea3d7b1cb0e0ce8108cf9da0df/addons/hr/models/mail_activity_plan.py#L12

# Proposed solution
Backport of this commit : https://github.com/odoo/odoo/pull/240167

opw-6058697

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
