### PR TITLE
[FIX] point_of_sale: guard isPrivateIp against non-string ip value

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -196,6 +196,9 @@ export function isValidEmail(email) {
 // 169.254.0.0 - 169.254.255.255
 // 192.168.0.0 - 192.168.255.255
 export function isPrivateIp(ip) {
+    if (!ip || typeof ip !== "string") {
+        return false;
+    }
     const blocks = ip.split(".");
     if (blocks.length !== 4) {
         return false;


### PR DESCRIPTION
When `epson_printer_ip` is not set, `isPrivateIp` would crash with "ip.split is not a function" because the value is undefined/null. Add an early return of false when the argument is falsy or not a string.

opw-6067382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
