### PR TITLE
[FIX] l10n_jo_edi_pos: ensure order UUID exists

### DIFF
--- a/addons/l10n_jo_edi_pos/models/pos_edi_ubl_21_jo.py
+++ b/addons/l10n_jo_edi_pos/models/pos_edi_ubl_21_jo.py
@@ -126,6 +126,7 @@ class PosEdiXmlUBL21Jo(models.AbstractModel):
 
     def _add_pos_order_header_nodes(self, document_node, vals):
         pos_order = vals['pos_order']
+        pos_order._compute_l10n_jo_edi_pos_uuid()
         document_node.update({
             'cbc:ProfileID': {'_text': 'reporting:1.0'},
             'cbc:ID': {'_text': (pos_order.name or '').replace('/', '_')},


### PR DESCRIPTION
Currently, POS orders in Jordan do not have a UUID if they were created
before installing the module. This causes submission failures to JoFotara.

Steps to reproduce:
- Create a POS order in Jordan without the module l10n_jo_edi_pos installed
- Install l10n_jo_edi_pos
- Try to submit the order to JoFotara, it fails due to
missing UUID with the error "Invoice UUID is required"

This fix force a computation of the order UUID when we add the header
node, to ensure that this will not cause submission failures to JoFotara.

opw-6041688