### PR TITLE
[FIX] html_builder: fix table row menu position in RTL layout

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -25,6 +25,7 @@ import { setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
 import { isVisible } from "@html_builder/utils/utils";
+import { localization } from "@web/core/l10n/localization";
 
 /**
  * @typedef {(() => void)[]} on_mobile_preview_clicked
@@ -194,6 +195,7 @@ export class Builder extends Component {
                 cleanEmptyStructuralContainers: false,
                 isEditableRTL: false,
                 publicAttachments: true,
+                direction: localization.direction || "ltr",
             },
             this.env.services
         );


### PR DESCRIPTION
Problem:
In RTL websites, the table row menu is not placed correctly.

Cause:
The `inlineStartOffset` calculation in `table_menu` depends on the
`direction` parameter, which was not passed during the editor
initialization.

Solution:
Ensure the `direction` parameter is properly passed during editor
initialization so the `inlineStartOffset` is computed correctly in
RTL layouts.

Before:
<img width="1091" height="682" alt="image" src="https://github.com/user-attachments/assets/964903b2-d33b-48aa-86c2-632cc5adac9a" />
After:
<img width="1093" height="658" alt="image" src="https://github.com/user-attachments/assets/846fd39c-1114-408d-a1f4-75b27218b9b0" />


Steps to reproduce:
- Change website language to Arabic.
- Add a text block and insert a table inside.
- Hover over the first table row.
- Observe the row menu is misplaced.

opw-6049260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
