### PR TITLE
[FIX] point_of_sale: session report decimals

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -394,14 +394,16 @@ class ReportSaleDetails(models.AbstractModel):
     def _get_total_and_qty_per_category(self, categories):
         all_qty = 0
         all_total = 0
+        qty_precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        price_precision = self.env['decimal.precision'].precision_get('Product Price')
         for category_dict in categories:
             qty_cat = 0
             total_cat = 0
             for product in category_dict['products']:
                 qty_cat += product['quantity']
                 total_cat += product['base_amount']
-            category_dict['total'] = total_cat
-            category_dict['qty'] = qty_cat
+            category_dict['total'] = round(total_cat, price_precision)
+            category_dict['qty'] = round(qty_cat, qty_precision)
         # IMPROVEMENT: It would be better if the `products` are grouped by pos.order.line.id.
         unique_products = list({tuple(sorted(product.items())): product for category in categories for product in category['products']}.values())
         all_qty = sum([product['quantity'] for product in unique_products])

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -392,3 +392,39 @@ class TestReportSession(TestPoSCommon):
         report = self.env['report.point_of_sale.report_saledetails'].get_sale_details()
         self.assertEqual(report["discount_amount"], 12.0, "Discount amount should be equal to 12.0")
         self.assertEqual(report["taxes_info"]["base_amount"], 90.0, "Base amount should be equal to 90.0")
+
+    def test_report_session_category_qty_round(self):
+        self.config.open_ui()
+        session_id_1 = self.config.current_session_id.id
+        quantities = [12.45, 88.21, 45.09, 7.33, 56.12, 92.84, 31.56, 19.47, 64.91, 5.02, 77.38, 41.65, 23.19, 99.72, 10.88]
+        products = [self.create_product(f'Product {i}', self.categ_basic, 100) for i in range(len(quantities))]
+        total = sum(quantities)
+        order_info = {
+            'company_id': self.env.company.id,
+            'session_id': session_id_1,
+            'partner_id': self.partner_a.id,
+            'lines': [(0, 0, {
+                'name': f"OL/{str(i).zfill(4)}",
+                'product_id': product.id,
+                'price_unit': 1,
+                'discount': 0,
+                'qty': qty,
+                'tax_ids': [],
+                'price_subtotal': qty,
+                'price_subtotal_incl': qty,
+                }) for i, (product, qty) in enumerate(zip(products, quantities), 1)],
+            'pricelist_id': self.config.pricelist_id.id,
+            'amount_paid': total,
+            'amount_total': total,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        }
+
+        order = self.env['pos.order'].create(order_info)
+        self.make_payment(order, self.bank_pm1, total)
+        self.config.current_session_id.action_pos_session_closing_control()
+
+        report = self.env['report.point_of_sale.report_saledetails'].get_sale_details()
+        self.assertEqual(report['products'][0]['qty'], 675.82)
+        self.assertEqual(report['products'][0]['total'], 675.82)


### PR DESCRIPTION
When selling a lot of product with different quantities (quantities with decimals) the session report total by category might have a lot of decimals instead of 2.

Steps to reproduce:
-------------------
* Open PoS
* Make an order with a lot of product and modify the quantities to have random values with decimals
* Close the session
* Generate the session report
> Observation: The total qty by category has a lot of decimals instead
  of the 2 expected. The same error also happens for the total price

Why the fix:
------------
We round each value with their respective precision to make sure we don't have 15 decimals.

opw-6039016