### PR TITLE
[IMP] hr: set default joint committee on employee

### DIFF
--- a/addons/hr/models/hr_employee_type.py
+++ b/addons/hr/models/hr_employee_type.py
@@ -10,6 +10,7 @@ class HrEmployeeType(models.Model):
     name = fields.Char(required=True, translate=True)
     code = fields.Char(compute='_compute_code', store=True, readonly=False)
     country_id = fields.Many2one('res.country', domain=lambda self: [('id', 'in', self.env.companies.country_id.ids)])
+    country_code = fields.Char(related='country_id.code')
     employees_count = fields.Integer(compute='_compute_employee_count', string='Employees')
     sequence = fields.Integer(default=10)
 


### PR DESCRIPTION
This commit extends changes in enterprise to add a field `country_code` to `hr.employee` to be able to use it to filter out non-Belgian companies.

TaskID-5972507

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
