### PR TITLE
[FIX] hr_expense: prevent attachment leakage when posting multiple expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1570,14 +1570,12 @@ class HrExpense(models.Model):
         return moves_sudo.sudo(self.env.su)
 
     def _prepare_bills_vals(self):
-        attachments_data = []
-        for attachment in self.attachment_ids:
-            attachments_data.append(
-                Command.create(attachment.copy_data({'res_model': 'account.move', 'res_id': False, 'raw': attachment.raw})[0])
-            )
-
         return_vals = []
         for employee_sudo, expenses_sudo in self.sudo().grouped('employee_id').items():
+            attachments_data = [
+                Command.create(attachment.copy_data({'res_model': 'account.move', 'res_id': False, 'raw': attachment.raw})[0])
+                for attachment in expenses_sudo.attachment_ids
+            ]
             multiple_expenses_name = _("Expenses of %(employee)s", employee=employee_sudo.name)
             move_ref = expenses_sudo.name if len(expenses_sudo) == 1 else multiple_expenses_name
             return_vals.append({

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1088,3 +1088,42 @@ class TestExpenses(TestExpenseCommon):
         expense_paid_by_employee.action_approve()
         self.post_expenses_with_wizard(expense_paid_by_employee)
         self.assertEqual(expense_paid_by_employee.account_move_id.company_id, branch_company)
+
+    def test_attachments_on_multiple_posting_from_own_expense(self):
+        """ Checks that attachments are not leaked between moves when posting expenses from different employees. """
+        employee_2 = self.env['hr.employee'].create({
+            'name': 'expense_employee_2',
+            'user_id': self.expense_user_manager_2.id,
+            'expense_manager_id': self.expense_user_manager.id,
+            'work_contact_id': self.expense_user_manager_2.partner_id.id,
+        })
+        expenses = expense_1, expense_2 = self.create_expenses([
+            {'name': 'Employee 1 expense'},
+            {'name': 'Employee 2 expense', 'employee_id': employee_2.id},
+        ])
+        self.env['ir.attachment'].create([{
+            'raw': b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+            'name': f'file_{index}.png',
+            'res_model': 'hr.expense',
+            'res_id': expense.id,
+        } for index, expense in enumerate([expense_1] * 2 + [expense_2] * 3)])
+
+        expenses.action_submit()
+        expenses.action_approve()
+        self.post_expenses_with_wizard(expenses)
+
+        self.assertRecordValues(
+            expense_1.account_move_id.attachment_ids.sorted('name'),
+            [
+                {'name': 'file_0.png', 'res_model': 'account.move', 'res_id': expense_1.account_move_id.id},
+                {'name': 'file_1.png', 'res_model': 'account.move', 'res_id': expense_1.account_move_id.id},
+            ]
+        )
+        self.assertRecordValues(
+            expense_2.account_move_id.attachment_ids.sorted('name'),
+            [
+                {'name': 'file_2.png', 'res_model': 'account.move', 'res_id': expense_2.account_move_id.id},
+                {'name': 'file_3.png', 'res_model': 'account.move', 'res_id': expense_2.account_move_id.id},
+                {'name': 'file_4.png', 'res_model': 'account.move', 'res_id': expense_2.account_move_id.id},
+            ]
+        )


### PR DESCRIPTION
Steps to reproduce:
1. Create two expenses for different employees (e.g., Expense A for Employee 1, Expense B for Employee 2).
2. Upload different attachments to each (e.g., 2 files for A, 3 files for B).
3. Select both expenses and use the 'Post' action to open the posting wizard.
4. Click 'Post' in the wizard.
5. Check the generated journal entries (vendor bills).
Result: Both vendor bills contain all 5 attachments (copies of A's files and copies of B's files).

Issue:
In `_prepare_bills_vals`, `self.attachment_ids` is collected before the
`grouped('employee_id')` loop (see: https://github.com/odoo/odoo/blob/6b7fff433335edf7459f7a6eb5c274c0f4d5d1df/addons/hr_expense/models/hr_expense.py#L1572-L1578).
Since `self` refers to the full expense recordset, `self.attachment_ids` returns
the union of all attachments across every expense. This combined list is then
assigned to every bill created inside the loop, causing attachments from one
employee's expenses to leak into another employee's journal entry.

opw-6056590