### PR TITLE
[FIX] pos_loyalty: record gross issued/used points in loyalty history

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -150,15 +150,20 @@ class PosOrder(models.Model):
                 coupon_per_report[report.id].append(coupon.id)
 
         # Adding loyalty history lines
-        loyalty_points = [
-            {
+        loyalty_points = []
+        for coupon_id, coupon_vals in coupon_data.items():
+            if 'points_earned' in coupon_vals and 'points_spent' in coupon_vals:
+                won = coupon_vals['points_earned']
+                spent = coupon_vals['points_spent']
+            else:
+                won = coupon_vals['points'] if coupon_vals['points'] > 0 else 0
+                spent = -coupon_vals['points'] if coupon_vals['points'] < 0 else 0
+            loyalty_points.append({
                 'order_id': self.id,
                 'card_id': coupon_id,
-                'spent': -coupon_vals['points'] if coupon_vals['points'] < 0 else 0,
-                'won': coupon_vals['points'] if coupon_vals['points'] > 0 else 0,
-            }
-            for coupon_id, coupon_vals in coupon_data.items()
-        ]
+                'spent': spent,
+                'won': won,
+            })
         coupon_updates = [
             {
                 'id': coupon.id,

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -816,8 +816,12 @@ patch(PosStore.prototype, {
         const rewardLines = order._get_reward_lines();
         const partner = order.get_partner();
         let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {
+            const earnedPoints =
+                pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id));
             agg[pe.coupon_id] = Object.assign({}, pe, {
-                points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),
+                points: earnedPoints,
+                points_earned: earnedPoints,
+                points_spent: 0,
             });
             const program = ProgramModel.get(pe.program_id);
             if (
@@ -837,6 +841,8 @@ patch(PosStore.prototype, {
             if (!couponData[couponId]) {
                 couponData[couponId] = {
                     points: 0,
+                    points_earned: 0,
+                    points_spent: 0,
                     program_id: reward.program_id.id,
                     coupon_id: couponId,
                     barcode: false,
@@ -852,6 +858,7 @@ patch(PosStore.prototype, {
                 !couponData[couponId].line_codes.push(line.reward_identifier_code);
             }
             couponData[couponId].points -= line.points_cost;
+            couponData[couponId].points_spent += line.points_cost;
         }
         // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
         couponData = Object.fromEntries(

--- a/addons/pos_loyalty/static/tests/tours/loyalty_history_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/loyalty_history_tour.js
@@ -17,3 +17,21 @@ registry.category("web_tour.tours").add("LoyaltyHistoryTour", {
             PosLoyalty.finalizeOrder("Cash", "10"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_loyalty_history_earn_and_spend", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            // Select the partner first so their pre-loaded points are visible
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAA Test Partner"),
+            // Buy a $10 product — this earns 10 points
+            ProductScreen.addOrderline("Whiteboard Pen", "1"),
+            // Claim the reward that costs 5 points (10% discount on the order)
+            PosLoyalty.claimReward("10% on your order"),
+            // $10 - 10% = $9.00
+            PosLoyalty.orderTotalIs("9.00"),
+            PosLoyalty.finalizeOrder("Cash", "9"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_loyalty_history.py
+++ b/addons/pos_loyalty/tests/test_loyalty_history.py
@@ -120,6 +120,51 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
         new_pos_order.confirm_coupon_programs(coupon_data)
         check_coupon(40, 2)
 
+    def test_loyalty_history_earn_and_spend(self):
+        """When points are earned and spent in the same order, the loyalty history
+        must record the gross issued and used amounts separately, not only the net
+        difference. Regression test for: earn 10 pts + spend 5 pts → issued=10,
+        used=5 (instead of the incorrect issued=5, used=0)."""
+        partner_aaa = self.env['res.partner'].create({'name': 'AAA Test Partner'})
+        self.whiteboard_pen.write({'lst_price': 10})
+        self.main_pos_config.write({
+            'tax_regime_selection': False,
+            'use_pricelist': False,
+        })
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Test Loyalty Program',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [Command.create({
+                'reward_point_amount': 1,
+                'reward_point_mode': 'money',
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'percent',
+                'discount': 10,
+                'required_points': 5,
+                'discount_applicability': 'order',
+            })],
+        })
+        # Pre-load the partner with 5 points so they can immediately claim the reward
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': partner_aaa.id,
+            'points': 5,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_loyalty_history_earn_and_spend")
+
+        loyalty_card.invalidate_recordset()
+        history = loyalty_card.history_ids
+        self.assertEqual(len(history), 1, "One history entry should be created for the order")
+        # $10 product → 10 pts earned; 10% discount reward → 5 pts spent
+        self.assertEqual(history.issued, 10.0, "Issued should be 10 (gross earned), not the net")
+        self.assertEqual(history.used, 5.0, "Used should be 5 (gross spent), not the net")
+
     def test_gift_card_partner(self):
         """ Test that the gift card's partner is correctly set as the customer who bought it."""
         test_partner = self.env['res.partner'].create({'name': 'Test Partner'})


### PR DESCRIPTION
When a loyalty card both earned and spent points in the same POS order, the history entry only reflected the net difference instead of the gross amounts.

The root cause was that the JS payload sent only a single `points` field representing the net change. Fix by tracking `points_earned` and `points_spent` separately in `couponData` and sending them to the server.

opw-6041420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
