### PR TITLE
[IMP] html_editor: qweb directive expression tooltip on click

### DIFF
--- a/addons/html_editor/static/src/others/qweb_picker.js
+++ b/addons/html_editor/static/src/others/qweb_picker.js
@@ -3,7 +3,7 @@ import { Component } from "@odoo/owl";
 
 export class QWebPicker extends Component {
     static template = "html_editor.QWebPicker";
-    static props = ["groups", "select"];
+    static props = ["groups", "select", "expression?"];
 
     setup() {
         this.state = useState({ groups: this.props.groups });

--- a/addons/html_editor/static/src/others/qweb_picker.xml
+++ b/addons/html_editor/static/src/others/qweb_picker.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.QWebPicker">
-        <div class="o-we-qweb-picker bg-white my-1">
+        <div class="o-we-qweb-picker rounded bg-white my-1">
             <t t-foreach="this.state.groups" t-as="group" t-key="group_index">
                 <select class="form-select" t-on-change="this.onChange">
                     <t t-foreach="group" t-as="element" t-key="element_index">
@@ -9,6 +9,11 @@
                         </option>
                     </t>
                 </select>
+            </t>
+            <t t-if="this.props.expression and !this.state.groups.length">
+                <div class="px-2 py-1 shadow-sm border rounded">
+                    <t t-out="this.props.expression"/>
+                </div>
             </t>
         </div>
     </t>

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -183,7 +183,7 @@ export class QWebPlugin extends Plugin {
             }
         }
         const targetNode = ev.target;
-        if (targetNode.closest("[data-oe-t-group]")) {
+        if (targetNode.closest("[data-oe-t-group], [t-out], [t-field]")) {
             this.selectNode(targetNode);
         }
     }
@@ -194,11 +194,15 @@ export class QWebPlugin extends Plugin {
             return;
         }
         this.selectedNode = node;
+        const attr = ["t-out", "t-field"].find((a) => node.hasAttribute(a));
         this.picker.open({
             target: node,
             props: {
                 groups: this.getNodeGroups(node),
                 select: this.select.bind(this),
+                ...(attr && {
+                    expression: `${attr}: ${node.getAttribute(attr)}`,
+                }),
             },
         });
     }

--- a/addons/html_editor/static/src/others/qweb_plugin.scss
+++ b/addons/html_editor/static/src/others/qweb_plugin.scss
@@ -9,13 +9,18 @@
     t,
     [t-esc],
     [t-out],
-    [t-raw] {
+    [t-raw],
+    [t-field] {
         border-radius: 2px;
     }
     [t-esc],
     [t-out],
-    [t-raw] {
+    [t-raw],
+    [t-field] {
         background-color: rgba(36, 154, 255, 0.16) !important;
+    }
+    [t-field]:empty::before {
+        content: attr(t-field);
     }
     [t-esc]:empty::before {
         content: attr(t-esc);

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -14,6 +14,7 @@ import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { processThroughCleanForSave } from "./_helpers/dispatch";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 const config = { Plugins: [...MAIN_PLUGINS, QWebPlugin] };
 describe("qweb picker", () => {
@@ -250,6 +251,34 @@ describe("qweb picker", () => {
     });
 });
 
+test("show t-out expression in picker on click", async () => {
+    const { el } = await setupEditor(`<div><t t-out="test">Hello</t></div>`, {
+        config,
+    });
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
+    await click(queryOne(`[t-out]`));
+    await expectElementCount(".o-we-qweb-picker", 1);
+    expect(queryOne(".o-we-qweb-picker div")).toHaveText("t-out: test");
+});
+
+test("show t-field expression in picker on click", async () => {
+    const { el } = await setupEditor(`<div><t t-field="test">Hello</t></div>`, {
+        config,
+    });
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
+    await click(queryOne(`[t-field]`));
+    await expectElementCount(".o-we-qweb-picker", 1);
+    expect(queryOne(".o-we-qweb-picker div")).toHaveText("t-field: test");
+});
+
 test("select text inside t-out", async () => {
     const { el } = await setupEditor(`<div><t t-out="test">Hello</t></div>`, {
         config,
@@ -277,27 +306,27 @@ test("select text inside t-out", async () => {
 });
 
 test("select text inside t-esc", async () => {
-    const { el } = await setupEditor(`<div><t t-out="test">Hello</t></div>`, {
+    const { el } = await setupEditor(`<div><t t-esc="test">Hello</t></div>`, {
         config,
     });
     expect(getContent(el)).toBe(
         '<p data-selection-placeholder=""><br></p>' +
-            `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
             '<p data-selection-placeholder=""><br></p>'
     );
 
-    setSelection({ anchorNode: el.querySelector("t[t-out]").childNodes[0], anchorOffset: 1 });
+    setSelection({ anchorNode: el.querySelector("t[t-esc]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
         '<p data-selection-placeholder=""><br></p>' +
-            `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>` +
+            `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>` +
             '<p data-selection-placeholder=""><br></p>'
     );
     await dblclick("t");
     expect(getContent(el)).toBe(
         '<p data-selection-placeholder=""><br></p>' +
-            `<div>[<t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>` +
+            `<div>[<t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>` +
             '<p data-selection-placeholder=""><br></p>'
     );
 });


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- Clicking a qweb output directive (t-out, t-esc, t-field) in the editor required switching to code view to inspect its expression.

#### Desired behavior after PR is merged:

- Clicking on a qweb output directive node in the editor shows its expression (e.g. "t-out: object.partner_id.name or ") in a tooltip without switching to code view.

task-6045177

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
