### PR TITLE
[FIX] mrp: update move reference when operation type changes

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1032,7 +1032,9 @@ class MrpProduction(models.Model):
                 if production.state in ('cancel', 'done'):
                     continue
                 if picking_type != production.picking_type_id:
+                    prev_production_name = production.name
                     production.name = picking_type.sequence_id.next_by_id()
+                    production.move_raw_ids.reference_ids.filtered(lambda r: r.name == prev_production_name).name = production.name
                     moves_to_reassign |= production.move_raw_ids
 
         res = super(MrpProduction, self).write(vals)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1991,8 +1991,11 @@ class TestBoM(TestMrpCommon):
         mo_form.bom_id = self.bom_1
         mo_form.picking_type_id = self.picking_type_manu
         mo_1 = mo_form.save()
+        picking_type_manu_clone = self.picking_type_manu.copy({'sequence_code': 'NEW_CODE'})
+        mo_1.picking_type_id = picking_type_manu_clone
         mo_1.action_confirm()
         picking = mo_1.picking_ids
+        self.assertEqual(picking.origin, mo_1.name)
         self.assertRecordValues(picking.move_ids, [
             {'product_id': self.product_2.id, 'product_uom_qty': 2},
             {'product_id': self.product_1.id, 'product_uom_qty': 4},

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1971,8 +1971,11 @@ class TestBoM(TestMrpCommon):
         mo_form.bom_id = self.bom_1
         mo_form.picking_type_id = self.picking_type_manu
         mo_1 = mo_form.save()
+        picking_type_manu_clone = self.picking_type_manu.copy({'sequence_code': 'NEW_CODE'})
+        mo_1.picking_type_id = picking_type_manu_clone
         mo_1.action_confirm()
         picking = mo_1.picking_ids
+        self.assertEqual(picking.origin, mo_1.name)
         self.assertRecordValues(picking.move_ids, [
             {'product_id': self.product_2.id, 'product_uom_qty': 2},
             {'product_id': self.product_1.id, 'product_uom_qty': 4},


### PR DESCRIPTION
**Issue**:
When the name of a MO changes before confirmation, the picking origin
may remain incorrect after confirmation.

**Steps to reproduce**:
- Make sure that multi-step route is enabled in the settings
- Configure the manufacturing route as 2-step
- Go to Inventory > Configuration > Warehouse Management > Operations Types
- Clone the "Manufacturing" operation type and assign a different Sequence Prefix
- Create and save a MO, without confirming it
- Change and save the operation type to the cloned one (the MO name changes)
- Confirm the MO
-> The picking source document uses the previous MO name instead of the new one

**Cause**:
The source document of the picking (`origin`) comes from its move:
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/stock/models/stock_move.py#L1526
The move origin comes from the procurement values:
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/stock/models/stock_move.py#L1575C13-L1575C56
Which relies on `self.reference_ids[0].name`:
https://github.com/odoo/odoo/blob/95c73aa4dd7433f394799fdaaad57a84d750ec5a/addons/stock/models/stock_move.py#L1639
which is never updated, causing the origin to keep the previous MO name.

opw-5979778