### PR TITLE
[FIX] account_edi_ubl_cii: apply peppol bis3 rule SE-R-005

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1467,6 +1467,14 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 },
             })
 
+        if commercial_partner.country_code == 'SE':
+            nodes.append({
+                'cbc:CompanyID': {'_text': "GODKÄND FÖR F-SKATT"},
+                'cac:TaxScheme': {
+                    'cbc:ID': {'_text': "TAX"},
+                },
+            })
+
     def _add_invoice_accounting_supplier_party_nodes(self, document_node, vals):
         # OVERRIDE
         sub_vals = {


### PR DESCRIPTION
After this commit 9cb237d, the rule was added, but from 18.0 and upper the old helps has been deprecated and removed on saas~18.4.

With this commit, we add the rule also to the new helpers.

OPW-5881918

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
