### PR TITLE
[FIX] pos_mrp: fix access error on phantom BOM check in multi-company

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -21,8 +21,8 @@ class PosOrderLine(models.Model):
     def _get_product_cost_with_moves(self, moves):
         self.ensure_one()
         product = self.product_id
-        if any(bom.type == 'phantom' for bom in product.bom_ids):
-            bom = self.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
+        bom = self.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom').get(product)
+        if bom:
             return moves._get_kit_price_unit(product, bom, self.qty)
         return super()._get_product_cost_with_moves(moves)
 


### PR DESCRIPTION
When computing the product cost in `_get_product_cost_with_moves`, iterating over `product.bom_ids` would include BOMs from all companies, causing an `AccessError` when the current user lacked read access to a BOM belonging to another company.

opw-6060735


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
