### PR TITLE
[FIX] tests: not detected query count

### DIFF
--- a/addons/purchase_stock/tests/test_uninstall.py
+++ b/addons/purchase_stock/tests/test_uninstall.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from unittest.mock import patch
 
 from odoo import fields
-from odoo.addons.purchase_stock.models.purchase_order_line import PurchaseOrderLine
 from odoo.tests.common import tagged
 
 from .common import PurchaseTestCommon
@@ -37,15 +34,7 @@ class TestUninstallPurchaseStock(PurchaseTestCommon):
             ('value', '=', 'stock_moves'),
         ])
 
-        original_compute = PurchaseOrderLine._compute_qty_received
-        def _compute_qty_received(records):
-            records.read()
-            with self.assertQueryCount(5):
-                original_compute(records)
-                records.flush_recordset()
-
-        with patch.object(PurchaseOrderLine, '_compute_qty_received', _compute_qty_received):
-            stock_moves_option.sudo().with_context(force_delete=True).unlink()
+        stock_moves_option.sudo().with_context(force_delete=True).unlink()
 
         self.assertEqual(order_line.qty_received_method, 'manual')
         self.assertEqual(order_line.qty_received, 1)

--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -19,7 +19,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
         })
         self.assertFalse(project.task_ids.sale_line_id)
         self.env.invalidate_all()
-        with self.assertQueryCount(85):
+        with self.assertQueryCount(165):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,
@@ -34,7 +34,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
             'project_id': project.id,
         } for i in range(50, 100)])
         self.env.invalidate_all()
-        with self.assertQueryCount(130):
+        with self.assertQueryCount(236):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -51,15 +51,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch discuss_channel_member
     #   1. search discuss_channel (chathub given channel ids)
     #   1: search bus_bus (_bus_last_id)
-    #   1: search_fetch discuss_channel_member (_store_init_messaging_global_fields)
+    #   2: search_fetch discuss_channel_member (_store_init_messaging_global_fields)
     #   1: _compute_message_unread (_init_messaging_global_fields discuss)
     #   2: _init_messaging (mail)
     #       - _get_needaction_count (inbox counter)
     #       - search mail_message (bookmark counter)
-    #   23: _process_request_for_all (discuss):
+    #   26: _process_request_for_all (discuss):
     #       - search_fetch discuss_channel (channels_domain)
+    #       2: check permissions
     #       - fetch discuss_channel (chathub given channel ids, missing search_fetch)
-    #       21: store add channel:
+    #       22: store add channel:
     #           - read group member (prefetch _compute_self_member_id from _compute_is_member)
     #           - read group member (_compute_invited_member_ids)
     #           - search discuss_channel_rtc_session
@@ -84,7 +85,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #           - search_fetch ir_attachment (_compute_avatar_cache_key -> _compute_avatar_128)
     #           - search discuss_channel_res_groups_rel (group_ids)
     #           - fetch res_groups (group_public_id)
-    _query_count_init_messaging = 31
+    #           - select the current db snapshot
+    _query_count_init_messaging = 35
     # Queries for _query_count_discuss_channels (in order):
     #   3: _search_is_member (for current user, first occurence channels_as_member)
     #       - fetch res_users

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -61,6 +61,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - read group rating_rating (_rating_get_stats_per_record for product.template)
         #           - compute message_needaction for slide.channel
         #           - compute message_needaction for product.template
+        #       - select current db snapshot
         first_model_records = self.env["product.template"].create(
             [{"name": "Product A1"}, {"name": "Product A2"}]
         )
@@ -75,5 +76,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(40):
+        with self.assertQueryCount(41):
             self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -434,9 +434,6 @@ class Cursor(_CursorProtocol):
     def print_log(self) -> None:
         global sql_counter
 
-        if not _logger.isEnabledFor(logging.DEBUG):
-            return
-
         def process(log_type: str):
             sqllogs = {'from': self.sql_from_log, 'into': self.sql_into_log}
             sqllog = sqllogs[log_type]
@@ -453,7 +450,6 @@ class Cursor(_CursorProtocol):
 
         process('from')
         process('into')
-        self.sql_log_count = 0
 
     @contextmanager
     def _enable_logging(self):
@@ -492,7 +488,8 @@ class Cursor(_CursorProtocol):
             self._closed = True
 
             # Advanced stats only at logging.DEBUG level
-            self.print_log()
+            if _logger.isEnabledFor(logging.DEBUG):
+                self.print_log()
 
             # This force the cursor to be freed, and thus, available again. It is
             # important because otherwise we can overload the server very easily

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -821,7 +821,6 @@ class BaseCase(case.TestCase):
             return Cursor_execute(self, query, params, log_exceptions)
 
         if flush:
-            self.env.flush_all()
             self.env.cr.flush()
 
         with (
@@ -830,7 +829,6 @@ class BaseCase(case.TestCase):
         ):
             yield actual_queries
             if flush:
-                self.env.flush_all()
                 self.env.cr.flush()
 
     @contextmanager
@@ -875,19 +873,16 @@ class BaseCase(case.TestCase):
 
             The second form is convenient when used with :func:`users`.
         """
+        flush_func = self.env.cr.flush if flush else lambda: None
         if self.warm:
             # mock random in order to avoid random bus gc
             with patch('random.random', lambda: 1):
                 login = self.env.user.login
                 expected = counters.get(login, default)
-                if flush:
-                    self.env.flush_all()
-                    self.env.cr.flush()
+                flush_func()
                 count0 = self.cr.sql_log_count
                 yield
-                if flush:
-                    self.env.flush_all()
-                    self.env.cr.flush()
+                flush_func()
                 count = self.cr.sql_log_count - count0
                 if count != expected:
                     # add some info on caller to allow semi-automatic update of query count
@@ -907,13 +902,9 @@ class BaseCase(case.TestCase):
         else:
             # flush before and after during warmup, in order to reproduce the
             # same operations, otherwise the caches might not be ready!
-            if flush:
-                self.env.flush_all()
-                self.env.cr.flush()
+            flush_func()
             yield
-            if flush:
-                self.env.flush_all()
-                self.env.cr.flush()
+            flush_func()
 
     def assertRecordValues(
             self,

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -895,6 +895,10 @@ class BaseCase(case.TestCase):
                         # add a subtest in order to continue the test_method in case of failures
                         with self.subTest():
                             self.fail(msg % (login, count, expected, funcname, filename, linenum))
+                    elif expected and not count:
+                        msg = "Query count did not detect any queries %s: expected %d in %s at %s:%s"
+                        with self.subTest():
+                            self.fail(msg % (login, expected, funcname, filename, linenum))
                     else:
                         logger = logging.getLogger(type(self).__module__)
                         msg = "Query count less than expected for user %s: %d < %d in %s at %s:%s"

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -83,6 +83,7 @@ class TestCursor(Cursor):
             tos = self._cursors_stack.pop()
             if tos is not self:
                 _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
+            self._cnx._cursor.sql_log_count += self.sql_log_count  # propagate stats to the main cursor
             self._lock.release()
 
     def commit(self) -> None:


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/251946, query counts are not always detected.
We propagate the query count from the test cursors to the main cursor.

task-6067011


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
