### PR TITLE
[IMP] l10n_th: is_company as per vat

### DIFF
--- a/addons/l10n_th/__manifest__.py
+++ b/addons/l10n_th/__manifest__.py
@@ -22,6 +22,7 @@ Thai accounting chart and localization.
     'data': [
         'data/account_tax_report_data.xml',
         'views/report_invoice.xml',
+        'views/res_partner_view.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_th/models/res_partner.py
+++ b/addons/l10n_th/models/res_partner.py
@@ -8,6 +8,12 @@ class ResPartner(models.Model):
 
     l10n_th_branch_name = fields.Char(compute="_compute_l10n_th_branch_name")
 
+    def _compute_is_company(self):
+        super()._compute_is_company()
+        self.filtered(
+            lambda p: p.country_code == 'TH' and not (p.vat or '').startswith("0"),
+        ).is_company = False
+
     def _compute_l10n_th_branch_name(self):
         for partner in self:
             if not partner.is_company or partner.country_code != 'TH':

--- a/addons/l10n_th/tests/__init__.py
+++ b/addons/l10n_th/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_res_partner
 from . import test_l10n_th_emv_qr

--- a/addons/l10n_th/tests/test_res_partner.py
+++ b/addons/l10n_th/tests/test_res_partner.py
@@ -1,0 +1,32 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class L10nTHTest(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_th_company = cls.env['res.partner'].create({
+            'name': 'TH Company',
+            'vat': '0107537002443',
+            'country_id': cls.env.ref('base.th').id,
+        })
+
+        cls.partner_th_individual = cls.env['res.partner'].create({
+            'name': 'TH Individual',
+            'vat': '1103900016621',
+            'country_id': cls.env.ref('base.th').id,
+        })
+
+    def test_is_company_th(self):
+        self.assertTrue(
+            self.partner_th_company.is_company,
+            "TH Partner with VAT starting with '0' should be treated as a company.",
+        )
+        self.assertFalse(
+            self.partner_th_individual.is_company,
+            "TH Partner with VAT not starting with '0' should be treated as an individual.",
+        )

--- a/addons/l10n_th/views/res_partner_view.xml
+++ b/addons/l10n_th/views/res_partner_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="view_partner_form_inherit_l10n_th" model="ir.ui.view">
+            <field name="name">res.partner.form.inherit.l10n_th</field>
+            <field name="model">res.partner</field>
+            <field name="priority">14</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <field name="company_registry" position="attributes">
+                    <attribute name="invisible" add="(is_company and country_code == 'TH')" separator=" or "/>
+                </field>
+                <field name="vat" position="after">
+                    <field name="company_registry"
+                           string="Branch Code"
+                           placeholder="Empty for Head Office"
+                           invisible="parent_id or not (is_company and country_code == 'TH')"
+                           help="The 5-digit branch code as registered with the Revenue Department."/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
In this commit:
- For Thailand, TIN is distinguishable between an individual and a company by a prefix.
- TIN starting with '0' means the contact is a registered corporate entity, such as a company or partnership. If TIN begins with any digit from 1-9, it indicates that the contact should be treated as an Individual.

task-6002111