### PR TITLE
[IMP] website_sale: new border design option

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1972,6 +1972,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Restrict options we can write to.
         writable_fields = {
             "shop_page_container",
+            "shop_border_color",
             "shop_ppg",
             "shop_ppr",
             "shop_default_sort",
@@ -1992,6 +1993,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "wishlist_grid_columns",
             "wishlist_mobile_columns",
             "wishlist_gap",
+            "product_page_border_color",
         }
         # Default ppg to 1.
         if "ppg" in options and not options["ppg"]:

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -116,6 +116,9 @@ class Website(models.Model):
     shop_page_container = fields.Selection(
         selection=[("regular", "Regular"), ("fluid", "Full-width")], default="regular"
     )
+    shop_border_color = fields.Selection(
+        selection=[("default", "Default"), ("strong", "Strong")], default="default"
+    )
     shop_ppg = fields.Integer(string="Number of products in the grid on the shop", default=21)
     shop_ppr = fields.Integer(string="Number of grid columns on the shop", default=3)
 
@@ -147,6 +150,10 @@ class Website(models.Model):
 
     product_page_container = fields.Selection(
         selection=[("unset", "Unset"), ("regular", "Regular"), ("fluid", "Full-width")],
+        default="unset",
+    )
+    product_page_border_color = fields.Selection(
+        selection=[("unset", "Unset"), ("default", "Default"), ("strong", "Strong")],
         default="unset",
     )
 
@@ -942,6 +949,13 @@ class Website(models.Model):
             self.shop_page_container
             if self.product_page_container == "unset"
             else self.product_page_container
+        )
+
+    def _get_product_page_border_color(self):
+        return (
+            self.shop_border_color
+            if self.product_page_border_color == "unset"
+            else self.product_page_border_color
         )
 
     @api.model

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -672,11 +672,12 @@
         }
     }
 }
+
 .o_wsale_products_opt_design_grid {
     --o-wsale-card-height: 100%;
-    --o-wsale-card-border-width: 0 var(--border-width, #{$border-width}) var(--border-width, #{$border-width}) 0 #{"/*rtl: 0 0 0 " + $border-width + "*/"};
     --o-wsale-card-info-grow: 1;
     --o-wsale-card-info-shadow: inset 0 var(--border-width, #{$border-width}) 0 0 var(--o-border-color);
+    --o-wsale-card-border-width: 0 var(--border-width, #{$border-width}) var(--border-width, #{$border-width}) 0 #{"/*rtl: 0 0 " + var(--border-width, #{$border-width}) + " " + var(--border-width, #{$border-width}) + "*/"};
     --o-wsale-card-thumb-margin: calc(var(--o-wsale-products-grid-gap-y) * 0.5);
     --o-wsale-card-info-padding: MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)}) MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)}) MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)});
     --o-wsale-card-border-radius: 0px !important;

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -89,6 +89,7 @@
     }
     .oe_product_image {
         min-width: var(--o-wsale-card-thumb-size);
+        margin: var(--o-wsale-card-thumb-margin, 0);
         width: var(--o-wsale-card-thumb-size);
         border-radius: var(--o-wsale-card-thumb-border-radius, inherit);
         box-shadow: var(--o-wsale-card-thumb-shadow);
@@ -178,6 +179,7 @@
         transform: var(--o-wsale-card-info-transform);
         transition: var(--o-wsale-card-info-transition);
         font-size: var(--o-wsale-card-info-font-size, var(--o-wsale-card-info-responsive-font-size, #{unquote("clamp(12px, calc(0.5rem + 3.3cqw), 1.2rem)")}));
+        box-shadow: var(--o-wsale-card-info-shadow, none);
     }
 
     .o_unpublished_badge {
@@ -422,7 +424,7 @@
             transform: translateY(-100%);
 
             &.show_on_hover {
-                padding: map-get($spacers, 3) map-get($spacers, 1);
+                padding: var(--o-wsale-card-attribute-previewer-padding-catalog-hover-lg, #{map-get($spacers, 3)}) #{map-get($spacers, 1)};
             }
         }
 
@@ -677,17 +679,21 @@
 .o_wsale_products_opt_design_grid {
     --o-wsale-card-height: 100%;
     --o-wsale-card-border-width: 0 #{$border-width $border-width} 0;
-    --o-wsale-card-info-padding: #{map-get($spacers, 2)};
     --o-wsale-card-info-grow: 1;
+    --o-wsale-card-info-shadow: inset 0 #{$border-width} 0 0 var(--o-border-color);
+    --o-wsale-card-thumb-margin: calc(var(--o-wsale-products-grid-gap-y) * 0.5);
+    --o-wsale-card-info-padding: MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)}) MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)}) MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)});
     --o-wsale-card-border-radius: 0px !important;
-    --o-wsale-card-padding: calc(var(--o-wsale-products-grid-gap-y) * 0.5) calc(var(--o-wsale-products-grid-gap, 16px) * 0.5);
     --o-wsale-topbar-padding-left: #{$container-padding-x * 0.5};
     --o-wsale-topbar-padding-right: calc(var(--o-wsale-container-fluid-padding-xl, var(--gutter-x)) * 0.5);
     --o-wsale-topbar-border-width: 0 0 #{$border-width};
-    --o-border-color: #{$gray-300};
-    --border-color: #{$gray-300};
+    --o-border-color: var(--o-wsale-card-border-color, #{$gray-300});
+    --border-color: var(--o-border-color);
     --gap: 0px;
     --o-wsale-card-attribute-previewer-thumbnail-border-radius: 0;
+
+    --o-wsale-card-attribute-previewer-padding: 0 0 calc(MAX(var(--o-wsale-card-thumb-margin), #{map-get($spacers, 2)}) + #{map-get($spacers, 2)});
+    --o-wsale-card-attribute-previewer-padding-catalog-hover-lg: var(--o-wsale-card-attribute-previewer-padding);
 
     --o-wsale-card-offset-top: 0px;
     --o-wsale-card-offset-x: 0px;
@@ -695,6 +701,7 @@
     &.o_wsale_products_opt_layout_list {
         --o-wsale-card-info-attributes-display: flex;
         --o-wsale-card-info-margin: 0;
+        --o-wsale-card-info-shadow: none;
         --o-wsale-card-attribute-previewer-width: var(--o-wsale-card-info-text-width);
         --o-wsale-card-sub-display: contents;
         --o-wsale-card-price-display: flex;

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -88,16 +88,14 @@
         container-type: inline-size;
         container-name: o-wsale-grid;
         grid-template-rows: minmax(auto, auto);
-
-        /*rtl:ignore*/
-        border-left: var(--o-wsale-sidebar-border);
+        border-left: var(--o-wsale-product-grid-border);
     }
 
     // == Header (includes Title, Description, Filmstrip and Toolbar)
     #o_wsale_products_header {
         padding-left: var(--o-wsale-topbar-padding-left);
         padding-right: var(--o-wsale-topbar-padding-right);
-        border: 0px solid $border-color;
+        border: solid $border-color;
         border-width: var(--o-wsale-topbar-border-width, 0px);
 
         .o_wsale_products_header_search_form_container {
@@ -601,7 +599,16 @@
 
     // === Option: "Grid Design"
     &:where(:has(#o_wsale_products_grid.o_wsale_products_opt_design_grid)) {
+        --o-wsale-topbar-border-width: 0 0 var(--border-width) 0;
         --gap: 0;
+
+        .o_wsale_products_grid_table_wrapper {
+            margin-right: calc(var(--border-width)  * -1);
+        }
+
+        .o_wsale_products_grid_table {
+            box-shadow: inset 0 calc(var(--border-width) * -1) 0 0px var(--o-border-color);
+        }
 
         @include media-breakpoint-down(lg) {
             #products_grid {
@@ -613,88 +620,41 @@
             #products_grid {
                 padding-left: 0;
                 padding-right: 0 !important;
-            }
-
-            #o_wsale_products_grid {
-                box-shadow: inset 0 -1px 0 0px var(--o-border-color);
+                overflow: hidden;
             }
         }
 
         &.o_wsale_page_contained {
-            --o-wsale-topbar-border-width: 0 0 var(--border-width) 0;
-
             @include media-breakpoint-up(sm) {
-                --o-wsale-topbar-border-width: 0 var(--border-width) var(--border-width) var(--border-width);
-            }
-
-            &:where(:not(.o_wsale_has_sidebar)) {
-                @include media-breakpoint-up(sm) {
-                    #o_wsale_pager {
-                        border-right: var(--border-width) solid var(--border-color);
-                        border-left: var(--border-width) solid var(--border-color);
-                    }
+                #products_grid {
+                    padding-right: var(--border-width);
+                    box-shadow: inset calc(var(--border-width) * -1) 0 0 0 var(--border-color);
                 }
-                @include media-breakpoint-up(lg) {
-                    --o-wsale-topbar-border-width: 0 var(--border-width) var(--border-width) var(--border-width);
-                    #category_footer {
-                        border-right: var(--border-width) solid var(--border-color);
-                        border-left: var(--border-width) solid var(--border-color);
-                    }
-                }
-            }
-
-            &.o_wsale_has_sidebar {
-                @include media-breakpoint-up(sm) {
-                    #o_wsale_pager {
-                        border-left: var(--border-width) solid var(--border-color);
-                        border-right: var(--border-width) solid var(--border-color);
-                    }
-                }
-                @include media-breakpoint-up(lg) {
-                    --o-wsale-topbar-border-width: 0 var(--border-width) var(--border-width) 0;
-
-                    #o_wsale_pager {
-                        /*rtl:ignore*/
-                        border-left: 0;
-                    }
-                    #category_footer {
-                        border-right: var(--o-wsale-sidebar-border);
-                    }
-                }
-            }
-
-            #o_wsale_products_grid {
-                /*rtl:ignore*/
-                box-shadow: inset calc(var(--border-width) * -1) calc(var(--border-width) * -1) 0 0px var(--o-border-color);
             }
 
             &:where(:not(.o_wsale_has_sidebar)) #o_wsale_products_grid {
                 border-left: var(--border-width) solid var(--border-color);
             }
 
-            &.o_wsale_has_sidebar .o_wsale_products_opt_layout_catalog#o_wsale_products_grid {
-                @include media-breakpoint-down(lg) {
-                    border-left: var(--border-width) solid var(--border-color);
+            &.o_wsale_has_sidebar {
+                    @include media-breakpoint-between(sm, lg) {
+                        --o-wsale-product-grid-border: var(--border-width) solid var(--border-color);
+                    }
+                @include media-breakpoint-up(lg) {
+                    .o_wsale_products_main_row {
+                        border-left: var(--border-width) solid #{$border-color};
+                        margin: 0;
+                    }
                 }
             }
         }
 
         &.o_wsale_has_sidebar {
             @include media-breakpoint-up(lg) {
-                --o-wsale-sidebar-border: var(--border-width) solid #{$border-color};
-            }
-            @include media-breakpoint-up(lg) {
+                --o-wsale-product-grid-border: var(--border-width) solid #{$border-color};
+
                 #products_grid {
-                    /*rtl:ignore*/
                     padding-left: 0;
-                    /* rtl:raw:
-                        margin-left: calc(var(--gutter-x) * .5);
-                        padding-left: 0;
-                    */
-                }
-                .o_wsale_products_main_row {
-                    border-left: var(--border-width) solid #{$border-color};
-                    margin-left: 0;
                 }
             }
 
@@ -708,6 +668,9 @@
 
                     .accordion-item {
                         padding-inline: map-get($spacers, 3);
+                        &:last-child {
+                            border-bottom: var(--border-width) solid var(--border-color);
+                        }
                     }
                 }
             }
@@ -864,19 +827,6 @@
         }
 
         &:where(:has(#o_wsale_products_grid.o_wsale_products_opt_design_grid)) {
-            &.o_wsale_page_contained .oe_product_cart {
-                --o-wsale-card-border-width: 0 var(--border-width) var(--border-width) var(--border-width);
-
-                @include media-breakpoint-up(lg) {
-                    --o-wsale-card-border-width: 0 var(--border-width) var(--border-width) 0;
-                }
-            }
-
-            &.o_wsale_page_fluid .oe_product_cart {
-                --o-wsale-card-border-width: 0 0 #{$border-width} ;
-                --o-wsale-card-padding: calc(var(--o-wsale-products-grid-gap-y) * 0.5) 0 calc(var(--o-wsale-products-grid-gap-y) * 0.5) calc(var(--o-wsale-products-grid-gap, 16px) * 0.5);
-            }
-
             &[style*="--o-wsale-products-grid-gap: 0px"] .oe_product_image_link,
             &[style*="--o-wsale-products-grid-gap:0px"] .oe_product_image_link {
                 @include media-breakpoint-down(lg) {
@@ -1720,6 +1670,7 @@ $-product-radius-map: (
             line-height: 2.5rem;
             @include font-size(1.15rem);
             border-radius: var(--btn-border-radius);
+            --border-width: var(--btn-border-width);
 
             @include media-breakpoint-down(lg) {
                 width: 2rem;

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1,6 +1,22 @@
 // Website Sale
 // =============================================================================
 
+:where(body[class*="o_website_sale_"]) {
+    .o_wsale_border_strong {
+        --o-wsale-border-color: currentColor;
+    }
+
+    .o_wsale_product_border_strong {
+        --o-wsale-product-border-color: currentColor;
+    }
+
+    .o_wsale_custom_border {
+        --o-border-color: var(--o-wsale-product-border-color, var(--o-wsale-border-color));
+        --border-color: var(--o-wsale-product-border-color, var(--o-wsale-border-color));
+        --o-wsale-card-border-color: var(--o-border-color);
+    }
+}
+
 
 // ==== Products list Pages (/shop, /category, /search) ========================
 // =============================================================================
@@ -31,6 +47,7 @@
         }
 
         .o_wsale_products_grid_before_rail{
+            max-height: 100vh;
             scrollbar-width: none;
             -ms-overflow-style: none;
         }
@@ -249,6 +266,7 @@
         &.o_wsale_filmstrip_grid {
             --o-wsale-filmstrip-wrapper-border-width: #{$border-width} 0 #{$border-width} 0;
             --o-wsale-filmstrip-wrapper-padding-bottom: 0;
+            --o-wsale-filmstrip-wrapper-width: 100%;
 
             --o-wsale-filmstrip-gap: 0;
 
@@ -384,6 +402,7 @@
 
         .o_wsale_filmstrip_wrapper {
             margin-bottom: map-get($spacers, 1);
+            width: var(--o-wsale-filmstrip-wrapper-width, auto);
             border-width: var(--o-wsale-filmstrip-wrapper-border-width, 0);
             border-style: solid;
             border-color: $border-color;
@@ -582,7 +601,7 @@
             }
 
             #o_wsale_products_grid {
-                box-shadow: inset 0 -1px 0 0px var(--border-color);
+                box-shadow: inset 0 -1px 0 0px var(--o-border-color);
             }
         }
 
@@ -602,6 +621,10 @@
                 }
                 @include media-breakpoint-up(lg) {
                     --o-wsale-topbar-border-width: 0 #{$border-width} #{$border-width} #{$border-width};
+                    #category_footer {
+                        border-right: #{$border-width} solid #{$border-color};
+                        border-left: #{$border-width} solid #{$border-color};
+                    }
                 }
             }
 
@@ -618,11 +641,14 @@
                     #o_wsale_pager {
                         border-left: 0;
                     }
+                    #category_footer {
+                        border-right: var(--o-wsale-sidebar-border);
+                    }
                 }
             }
 
             #o_wsale_products_grid {
-                box-shadow: inset -1px -1px 0 0px var(--border-color);
+                box-shadow: inset -1px -1px 0 0px var(--o-border-color);
             }
 
             &:where(:not(.o_wsale_has_sidebar)) #o_wsale_products_grid {

--- a/addons/website_sale/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale/static/src/scss/website_sale_comparison.scss
@@ -91,8 +91,6 @@
 
 // Specifications
 #product_full_spec {
-    border-top: 1px solid map-get($grays, '400');
-
     .o_add_compare_dyn {
         @include font-size(1.1rem);
     }

--- a/addons/website_sale/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale/static/src/scss/website_sale_wishlist.scss
@@ -29,6 +29,8 @@
 }
 
 #o_comparelist_table {
+    box-shadow: inset calc(var(--border-width) * -1) calc(var(--border-width) * -1) 0 0px var(--o-border-color);
+
     &.o_wsale_products_opt_layout_catalog,
     &.o_wsale_products_opt_layout_list {
         --o-wsale-products-grid-gap: var(--o-wsale-wishlist-grid-gap, 16px);
@@ -265,7 +267,7 @@
                     &:before {
                         @include o-position-absolute(0, auto, 0);
                         transform: translateX(calc(var(--_line-gap) * -1));
-                        border-left: $border-width solid $border-color;
+                        border-left: var(--border-width) solid var(--border-color);
                         content: "";
                     }
                 }

--- a/addons/website_sale/static/src/website_builder/product_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_page_option.xml
@@ -22,6 +22,12 @@
             />
         </BuilderButtonGroup>
     </BuilderRow>
+    <BuilderRow label.translate="Borders">
+        <BuilderButtonGroup action="'setProductPageBorderColor'" applyTo="'.o_wsale_product_page'">
+            <BuilderButton actionValue="'default'" actionParam="{ previewClass: 'o_wsale_border_default'}">Default</BuilderButton>
+            <BuilderButton actionValue="'strong'" actionParam="{ previewClass: 'o_wsale_custom_border o_wsale_product_border_strong'}">Strong</BuilderButton>
+        </BuilderButtonGroup>
+    </BuilderRow>
     <BuilderRow label.translate="Images Area">
         <BuilderSelect
             id="'o_wsale_image_width'"

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -26,6 +26,7 @@ export class ProductPageOptionPlugin extends Plugin {
             ProductReplaceMainImageAction,
             ProductAddExtraImageAction,
             ProductRemoveAllExtraImagesAction,
+            SetProductPageBorderColor,
         },
         clean_for_save_processors: (el) => {
             // TODO the content of this clean_for_save_processors should probably
@@ -412,6 +413,18 @@ export class ProductRemoveAllExtraImagesAction extends BaseProductPageAction {
             product_template_id: this.productTemplateID,
             combination_ids: this.getSelectedVariantValues(el),
         })
+    }
+}
+
+export class SetProductPageBorderColor extends PreviewableWebsiteConfigAction {
+    static id = "setProductPageBorderColor";
+
+    async apply({ editingElement, isPreviewing, params, value }) {
+        await super.apply({ editingElement, isPreviewing, params, value });
+
+        if (!isPreviewing) {
+            await rpc("/shop/config/website", { product_page_border_color: value });
+        }
     }
 }
 

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.js
@@ -1,5 +1,6 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { products_sort_mapping } from "@website_sale/website_builder/shared";
+import { onPatched } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
 export class ProductsListPageOption extends BaseOptionComponent {
@@ -9,6 +10,29 @@ export class ProductsListPageOption extends BaseOptionComponent {
     setup() {
         super.setup();
         this.products_sort_mapping = products_sort_mapping;
+
+        onPatched(() => {
+            if (!this.isBordersOptionVisible) {
+                this.env.editor.shared.builderActions.getAction("resetShopStrongBorder").apply();
+            }
+        });
+    }
+
+    get isBordersOptionVisible() {
+        return (
+            // Is sidebar visible
+            this.isActiveItem("categories_opt") ||
+            this.isActiveItem("attributes_opt") ||
+            // Is product tile not any of the unsupported templates
+            (!this.isActiveItem("list_thumbs_view_opt") &&
+            !this.isActiveItem("showcase_design_opt") &&
+            !this.isActiveItem("bento_design_opt")) ||
+            // Is filmstrip visible and not any of the unsupported templates
+            (this.isActiveItem("categories_opt_top") && (
+            !this.isActiveItem("filmstrip_default_opt") &&
+            !this.isActiveItem("filmstrip_images_opt") &&
+            !this.isActiveItem("filmstrip_large_images_opt")))
+        );
     }
 }
 

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -22,6 +22,12 @@
         </BuilderButtonGroup>
     </BuilderRow>
 
+    <BuilderRow label.translate="Borders">
+        <BuilderButtonGroup action="'setBorderColor'">
+            <BuilderButton actionValue="'default'" actionParam="{ previewClass: 'o_wsale_border_default'}">Default</BuilderButton>
+            <BuilderButton actionValue="'strong'" actionParam="{ previewClass: 'o_wsale_custom_border o_wsale_border_strong'}">Strong</BuilderButton>
+        </BuilderButtonGroup>
+    </BuilderRow>
 
     <BuilderContext applyTo="'#o_wsale_products_grid'">
         <ProductsDesignPanel

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -22,13 +22,6 @@
         </BuilderButtonGroup>
     </BuilderRow>
 
-    <BuilderRow label.translate="Borders">
-        <BuilderButtonGroup action="'setBorderColor'">
-            <BuilderButton actionValue="'default'" actionParam="{ previewClass: 'o_wsale_border_default'}">Default</BuilderButton>
-            <BuilderButton actionValue="'strong'" actionParam="{ previewClass: 'o_wsale_custom_border o_wsale_border_strong'}">Strong</BuilderButton>
-        </BuilderButtonGroup>
-    </BuilderRow>
-
     <BuilderContext applyTo="'#o_wsale_products_grid'">
         <ProductsDesignPanel
             recordName="'shop_opt_products_design_classes'"
@@ -48,6 +41,18 @@
                         classAction="'o_wsale_products_opt_layout_catalog'"
                     />
                     <BuilderButton classAction="'o_wsale_products_opt_layout_list'"/>
+                    <BuilderButton
+                        id="'list_thumbs_view_opt'"
+                        classAction="'o_wsale_products_opt_layout_catalog o_wsale_products_opt_design_thumbs'"
+                    />
+                    <BuilderButton
+                        id="'showcase_design_opt'"
+                        classAction="'o_wsale_products_opt_design_showcase'"
+                    />
+                    <BuilderButton
+                        id="'bento_design_opt'"
+                        classAction="'o_wsale_products_opt_design_bento'"
+                    />
                 </BuilderButtonGroup>
             </BuilderRow>
         </div>
@@ -103,6 +108,7 @@
         <BuilderSelect action="'websiteConfig'" t-if="this.isActiveItem('categories_opt_top')">
             <BuilderSelectItem actionParam="{views: []}" title.translate="Default">
                 <Image
+                    id="'filmstrip_default_opt'"
                     src="'/website_sale/static/src/img/filmstrips/default.svg'"
                     style="'width:120px;'"
                 />
@@ -135,6 +141,7 @@
                 />
             </BuilderSelectItem>
             <BuilderSelectItem
+                id="'filmstrip_images_opt'"
                 actionParam="{views: ['website_sale.filmstrip_categories_images']}"
                 title.translate="Images"
             >
@@ -153,6 +160,7 @@
                 />
             </BuilderSelectItem>
             <BuilderSelectItem
+                id="'filmstrip_large_images_opt'"
                 actionParam="{views: ['website_sale.filmstrip_categories_large_images']}"
                 title.translate="Large Images"
             >
@@ -162,6 +170,13 @@
                 />
             </BuilderSelectItem>
         </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow t-if="this.isBordersOptionVisible" label.translate="Borders">
+        <BuilderButtonGroup action="'setBorderColor'">
+            <BuilderButton actionValue="'default'" actionParam="{ previewClass: 'o_wsale_border_default'}">Default</BuilderButton>
+            <BuilderButton actionValue="'strong'" actionParam="{ previewClass: 'o_wsale_custom_border o_wsale_border_strong'}">Strong</BuilderButton>
+        </BuilderButtonGroup>
     </BuilderRow>
 
     <BuilderRow t-if="this.isActiveItem('categories_opt')" label.translate="Collapse Category Recursive" level="1">

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -10,6 +10,7 @@ export class ProductsListPageOptionPlugin extends Plugin {
     resources = {
         builder_actions: {
             SetShopContainerAction,
+            SetBorderColor,
             SetPpgAction,
             SetPprAction,
             SetDefaultSortAction,
@@ -68,6 +69,18 @@ export class SetDefaultSortAction extends BuilderAction {
     }
     apply({ value }) {
         return rpc("/shop/config/website", { shop_default_sort: value });
+    }
+}
+
+export class SetBorderColor extends PreviewableWebsiteConfigAction {
+    static id = "setBorderColor";
+
+    async apply({ editingElement: productDetailMainEl, isPreviewing, params, value }) {
+        await super.apply({ editingElement: productDetailMainEl, isPreviewing, params, value });
+
+        if (!isPreviewing) {
+            await rpc("/shop/config/website", { 'shop_border_color': value });
+        }
     }
 }
 

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -11,12 +11,14 @@ export class ProductsListPageOptionPlugin extends Plugin {
         builder_actions: {
             SetShopContainerAction,
             SetBorderColor,
+            ResetShopStrongBorderAction,
             SetPpgAction,
             SetPprAction,
             SetDefaultSortAction,
         },
     };
 }
+
 export class SetShopContainerAction extends PreviewableWebsiteConfigAction {
     static id = "setShopContainer";
 
@@ -80,6 +82,21 @@ export class SetBorderColor extends PreviewableWebsiteConfigAction {
 
         if (!isPreviewing) {
             await rpc("/shop/config/website", { 'shop_border_color': value });
+        }
+    }
+}
+
+// Action to reset the strong border -> default on the #o_wsale_container element
+// when the Border option is not visible.
+export class ResetShopStrongBorderAction extends BuilderAction {
+    static id = "resetShopStrongBorder";
+
+    apply() {
+        const el = this.editable.querySelector("#o_wsale_container");
+        if (el.classList.contains("o_wsale_border_strong")) {
+            el.classList.remove("o_wsale_border_strong", "o_wsale_custom_border");
+            el.classList.add("o_wsale_border_default");
+            return rpc("/shop/config/website", { shop_border_color: "default" });
         }
     }
 }

--- a/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
+++ b/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
@@ -13,7 +13,7 @@
                 t-attf-class="d-flex align-items-center gap-3 btn btn-light mb-2 me-3"
             >
                 <i class="fa fa-image fs-2 opacity-25" role="img"/>
-                <div class="placeholder opacity-25" t-att-style="`width: ${(this.c % 3) + 4}rem`"/>
+                <div class="placeholder opacity-25" t-att-style="`width: ${(category_placeholder_index % 3) + 4}rem`"/>
             </div>
         </div>
     </div>

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -188,7 +188,7 @@
                 t-set="show_mobile_cart_summary"
                 t-value="True if show_mobile_cart_summary is None else show_mobile_cart_summary"
             />
-            <div id="wrap" class="d-flex flex-column flex-grow-1">
+            <div id="wrap" t-attf-class="d-flex flex-column flex-grow-1 {{website.shop_border_color == 'default' and 'o_wsale_border_default' or 'o_wsale_custom_border o_wsale_border_' + website.shop_border_color}}">
                 <div class="oe_website_sale o_website_sale_checkout_container container d-flex flex-column flex-grow-1 py-lg-2">
                     <div t-attf-class="row #{not show_wizard_checkout and 'mt32'} mb32">
                         <div t-if="show_wizard_checkout" class="col-12">

--- a/addons/website_sale/templates/comparison_templates.xml
+++ b/addons/website_sale/templates/comparison_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="website_sale.product_compare" name="Comparator Page">
         <t t-call="website.layout" additional_title.translate="Shop Comparator">
-            <div id="wrap" class="o_wsale_comparison_page">
+            <div id="wrap" t-attf-class="o_wsale_comparison_page {{website.shop_border_color == 'default' and 'o_wsale_border_default' or 'o_wsale_custom_border o_wsale_border_' + website.shop_border_color}}">
                 <div class="oe_structure oe_empty" id="oe_structure_website_sale_comparison_product_compare_1"/>
                 <div t-attf-class="oe_website_sale pb-5 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                     <h1 class="h4 mt-4 mb-3">Compare Products</h1>
@@ -223,7 +223,7 @@
                 </div>
                 <div class="oe_structure" id="oe_structure_website_sale_comparison_product_compare_2"/>
                 <div class="align-items-end bottom-0 d-flex end-0 justify-content-end o_not_editable p-0 position-absolute top-0 start-0 pe-none">
-                    <div class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body pe-auto">
+                    <div t-attf-class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body pe-auto bg-danger">
                         <div t-attf-class="d-flex align-items-center py-3 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                             <a
                                 href="/shop"

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -23,7 +23,7 @@
         <t t-set="is_50_pc" t-value="website.product_page_image_width == '50_pc'"/>
 
         <t t-call="website.layout" additional_title="product.name">
-            <div id="wrap" class="o_wsale_product_page">
+            <div id="wrap" t-attf-class="o_wsale_product_page {{website._get_product_page_border_color() == 'default' and 'o_wsale_border_default' or' o_wsale_custom_border o_wsale_product_border_' + website._get_product_page_border_color()}}">
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
                 <section id="product_detail"
                          t-attf-class="oe_website_sale mt-1 mt-lg-2 mb-5 #{'discount'
@@ -824,7 +824,7 @@
         inherit_id="website_sale.product"
         name="Image Zoom On Click"
     >
-        <xpath expr='//div[hasclass("o_wsale_product_page")]' position='attributes'>
+        <xpath expr='//div[contains(@t-attf-class, "o_wsale_product_page")]' position='attributes'>
             <attribute name="data-ecom-zoom-click">1</attribute>
             <attribute name="t-att-data-image-ratio">website.product_page_image_ratio</attribute>
             <attribute name="t-att-data-image-ratio-mobile">website.product_page_image_ratio_mobile</attribute>
@@ -1360,7 +1360,7 @@
         <xpath expr="//div[@id='product_full_description']" position="after">
             <t t-set="attrib_categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-if="attrib_categories">
-                <section class="pt32 pb32" id="product_full_spec">
+                <section class="pt32 pb32 border-top" id="product_full_spec">
                     <div class="container">
                         <div class="d-flex justify-content-between align-items-center mb-4">
                             <h2 class="m-0 h3">Specifications</h2>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -227,7 +227,8 @@
                         {{opt_wsale_floating_bar and 'o_wsale_has_floating_bar'}}
                         {{hasLeftColumn and 'o_wsale_has_sidebar'}}
                         {{editionPreviews and 'o_wsale_edit_preview_enabled'}}
-                        {{opt_wsale_design_grid and 'o_wsale_uses_grid_design'}}"
+                        {{opt_wsale_design_grid and 'o_wsale_uses_grid_design'}}
+                        {{website.shop_border_color == 'default' and 'o_wsale_border_default' or 'o_wsale_custom_border o_wsale_border_' + website.shop_border_color}}"
                     t-att-data-ppg="ppg"
                     t-att-data-ppr="ppr"
                     t-att-data-default-sort="website.shop_default_sort"
@@ -239,7 +240,7 @@
                             class="d-none d-lg-block position-sticky align-self-start col clearfix pt-2"
                         >
                             <t t-call="website_sale.sidebar_dropzone_at_top"/>
-                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 px-lg-2 ps-2 overflow-y-scroll">
+                            <div class="o_wsale_products_grid_before_rail ms-n2 px-lg-2 ps-2 overflow-y-scroll">
                                 <t
                                     t-set="is_sidebar_collapsible"
                                     t-value="is_view_active('website_sale.products_categories_list_collapsible')"
@@ -559,7 +560,7 @@
                                     "<t t-out='category.name'/>" category.
                                 </t>
                                 <div
-                                    class="mb16"
+                                    class="pb16"
                                     id="category_footer"
                                     t-att-data-editor-message="footer_editor_message"
                                     t-field="category.website_footer"

--- a/addons/website_sale/templates/wishlist_templates.xml
+++ b/addons/website_sale/templates/wishlist_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="website_sale.product_wishlist" name="Wishlist Page">
         <t t-call="website.layout" additional_title.translate="Shop Wishlist">
-            <div id="wrap" class="o_wsale_wishlist_page">
+            <div id="wrap" t-attf-class="o_wsale_wishlist_page {{website.shop_border_color and 'o_wsale_custom_border o_wsale_border_' + website.shop_border_color}}">
                 <div class="oe_structure" id="oe_structure_website_sale_wishlist_product_wishlist_1"/>
                 <div class="container oe_website_sale">
                     <section class="container wishlist-section pb-5">


### PR DESCRIPTION
- Add a new "border strong" setting for website_sale.
  This setting if set in the shop page is applied everywhere but can be
  overridden with the product page border setting.

- Review the products_opt_design_grid design to better showcase borders
- Let the grid filmstrip fill the width. It was causing an issue with
the centered category setting.
- Remove vh-100 on the sidebar for a max-width it was causing an issue
when the grid < page height.
- Fix #category_footer missing border on category pages.

task-5006187



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
