### PR TITLE
[IMP] html_editor: add public param to attachment creation

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -87,7 +87,7 @@ def get_existing_attachment(IrAttachment, vals):
     return IrAttachment.search(domain, limit=1) or None
 
 
-def attachment_create(IrAttachment, name='', data=False, url=False, res_id=False, res_model='ir.ui.view'):
+def attachment_create(IrAttachment, name='', data=False, url=False, res_id=False, res_model='ir.ui.view', public=False):
     """Create and return a new attachment."""
     if name.lower().endswith('.bmp'):
         # Avoid mismatch between content type and mimetype, see commit msg
@@ -103,7 +103,7 @@ def attachment_create(IrAttachment, name='', data=False, url=False, res_id=False
 
     attachment_data = {
         'name': name,
-        'public': res_model == 'ir.ui.view',
+        'public': public,
         'res_id': res_id,
         'res_model': res_model,
     }
@@ -427,7 +427,7 @@ class HTML_Editor(Controller):
         )
 
     @route(['/web_editor/attachment/add_data', '/html_editor/attachment/add_data'], type='jsonrpc', auth='user', methods=['POST'], website=True)
-    def add_data(self, name, data, is_image, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', **kwargs):
+    def add_data(self, name, data, is_image, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', public=False, **kwargs):
         data = b64decode(data)
         if is_image:
             format_error_msg = _("Uploaded image's format is not supported. Try with: %s", ', '.join(SUPPORTED_IMAGE_MIMETYPES.values()))
@@ -448,13 +448,13 @@ class HTML_Editor(Controller):
                 return {'error': e.args[0]}
 
         self._clean_context()
-        attachment = attachment_create(request.env['ir.attachment'], name=name, data=data, res_id=res_id, res_model=res_model)
+        attachment = attachment_create(request.env['ir.attachment'], name=name, data=data, res_id=res_id, res_model=res_model, public=public)
         return attachment._get_media_info()
 
     @route(['/web_editor/attachment/add_url', '/html_editor/attachment/add_url'], type='jsonrpc', auth='user', methods=['POST'], website=True)
-    def add_url(self, url, res_id=False, res_model='ir.ui.view', **kwargs):
+    def add_url(self, url, res_id=False, res_model='ir.ui.view', public=False, **kwargs):
         self._clean_context()
-        attachment = attachment_create(request.env['ir.attachment'], url=url, res_id=res_id, res_model=res_model)
+        attachment = attachment_create(request.env['ir.attachment'], url=url, res_id=res_id, res_model=res_model, public=public)
         return attachment._get_media_info()
 
     @route(['/web_editor/modify_image/<model("ir.attachment"):attachment>', '/html_editor/modify_image/<model("ir.attachment"):attachment>'], type="jsonrpc", auth="user", website=True)

--- a/addons/html_editor/static/src/main/media/image_save_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_save_plugin.js
@@ -76,6 +76,7 @@ export class ImageSavePlugin extends Plugin {
             is_image: true,
             res_model: resModel,
             res_id: resId,
+            public: true,
         });
     }
 
@@ -113,19 +114,7 @@ export class ImageSavePlugin extends Plugin {
             el.dataset.fileName = attachment.name;
             return this.saveModifiedImage(el, resModel, resId);
         } else {
-            let src = attachment.image_src;
-            if (!attachment.public) {
-                let accessToken = attachment.access_token;
-                if (!accessToken) {
-                    [accessToken] = await this.services.orm.call(
-                        "ir.attachment",
-                        "generate_access_token",
-                        [attachment.id]
-                    );
-                }
-                src += `?access_token=${encodeURIComponent(accessToken)}`;
-            }
-            el.setAttribute("src", src);
+            el.setAttribute("src", attachment.image_src);
         }
         el.classList.remove("o_b64_image_to_save");
     }

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -69,6 +69,7 @@ export const uploadService = {
                 is_image: true,
                 width: 0,
                 quality: 0,
+                public: true,
             });
         };
 
@@ -206,6 +207,7 @@ export const uploadService = {
                                 is_image: !!isImage,
                                 width: 0,
                                 quality: 0,
+                                public: true,
                             },
                             { xhr: currentXHR }
                         );

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2485,12 +2485,11 @@ describe("save image", () => {
         ];
         onRpc("/html_editor/attachment/add_data", async (request) => {
             const { params } = await request.json();
-            const { res_id, res_model } = params;
-            expect.step(`add_data: ${res_model} ${res_id}`);
+            expect.step(`add_data: ${params.res_model} ${params.res_id}`);
+            expect(params.public).toBe(true);
             return {
                 image_src: "/test_image_url.png",
-                access_token: "1234",
-                public: false,
+                public: true,
             };
         });
 
@@ -2519,7 +2518,7 @@ describe("save image", () => {
 
         // Save changes.
         await contains(".o_form_button_save").click();
-        expect(img.getAttribute("src")).toBe("/test_image_url.png?access_token=1234");
+        expect(img.getAttribute("src")).toBe("/test_image_url.png");
         expect(img).not.toHaveClass("o_b64_image_to_save");
         expect.verifySteps(["add_data: partner 1"]);
     });
@@ -2535,21 +2534,20 @@ describe("save image", () => {
         const def = new Deferred();
         onRpc("/html_editor/attachment/add_data", async (request) => {
             const { params } = await request.json();
-            const { res_id, res_model } = params;
-            expect.step(`add_data-start: ${res_model} ${res_id}`);
+            expect.step(`add_data-start: ${params.res_model} ${params.res_id}`);
+            expect(params.public).toBe(true);
             await def;
-            expect.step(`add_data-end: ${res_model} ${res_id}`);
+            expect.step(`add_data-end: ${params.res_model} ${params.res_id}`);
             return {
                 image_src: "/test_image_url.png",
-                access_token: "1234",
-                public: false,
+                public: true,
             };
         });
 
         onRpc("partner", "web_save", ({ args }) => {
             expect.step("web_save");
             expect(args[1].txt).toBe(
-                `<p class="test_target"><img class="img-fluid" data-file-name="test_image.png" src="/test_image_url.png?access_token=1234"></p>`
+                `<p class="test_target"><img class="img-fluid" data-file-name="test_image.png" src="/test_image_url.png"></p>`
             );
         });
 
@@ -2583,7 +2581,7 @@ describe("save image", () => {
 
         def.resolve();
         await tick();
-        expect(img.getAttribute("src")).toBe("/test_image_url.png?access_token=1234");
+        expect(img.getAttribute("src")).toBe("/test_image_url.png");
         expect(img).not.toHaveClass("o_b64_image_to_save");
 
         expect.verifySteps(["add_data-start: partner 1", "add_data-end: partner 1", "web_save"]);
@@ -2604,21 +2602,20 @@ describe("save image", () => {
         const def = new Deferred();
         onRpc("/html_editor/attachment/add_data", async (request) => {
             const { params } = await request.json();
-            const { res_id, res_model } = params;
-            expect.step(`add_data-start: ${res_model} ${res_id}`);
+            expect.step(`add_data-start: ${params.res_model} ${params.res_id}`);
+            expect(params.public).toBe(true);
             await def;
-            expect.step(`add_data-end: ${res_model} ${res_id}`);
+            expect.step(`add_data-end: ${params.res_model} ${params.res_id}`);
             return {
                 image_src: "/test_image_url.png",
-                access_token: "1234",
-                public: false,
+                public: true,
             };
         });
 
         onRpc("partner", "web_save", ({ args }) => {
             expect.step("web_save");
             expect(args[1].txt).toBe(
-                `<p class="test_target"><img class="img-fluid" data-file-name="test_image.png" src="/test_image_url.png?access_token=1234"></p>`
+                `<p class="test_target"><img class="img-fluid" data-file-name="test_image.png" src="/test_image_url.png"></p>`
             );
         });
 
@@ -2659,59 +2656,6 @@ describe("save image", () => {
         expect.verifySteps(["add_data-start: partner 1", "add_data-end: partner 1", "web_save"]);
     });
 
-    test("Pasted/dropped images are converted to attachments without access_token on save", async () => {
-        Partner._records = [
-            {
-                id: 1,
-                txt: "<p class='test_target'><br></p>",
-            },
-        ];
-        onRpc("/html_editor/attachment/add_data", async (request) => {
-            const { params } = await request.json();
-            const { res_id, res_model } = params;
-            expect.step(`add_data: ${res_model} ${res_id}`);
-            return {
-                image_src: "/test_image_url.png",
-                id: 123,
-                public: false,
-            };
-        });
-
-        onRpc("ir.attachment", "generate_access_token", ({ args }) => {
-            expect.step(`generate_access_token: ${args}`);
-            return ["12345"];
-        });
-
-        await mountView({
-            type: "form",
-            resId: 1,
-            resModel: "partner",
-            arch: `
-                <form>
-                    <field name="txt" widget="html"/>
-                </form>`,
-        });
-        setSelectionInHtmlField(".test_target");
-
-        // Paste image.
-        pasteFile(
-            htmlEditor,
-            createBase64ImageFile(
-                "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
-            )
-        );
-        await waitFor("img");
-        const img = htmlEditor.editable.querySelector("img");
-        expect(img.src.startsWith("data:image/png;base64,")).toBe(true);
-        expect(img).toHaveClass("o_b64_image_to_save");
-
-        // Save changes.
-        await contains(".o_form_button_save").click();
-        expect(img.getAttribute("src")).toBe("/test_image_url.png?access_token=12345");
-        expect(img).not.toHaveClass("o_b64_image_to_save");
-        expect.verifySteps(["add_data: partner 1", "generate_access_token: 123"]);
-    });
-
     test("Ensure a traceback is not raised when hiding an HtmlField with unsaved images", async () => {
         Partner._records = [
             {
@@ -2722,15 +2666,14 @@ describe("save image", () => {
 
         onRpc("/html_editor/attachment/add_data", async (request) => {
             const { params } = await request.json();
-            const { res_id, res_model } = params;
-            expect.step(`add_data-start: ${res_model} ${res_id}`);
+            expect.step(`add_data-start: ${params.res_model} ${params.res_id}`);
+            expect(params.public).toBe(true);
             // add a delay to emulate saving a big image.
             await delay(50);
-            expect.step(`add_data-end: ${res_model} ${res_id}`);
+            expect.step(`add_data-end: ${params.res_model} ${params.res_id}`);
             return {
                 image_src: "/test_image_url.png",
-                access_token: "1234",
-                public: false,
+                public: true,
             };
         });
 
@@ -2770,7 +2713,7 @@ describe("save image", () => {
         await waitFor(".o_notebook_headers .nav-link.active[name='html']");
         await waitFor(".odoo-editor-editable", { timeout: 1500 });
         const savedImg = htmlEditor.editable.querySelector("img");
-        expect(savedImg.getAttribute("src")).toBe("/test_image_url.png?access_token=1234");
+        expect(savedImg.getAttribute("src")).toBe("/test_image_url.png");
         expect(savedImg).not.toHaveClass("o_b64_image_to_save");
 
         expect.verifySteps(["add_data-start: partner 1", "add_data-end: partner 1"]);

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -123,17 +123,17 @@ test("pasted/dropped images are converted to attachments on save in website edit
         ).toBe(true);
         expect(params.res_id).toBe(`${setupWebsiteBuilderOeId}`);
         expect(params.res_model).toBe("ir.ui.view");
+        expect(params.public).toBe(true);
         expect.step("add_data");
         return {
             image_src: "/test_image_url.png",
-            access_token: "1234",
-            public: false,
+            public: true,
         };
     });
 
     onRpc("ir.ui.view", "save", ({ args }) => {
         expect.step("save");
-        expect(args[1]).toInclude('src="/test_image_url.png?access_token=1234"');
+        expect(args[1]).toInclude('src="/test_image_url.png"');
         return true;
     });
 
@@ -148,7 +148,7 @@ test("pasted/dropped images are converted to attachments on save in website edit
     const editor = getEditor();
 
     // Paste image
-    var p = queryOne(":iframe section > p:has(br)");
+    const p = queryOne(":iframe section > p:has(br)");
     setSelection({ anchorNode: p, anchorOffset: 0 });
     pasteFile(
         editor,
@@ -174,24 +174,24 @@ test("pasted/dropped images are converted to attachments on snippet save", async
     onRpc("/html_editor/attachment/add_data", async (request) => {
         const { params } = await request.json();
         expect(params.data).toBe(imageData + "=");
+        expect(params.public).toBe(true);
         expect.step(`add_data ${params.name}`);
         return {
             image_src: `/url_${params.name}`,
-            access_token: "1234",
-            public: false,
+            public: true,
         };
     });
 
     onRpc("ir.ui.view", "save_snippet", ({ kwargs }) => {
         expect.step("save snippet");
-        expect(kwargs.arch).toInclude('src="/url_image-1.png?access_token=1234"');
+        expect(kwargs.arch).toInclude('src="/url_image-1.png"');
         return "Custom Cover";
     });
 
     onRpc("ir.ui.view", "save", ({ args }) => {
         expect.step("save");
-        expect(args[1]).toInclude('src="/url_image-1.png?access_token=1234"');
-        expect(args[1]).toInclude('src="/url_image-2.png?access_token=1234"');
+        expect(args[1]).toInclude('src="/url_image-1.png"');
+        expect(args[1]).toInclude('src="/url_image-2.png"');
         return true;
     });
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Attachment visibility (public/private) was implicitly determined based on `res_model == 'ir.ui.view'`.
- Attachments created in other contexts were private by default.
- The frontend had to generate an access_token via an extra RPC and manually update image URLs to make them accessible.

### Desired behavior after PR is merged:

- A `public` parameter is introduced in attachment creation to explicitly control visibility.
- Attachments that should be public are created as such directly.
- The need for `generate_access_token` calls and manual URL patching in the frontend is removed.
- This simplifies the flow, removes implicit logic based on `res_model`, and avoids unnecessary RPC calls.

task-6034214

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
