### PR TITLE
[FIX] web: wait canvas before sign

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -109,6 +109,9 @@ export class NameAndSignature extends Component {
             return;
         }
         const canvas = this.signatureRef.el;
+        if (!canvas) {
+            return;
+        }
         const img = this.getSVGText(font, text, canvas.width, canvas.height);
         await this.printImage(img);
     }

--- a/addons/web_tour/static/src/js/tour_automatic/tour_helpers_hoot.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_helpers_hoot.js
@@ -356,10 +356,16 @@ patch(TourHelpers.prototype, {
             throw new Error(`canvasNotEmpty is only suitable for canvas elements.`);
         }
         await hoot.waitUntil(() => {
+            if (!canvas || canvas.width === 0 || canvas.height === 0) {
+                return false;
+            }
             const context = canvas.getContext("2d");
+            if (!context) {
+                return false;
+            }
             const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
             const pixels = new Uint32Array(imageData.data.buffer);
-            return pixels.some((pixel) => pixel !== 0); // pixel is on
+            return pixels.some((pixel) => pixel !== 0);
         });
     },
 


### PR DESCRIPTION
Ensure drawCurrentName waits until the signature canvas is populated with pixel data before rendering. Prevents runtime errors when the canvas is not yet initialized or empty.

runbot-error-id~238520

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
