### PR TITLE
[FIX] hr_attendance: Overtime Ruleset form view title UI

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -106,12 +106,10 @@
                         help="Regenerate overtimes for this ruleset"/>
                 </header>
                 <sheet>
-                    <header>
-                        <div class="oe_title">
-                            <label for="name" string="Ruleset Name"/>
-                            <h1><field name="name" placeholder="e.g. Legal Rules"/></h1>
-                        </div>
-                    </header>
+                    <div class="oe_title">
+                        <label for="name" string="Ruleset Name"/>
+                        <h1><field name="name" placeholder="e.g. Legal Rules"/></h1>
+                    </div>
                     <group>
                         <group>
                             <field name="rate_combination_mode"/>


### PR DESCRIPTION
**Before this commit**
The title of an overtime ruleset record was shown with the incorrect background color and width. This is because the field was mistakenly wrapped in a `<header>` element. This makes the overtime ruleset titles look inconsistent compared to other forms in Odoo.

Light mode
<img width="1573" height="1027" alt="Screenshot 2026-03-25 at 12 48 14 PM" src="https://github.com/user-attachments/assets/602ae625-d80d-45c3-bc01-f928ab179b7a" />

Dark mode
<img width="1570" height="1025" alt="Screenshot 2026-03-25 at 12 49 03 PM" src="https://github.com/user-attachments/assets/14b3a1ee-33c0-4c3e-b66f-79d450baa6ac" />


**After this commit**
We remove the `<header>` element that wraps the title so that its background and width match the expected styling for forms in Odoo.

Light mode
<img width="1575" height="1027" alt="Screenshot 2026-03-25 at 2 19 35 PM" src="https://github.com/user-attachments/assets/ee2dd6bd-3ab2-487c-8826-c2334f5e1258" />

Dark mode
<img width="1573" height="1024" alt="Screenshot 2026-03-25 at 2 19 09 PM" src="https://github.com/user-attachments/assets/cb59bdeb-f599-4553-acc1-991bf923756d" />

opw-6069360