### PR TITLE
[FIX] mrp, mrp_plm: prevent crash when updating BoM after ECO revision

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2599,7 +2599,8 @@ class MrpProduction(models.Model):
             if self.state == 'draft':
                 # Don't straight delete the moves/workorders to avoid to cancel the MO, those will
                 # be deleted once the BoM is assigned (and thus after new moves/WO were created).
-                moves_to_unlink = self.move_raw_ids
+                # except if the BoM has changed, in which case the moves will be removed in compute_move_raw_ids.
+                moves_to_unlink = self.move_raw_ids.filtered(lambda m: m.bom_line_id.bom_id == bom)
                 workorders_to_unlink = self.workorder_ids
             self.bom_id = bom
             moves_to_unlink.unlink()


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product "P1"
- Create a BoM:
    - Component: C1

- Create a manufacturing order to produce 1 unit of P1
- Keep the MO in draft state
- Open the BoM:
- Click on the ECO smart button
- Create a new ECO and start the revision

- Open BoM V2:
    - Delete component C1 and replace it with component C2
    - Validate the revision

-> BoM V1 is archived (expected behavior)

- Open the MO: -> Since BoM V1 is archived, BoM V2 is automatically set in the field `latest_bom_id` through `_compute_latest_bom_id`

Result:
The "Update BoM" button becomes visible in the view and can be clicked:

https://github.com/odoo/enterprise/blob/d1e75bf651ba06ce065afa8e6ca18e6b25e2dfce/mrp_plm/views/mrp_production_views.xml#L32

Problem:
Clicking on "Update BoM" raises the following error:

```
Record does not exist or has been deleted.
(Record: stock.move(29,), User: 2)
```

Explanation:
When clicking on "Update BoM", the method `action_update_bom` calls `_link_bom` with the new BoM (V2).

https://github.com/odoo/enterprise/blob/96ef7f9eab64c22de4bb63ddb2ca1265d507aff7/mrp_plm/models/mrp_production.py#L78-L79

Before assigning the new BoM and creating the new component moves, the existing moves (linked to component C1) are stored in a variable, to be unlinked later:
https://github.com/odoo/odoo/blob/e831903612efbb21698d911c5b156ecdcdcae531/addons/mrp/models/mrp_production.py#L2163-L2165

Then the new BoM is assigned, which triggers `_compute_move_raw_ids`. Since this is a real BoM change (V1 → V2) and not a simple recomputation of the same BoM, the existing moves are automatically unlinked.

https://github.com/odoo/odoo/blob/e831903612efbb21698d911c5b156ecdcdcae531/addons/mrp/models/mrp_production.py#L714-L715

After that, `_link_bom` still tries to unlink the previously stored moves, which no longer exist, and this raises the error.

https://github.com/odoo/odoo/blob/e831903612efbb21698d911c5b156ecdcdcae531/addons/mrp/models/mrp_production.py#L2166

Solution:
Only unlink the moves that still belong to the current BoM in order to avoid trying to delete already removed records.

opw-6069371