### PR TITLE
[FIX] html_editor: preserve icons when creating links from selections

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -397,7 +397,7 @@ export class LinkPlugin extends Plugin {
         }
 
         const selectionTextContent = selection?.textContent();
-        const isImage = !!findInSelection(selection, "img");
+        const isImage = !!findInSelection(selection, "img, .fa");
 
         const applyCallback = (url, label, classes, attachmentId) => {
             if (this.linkInDocument && isImage) {
@@ -524,7 +524,7 @@ export class LinkPlugin extends Plugin {
                 });
                 this.dependencies.color.removeAllColor();
                 // Remove the current link (linkInDocument) if it has no content
-                if (cleanZWChars(link.innerText) === "" && !link.querySelector("img")) {
+                if (cleanZWChars(link.innerText) === "" && !link.querySelector("img, .fa")) {
                     const [anchorNode, anchorOffset] = rightPos(link);
                     // We force the cursor after the link before removing the link
                     // to ensure we don't lose the selection position.
@@ -631,7 +631,7 @@ export class LinkPlugin extends Plugin {
         } else if (!selection.isCollapsed) {
             // Open the link tool only if we have an image selected and the selection
             // is fully contained in the image parent link.
-            const imageNode = findInSelection(selection, "img");
+            const imageNode = findInSelection(selection, "img, .fa");
             const parentElement = imageNode?.parentElement;
             if (
                 imageNode?.parentNode?.tagName === "A" &&

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -339,3 +339,19 @@ test("should insert two empty paragraphs when Enter is pressed twice before the 
         `<p><br></p><p><br></p><p>\ufeff[]<span class="fa fa-glass" contenteditable="false">\u200B</span>\ufeff</p>`
     );
 });
+
+test("should not allow to edit label if selection contain icon", async () => {
+    await setupEditor(`<p>[ab<span class="fa fa-glass" contenteditable="false"></span>]</p>`);
+    await waitFor(".o-we-toolbar");
+    await click('.o-we-toolbar button[title="Link"]');
+    await waitFor('[name="o_linkpopover_url_img"]');
+    expect('[name="o_linkpopover_url_img"]').toHaveCount(1);
+});
+
+test("should be able to unlink an icon", async () => {
+    await setupEditor(
+        `<p><a href="#" class="my_link o_link_in_selection">[<span class="fa fa-glass" contenteditable="false"></span>]</a></p>`
+    );
+    await click(".o_we_remove_link");
+    expect(".my_link").toHaveCount(0);
+});


### PR DESCRIPTION
Problem:
When a selection contains both text and an icon, creating a link removes the icon from the content.

Cause:
Icons should be treated the same way as images during link creation. If an icon is present in the selection but not handled like an image, it gets removed when the link is applied.

Solution:
Handle icons in the same way as images when processing selections for link creation, ensuring they are preserved.

Steps to reproduce:
- Add text "abc" followed by an icon.
- Select both the text and the icon.
- Create a link.
- Observe that the icon is removed and only the text remains.

opw-6066195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
