### PR TITLE
[FIX] website, html_builder: unfold parent's option if likely intended

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -1,7 +1,7 @@
 declare module "plugins" {
     import { AnchorShared } from "@html_builder/core/anchor/anchor_plugin";
     import { builder_components, BuilderComponentShared } from "@html_builder/core/builder_component_plugin";
-    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
+    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, on_restore_containers_handlers, remove_disabled_reason_providers, auto_unfold_container_providers } from "@html_builder/core/builder_options_plugin";
     import { BuilderOverlayShared } from "@html_builder/core/builder_overlay/builder_overlay_plugin";
     import { CachedModelShared } from "@html_builder/core/cached_model_plugin";
     import { CloneShared, on_cloned_handlers, on_will_clone_handlers } from "@html_builder/core/clone_plugin";
@@ -121,6 +121,7 @@ declare module "plugins" {
         // Processors
 
         // Providers
+        auto_unfold_container_providers: auto_unfold_container_providers;
         background_filter_target_providers: background_filter_target_providers;
         background_shape_target_providers: background_shape_target_providers;
         clone_disabled_reason_providers: clone_disabled_reason_providers;

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -67,6 +67,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  *
  * @typedef {((el: HTMLElement) => [] | BuilderButtonDescriptor[])[]} get_options_container_top_buttons
  *
+ * @typedef {({selector: CSSSelector, target: CSSSelector})[]} auto_unfold_container_providers
  * @typedef {{
  *     Component: Component;
  *     selector: CSSSelector;
@@ -416,6 +417,19 @@ export class BuilderOptionsPlugin extends Plugin {
         const lastContainerWithOptions = containers.findLast((c) => c.options.length);
         if (lastContainerWithOptions) {
             lastContainerWithOptions.folded = false;
+            // The following is used in case the options in the last container
+            // are not likely the ones the user wants. After we re-organize the
+            // options to avoid these cases, this will be removed
+            for (const { selector, target } of this.getResource(
+                "auto_unfold_container_providers"
+            )) {
+                if (lastContainerWithOptions.element.matches(selector)) {
+                    const ancestorContainer = containers.findLast((c) => c.element.matches(target));
+                    if (ancestorContainer) {
+                        ancestorContainer.folded = false;
+                    }
+                }
+            }
         }
         return containers;
     }

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -268,6 +268,41 @@ test("last container with options is unfolded regardless of containers without o
     expect(".options-container-header i.fa-caret-down").toHaveCount(1);
 });
 
+test("unfold parent of last container if there is a match in `auto_unfold_container_providers`", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderRow label="'Row 1'">A</BuilderRow>`;
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-child";
+            static template = xml`<BuilderRow label="'Row 2'">B</BuilderRow>`;
+        }
+    );
+    addBuilderPlugin(
+        class extends Plugin {
+            static id = "testAutoUnfoldParent";
+            resources = {
+                auto_unfold_container_providers: {
+                    selector: ".test-options-child",
+                    target: ".test-options-target",
+                },
+            };
+        }
+    );
+    await setupHTMLBuilder(
+        `<section class="test-options-target" data-name="Target">
+            <div class="test-options-child" data-name="Child">
+                Text
+            </div>
+        </section>`
+    );
+    await contains(":iframe .test-options-child").click();
+    expect(".options-container-header i.fa-caret-down").toHaveCount(2);
+});
+
 test("options restricted to groups excluding current user do not make an empty folded group appear", async () => {
     onRpc("res.users", "has_group", ({ args: [_, group] }) => {
         if (group === "another_group") {

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -114,6 +114,10 @@ export class FormOptionPlugin extends Plugin {
                 },
             },
         ],
+        auto_unfold_container_providers: [
+            { selector: ".s_website_form_submit", target: ".s_website_form" },
+            { selector: ".s_website_form_send", target: ".s_website_form_submit" },
+        ],
         clone_disabled_reason_providers: ({ el, reasons }) => {
             if (
                 el.classList.contains("s_website_form_field") &&

--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -30,6 +30,7 @@ class accordionOptionPlugin extends Plugin {
         },
         content_not_editable_selectors: [".accordion-button"],
         content_editable_selectors: [".accordion-button span"],
+        auto_unfold_container_providers: { selector: ".accordion-item", target: ".s_accordion" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
@@ -8,6 +8,7 @@ class FooterCopyrightOptionPlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [FooterCopyrightOption],
+        auto_unfold_container_providers: { selector: ".o_footer_copyright", target: "footer" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -128,6 +128,7 @@ class FooterOptionPlugin extends Plugin {
         builder_actions: {
             WebsiteConfigFooterAction,
         },
+        auto_unfold_container_providers: { selector: "#footer > section", target: "footer" },
         on_prepare_drag_handlers: this.prepareDrag.bind(this),
         unremovable_node_predicates: (node) => node.id === "o_footer_scrolltop",
         footer_templates_providers: [

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -171,6 +171,10 @@ class SocialMediaOptionPlugin extends Plugin {
             ".s_social_media a > i",
             ".s_social_media .s_social_media_title",
         ],
+        auto_unfold_container_providers: {
+            selector: ".s_social_media > a > i",
+            target: ".s_social_media",
+        },
     };
 
     /** The social media's name for which there is an entry in the orm */

--- a/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
@@ -48,6 +48,7 @@ class TimelineOptionPlugin extends Plugin {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
         is_movable_selector: { selector: ".s_timeline_row", direction: "vertical" },
+        auto_unfold_container_providers: { selector: ".s_timeline_row", target: ".s_timeline" },
     };
 
     setup() {

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -222,7 +222,6 @@ registerWebsitePreviewTour(
                 ":has(a:eq(8)[href='https://whatever.it/1EdSw9X']:has(i.fa-heart))" +
                 ":has(a:eq(9)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
         },
-        ...unfoldOptionsGroup("Social Media"),
         // Create a social network but replace its icon by an image before setting
         // the link (`replaceIcon` parameter set to `true`).
         ...addNewSocialNetwork(10, 10, "https://google.com", true),


### PR DESCRIPTION
Since [folding of groups of options], the last group, the one corresponding to the element the user clicked, is unfolded. In some cases, it is likely that the user intended to open the parent element's options:
- footer: when clicking on the container or the copyright
- social media snippet: when clicking on an icon
- accordion: when clicking on accordion item
- timeline: when clicking on milestone row
- form: when clicking on the row of the submit button
- submit button's row: when clicking on the button

With this commit, in those cases, the ancestor's options are unfolded as well.

Steps to reproduce:
- Open website builder
- Click on the footer
- Bug: the container's options open instead of the footer's options

[folding of groups of options]: 64d35ccd6fade9e0473686b8484f561b5f4215ce

task-6069263