### PR TITLE
[FIX] hr: fix contract template button classes on employee form

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -2,7 +2,7 @@
 <template>
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
-            <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="onClickNewContractBtn"
+            <button class="btn btn-link p-0 o_field_widget text-end w-auto text-nowrap" t-on-click="onClickNewContractBtn"
                     t-ref="datetime-picker-target-new-contract" t-if="props.record.resId and props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>

--- a/addons/hr/static/src/xml/contract_template_button.xml
+++ b/addons/hr/static/src/xml/contract_template_button.xml
@@ -3,7 +3,8 @@
     <t t-name="hr.ContractTemplateField">
         <button 
             type="button" 
-            class="btn btn-link p-0 text-start"
+            class="btn btn-link border-0 p-0 text-start"
+            style="font-size: 0.8125rem;"
             t-on-click="onSelectTemplate"
             t-ref="templateButton"
             title="Load Contract Template"

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -365,7 +365,7 @@
                                             <span>Contract Overview</span>
                                             <field name="contract_template_id"
                                                 widget="contract_template_button"
-                                                class="btn btn-addr btn-link ms-auto text-end w-auto lh-1 h-100 p-0"
+                                                class="ms-auto text-end w-auto p-0 mb-0 border-0 lh-1"
                                                 nolabel="1"/>
                                         </div>
                                         <label for="contract_date_start" string="Contract"/>


### PR DESCRIPTION
- Add `text-nowrap` to the "New Contract" button to prevent text from splitting at narrow viewport widths
- Fix contract template button styling: remove incorrect classes and align font-size and border with the surrounding UI

task-6068488

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
