### PR TITLE
[FIX] website_sale: preview dynamic content of custom snippet "Category"

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
@@ -61,3 +61,7 @@ registry
 registry
     .category('public.interactions.edit')
     .add('website_sale.dynamic_snippet_category', {Interaction: DynamicSnippetCategory});
+
+registry
+    .category("public.interactions.preview")
+    .add('website_sale.dynamic_snippet_category', {Interaction: DynamicSnippetCategory});


### PR DESCRIPTION
Commit 00cf9375b356b2316e24d97234474685e3fb7f94 added the new dynamic snippet for category of product, with a specific interaction.

Commit 534a42029d757935788220549aabb8914302a4f3 shows dynamic content of dynamic snippet in snippets preview dialog, but `DynamicSnippetCategory` was missed (in forward port).

This commit includes the interaction to load the dynamic content of "Category" dynamic snippet in the snippets preview dialog.

Steps to reproduce:
- Open website builder
- Add a dynamic snippet `s_dynamic_snippet_category_list`
- Save the snippet as a custom snippet
- Click on "Custom" snippet category
- Bug: The preview for the custom snippet does not have the dynamic part

task-5427353