### PR TITLE
[FIX] im_livechat: pregenerate .assets_embed_external bundle in tests

### DIFF
--- a/addons/im_livechat/models/__init__.py
+++ b/addons/im_livechat/models/__init__.py
@@ -7,6 +7,7 @@ from . import chatbot_script_step
 from . import res_users
 from . import res_partner
 from . import im_livechat_channel
+from . import ir_qweb
 from . import discuss_channel
 from . import discuss_channel_member
 from . import mail_message

--- a/addons/im_livechat/models/ir_qweb.py
+++ b/addons/im_livechat/models/ir_qweb.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class IrQWeb(models.AbstractModel):
+    _inherit = "ir.qweb"
+
+    def _get_bundles_to_pregenarate(self):
+        js_assets, css_assets = super()._get_bundles_to_pregenarate()
+        assets = {"im_livechat.assets_embed_external"}
+        return (js_assets | assets, css_assets | assets)


### PR DESCRIPTION
This commit sets the `im_livechat.assets_embed_external` bundle to be pregenerated while running tests to avoid rebuilding it at runtime (i.e. +280 times with a db "all").
