### PR TITLE
[FIX] l10n_sa_edi: fixing BinarySecurityToken decoding

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -482,7 +482,7 @@ class AccountEdiFormat(models.Model):
             _logger.warning("No attachment found for invoice %s", edi_document.move_id.name)
             return
 
-        xml_content = attachment.raw
+        xml_content = attachment.raw.content
         file_name = attachment.name
 
         pdf_writer.add_attachment(file_name, xml_content, subtype='text/xml')

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -233,7 +233,7 @@ class AccountJournal(models.Model):
 
         cert_id = self.env['certificate.certificate'].sudo().create({
             'name': 'CCSID Certificate',
-            'content': BinaryBytes(b64decode(CCSID_data['binarySecurityToken'])),
+            'content': BinaryBytes(b64decode(b64decode(CCSID_data['binarySecurityToken']))),
             'private_key_id': self.company_id.sudo().l10n_sa_private_key_id.id,
             'company_id': self.company_id.id,
         }).id
@@ -272,7 +272,7 @@ class AccountJournal(models.Model):
         self_sudo.l10n_sa_production_csid_json = json.dumps(PCSID_data)
         pcsid_certificate = self_sudo.env['certificate.certificate'].create({
             'name': 'PCSID Certificate',
-            'content': BinaryBytes(b64decode(PCSID_data['binarySecurityToken'])),
+            'content': BinaryBytes(b64decode(b64decode(PCSID_data['binarySecurityToken']))),
         })
         self.l10n_sa_production_csid_certificate_id = pcsid_certificate
 

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -54,7 +54,7 @@ class AccountMove(models.Model):
                                                             move.l10n_sa_invoice_signature, True)
                     qr_code_str = b64encode(qr_code_str).decode()
                 elif zatca_document.state == 'sent' and zatca_document.attachment_id.raw:
-                    document_xml = zatca_document.attachment_id.raw.decode()
+                    document_xml = zatca_document.attachment_id.raw.content
                     root = etree.fromstring(document_xml)
                     qr_node = root.xpath('//*[local-name()="ID"][text()="QR"]/following-sibling::*/*')[0]
                     qr_code_str = qr_node.text

--- a/addons/l10n_sa_edi/models/certificate.py
+++ b/addons/l10n_sa_edi/models/certificate.py
@@ -1,3 +1,5 @@
+import base64
+
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import ObjectIdentifier
@@ -161,4 +163,4 @@ class CertificateCertificate(models.Model):
         private_key = serialization.load_pem_private_key(journal.company_id.l10n_sa_private_key_id.pem_key, password=None)
         request = builder.sign(private_key, hashes.SHA256())
 
-        return request.public_bytes(serialization.Encoding.PEM)
+        return base64.b64encode(request.public_bytes(serialization.Encoding.PEM))


### PR DESCRIPTION
In

https://github.com/odoo/odoo/pull/244421/changes#diff-a7fda73aa70accaf57b1014494cf48d48c0f6b550b3786dcf78317dde0428154L150

this line was removed, so we needed to apply the b64decode to ZATCA's CSID BinarySecurityToken

Also, this commit applies a fix to '_l10n_sa_get_csr_bin' since the return value needs to have b64encoding

task-6024582

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
