### PR TITLE
[FIX] hr_expense: exclude payment methods from inactive journals

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -287,6 +287,7 @@ class HrExpenseSheet(models.Model):
             else:
                 sheet.selectable_payment_method_line_ids = self.env['account.payment.method.line'].search([
                     ('payment_type', '=', 'outbound'),
+                    ('journal_id.active', '=', True),
                     ('company_id', 'parent_of', sheet.company_id.id)
                 ])
 


### PR DESCRIPTION
Add the domain ('journal_id.active', '=', True) in selectable_payment_method_line_ids so only payment methods linked to active journals are selectable.

This prevents selecting payment methods from inactive journals in expense sheets.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
