### PR TITLE
[FIX] html_editor: button's popover style initialization in website

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -97,6 +97,14 @@ export class LinkPopover extends Component {
             textContent + "/" === linkElement.getAttribute("href");
 
         const computedStyle = this.props.document.defaultView.getComputedStyle(linkElement);
+        const hasButtonSizeOrShapeOrCustom = this.props.linkElement.className.match(
+            /btn-(lg|sm|xs|custom)|rounded-circle|(?:^|\\s)(outline|fill|flat)(?:\\s|$)/
+        );
+        const buttonType = hasButtonSizeOrShapeOrCustom
+            ? "custom"
+            : this.props.linkElement.className
+                  .match(/btn(-[a-z0-9_-]*)(primary|secondary)/)
+                  ?.pop() || "";
         this.state = useState({
             editing: this.props.LinkPopoverState.editing,
             // `.getAttribute("href")` instead of `.href` to keep relative url
@@ -111,10 +119,7 @@ export class LinkPopover extends Component {
             urlDescription: "",
             linkPreviewName: "",
             imgSrc: "",
-            type:
-                this.props.type ||
-                linkElement.className.match(/btn(-[a-z0-9_-]*)(primary|secondary|custom)/)?.pop() ||
-                "",
+            type: this.props.type || buttonType,
             linkTarget: linkElement.target === "_blank" ? "_blank" : "",
             directDownload: true,
             isDocument: false,

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -308,6 +308,22 @@ describe("Custom button style", () => {
             '<p><a href="https://test.com/" class="rounded-circle btn btn-fill-custom" style="color: rgb(0, 0, 0); background-color: rgb(166, 227, 226); border-width: 1px; border-color: rgb(0, 143, 140); border-style: dashed; ">link[]Label</a></p>'
         );
     });
+
+    test("button with size classes should be detected as custom type", async () => {
+        // Setup: Editor with a button link containing size class (btn-lg) + primary class
+        await setupEditor(
+            '<p><a href="https://test.com/" class="btn btn-lg btn-primary">link[]Label</a></p>',
+            allowCustomOpt
+        );
+
+        // Wait for popover and click edit
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+
+        // The button type should be detected as "custom" because it has btn-lg
+        expect(queryOne('select[name="link_type"]').selectedOptions[0].value).toBe("custom");
+    });
 });
 
 describe("button edit", () => {


### PR DESCRIPTION
Before this commit: Since the removal of button style options for the preset
primary and secondary styling, the type of a primary/secondary button with size
or shape defined in the class should be "custom".

The fix is made to saas-18.4 cause the custom button option is removed in
saas-18.3 and reintroduced only from saas-18.4.

The button option removal commit: https://github.com/odoo/odoo/commit/a7b71d700e4997e4a2f646e2ae12f58f20058dc4
The button custom option reintroduction: https://github.com/odoo/odoo/commit/ea22b28bbae009c9eab4ff397affa9a3cb71037a

After this commit: when the button has size or shape classes, we consider it as
"custom" button.

task-6061443


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
