### PR TITLE
[FIX] project: fix project updates kanban status colors

### DIFF
--- a/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
+++ b/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
@@ -48,28 +48,34 @@
         }
     }
 
-    .oe_kanban_color_20 {
+    .oe_kanban_color_8 {
         border-left-color: $o-success;
         &:after {
             background-color: $o-success;
         }
     }
-    .oe_kanban_color_21 {
+    .oe_kanban_color_9 {
         border-left-color: $o-info;
         &:after {
             background-color: $o-info;
         }
     }
-    .oe_kanban_color_22 {
+    .oe_kanban_color_10 {
         border-left-color: $o-warning;
         &:after {
             background-color: $o-warning;
         }
     }
-    .oe_kanban_color_23 {
+    .oe_kanban_color_11 {
         border-left-color: $o-danger;
         &:after {
             background-color: $o-danger;
+        }
+    }
+    .oe_kanban_color_0 {
+        border-left-color: $primary;
+        &:after {
+            background-color: $primary;
         }
     }
 }


### PR DESCRIPTION
### The Issue:
The frontend Kanban view enforces a strict 12-color limit using a
modulo 12 mathematical rule (which calculates the remainder after
dividing by 12).

When the frontend receives our high backend IDs (20-24), it runs this
modulo math (e.g., 23 % 12) to force them into the allowed limit,
converting them into the remainders: IDs  8, 9, 10, 11 and 0.

Because stylesheet was still searching for the original high
numbers (20-24) instead of these modulo results, the custom colors
were completely ignored by the browser.

### The Fix:
Updated the stylesheet to target the actual modulo-computed classes
(.oe_kanban_color_8 through 11 and 0). Mapped these classes to their correct
 variables (-success, -info, -warning, -danger, -primary) and
fixed the left border styling so the colors render properly.

task-6064106
