### PR TITLE
[FIX] bus: fine-tune resilient websocket kick_all

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -1161,16 +1161,16 @@ def _kick_all(code=CloseCode.GOING_AWAY):
 
         # Every websocket has been signaled to shut down, but the
         # closing handshake might not be complete yet, wait up to
-        # TIMEOUT/10 seconds for all handshaked to be done.
-        for _ in range(int(TimeoutManager.TIMEOUT)):
+        # 5 seconds for all handshakes to be done.
+        for _ in range(50):
+            time.sleep(.1)
             if all(
                 websocket.state is ConnectionState.CLOSED
                 for websocket in _websocket_instances
             ):
                 break
-            time.sleep(.1)
         else:
-            _logger.warning("There remain %s closing websockets", sum(
+            _logger.info("There remain %s closing websockets", sum(
                 1
                 for websocket in _websocket_instances
                 if websocket.state is not ConnectionState.CLOSED


### PR DESCRIPTION
It sometimes logs "Warning: There remain 0 closing websockets". It logs a warning because we didn't slept long enough. It logs "0" because we check first and then sleep, it should be the contrary.

Reference-to: d06f0ea9672 ([FIX] bus: more resilient websocket kick_all)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
