### PR TITLE
[FIX] iot_drivers: `get_conf` from wrong module

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -87,7 +87,7 @@ class Manager(Thread):
             'token': helpers.get_token(),
             'version': self.version,
             'name': socket.gethostname(),  # TODO: remove when v18.0 is deprecated (backward compatibility)
-            "l10n_eg_proxy_token": helpers.get_conf("proxy_access_token", "default"),
+            "l10n_eg_proxy_token": system.get_conf("proxy_access_token", "default"),
         }
         devices_list = {}
         for device in self.previous_iot_devices.values():


### PR DESCRIPTION
`get_conf` was moved to `system` instead of `helpers`, and a call in `main.py` hasn't been updated in a fw port. This commit fixes it.