### PR TITLE
[FIX] account_edi_ubl_cii: Don't re-use imported XML on invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -447,11 +447,12 @@ class AccountEdiCommon(models.AbstractModel):
             self._correct_invoice_tax_amount(tree, invoice)
 
         # Set XML as ubl_cii_xml_file (XML used to import)
-        file_data['attachment'].write({
-            'res_field': 'ubl_cii_xml_file',
-            'res_model': invoice._name,
-            'res_id': invoice.id,
-        })
+        if invoice.is_purchase_document(include_receipts=True):
+            file_data['attachment'].write({
+                'res_field': 'ubl_cii_xml_file',
+                'res_model': invoice._name,
+                'res_id': invoice.id,
+            })
 
         attachments = self._import_attachments(invoice, tree)
         if attachments:


### PR DESCRIPTION
Problem
---------
Currently, when importing a move, `ubl_cii_xml_file` gets set with said XML. This XML is then re-used during the export rather that regenerate a new XML each time.

This is fine for customer bills as those are not meant to be modified. This is not the case of customer invoices. Client may import an invoice XML and later update that invoice. In such a case, we want to regenerate the XML and not reuse the imported version.

Solution
---------
Only set `ubl_cii_xml_file` for purchase move during the import.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
