### PR TITLE
[FIX] bus: pregenerate bus.websocket_worker_assets bundle in tests

### DIFF
--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -3,6 +3,7 @@ from . import bus
 from . import bus_presence
 from . import ir_http
 from . import ir_model
+from . import ir_qweb
 from . import ir_websocket
 from . import res_users
 from . import res_partner

--- a/addons/bus/models/ir_qweb.py
+++ b/addons/bus/models/ir_qweb.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class IrQWeb(models.AbstractModel):
+    _inherit = "ir.qweb"
+
+    def _get_bundles_to_pregenarate(self):
+        js_assets, css_assets = super()._get_bundles_to_pregenarate()
+        assets = {"bus.websocket_worker_assets"}
+        return (js_assets | assets, css_assets | assets)


### PR DESCRIPTION
This commit sets the `bus.websocket_worker_assets` bundle to be pregenerated while running tests to avoid rebuilding it at runtime (i.e. +900 times with a db "all").
