### PR TITLE
[FIX] account: Trigger the constraint for tax country when a bill is imported

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -914,6 +914,8 @@ class AccountJournal(models.Model):
 
             invoice._extend_with_attachments(attachment, new=True)
 
+            invoice._validate_fields(["fiscal_position_id"])
+
             all_invoices |= invoice
 
             invoice.with_context(


### PR DESCRIPTION
**Steps to reproduce:**
- Create a company in Belgium and set the fiscal localisation accordingly.
- In the same company, create a fiscal position in Switzerland, set the foreign tax ID and then generate the taxes for it.
- Install the module account_edi (to be able to export/import invoices).
- Create and invoice for a belgian customer, with one product line having a 0% tax.
- Export the invoice as XML.
- Go to taxes, filter by purchase, and make sure that the 0% switzerland tax has a higher sequence than the belgian 0% tax.
- Import the previous invoice XML as a vendor bill.

**Issue:**
After importing the bill, the switzerland tax is used even though the fiscal localisation is belgian, and no error is shown. There is a constraint that covers this case (_validate_taxes_country). It was created to prevent the user from changing the fiscal localisation to another country before removing the taxes from the first country. But in this case, the import process bypasses this process by validating the fields before the lines are created.

**Solution:**
Added a validation step for the field fiscal_position_id when the move is imported, and right after the lines are created.

opw-5467936
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
