### PR TITLE
[FIX] sale_management: prevent line breaks in section line of quotation template

### DIFF
--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -93,7 +93,7 @@
                                 <field name="display_type" column_invisible="True"/>
                                 <field name="sequence" widget="handle"/>
                                 <field name="product_id"/>
-                                <field name="name"/>
+                                <field name="name" widget="section_and_note_text"/>
                                 <field name="product_uom_qty"/>
                                 <field
                                     name="product_uom_id"


### PR DESCRIPTION
Steps to produce:
---
- Install `Sales` module.
- Go to `Sales > Configuration > Sales Orders > Quotation Templates`.
- Create a new template and add a section.
- In the section name, add text with line breaks using `Shift + Enter`.
- Go to sale orders > Create new SO > Set quotation template created above.

Issue:
---
- Line breaks entered in the quotation template section lines are stripped when the template is applied to a sale order. These intentional sections are meant to be single-line titles; users should create a new section instead of using line breaks within one.

Root cause:
---
- At [1], the `name` field is defined without the `section_and_note_text` widget. This widget is responsible for rendering section lines as a `CharField` instead of a `TextField`, as seen at [2].

Solution:
---
- Add `widget="section_and_note_text"` to the `name` field. This ensures section lines consistently use `CharField`, preventing line breaks from being entered.

[1]https://github.com/odoo/odoo/blob/951b44c0ed5ffb90cff6fa2934ca2664d2faa59d/addons/sale_management/views/sale_order_template_views.xml#L96
[2]https://github.com/odoo/odoo/blob/951b44c0ed5ffb90cff6fa2934ca2664d2faa59d/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js#L79-L86

opw-6034255
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
