### PR TITLE
[FIX] account: pick the currency rate of the selected date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5,7 +5,7 @@ import calendar
 from collections import Counter, defaultdict
 from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager, nullcontext
-from datetime import date, timedelta
+from datetime import date, date as date_t, timedelta
 from dateutil.relativedelta import relativedelta
 from hashlib import sha256
 from json import dumps
@@ -5937,12 +5937,15 @@ class AccountMove(models.Model):
     def get_currency_rate(self, company_id, to_currency_id, date):
         company = self.env['res.company'].browse(company_id)
         to_currency = self.env['res.currency'].browse(to_currency_id)
+        # _get_conversion_rate return the first rate before the given date,
+        # usually the rate for the previous day. Therefore, we need to give the next day.
+        next_day = (date_t.fromisoformat(date) + timedelta(days=1)).isoformat()
 
         return self.env['res.currency']._get_conversion_rate(
             from_currency=company.currency_id,
             to_currency=to_currency,
             company=company,
-            date=date,
+            date=next_day,
         )
 
     def refresh_invoice_currency_rate(self):

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -5006,6 +5006,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 {'name': '2026-01-01', 'rate': 2.0, 'currency_id': self.other_currency.id, 'company_id': self.env.company.id},
             ]
         )
+        self.assertEqual(self.env['account.move'].get_currency_rate(self.env.company.id, self.other_currency.id, '2026-01-01'), 2.0)
         with (freeze_time('2025-01-02'), patch.object(self.env.cr, 'now', lambda: fields.Datetime.to_datetime("2025-01-02 10:00:00"))):
             move = self.env['account.move'].create({
                 'move_type': 'out_invoice',


### PR DESCRIPTION
Issue:
When selecting a rate with the date picker, it applies the rate of the previous day

Steps to reproduce:
- Add a currency
- On this currency, add a currency rate to today's date
- Create en invoice in the added currency
- On the currency rate picker take today's rate

Current behavior:
- take the first currency rate before selected date

Expected behavior:
- take the currency rate of the selected date

Cause:
Since 59f6a4848a160f99eb9f5c43755bb18f2f8b8a4b, account move take the currency rate of the date before the Bill/Invoice date. As the date picker uses the same methods, it returns the currency rate of the date before the selected date.

opw-6046169

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
