### PR TITLE
[FIX] sale_edi_ubl: fix IssueDate timezone mismatch in EDI export

### DIFF
--- a/addons/sale_edi_ubl/tests/test_sale_order_edi_gen.py
+++ b/addons/sale_edi_ubl/tests/test_sale_order_edi_gen.py
@@ -6,7 +6,6 @@ from odoo.tests import tagged
 from odoo.tools import file_open
 
 from lxml import etree
-from datetime import datetime
 
 
 @tagged('post_install', '-at_install')
@@ -42,7 +41,7 @@ class TestSaleOrderEDIGen(TestSaleCommon):
         generated_xml = etree.fromstring(file_content)
 
         with file_open('sale_edi_ubl/tests/data/test_so_edi.xml', 'r') as f:
-            current_date = f'{datetime.today().date()}'
+            current_date = f'{so.create_date.date()}'
             validity_date = f'{so.validity_date}'
             xml_template = f.read().encode().replace(b'create_date_placeholder', current_date.encode()).replace(b'validity_date_placeholder', validity_date.encode())
             expected_xml = etree.fromstring(xml_template)


### PR DESCRIPTION
The Issue:
Before this commit, the generated EDI XML used
`sale_order.create_date.date()` to populate the IssueDate node, while the test used `datetime.today().date()` to build the expected value. Since `create_date` is a UTC timestamp set by the database and `datetime.today()` returns the local system time, these diverge when the server timezone is ahead of UTC and the test runs shortly after local midnight (e.g., runbot at 01:00 CET produces UTC date Jan 11 vs local date Jan 12).

The Fix:
Align the test to derive its expected date from `so.create_date.date()` instead of `datetime.today().date()`, ensuring both sides use the same timezone-consistent source of truth.

runbot-237841

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
