### PR TITLE
[FIX] sale: use translated document name in quotation email

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -11,7 +11,7 @@
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
-        <t t-set="doc_name" t-value="'quotation' if object.state in ('draft', 'sent') else 'order'"/>
+        <t t-set="doc_name" t-value="object.type_name"/>
         Hello,
         <br/><br/>
         Your


### PR DESCRIPTION
The quotation email template built the document label from hardcoded English strings (quotation/order), so the text remain untranslated for recipients in another language.

Use `sale.order.type_name` instead, which provides the document name in the proper language context.

opw-6031392
