### PR TITLE
[FIX] orm,account,l10n_it_edi: stops rounding the discount on import

### DIFF
--- a/addons/account/models/decimal_precision.py
+++ b/addons/account/models/decimal_precision.py
@@ -6,5 +6,5 @@ class DecimalPrecision(models.Model):
     def precision_get(self, application):
         stackmap = self.env.cr.cache.get('account_disable_recursion_stack', {})
         if application == 'Discount' and stackmap.get('ignore_discount_precision'):
-            return 100
+            return 13
         return super().precision_get(application)

--- a/addons/account/models/decimal_precision.py
+++ b/addons/account/models/decimal_precision.py
@@ -6,5 +6,5 @@ class DecimalPrecision(models.Model):
     def precision_get(self, application):
         stackmap = self.env.cr.cache.get('account_disable_recursion_stack', {})
         if application == 'Discount' and stackmap.get('ignore_discount_precision'):
-            return 100
+            return None
         return super().precision_get(application)

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -320,6 +320,40 @@ class TestItEdiImport(TestItEdi):
             ],
         }], applied_xml)
 
+    def test_receive_bill_with_discount_rounding_issue(self):
+        applied_xml = """
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]" position="inside">
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>50.00</Percentuale>
+                </ScontoMaggiorazione>
+            </xpath>
+
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]/PrezzoUnitario" position="replace">
+                <PrezzoUnitario>11.85</PrezzoUnitario>
+            </xpath>
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]/Quantita" position="replace">
+                <Quantita>3</Quantita>
+            </xpath>
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]/PrezzoTotale" position="replace">
+                <PrezzoTotale>17.78</PrezzoTotale>
+            </xpath>
+        """
+
+        self._assert_import_invoice('IT01234567890_FPR01.xml', [{
+            'invoice_date': fields.Date.from_string('2014-12-18'),
+            'amount_untaxed': 17.78,
+            'amount_tax': 3.91,
+            'invoice_line_ids': [
+                {
+                    'quantity': 3.0,
+                    'name': 'DESCRIZIONE DELLA FORNITURA',
+                    'price_unit': 11.85,
+                    'discount': 50.0,
+                },
+            ],
+        }], applied_xml)
+
     def test_invoice_user_can_compute_is_self_invoice(self):
         """Ensure that a user having only group_account_invoice can compute field l10n_it_edi_is_self_invoice"""
         user = new_test_user(self.env, login='jag', groups='account.group_account_invoice')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1533,7 +1533,7 @@ class Float(Field):
     def get_digits(self, env):
         if isinstance(self._digits, str):
             precision = env['decimal.precision'].precision_get(self._digits)
-            return 16, precision
+            return (16, precision) if precision else None
         else:
             return self._digits
 


### PR DESCRIPTION
**PROBLEM**
When importing an invoice, we don't want to round the discounts, to avoid discrepancy between the subtotal computed by Odoo, and the subtotal of the file we import. To do this, we change the decimal precision of discount to 100 digits when importing files. However, float_round wasn't built with this in mind, in float round, we add a small epsilon to fix some rounding issue. This small epsilon changes the amount of the discount (50.0 -> 0.5000000000004) and this changes the subtotal.

**STEP TO REPRODUCE**
1. Install l10n_edi_it.
2. Change the VAT number of IT Company to 05098540288 (to match the one on the file to import).
3. Import the file present in the bug ticket.
4. Notice the subtotal of the line doesn't match what's in the invoice.

**FIX**
We skip rounding of the discount on import.

Ticket [link](https://www.odoo.com/odoo/project.task/6046324)
opw-6046324