### PR TITLE
[FIX] im_livechat: fix /lead command history issue

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -152,11 +152,12 @@ class DiscussChannel(models.Model):
         """
         Converting message body back to plaintext for correct data formatting in HTML field.
         """
-        # sudo - chatbot.message: visitor can access chat bot messages.
+        # sudo - mail.message: visitors can access messages on chats they have access to
+        messages = self.sudo().chatbot_message_ids.mail_message_id or self.message_ids
         return Markup("").join(
             Markup("%s: %s<br/>")
             % (m.author_id.name or self.anonymous_name, html2plaintext(m.body))
-            for m in self.sudo().chatbot_message_ids.mail_message_id.sorted("id")
+            for m in messages.sorted("id")
         )
 
     # =======================

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from freezegun import freeze_time
 from unittest.mock import patch, PropertyMock
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tools.misc import limited_field_access_token
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.mail.tests.common import MailCommon
@@ -396,3 +396,21 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             partner_ids=self.operators[0].partner_id.ids
         )
         self.assertEqual(self_member.partner_id, self.operators[0].partner_id)
+
+    def test_livechat_conversation_history(self):
+        self.authenticate(self.operators[0].login, self.password)
+        channel = self.env["discuss.channel"].create(
+            {
+                "name": "test",
+                "channel_type": "livechat",
+                "livechat_operator_id": self.operators[0].partner_id.id,
+                "channel_member_ids": [
+                    Command.create({"partner_id": self.operators[0].partner_id.id}),
+                    Command.create({"partner_id": self.visitor_user.partner_id.id}),
+                ],
+            }
+        )
+        channel.message_post(author_id=self.operators[0].partner_id.id, body="Operator Here")
+        channel.with_user(self.visitor_user).message_post(author_id=self.visitor_user.partner_id.id, body="Visitor Here")
+        channel_history = channel._get_channel_history()
+        self.assertEqual(channel_history, "Michel: Operator Here<br/>Rajesh: Visitor Here<br/>")


### PR DESCRIPTION
In PR: https://github.com/odoo/odoo/pull/253566, _get_channel_history was modified to fetch messages from `chatbot_message_ids.mail_message_id` instead of `message_ids`.

This caused an issue where the `/lead` command was not working correctly when no chatbot is associated, resulting in an empty conversation history.

This commit fixes the issue by falling back to `message_ids` when `chatbot_message_ids` is not available.