### PR TITLE
[FIX] website_sale: fix pinch-to-zoom behavior on mobile product image viewer

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -137,6 +137,7 @@
             # backend.
             'delivery/static/src/js/location_selector/**/*',
             'website_sale/static/src/js/location_selector/**/*',
+            'website_sale/static/src/js/utils/image_viewer_gestures.js',
         ],
         'web._assets_primary_variables': [
             'website_sale/static/src/scss/primary_variables.scss',

--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -1,6 +1,8 @@
 import { onMounted, onRendered, useEffect, useRef, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { patch } from "@web/core/utils/patch";
+import { ImageViewerTouchMixin } from "@website_sale/js/utils/image_viewer_gestures";
 
 const ZOOM_STEP = 0.1;
 const TOUCHMOVE_STEP = 96;
@@ -30,6 +32,8 @@ export class ProductImageViewer extends Dialog {
             carouselOffset: 0,
         });
         this.isDragging = false;
+        this.initialPinchDistance = null;
+        this.initialPinchScale = 1;
         this.dragStartPos = { x: 0, y: 0 };
         // Doing a full render for the translate is too slow.
         this.imageTranslate = { x: 0, y: 0 };
@@ -211,4 +215,6 @@ export class ProductImageViewer extends Dialog {
         }
     }
 }
+
+patch(ProductImageViewer.prototype, ImageViewerTouchMixin);
 delete ProductImageViewer.props.slots;

--- a/addons/website_sale/static/src/js/utils/image_viewer_gestures.js
+++ b/addons/website_sale/static/src/js/utils/image_viewer_gestures.js
@@ -1,0 +1,61 @@
+/**
+ * Mixin providing pinch-to-zoom touch gesture methods for the ProductImageViewer.
+ */
+export const ImageViewerTouchMixin = {
+    _getTouchDistance(ev) {
+        return Math.hypot(
+            ev.touches[0].clientX - ev.touches[1].clientX,
+            ev.touches[0].clientY - ev.touches[1].clientY
+        );
+    },
+
+    _onTouchendImage(ev) {
+        if (ev.touches.length === 0) {
+            if (this._pendingScale !== undefined) {
+                this.state.imageScale = this._pendingScale;
+                this._pendingScale = undefined;
+                ev.currentTarget.classList.add('transition-base');
+                this.initialPinchDistance = null;
+            }
+            // Delay reset so the ghost click after touchend doesn't trigger drag logic
+            setTimeout(() => {
+                this.isDragging = false;
+            }, 50);
+        } else if (ev.touches.length === 1 && this.initialPinchDistance) {
+            this.initialPinchDistance = null;
+            this.isDragging = false;
+        }
+    },
+
+    _onTouchstartImage(ev) {
+        if (ev.touches.length === 2) {
+            this.isDragging = false;
+            this.initialPinchDistance = this._getTouchDistance(ev)
+            this.initialPinchScale = this.state.imageScale;
+            this._pendingScale = this.state.imageScale;
+            ev.currentTarget.classList.remove('transition-base');
+        } else if (ev.touches.length === 1 && !this.initialPinchDistance) {
+            this.isDragging = true;
+            this.dragStartPos = {
+                x: ev.touches[0].clientX - this.imageTranslate.x,
+                y: ev.touches[0].clientY - this.imageTranslate.y,
+                clientX: ev.touches[0].clientX,
+                clientY: ev.touches[0].clientY,
+            };
+        }
+    },
+
+    _onTouchmoveImage(ev) {
+        ev.preventDefault();
+        if (ev.touches.length === 2 && this.initialPinchDistance) {
+            const currentDist = this._getTouchDistance(ev);
+            const newScale = Math.max(0.5, this.initialPinchScale * (currentDist / this.initialPinchDistance));
+            this._pendingScale = newScale;
+            ev.currentTarget.style.transform = `scale3d(${newScale}, ${newScale}, 1)`;
+        } else if (ev.touches.length === 1 && this.isDragging && !this.initialPinchDistance) {
+            this.imageTranslate.x = ev.touches[0].clientX - this.dragStartPos.x;
+            this.imageTranslate.y = ev.touches[0].clientY - this.dragStartPos.y;
+            this.updateImage();
+        }
+    },
+};

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -22,6 +22,9 @@
                                 t-att-src="selectedImage.src"
                                 t-att-style="imageStyle"
                                 t-on-mousedown="onMousedownImage"
+                                t-on-touchend="_onTouchendImage"
+                                t-on-touchmove="_onTouchmoveImage"
+                                t-on-touchstart="_onTouchstartImage"
                                 t-on-wheel.stop="onWheelImage"
                             />
                         </div>


### PR DESCRIPTION
Steps to reproduce:
- Open Runbot on a mobile device
- Go to Shop > Open any product page
- Ensure zoom on click is enabled
- Tap the product image to open the popup
- Zoom in with a single tap (works as expected)
- Use two fingers to pinch and zoom
- Notice the whole page zooms instead of just the image

Issue:
- Pinch-to-zoom gesture zooms the entire page instead of only the product image popup on mobile devices.

Cause:
- Touch events are not handled, allowing the browser’s default zoom behavior instead of applying zoom only to the image viewer.

Fix:
- Implement proper touch gesture handling to detect pinch zoom, prevent default browser behavior, and apply scaling only to the image inside the viewer.

opw-5950490