### PR TITLE
[FIX] delivery: bug on shipping cost calculation for combo products

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -403,7 +403,7 @@ class DeliveryCarrier(models.Model):
                 total_delivery += line.price_total
             if not line.product_id or line.is_delivery:
                 continue
-            if line.product_id.type == "service":
+            if line.product_id.type in {"service", "combo"}:
                 continue
             qty = line.product_uom._compute_quantity(line.product_uom_qty, line.product_id.uom_id)
             weight += (line.product_id.weight or 0.0) * qty

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -598,3 +598,51 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
         delivery_sol = so.order_line[-1]
         self.assertEqual(delivery_sol.product_id, delivery.product_id)
         self.assertEqual(delivery_sol.price_subtotal, 12.5)
+
+    def test_base_on_rule_cost_for_combo_product(self):
+        """
+        For based on rules delivery methods that use the quantity to compute the cost,
+        check that the cost is computed correctly when there is a combo product.
+        """
+        delivery = self.env["delivery.carrier"].create({
+            "name": "Delivery Charges",
+            "delivery_type": "base_on_rule",
+            "product_id": self.product_delivery_normal.id,
+            "price_rule_ids": [
+                Command.create({
+                    "variable": "quantity",
+                    "operator": ">=",
+                    "max_value": 0,
+                    "list_base_price": 0,
+                    "list_price": 5,
+                    "variable_factor": "quantity",
+                })
+            ],
+        })
+
+        combo = self.env["product.combo"].create({
+            "name": "Desks Combo",
+            "combo_item_ids": [Command.create({"product_id": self.product.id})],
+        })
+
+        product_combo = self._create_product(type="combo", combo_ids=combo.ids)
+
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner_4.id,
+            "partner_invoice_id": self.partner_4.id,
+            "partner_shipping_id": self.partner_4.id,
+            "order_line": [
+                Command.create({
+                    "product_id": product_combo.id,
+                    "product_uom_qty": 5,
+                    "product_uom": self.uom_unit.id,
+                }),
+                Command.create({
+                    "product_id": self.product.id,
+                    "product_uom_qty": 5,
+                    "product_uom": self.uom_unit.id,
+                })
+            ],
+        })
+
+        self.assertEqual(delivery._get_price_available(so), 25)


### PR DESCRIPTION
**Issue:**
When using a delivery method that has a shipping cost based on the quantity of the product, the shipping cost is incorrect if there is a combo product. The quantity of the combo product was added to the total quantity of its components.

**How to reproduce:**
1. Create a delivery method based on rules.
2. Create a rule that uses the quantity (ex: 0$ + 5$ times the quantity)
3. Create a combo product
4. Create a sale order and add the combo product to it
5. Add the shipping

=> The shipping cost is incorrect
    ex: With 1 combo choice, the shipping cost is doubled

**Fix:**
When calculating shipping cost, skip the sale order line of the combo product and only use the sale order lines of the components.

opw-6016209

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
