### PR TITLE
[FIX] website: prevent crash on field deletion used by website form

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -2,7 +2,7 @@
 
 from ast import literal_eval
 
-from lxml import etree
+from lxml import html
 
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -158,7 +158,7 @@ class website_form_model_fields(models.Model):
                 domain = [(field_name, 'ilike', f'data-model_name="{field.model}"')]
                 records = self.env[model_name].with_context(active_test=False).search(domain)
                 for record in records:
-                    arch_parsed = etree.fromstring(record[field_name])
+                    arch_parsed = html.fromstring(record[field_name])
                     xpath_selector = f'//form[@data-model_name="{field.model}"]//*[@name="{field.name}"]'
                     if arch_parsed.xpath(xpath_selector):
                         raise ValidationError(_(

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
 
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import users, HttpCase, tagged
 from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
@@ -224,3 +224,24 @@ class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
         self.url_open('/web_editor/field/translation/update', data=json.dumps(payload), headers=self.headers)
         self.assertEqual('Todos os blogs', blog_post.with_context(lang=br_lang.code).content)
         self.assertEqual('Updated blogs', blog_post.with_context(lang=en_lang.code).content)
+
+    def test_cannot_delete_field_used_in_website_blog(self):
+        self.partner_model = self.env['ir.model'].search([('model', '=', 'res.partner')])
+        self.test_field = self.env['ir.model.fields'].create({
+            'name': 'x_test_field',
+            'model_id': self.partner_model.id,
+            'ttype': 'char',
+            'field_description': 'test',
+        })
+        self.env['blog.post'].create({
+            'name': 'Test Blog',
+            'content': f'''
+                <form data-model_name="res.partner">
+                    <input name="{self.test_field.name}">
+                </form>
+            ''',
+        })
+        with self.assertRaisesRegex(ValidationError, f"The field '{self.test_field.name}' cannot be deleted because it is referenced in a website view."):
+            self.test_field.unlink()
+
+        self.assertTrue(self.test_field.exists())


### PR DESCRIPTION
Steps to reproduce
==================

tl;dr: html fields are parsed as xml

- Go to Helpdesk > Tickets > Warranty
- Open studio
- Add a new text field named "TEST"
- Remove it from the view
- Exit studio
- Go to the website
- Click on new
- Add a new blogpost
- Set a title and save
- Click on "Contact & Forms"
- Click on the first block
- Click on the form
- Change the form action to "Create a ticket"
- Click on "+ Field"
- Change the Type selection to "TEST"
- Click on save
- Enable debug mode
- Go to "Settings / Technical / Database Structure / Fields"
- Type x_ in the search bar and press enter
- Delete the field

=> lxml.etree.XMLSyntaxError

Cause of the issue
==================

When deleting a field, `_check_if_used_in_website_form` is called to prevent the deletion if a field is used in an html field.

The html fields were parsed with an xml parser..

opw-5946029