### PR TITLE
[FIX] mrp: fix Update BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2602,8 +2602,8 @@ class MrpProduction(models.Model):
                 moves_to_unlink = self.move_raw_ids
                 workorders_to_unlink = self.workorder_ids
             self.bom_id = bom
-            moves_to_unlink.unlink()
-            workorders_to_unlink.unlink()
+            moves_to_unlink.exists().unlink()
+            workorders_to_unlink.exists().unlink()
             if self.state == 'draft':
                 # we reset the product_qty/uom when the bom is changed on a draft MO
                 # change them back to the original value


### PR DESCRIPTION
Steps to Reproduce

- Create a draft manufacturing order : Desk Combination
- Update bom using ECO
- Add a new Line with Screw with 10 qty
- Apply Changes
- Update BOM in the manufacturing order

-> Record does not exist or has been deleted.

Changing bom_id causes the computes state/move_finished_ids/move_raw_ids & workorder_ids to be triggered.

Since https://github.com/odoo/odoo/pull/195995, raw_material_production_id have ondelete='cascade'
Therefore
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/mrp/models/mrp_production.py#L828 will unlink the raw moves, see
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/odoo/orm/fields_relational.py#L980

Due to
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/mrp/models/mrp_bom.py#L265 unlink cannot be removed, so exists() will do the job.

Also fix unlinking of workorder_ids which causes the same error message in 18.0

issue: 254376

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
