### PR TITLE
[FIX] html_editor: make phone url deducing more strict

### DIFF
--- a/addons/html_editor/static/src/main/link/utils.js
+++ b/addons/html_editor/static/src/main/link/utils.js
@@ -31,7 +31,7 @@ const httpCapturedRegex = `(https?:\\/\\/)`;
 
 export const URL_REGEX = new RegExp(`((?:(?:${httpCapturedRegex}${urlRegexBase})`, "i");
 export const EMAIL_REGEX = /^(mailto:)?[\w-.]+@(?:[\w-]+\.)+[\w-]{2,4}$/i;
-export const PHONE_REGEX = /^(tel:(?:\/\/)?)?\+?[\d\s.\-()/]{3,25}$/;
+export const PHONE_REGEX = /^(?=.*\d)(tel:(?:\/\/)?)?\+? ?[\d(][\d .\-()/]{2,24}$/;
 
 export function cleanZWChars(text) {
     return text.replace(/\u200B|\uFEFF/g, "");

--- a/addons/html_editor/static/tests/utils/regex.test.js
+++ b/addons/html_editor/static/tests/utils/regex.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { URL_REGEX } from "@html_editor/utils/regex";
+import { PHONE_REGEX } from "../../src/main/link/utils";
 
 function testUrlRegex(content, { expectedUrl, insideText } = {}) {
     const message = expectedUrl
@@ -26,6 +27,16 @@ function testNotUrlRegex(content, { insideText } = {}) {
         }
         expect(content).not.toMatch(URL_REGEX);
     });
+}
+
+function testPhoneRegex(value, isPhoneRegex = true) {
+    test(`Should ${isPhoneRegex ? "" : "NOT "}be a phone link: ${value}`, () => {
+        if(isPhoneRegex) {
+            expect(value).toMatch(PHONE_REGEX);
+        } else {
+            expect(value).not.toMatch(PHONE_REGEX);
+        }
+    })
 }
 
 testUrlRegex("google.com");
@@ -154,3 +165,20 @@ testUrlRegex("http://abc.abc.abc", { insideText: true });
 testUrlRegex("https://abc.abc.abc", { insideText: true });
 testUrlRegex("1234-abc.runbot007.odoo.com/web#id=3&menu_id=221", { insideText: true });
 testUrlRegex("https://1234-abc.runbot007.odoo.com/web#id=3&menu_id=221", { insideText: true });
+
+//Phone links
+testPhoneRegex("+32 470 12 34 56")
+testPhoneRegex("+ 32 470 12 34 56")
+testPhoneRegex("+14155552671")
+testPhoneRegex("0470 12 34 56")
+testPhoneRegex("(415) 555-2671")
+testPhoneRegex("0470-12-34-56")
+testPhoneRegex("415.555.2671")
+testPhoneRegex("4155552671")
+testPhoneRegex("tel:+32 (0)2 123 45 67")
+testPhoneRegex("tel://+1-415-555-2671")
+testPhoneRegex("/3-14", false)
+testPhoneRegex("/1234567", false)
+testPhoneRegex("...", false)
+testPhoneRegex("( )", false)
+testPhoneRegex("-67", false)


### PR DESCRIPTION
# How to reproduce
- Add a new website page with a title that ressembles a phone number (3-14 does the trick even though it does not really look like a phone number)
- Go to another page in edit mode
- Select a button
- In the "Enter URL, /page, or #anchor" input, write the url to your page (/3-14)
- Click on Apply

# The problem
Instead of a link to our page, the button has a link with a tel: protocol.

# Cause
When clicking on the Apply button, the `applyDeducedUrl()` function will be run.

https://github.com/odoo/odoo/blob/892b15963625acc89b7ed7b1c6f94392111df6be/addons/html_editor/static/src/main/link/link_popover.js#L294

That function will change the selected url with the URL deduced from `deduceURLfromText()` if any is found. In our case "/3-14" matches the `PHONE_REGEX` pattern so the url is prefixed with the tel: protocol.

https://github.com/odoo/odoo/blob/892b15963625acc89b7ed7b1c6f94392111df6be/addons/html_editor/static/src/main/link/utils.js#L71

https://github.com/odoo/odoo/blob/892b15963625acc89b7ed7b1c6f94392111df6be/addons/html_editor/static/src/main/link/utils.js#L34

That regex is a bit too permissive and allows our "/3-14" to be matched even though it starts with "/".
Side note : cases like "( )", "...", "--)" are also a match, which is not really an issue because they do not really represent anyting but it shows that the regex is not strict enough.

# Proposed solutin
We edit the regex to make it so it only matches strings that have atleast a digit and where the first character (after "+") is a digit or "("

opw-6047571

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
