### PR TITLE
[FIX] web_editor: allow snippet group click in website_forum

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -5147,9 +5147,13 @@ class SnippetsMenu extends Component {
                 dropZoneEls.forEach(dropZoneEl => dropZoneEl.classList.add("invisible"));
                 // Do not allow drop by click in another snippet
                 // (e.g., "table of content") unless it is a "s_popup".
-                dropZoneEls = [...dropZoneEls].filter(dropzoneEl => {
+                // If no dropzone is left after the filter, then allow the drop
+                // by click inside [data-snippet] elements
+                dropZoneEls = [...dropZoneEls];
+                const filteredDropzoneEls = dropZoneEls.filter(dropzoneEl => {
                     return !dropzoneEl.closest("[data-snippet]:not(.s_popup), #website_cookies_bar");
                 });
+                dropZoneEls = filteredDropzoneEls.length ? filteredDropzoneEls : dropZoneEls;
                 if (dropZoneEls?.length) {
                     hookEl = this._getClosestDropzone(dropZoneEls)
                         || dropZoneEls[dropZoneEls.length - 1];

--- a/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
+++ b/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
@@ -1,0 +1,60 @@
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "forum_cover_dropzone",
+    {
+        url: "/forum/help-1",
+        edition: true,
+    },
+    () => [
+        // Add a snippet on click.
+        {
+            content: "Click on the Text snippet group.",
+            trigger:
+                '#oe_snippets .oe_snippet[name="Text"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
+            run: "click",
+        },
+        {
+            content: "Add the s_title into the forum cover.",
+            trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_title"]:not(.d-none)',
+            run: "click",
+        },
+        {
+            content: "Check that the s_title was inserted in the forum cover.",
+            trigger: ":iframe .s_cover .s_title",
+        },
+        // Add a snippet with drag and drop.
+        ...insertSnippet({
+            id: "s_text_block",
+            name: "Text",
+            groupName: "Text",
+        }),
+        {
+            content: "Check that the s_text was inserted in the forum cover.",
+            trigger: ":iframe .s_cover .s_text_block",
+        },
+        // Check that it is impossible to drop "Embed Code" (= sanitized area).
+        {
+            content: "Open the Content snippet group.",
+            trigger:
+                '#oe_snippets .oe_snippet[name="Content"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
+            run: "click",
+        },
+        {
+            content: "Type 'embed' in the searchbar to find for the embed_code snippet",
+            trigger: '.o_add_snippet_dialog input[type="search"]',
+            run: "edit embed",
+        },
+        {
+            content: "Check that the search returns no results.",
+            trigger: '.o_add_snippet_dialog input[type="search"]',
+            run() {
+                const previewDocument =
+                    document.querySelector(".o_add_snippet_iframe").contentDocument;
+                if (previewDocument.querySelector(".o_snippet_preview_wrap")) {
+                    throw new Error("Expected no snippet results in the add snippet dialog.");
+                }
+            },
+        },
+    ]
+);

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -25,3 +25,6 @@ class TestUi(HttpCaseGamification):
         self.start_tour("/", 'forum_question', login="demo")
         tags = self.env['forum.tag'].search([('name', 'in', ['Tag', 'tag', 'test tag'])])
         self.assertEqual(len(tags), 3)
+
+    def test_03_admin_forum_cover_dropzone(self):
+        self.start_tour('/', 'forum_cover_dropzone', login='admin')


### PR DESCRIPTION
Steps to reproduce the issue:
- Go to Forum, then go to the Help page
- Enter Edit mode
- Try to drag and drop a snippet => The dropzone in the s_cover at the top of the page are available
- Try to click on a snippet group => Nothing happen, because all dropzones are filtered

The s_cover element has the [data-snippet] attribute. When clicking on a snippet group, the editor filters out dropzones inside other snippets. Since s_cover is treated as a snippet, its dropzones are excluded, even though they are the only ones available on the page.

The solution is to treat dropzones inside snippets as low priority instead of strictly forbidden. If no other valid dropzones exist, we allow these as a fallback to ensure snippet insertion remains possible.

task-5938138