### PR TITLE
[FIX] pos_self_order: payment terminals not working from kiosk

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -49,6 +49,15 @@ class PosPayment(models.Model):
     def _load_pos_data_domain(self, data, config):
         return [('pos_order_id', 'in', [order['id'] for order in data['pos.order']])]
 
+    @api.model
+    def _get_additional_payment_fields(self):
+        # This method is overridden by payment terminal modules to
+        # indicate additional fields that are safe to process from
+        # the Self Order Kiosk frontend.
+        # It is defined here rather than in `pos_self_order` so that
+        # the payment terminal modules don't need to depend on it.
+        return []
+
     @api.depends('amount', 'currency_id')
     def _compute_display_name(self):
         for payment in self:

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -11,6 +11,8 @@ class PosSelfOrderController(http.Controller):
     @http.route("/pos-self-order/process-order/<device_type>/", auth="public", type="jsonrpc", website=True)
     def process_order(self, order, access_token, table_identifier, device_type):
         pos_config, table = self._verify_authorization(access_token, table_identifier, order)
+        if not pos_config.self_ordering_mode == device_type:
+            raise Unauthorized("Invalid device type")
 
         # Create a safe copy of the order with only the necessary fields for order creation to
         # avoid potential security issues and to reduce the payload size

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -168,6 +168,31 @@ class PosOrder(models.Model):
         return []
 
     @api.model
+    def _check_pos_order_payment(self, device_type, order, payment):
+        if device_type != "kiosk" or not payment or len(payment) != 1 or len(payment[0]) != 3:
+            return []
+
+        command, payment_id = payment[0][0:2]
+        if command != Command.CREATE or payment_id != 0:
+            return []
+
+        payment_line = payment[0][2]
+        if "amount" not in payment_line or payment_line["amount"] != order.get("amount_total", 0):
+            return []
+
+        safe_fields = [
+            "payment_method_id", "card_type", "card_brand", "card_no", "cardholder_name",
+            "payment_ref_no", "payment_method_authcode", "payment_method_issuer_bank",
+            "payment_method_payment_mode", "transaction_id", "ticket", "uuid",
+        ] + self.env["pos.payment"]._get_additional_payment_fields()
+
+        return [[Command.CREATE, 0, {
+            'amount': order.get('amount_total'),
+            'payment_status': 'done',
+            **{field: payment_line.get(field) for field in safe_fields}
+        }]]
+
+    @api.model
     def _check_pos_order(self, pos_config, order, device_type, table=None):
         company = pos_config.company_id
         preset_id = order['preset_id'] if pos_config.use_presets else False
@@ -200,6 +225,8 @@ class PosOrder(models.Model):
         pricelist_id = preset_id.pricelist_id if preset_id else pos_config.pricelist_id
         lines = [self._check_pos_order_lines(pos_config, order, line, fiscal_position_id) for line in order.get('lines', [])]
         lines = [line for line in lines if len(line)]
+        payment_lines = self._check_pos_order_payment(device_type, order, order.get("payment_ids"))
+        payment_lines = [line for line in payment_lines if len(line)]
         partner_id = order.get('partner_id')
         partner = pos_config.env['res.partner'].browse(partner_id) if partner_id else None
 
@@ -242,6 +269,7 @@ class PosOrder(models.Model):
             'uuid': order.get('uuid'),
             'has_deleted_line': order.get('has_deleted_line'),
             'lines': lines,
+            'payment_ids': payment_lines,
             'relations_uuid_mapping': order.get('relations_uuid_mapping', {}),
         }
 

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -141,6 +141,40 @@ class TestSelfOrderController(SelfOrderCommonTest):
         self.assertEqual(len(data['pos.order']), 1)
         self.assertEqual(data['pos.order'][0]['id'], order2.id)
 
+    def test_process_order_in_kiosk_allows_payment(self):
+        self.pos_config.self_ordering_mode = 'kiosk'
+        self.pos_config.with_user(self.pos_user).open_ui()
+
+        order_data = self._create_order_data(
+            state='draft',
+            product=self.cola,
+            qty=3,
+            price_unit=1.0,
+            price_subtotal_incl=3.0,
+            payments=[[0, 0, {"payment_method_id": self.bank_payment_method.id, "amount": 3.0}]]
+        )
+
+        data = self.make_request_to_controller('/pos-self-order/process-order/kiosk', order_data)
+        pos_order = self.env['pos.order'].browse(data['pos.order'][0]['id'])
+
+        self.assertEqual(len(pos_order.payment_ids), 1)
+
+    def test_process_order_in_mobile_does_not_allow_payment(self):
+        self.pos_config.self_ordering_mode = 'mobile'
+        self.pos_config.with_user(self.pos_user).open_ui()
+        order_data = self._create_order_data(
+            state='draft',
+            product=self.cola,
+            qty=3,
+            price_unit=1.0,
+            price_subtotal_incl=3.0,
+            payments=[[0, 0, {"payment_method_id": self.bank_payment_method.id, "amount": 3.0}]]
+        )
+        data = self.make_request_to_controller('/pos-self-order/process-order/mobile', order_data)
+        pos_order = self.env['pos.order'].browse(data['pos.order'][0]['id'])
+
+        self.assertEqual(len(pos_order.payment_ids), 0)
+
     def test_access_right_with_message_follower(self):
         """ Test to ensure that user data is still displayed when a message follower is set on the order """
         self.pos_config.self_ordering_mode = 'mobile'
@@ -170,7 +204,7 @@ class TestSelfOrderController(SelfOrderCommonTest):
         self.assertEqual(len(data['pos.order']), 1)
         self.assertEqual(data['pos.order'][0]['id'], pos_order.id)
 
-    def _create_order_data(self, state, product, qty, price_unit, price_subtotal_incl=None):
+    def _create_order_data(self, state, product, qty, price_unit, price_subtotal_incl=None, payments=[]):
         return {
             'access_token': self.pos_config.access_token,
             'table_identifier': self.pos_table_1.identifier,
@@ -180,7 +214,7 @@ class TestSelfOrderController(SelfOrderCommonTest):
                 'state': state,
                 'preset_id': self.in_preset.id,
                 'session_id': self.pos_config.current_session_id.id,
-                'amount_total': 0,
+                'amount_total': price_subtotal_incl,
                 'amount_paid': 0,
                 'amount_tax': 0,
                 'amount_return': 0,
@@ -194,6 +228,7 @@ class TestSelfOrderController(SelfOrderCommonTest):
                     'tax_ids': [(6, 0, product.taxes_id.ids)],
                     'price_subtotal_incl': price_subtotal_incl or 0,
                 }]],
+                'payment_ids': payments,
             }
         }
 

--- a/addons/pos_viva_com/models/pos_payment.py
+++ b/addons/pos_viva_com/models/pos_payment.py
@@ -1,7 +1,11 @@
-from odoo import models, fields
+from odoo import api, models, fields
 
 
 class PosPayment(models.Model):
     _inherit = "pos.payment"
 
     viva_com_session_id = fields.Char(help="Session ID of the transaction, stored so that it can be used to refund the payment.")
+
+    @api.model
+    def _get_additional_payment_fields(self):
+        return super()._get_additional_payment_fields() + ["viva_com_session_id"]

--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -92,7 +92,7 @@ export class PaymentVivaCom extends PaymentInterface {
         var data = {
             sessionId: line.uiState.vivaSessionId,
             terminalId: line.payment_method_id.viva_com_terminal_id,
-            cashRegisterId: this.pos.config.uuid,
+            cashRegisterId: this.pos.config.name,
             amount: roundPrecision(Math.abs(line.amount * 100)),
             currencyCode: this.pos.currency.iso_numeric.toString(),
             merchantReference: line.uiState.vivaSessionId + "/" + this.pos.session.id,


### PR DESCRIPTION
Since odoo/odoo#249455 the order payload from the self order frontend is being checked to ensure the data is valid. However, these checks did not account for the situation where payment data is included, as is the case when using a self order kiosk with a payment terminal connected. The result was that using the kiosk with a payment terminal would result in an error even though the payment was successful on the terminal.

Steps to reproduce:
- Configure a self order kiosk POS
- Connect a payment terminal (Adyen, Stripe, Viva etc.)
- Try to pay for an order from the kiosk

EXPECTED:
- The order is made successfully.

ACTUAL:
- A generic error message is shown and the order fails. The payment goes through successfully on the payment terminal.

The fix is to allow a payment to be included in the self order data, but only in Kiosk mode and only if the payment amount is valid.

We also now validate that the self ordering type is correct, this
ensures that a kiosk payment cannot be spoofed for a mobile self order
POS.

Finally, there is also a small change for Viva.com to use the PoS config
name instead of UUID, since UUID is no longer loaded in self order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
