### PR TITLE
[IMP] mail: postpone `store.get_result()`

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -40,6 +40,9 @@ def get_notify_payload_max_length(default=8000):
 
 # max length in bytes for the NOTIFY query payload
 NOTIFY_PAYLOAD_MAX_LENGTH = get_notify_payload_max_length()
+# Sentinel used by `_prepare_payload` to indicate the notification
+# creation should be aborted.
+SKIP_NOTIFICATION = object()
 
 
 def fetch_bus_notifications(cr, channels, last=0, ignore_ids=None):
@@ -146,18 +149,15 @@ class BusBus(models.Model):
                 " Partners do not receive notifications unless they have dedicated user(s)."
                 " So please send on the expected res.users instead.",
             )
-        self.env.cr.precommit.data["bus.bus.values"].append(
-            {
-                "channel": json_dump(channel),
-                "message": json_dump(
-                    {
-                        "type": notification_type,
-                        "payload": message,
-                    }
-                ),
-            }
-        )
+        self.env.cr.precommit.data["bus.bus.values"].append((channel, notification_type, message))
         self.env.cr.postcommit.data["bus.bus.channels"].add(channel)
+
+    def _prepare_payload(self, payload):
+        """Compute and return the final payload for a bus notification. This method is
+        called **just before sending the notification**, allowing deferred computation.
+        Return the `SKIP_NOTIFICATION` sentinel to cancel the creation of the notification.
+        """
+        return payload
 
     def _ensure_hooks(self):
         if "bus.bus.values" not in self.env.cr.precommit.data:
@@ -165,7 +165,15 @@ class BusBus(models.Model):
 
             @self.env.cr.precommit.add
             def create_bus():
-                self.sudo().create(self.env.cr.precommit.data.pop("bus.bus.values"))
+                if values := [
+                    {
+                        "channel": json_dump(channel),
+                        "message": json_dump({"type": type_, "payload": formatted_payload}),
+                    }
+                    for channel, type_, payload in self.env.cr.precommit.data.pop("bus.bus.values")
+                    if (formatted_payload := self._prepare_payload(payload)) is not SKIP_NOTIFICATION
+                ]:
+                    self.sudo().create(values)
 
         if "bus.bus.channels" not in self.env.cr.postcommit.data:
             self.env.cr.postcommit.data["bus.bus.channels"] = OrderedSet()

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -188,7 +188,7 @@ class BusResult:
     def __init__(self, channel, type=None, payload=None):
         self.channel = channel
         self.type = type
-        self.payload = payload
+        self.payload = payload.as_dict() if hasattr(payload, "as_dict") else payload
         self.matched = False
         self.misordered_matched = False
         self.wrong_order_expected_idx = None
@@ -272,7 +272,7 @@ class BusResult:
 
 class BusCase(BaseCase):
     def _reset_bus(self):
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.env.cr.precommit.data.get("bus.bus.values", []).clear()
         self.env["bus.bus"].sudo().search([]).unlink()
 
     @contextlib.contextmanager

--- a/addons/cloud_storage/controllers/attachment.py
+++ b/addons/cloud_storage/controllers/attachment.py
@@ -7,7 +7,7 @@ from odoo.addons.mail.tools.discuss import mail_route
 
 
 class CloudAttachmentController(AttachmentController):
-    @mail_route(type="http")
+    @mail_route()
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
         is_cloud_storage = kwargs.get('cloud_storage')
         if (is_cloud_storage and not request.env['ir.config_parameter'].sudo().get_str('cloud_storage_provider')):

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -62,7 +62,7 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'channel_type': 'chat',
             'name': 'test'
         })
-        data = Store().add(channel, "_store_channel_fields").get_result()
+        data = Store().add(channel, "_store_channel_fields")._build_result()
         partner_info = next(p for p in data["res.partner"] if p["id"] == partner.id)
         partner2_info = next(p for p in data["res.partner"] if p["id"] == partner2.id)
         user_info = next(u for u in data["res.users"] if u["id"] == partner_info["main_user_id"])

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -62,14 +62,14 @@ class TestPartner(TransactionCase):
         self.leaves.write({'state': 'validate'})
         store_1 = Store().add(self.partner, "_store_partner_fields")
         self.assertEqual(
-            store_1.get_result()["hr.employee"][0]["leave_date_to"],
+            store_1._build_result()["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner",
         )
         self.leaves[0].action_refuse()
         store_2 = Store().add(self.partner, "_store_partner_fields")
         self.assertEqual(
-            store_2.get_result()["hr.employee"][0]["leave_date_to"],
+            store_2._build_result()["hr.employee"][0]["leave_date_to"],
             False,
             "Partner is not considered out of office if their main user is not on holiday",
         )
@@ -81,7 +81,7 @@ class TestPartner(TransactionCase):
         partner = self.partner.with_user(self.user_no_hr_access)
         store = Store().add(partner, "_store_partner_fields")
         self.assertEqual(
-            store.get_result()["hr.employee"][0]["leave_date_to"],
+            store._build_result()["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner, "
             "even if the user has no access to the company",

--- a/addons/im_livechat/controllers/attachment.py
+++ b/addons/im_livechat/controllers/attachment.py
@@ -10,7 +10,7 @@ from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LivechatAttachmentController(AttachmentController):
-    @mail_route(type="http")
+    @mail_route()
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
         thread = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
         if not thread:

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -15,7 +15,7 @@ class LivechatChatbotScriptController(http.Controller):
         chatbot_language = chatbot._get_chatbot_language()
         message = discuss_channel.with_context(lang=chatbot_language)._chatbot_restart(chatbot)
         store = Store().add(message, "_store_message_fields")
-        return {"message_id": message.id, "store_data": store.get_result()}
+        return {"message_id": message.id, "store_data": store}
 
     @mail_route("/chatbot/answer/save", type="jsonrpc", auth="public")
     def chatbot_save_answer(self, channel_id, message_id, selected_answer_id):
@@ -84,7 +84,7 @@ class LivechatChatbotScriptController(http.Controller):
             )
             store.resolve_data_request()
             store.bus_send()
-            return store.get_result()
+            return store
         # sudo: discuss.channel - updating current step on the channel is allowed
         discuss_channel.sudo().chatbot_current_step_id = next_step.id
         step_data = next_step._process_step(discuss_channel)
@@ -151,5 +151,5 @@ class LivechatChatbotScriptController(http.Controller):
                         value=posted_message,
                     ),
                 )
-                result["data"] = store.get_result()
+                result["data"] = store
         return result

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -192,7 +192,7 @@ class LivechatController(http.Controller):
             )
         if not request.env.user._is_public():
             store.add(request.env.user.partner_id, ["email"])
-        return {"store_data": store.get_result(), "channel_id": channel_id}
+        return {"store_data": store, "channel_id": channel_id}
 
     @mail_route("/im_livechat/feedback", type="jsonrpc", auth="public")
     def feedback(self, channel_id, rate, reason=None, **kwargs):

--- a/addons/im_livechat/controllers/rtc.py
+++ b/addons/im_livechat/controllers/rtc.py
@@ -8,7 +8,7 @@ from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LivechatRtcController(RtcController):
-    @mail_route(type="jsonrpc")
+    @mail_route()
     def channel_call_join(self, channel_id, check_rtc_session_ids=None, camera=False):
         # sudo: discuss.channel - visitor can check if there is an ongoing call
         if not request.env.user._is_internal() and request.env["discuss.channel"].sudo().search([

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -755,7 +755,7 @@ class DiscussChannel(models.Model):
                     "feedback": reason,
                     "rating_image_url": rating_url,
                     "channel_id": self.id,
-                    "store_data": store.get_result(),
+                    "store_data": store,
                 },
             )
 

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -169,38 +169,23 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             self.chatbot_script.operator_partner_id,
         )
         self.assertEqual(discuss_channel.name, "Testing Bot")
-
         member_bot = discuss_channel.channel_member_ids.filtered(
             lambda m: m.partner_id == self.chatbot_script.operator_partner_id
         )
-        member_bot_data = {
-            "channel_role": False,
-            "create_date": fields.Datetime.to_string(member_bot.create_date),
-            "id": member_bot.id,
-            "livechat_member_type": "bot",
-            "last_seen_dt": False,
-            "partner_id": member_bot.partner_id.id,
-            "seen_message_id": False,
-            "channel_id": discuss_channel.id,
-        }
 
         def notifications():
             messages = self.env["mail.message"].search([], order="id desc", limit=3)
             # only data relevant to the test are asserted for simplicity
             store = Store(bus_channel=discuss_channel).add(messages[1], "_store_message_fields")
-            transfer_message_data = store.get_result()
+            transfer_message_data = store._build_result()
             transfer_message_data["mail.message"][0].update(
                 {
                     "author_id": self.chatbot_script.operator_partner_id.id,
                     "body": ["markup", "<p>I will transfer you to a human.</p>"],
-                    # thread not renamed yet at this step
-                    "default_subject": "Testing Bot",
-                    "record_name": "Testing Bot",
                 }
             )
-            transfer_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
             store = Store(bus_channel=discuss_channel).add(messages[0], "_store_message_fields")
-            joined_message_data = store.get_result()
+            joined_message_data = store._build_result()
             joined_message_data["mail.message"][0].update(
                 {
                     "author_id": self.chatbot_script.operator_partner_id.id,
@@ -211,64 +196,25 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             f'{self.partner_employee.id}" class="o_mail_redirect">@Ernest Employee</a> to the conversation</div>'
                         ),
                     ],
-                    # thread not renamed yet at this step
-                    "default_subject": "Testing Bot",
-                    "record_name": "Testing Bot",
                 }
             )
-            joined_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
             member_emp = discuss_channel.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.partner_employee
             )
-            # data in-between join and leave
             store = Store(bus_channel=member_emp)
             store.add(discuss_channel, "_store_channel_fields")
-            channel_data_join = store.get_result()
-            channel_data_join["discuss.channel"][0]["livechat_outcome"] = "no_agent"
+            channel_data_join = store._build_result()
+            channel_data_join["discuss.channel"][0]["livechat_outcome"] = "no_answer"
             channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[1].id
             channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[1].id
-            channel_data_join["discuss.channel"][0]["member_count"] = 3
-            channel_data_join["discuss.channel"][0]["name"] = "Testing Bot"
-            channel_data_join["discuss.channel.member"].insert(0, member_bot_data)
-            channel_data_join["discuss.channel.member"][2]["last_seen_dt"] = False
-            channel_data_join["discuss.channel.member"][2]["seen_message_id"] = False
-            channel_data_join["discuss.channel.member"][2]["unpin_dt"] = False
-            # adding member_id to livechat history
-            # since the joined message is calculated before removing the bot from members
-            member_bot_history = next(
-                filter(
-                    lambda h: h.get("partner_id", None)
-                    == self.chatbot_script.operator_partner_id.id,
-                    channel_data_join["im_livechat.channel.member.history"],
-                )
-            )
-            member_bot_history["member_id"] = member_bot_data["id"]
-            del channel_data_join["res.partner"][1]
-            channel_data_join["res.partner"].insert(
-                0,
-                self._filter_partners_fields({
-                    "active": False,
-                    "avatar_128_access_token": self.chatbot_script.operator_partner_id._get_avatar_128_access_token(),
-                    "country_id": False,
-                    "id": self.chatbot_script.operator_partner_id.id,
-                    "im_status": "im_partner",
-                    "im_status_access_token": self.chatbot_script.operator_partner_id._get_im_status_access_token(),
-                    "is_public": False,
-                    "main_user_id": False,
-                    "mention_token": self.chatbot_script.operator_partner_id._get_mention_token(),
-                    "name": "Testing Bot",
-                    "user_livechat_username": False,
-                    "write_date": fields.Datetime.to_string(
-                        self.chatbot_script.operator_partner_id.write_date
-                    ),
-                })[0],
-            )
+            channel_data_join["discuss.channel"][0]["member_count"] = 2
+            channel_data_join["discuss.channel.member"][1]["unpin_dt"] = False
             store_1 = Store().add(discuss_channel, "_store_channel_fields")
-            channel_data = store_1.get_result()
+            channel_data = store_1._build_result()
             channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             channel_w_employee = discuss_channel.with_user(self.user_employee)
             store_2 = Store().add(channel_w_employee, "_store_channel_fields")
-            channel_data_emp = store_2.get_result()
+            channel_data_emp = store_2._build_result()
             channel_data_emp["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             channel_data_emp["discuss.channel.member"][1]["message_unread_counter_bus_id"] = 0
             agent_history_id = discuss_channel.livechat_channel_member_history_ids.filtered(
@@ -333,7 +279,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     discuss_channel,
                     "mail.record/insert",
                     {
-                        "discuss.channel": [{"id": discuss_channel.id, "member_count": 3}],
+                        "discuss.channel": [{"id": discuss_channel.id, "member_count": 2}],
                         "discuss.channel.member": [
                             {
                                 "channel_role": False,
@@ -349,19 +295,21 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         "res.country": [
                             {"code": "BE", "id": self.env.ref("base.be").id, "name": "Belgium"}
                         ],
-                        "res.partner": self._filter_partners_fields({
-                            "active": True,
-                            "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
-                            "country_id": self.env.ref("base.be").id,
-                            "id": self.partner_employee.id,
-                            "is_public": False,
-                            "mention_token": self.partner_employee._get_mention_token(),
-                            "name": "Ernest Employee",
-                            "user_livechat_username": False,
-                            "write_date": fields.Datetime.to_string(
-                                self.partner_employee.write_date
-                            ),
-                        }),
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "active": True,
+                                "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
+                                "country_id": self.env.ref("base.be").id,
+                                "id": self.partner_employee.id,
+                                "is_public": False,
+                                "mention_token": self.partner_employee._get_mention_token(),
+                                "name": "Ernest Employee",
+                                "user_livechat_username": False,
+                                "write_date": fields.Datetime.to_string(
+                                    self.partner_employee.write_date
+                                ),
+                            }
+                        ),
                     },
                 ),
                 BusResult(

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -159,18 +159,20 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
                 BusResult(
                     (channel, "internal_users"),
                     "mail.record/insert",
-                    Store(bus_channel=channel, bus_subchannel="internal_users")
-                    .add(channel, ["livechat_status", "livechat_looking_for_help_since_dt"])
-                    .get_result(),
+                    Store(bus_channel=channel, bus_subchannel="internal_users").add(
+                        channel,
+                        ["livechat_status", "livechat_looking_for_help_since_dt"],
+                    ),
                 ),
                 BusResult(
                     (group, "LOOKING_FOR_HELP"),
                     "mail.record/insert",
-                    Store(bus_channel=group, bus_subchannel="LOOKING_FOR_HELP")
-                    .add(channel, "_store_channel_fields")
-                    .get_result(),
+                    Store(bus_channel=group, bus_subchannel="LOOKING_FOR_HELP").add(
+                        channel,
+                        "_store_channel_fields",
+                    ),
                 ),
-            ]
+            ],
         ):
             channel.livechat_status = "need_help"
 

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -470,6 +470,10 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             }
         )
         channel.with_user(self.operators[0])._add_members(users=john)
-        data = john.partner_id.with_user(john).search_for_channel_invite("bob", channel.id)["store_data"]
+        data = (
+            john.partner_id.with_user(john)
+            .search_for_channel_invite("bob", channel.id)["store_data"]
+            ._build_result()
+        )
         self.assertIn(bob.partner_id.id, [p["id"] for p in data["res.partner"]])
         self.assertFalse(john.has_group("im_livechat.im_livechat_group_user"))

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -75,7 +75,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         chatbot_message = discuss_channel.chatbot_message_ids.mail_message_id[:1]
         store = Store().add(chatbot_message, "_store_message_fields")
         self.assertEqual(
-            store.get_result()["mail.message"],
+            store._build_result()["mail.message"],
             self._filter_messages_fields(
                 {
                     "attachment_ids": [],
@@ -141,7 +141,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             ),
         )
         self.assertEqual(
-            Store().add(message, "_store_message_fields").get_result(),
+            Store().add(message, "_store_message_fields")._build_result(),
             {
                 "mail.message": self._filter_messages_fields(
                     {

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -72,7 +72,11 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
                 "livechat_channel_id": livechat_channel.id,
             }
         )
-        data = operator.partner_id.with_user(operator).search_for_channel_invite("fr_FR", channel.id)["store_data"]
+        data = (
+            operator.partner_id.with_user(operator)
+            .search_for_channel_invite("fr_FR", channel.id)["store_data"]
+            ._build_result()
+        )
         john_data = next(filter(lambda partner: partner["id"] == john.partner_id.id, data["res.partner"]))
         self.assertEqual(
             john_data["user_livechat_username"],

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -79,10 +79,10 @@ class AttachmentController(ThreadController):
                     res.from_method("_store_ownership_fields"),
                 ),
             )
-            res = {"data": {"store_data": store.get_result(), "attachment_id": attachment.id}}
+            res = {"data": {"store_data": store, "attachment_id": attachment.id}}
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}
-        return res
+        return request.make_json_response(res)
 
     @mail_route("/mail/attachment/delete", methods=["POST"], type="jsonrpc", auth="public")
     def mail_attachment_delete(self, attachment_id, access_token=None):

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -141,10 +141,7 @@ class ChannelController(http.Controller):
             domain=[("id", "not in", known_member_ids), ("channel_id", "=", channel.id)],
             limit=100,
         )
-        store = Store()
-        store.add(channel, ["member_count"])
-        store.add(unknown_members, "_store_member_fields")
-        return store.get_result()
+        return Store().add(channel, ["member_count"]).add(unknown_members, "_store_member_fields")
 
     @mail_route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
     def discuss_channel_avatar_update(self, channel_id, data):
@@ -212,7 +209,7 @@ class ChannelController(http.Controller):
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
         attachments = request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
         store = Store().add(attachments, "_store_attachment_fields")
-        return {"store_data": store.get_result(), "count": len(attachments)}
+        return {"store_data": store, "count": len(attachments)}
 
     @mail_route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_create(self, parent_channel_id, from_message_id=None, name=None):
@@ -227,7 +224,7 @@ class ChannelController(http.Controller):
             )
         sub_channel = channel._create_sub_channel(from_message_id, name)
         store = Store().add(sub_channel, "_store_channel_fields")
-        return {"store_data": store.get_result(), "sub_channel": sub_channel.id}
+        return {"store_data": store, "sub_channel": sub_channel.id}
 
     @mail_route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_fetch(self, parent_channel_id, search_term=None, before=None, limit=30):
@@ -261,10 +258,7 @@ class ChannelController(http.Controller):
                 self.env["discuss.channel.member"].browse([r[0] for r in self.env.cr.fetchall()]),
                 "_store_member_fields",
             )
-        return {
-            "store_data": store.get_result(),
-            "sub_channel_ids": sub_channels.ids,
-        }
+        return {"store_data": store, "sub_channel_ids": sub_channels.ids}
 
     @mail_route("/discuss/channel/sub_channel/delete", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_delete_sub_channel(self, sub_channel_id):

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -121,7 +121,7 @@ class PublicPageController(http.Controller):
         return request.render(
             "mail.discuss_public_channel_template",
             {
-                "data": store.get_result(),
                 "session_info": channel.env["ir.http"].session_info(),
+                "store_data": store.as_dict(),
             },
         )

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -76,7 +76,7 @@ class RtcController(Controller):
         store = Store()
         # sudo: discuss.channel.rtc.session - member of current user can join call
         member.sudo()._rtc_join_call(store, check_rtc_session_ids=check_rtc_session_ids, camera=camera)
-        return store.get_result()
+        return store
 
     @mail_route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
     def channel_call_leave(self, channel_id, session_id=None):
@@ -139,9 +139,8 @@ class RtcController(Controller):
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         rtc_updates = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        store = Store().add(
+        return Store().add(
             member.channel_id,
             "_store_rtc_update_fields",
             fields_params={"added": rtc_updates[0], "removed": rtc_updates[1]},
         )
-        return store.get_result()

--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -27,4 +27,4 @@ class SearchController(http.Controller):
             channels |= channels.browse(query)
         store.add(channels, "_store_channel_fields")
         request.env["res.partner"]._search_for_channel_invite(store, search_term=term, limit=limit)
-        return store.get_result()
+        return store

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -24,7 +24,7 @@ class MessageReactionController(ThreadController):
         store = Store()
         # sudo: mail.message - access mail.message.reaction through an accessible message is allowed
         message.sudo()._message_reaction(content, action, partner, guest, store)
-        return store.get_result()
+        return store
 
     def _get_reaction_author(self, message, **kwargs):
         user, guest = request.env["res.users"]._get_current_persona()

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -123,7 +123,7 @@ class ThreadController(http.Controller):
         subtypes = record._mail_get_message_subtypes()
         store = Store().add(subtypes, ["name"]).add(follower, ["subtype_ids"])
         return {
-            "store_data": store.get_result(),
+            "store_data": store,
             "subtype_ids": subtypes.sorted(
                 key=lambda s: (
                     s.parent_id.res_model or "",
@@ -214,7 +214,7 @@ class ThreadController(http.Controller):
             **self._prepare_message_data(post_data, thread=thread, from_create=True, **kwargs),
         )
         store.add(message, "_store_message_fields")
-        return {"store_data": store.get_result(), "message_id": message.id}
+        return {"store_data": store, "message_id": message.id}
 
     @mail_route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
     def mail_message_update_content(self, message_id, update_data, **kwargs):
@@ -228,7 +228,7 @@ class ThreadController(http.Controller):
             message,
             **self._prepare_message_data(update_data, thread=thread, from_create=False, **kwargs),
         )
-        return Store().add(message, "_store_message_fields").get_result()
+        return Store().add(message, "_store_message_fields")
 
     # side check for access
     # ------------------------------------------------------------
@@ -241,13 +241,13 @@ class ThreadController(http.Controller):
     def mail_thread_unsubscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_unsubscribe(partner_ids)
-        return Store().add(thread, self._store_thread_follow_fields, as_thread=True).get_result()
+        return Store().add(thread, self._store_thread_follow_fields, as_thread=True)
 
     @mail_route("/mail/thread/subscribe", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_subscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_subscribe(partner_ids)
-        return Store().add(thread, self._store_thread_follow_fields, as_thread=True).get_result()
+        return Store().add(thread, self._store_thread_follow_fields, as_thread=True)
 
     @classmethod
     def _store_thread_follow_fields(cls, res: Store.FieldList):

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -30,7 +30,7 @@ class WebclientController(ThreadController):
         if context:
             request.update_context(**context)
         self._process_request_loop(store, fetch_params)
-        return store.get_result()
+        return store
 
     @classmethod
     def _process_request_loop(self, store: Store, fetch_params):

--- a/addons/mail/models/discuss/bus.py
+++ b/addons/mail/models/discuss/bus.py
@@ -1,14 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import models
+
+from odoo.addons.bus.models.bus import SKIP_NOTIFICATION
+from odoo.addons.mail.tools.discuss import Store
 
 
 class BusBus(models.Model):
     _inherit = "bus.bus"
 
-    @api.model
-    def _sendone(self, target, notification_type, message):
-        if mail_store := self.env.context.get("mail_store"):
-            mail_store.enqueue_bus_notification(target, notification_type, message)
-        else:
-            super()._sendone(target, notification_type, message)
+    def _prepare_payload(self, payload):
+        if isinstance(payload, Store):
+            return payload.as_dict() or SKIP_NOTIFICATION
+        return super()._prepare_payload(payload)

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -689,7 +689,7 @@ class DiscussChannel(models.Model):
                 payload = {
                     "channel_id": member.channel_id.id,
                     "invite_to_rtc_call": invite_to_rtc_call,
-                    "data": joined_store.get_result(),
+                    "data": joined_store,
                 }
                 if not member.is_self and not self.env.user._is_public():
                     payload["invited_by_user_id"] = self.env.user.id
@@ -979,7 +979,7 @@ class DiscussChannel(models.Model):
         store = Store(bus_channel=self).add(message, "_store_message_fields")
         if message.channel_id.parent_channel_id:
             store.add(message.channel_id, ["message_count"])
-        payload = {"data": store.get_result(), "id": self.id}
+        payload = {"data": store, "id": self.id}
         if temporary_id := self.env.context.get("temporary_id"):
             payload["temporary_id"] = temporary_id
         if kwargs.get("silent"):
@@ -1279,10 +1279,12 @@ class DiscussChannel(models.Model):
         # sudo : discuss.channel.member - prefetching member fields as sudo is acceptable,
         # and its necessary to get channel_role in the same query as the other fields.
         all_members.sudo().mapped("channel_role")
-        # prefetch in batch, including nested relations (member, guest, ...)
-        prefetch_store = Store(bus_channel=res.target.channel, bus_subchannel=res.target.subchannel)
-        prefetch_store.add(all_members, "_store_member_fields")
-        prefetch_store.get_result()  # execute the queued operations, which access the nested fields
+        # prefetch in batch, including nested relations (member, guest, ...).
+        # `_build_result` must be called as store is lazy.
+        Store(bus_channel=res.target.channel, bus_subchannel=res.target.subchannel).add(
+            all_members,
+            "_store_member_fields",
+        )._build_result()
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         res.attr("avatar_cache_key", predicate=is_channel_or_group)
@@ -1567,7 +1569,7 @@ class DiscussChannel(models.Model):
         """ Return 'limit'-first channels' name, channel_type and group_public_id fields such that the
             name matches a 'search' string. Exclude channels of type chat (DM) and group.
         """
-        store = Store().add(
+        return Store().add(
             self.search([("name", "ilike", search), ("channel_type", "=", "channel")], limit=limit),
             lambda res: (
                 res.extend(["name", "channel_type"]),
@@ -1575,7 +1577,6 @@ class DiscussChannel(models.Model):
                 res.attr("parent_channel_id"),
             ),
         )
-        return store.get_result()
 
     def _get_last_messages(self):
         """ Return the last message for each of the given channels."""

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -106,7 +106,7 @@ class DiscussChannelRtcSession(models.Model):
         store = Store(bus_channel=self.channel_id).add(self, "_store_extra_fields")
         self.channel_id._bus_send(
             "discuss.channel.rtc.session/update_and_broadcast",
-            {"data": store.get_result(), "channelId": self.channel_id.id},
+            {"data": store, "channelId": self.channel_id.id},
         )
 
     @api.autovacuum

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -73,7 +73,7 @@ class ResPartner(models.Model):
             **channel_invites,
             "email_already_sent": email_already_sent,
             "selectable_email": selectable_email,
-            "store_data": store.get_result(),
+            "store_data": store,
         }
 
     @api.readonly
@@ -157,4 +157,4 @@ class ResPartner(models.Model):
             store.add(roles, ["name", "user_ids_count"])
         except AccessError:
             pass
-        return store.get_result()
+        return store

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -20,7 +20,7 @@ class IrHttp(models.AbstractModel):
                     allowed_company_ids.append(company_id)
             user = user.with_context(allowed_company_ids=allowed_company_ids)
         store.add_global_values(user.sudo(False)._store_init_global_fields)
-        result["storeData"] = store.get_result()
+        result["storeData"] = store.as_dict()
         guest = self.env['mail.guest']._get_guest_from_context()
         if not request.session.uid and guest:
             user_context = {'lang': guest.lang}

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -716,7 +716,7 @@ class MailActivity(models.Model):
 
     @api.readonly
     def activity_format(self):
-        return Store().add(self, "_store_activity_fields").get_result()
+        return Store().add(self, "_store_activity_fields")
 
     def _store_activity_fields(self, res: Store.FieldList):
         res.attr("activity_category")

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -22,6 +22,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 if typing.TYPE_CHECKING:
     from odoo.models import BaseModel
+    from odoo.addons.mail.models.mail_followers import MailFollowers
 
 
 _logger = logging.getLogger(__name__)
@@ -955,7 +956,7 @@ class MailMessage(models.Model):
         store = Store().add(notifications.mail_message_id, "_store_message_fields")
         self.env.user._bus_send(
             "mail.message/mark_as_unread",
-            {"message_ids": notifications.mail_message_id.ids, "store_data": store.get_result()},
+            {"message_ids": notifications.mail_message_id.ids, "store_data": store},
         )
 
     @api.model
@@ -1105,7 +1106,7 @@ class MailMessage(models.Model):
         format_reply=True,
         msg_vals=False,
         inbox_fields=False,
-        followers=None,
+        followers: Store.LazyValue[MailFollowers] = None,
     ):
         """
         :param format_reply: if True, also get data about the parent message if it exists.
@@ -1217,6 +1218,8 @@ class MailMessage(models.Model):
                 domain &= Domain("partner_id", "=", target_user.partner_id.id)
                 # sudo: mail.followers - reading followers of current partner
                 followers = self.env["mail.followers"].sudo().search(domain)
+            else:
+                followers = followers.get(self.env)
             for follower in followers:
                 follower_by_record_and_partner[
                     self.env[follower.res_model].browse(follower.res_id),

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -27,7 +27,7 @@ from markupsafe import Markup, escape
 from requests import Session
 from werkzeug import urls
 
-from odoo import _, api, exceptions, fields, models, tools
+from odoo import _, api, exceptions, fields, models, modules, tools
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tools.web_push import (
     push_to_end_point, DeviceUnreachableError,
@@ -3414,13 +3414,18 @@ class MailThread(models.AbstractModel):
             # sudo: mail.notification - creating notifications is the purpose of notify methods
             self.env["mail.notification"].sudo().create(notif_create_values)
             users = self.env["res.users"].browse(i[1] for i in inbox_pids_uids if i[1])
-            # sudo: mail.followers - reading followers of target users in batch to send it to them
-            followers = self.env["mail.followers"].sudo().search(
-                [
-                    ("res_model", "=", message.model),
-                    ("res_id", "=", message.res_id),
-                    ("partner_id", "in", users.partner_id.ids),
-                ]
+            followers = Store.LazyValue(
+                lambda: (
+                    self.env["mail.followers"]
+                    .sudo()
+                    .search(
+                        [
+                            ("res_model", "=", message.model),
+                            ("res_id", "=", message.res_id),
+                            ("partner_id", "in", users.partner_id.ids),
+                        ],
+                    )
+                ),
             )
             batch_vals = {"msg_vals": msg_vals, "inbox_fields": True, "followers": followers}
             for user in users:
@@ -3429,7 +3434,10 @@ class MailThread(models.AbstractModel):
                     "_store_message_fields",
                     fields_params=batch_vals,
                 )
-                data = store.get_result()
+                # In tests, emails are sent immediately instead of in postcommit. The
+                # resulting mail unlink invalidates the ORM cache; call `as_dict()` now to
+                # benefit from the cache and maintain a realistic query count.
+                data = store.as_dict() if modules.module.current_test else store
                 user._bus_send("mail.message/inbox", {"message_id": message.id, "store_data": data})
 
     def _notify_thread_by_email(self, message, recipients_data, *, msg_vals=False,
@@ -4930,13 +4938,12 @@ class MailThread(models.AbstractModel):
 
     @api.readonly
     def message_get_followers(self, after=None, limit=100, filter_recipients=False):
-        store = Store().add(
+        return Store().add(
             self,
             "_store_message_followers_fields",
             fields_params={"after": after, "limit": limit, "filter_recipients": filter_recipients},
             as_thread=True,
         )
-        return store.get_result()
 
     def _store_message_followers_fields(
         self,

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -25,10 +25,10 @@ class Base(models.AbstractModel):
     # ------------------------------------------------------------
 
     def _flush(self):
-        if mail_store := self.env.context.get("mail_store"):
+        if store_version_ctx := self.env.context.get("store_version_ctx"):
             for field in self._fields.values():
                 if ids := self.env._field_dirty.get(field):
-                    mail_store.mark_field_as_written(field.model_name, ids, field.name)
+                    store_version_ctx.mark_field_as_written(field.model_name, ids, field.name)
         return super()._flush()
 
     def with_user(self, user):

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -294,7 +294,7 @@ class ResPartner(models.Model):
             store.add(roles, ["name", "user_ids_count"])
         except AccessError:
             pass
-        return store.get_result()
+        return store
 
     @api.model
     def _get_mention_suggestions_domain(self, search):

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1663,8 +1663,8 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
                     BusResult(
                         message.author_id.user_ids,
                         "mail.record/insert",
-                        Store().add(message, "_store_notification_fields").get_result(),
-                    )
+                        Store().add(message, "_store_notification_fields"),
+                    ),
                 ] * bus_notif_count
                 self._assertBusNotifications(expected)
 

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -375,7 +375,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_info_get(self):
         # `channel_get` should return a new channel the first time a partner is given
         channel = self.env["discuss.channel"]._get_or_create_chat(partners_to=self.test_partner.ids)
-        init_data = Store().add(channel, "_store_channel_fields").get_result()
+        init_data = Store().add(channel, "_store_channel_fields")._build_result()
         initial_channel_info = init_data["discuss.channel"][0]
         self.assertEqual(
             {persona["id"] for persona in init_data["res.partner"]},
@@ -385,21 +385,21 @@ class TestChannelInternals(MailCommon, HttpCase):
         # `channel_get` should return the existing channel every time the same partner is given
         same_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
         store_1 = Store().add(same_channel, "_store_channel_fields")
-        same_channel_info = store_1.get_result()["discuss.channel"][0]
+        same_channel_info = store_1._build_result()["discuss.channel"][0]
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return the existing channel when the current partner is given together with the other partner
         together_pids = (self.partner_employee_nomail + self.test_partner).ids
         together_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=together_pids)
         store_2 = Store().add(together_channel, "_store_channel_fields")
-        together_channel_info = store_2.get_result()["discuss.channel"][0]
+        together_channel_info = store_2._build_result()["discuss.channel"][0]
         self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return a new channel the first time just the current partner is given,
         # even if a channel containing the current partner together with other partners already exists
         solo_pids = self.partner_employee_nomail.ids
         solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=solo_pids)
-        solo_channel_data = Store().add(solo_channel, "_store_channel_fields").get_result()
+        solo_channel_data = Store().add(solo_channel, "_store_channel_fields")._build_result()
         solo_channel_info = solo_channel_data["discuss.channel"][0]
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
         self.assertEqual(
@@ -411,7 +411,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         same_solo_pids = self.partner_employee_nomail.ids
         same_solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=same_solo_pids)
         store_3 = Store().add(same_solo_channel, "_store_channel_fields")
-        same_solo_channel_info = store_3.get_result()["discuss.channel"][0]
+        same_solo_channel_info = store_3._build_result()["discuss.channel"][0]
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
 
     # `channel_get` will pin the channel by default and thus last interest will be updated.
@@ -443,7 +443,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
         self_member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
         self_member._mark_as_read(msg_2.id)
-        init_data = Store().add(chat, "_store_channel_fields").get_result()
+        init_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
             filter(lambda d: d["id"] == self_member.id, init_data["discuss.channel.member"])
         )
@@ -453,7 +453,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             "Last message id should have been updated",
         )
         self_member._mark_as_read(msg_1.id)
-        final_data = Store().add(chat, "_store_channel_fields").get_result()
+        final_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
             filter(lambda d: d["id"] == self_member.id, final_data["discuss.channel.member"])
         )

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -493,6 +493,17 @@ class TestDiscussChannelAccess(MailCommon):
             channel = DiscussChannel._create_channel("Channel", group_id=None)
             if membership == "member":
                 channel._add_members(users=user, guests=guest)
+        # Channel is added to the store, then the group is changed. In the case of
+        # `group_failing`, `other_user` is not allowed to read the channel anymore. If
+        # `Store.as_dict()` is called later to gather channel data, an access error is
+        # raised.
+        #
+        # Another issue is that the "unlink" tests create and unlink the channel in the
+        # same transaction which will lead to a missing error.
+        #
+        # This is unrelated to the scenarios being tested, clear the bus notification now
+        # thus preventing unrelated errors later on.
+        self._reset_bus()
         if channel_key == "no_group":
             channel.group_public_id = None
         elif channel_key == "group_matching":
@@ -503,6 +514,7 @@ class TestDiscussChannelAccess(MailCommon):
             channel = channel.sudo()._create_sub_channel()
             if membership == "member":
                 channel._add_members(users=user, guests=guest)
+            self._reset_bus()
         return channel.id
 
     def _execute_action_channel(self, user_key, channel_key, membership, operation, result, for_sub_channel):

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -79,7 +79,7 @@ class TestDiscussChannelMember(MailCommon):
         data = self.env["res.partner"].search_for_channel_invite(
             partner.name,
             channel_id=public_channel.id,
-        )["store_data"]
+        )["store_data"]._build_result()
         self.assertEqual(len(data["res.partner"]), 1)
         self.assertEqual(data["res.partner"][0]["id"], partner.id)
 

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -124,7 +124,7 @@ class TestChannelRTC(MailCommon, HttpCase):
         with self.assertBus(notifications):
             store = Store()
             channel_member._rtc_join_call(store)
-            res = store.get_result()
+            res = store._build_result()
         self.assertEqual(
             res,
             {
@@ -1526,7 +1526,7 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         store = Store()
         channel_member._rtc_join_call(store)
-        join_call_values = store.get_result()
+        join_call_values = store._build_result()
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
         test_channel_member = self.env['discuss.channel.member'].create({
             'guest_id': test_guest.id,

--- a/addons/mail/tests/discuss/test_store_versioning.py
+++ b/addons/mail/tests/discuss/test_store_versioning.py
@@ -1,16 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 import math
-from unittest.mock import patch
 
 from odoo.http import Controller
 from odoo.tests import new_test_user
 
-from odoo.addons.base.tests.common import HttpCase, TransactionCase
+from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.bus.tests.common import BusResult
-from odoo.addons.mail.models.discuss.discuss_channel import DiscussChannel
 from odoo.addons.mail.tests.common import MailCase
-from odoo.addons.mail.tools.discuss import Store, mail_route, store_version
+from odoo.addons.mail.tools.discuss import Store, mail_route
 
 
 class TestStoreVersioning(HttpCase, MailCase):
@@ -28,7 +26,7 @@ class TestStoreVersioning(HttpCase, MailCase):
                     record = self.env[model_name].browse(int(record_id))
                     record.write(values)
                     store.add(record, list(values.keys()))
-                return store.get_result()
+                return store
 
             @mail_route("/store/version/read_fields", type="jsonrpc")
             def read_fields(self, fields_to_read_by_id):
@@ -36,7 +34,7 @@ class TestStoreVersioning(HttpCase, MailCase):
                 for key, fnames in fields_to_read_by_id.items():
                     model_name, record_id = key.split(":")
                     store.add(self.env[model_name].browse(int(record_id)), fnames)
-                return store.get_result()
+                return store
 
             @mail_route("/store/version/send_bus_notifications", type="jsonrpc")
             def send_bus_notifications(self, fields_by_channel):
@@ -179,68 +177,4 @@ class TestStoreVersioning(HttpCase, MailCase):
                         f"discuss.channel:{general.id}": ["name"],
                     },
                 },
-            )
-
-
-# This test ensures that an "inner" read-only call captures the correct version, and that
-# later writes in an "outer" call update the version independently, without affecting the
-# previously retrieved inner version.
-#
-# Using a transaction case as any database modification would assign a TX id right away
-# (including `HttpCase.setupClass`).
-class TestStoreVersioningTransactionCase(TransactionCase):
-    def test_store_version_nested_calls(self):
-        @store_version
-        def inner(self, fields_to_read):
-            store = Store(bus_channel=self).add(self, fields_to_read)
-            store.bus_send()
-            return store.get_result()
-
-        @store_version
-        def outer(self, fields_to_write, fields_to_read):
-            inner_store_data = self.inner(fields_to_read)
-            self.write(fields_to_write)
-            store = Store(bus_channel=self).add(self, [*fields_to_write.keys()])
-            store.bus_send()
-            return {
-                "outer_store_data": store.get_result(),
-                "inner_store_data": inner_store_data,
-            }
-
-        with (
-            patch.object(DiscussChannel, "inner", inner, create=True),
-            patch.object(DiscussChannel, "outer", outer, create=True),
-        ):
-            channel = self.env.ref("mail.channel_all_employees")
-            self.env.cr.execute("select pg_current_xact_id_if_assigned()")
-            # No TX id at the beginning as the DB wasn't updated.
-            self.assertIsNone(self.env.cr.fetchone()[0])
-            result = channel.outer(
-                fields_to_write={"name": "written"},
-                fields_to_read=["description"],
-            )
-            self.assertEqual(
-                result["inner_store_data"]["discuss.channel"],
-                [
-                    {
-                        "id": channel.id,
-                        "description": "A place to connect and exchange news with colleagues across the company.",
-                    },
-                ],
-            )
-            inner_version = result["inner_store_data"]["__store_version__"]
-            # Writes occured after `inner` execution, version should not be impacted by the
-            # later writes.
-            self.assertFalse(inner_version["snapshot"]["current_xact_id"])
-            self.assertFalse(inner_version["written_fields_by_record"])
-            self.assertEqual(
-                result["outer_store_data"]["discuss.channel"],
-                [{"id": channel.id, "name": "written"}],
-            )
-            outer_version = result["outer_store_data"]["__store_version__"]
-            # But `outer` wrote on some fields, version should have been updated.
-            self.assertTrue(outer_version["snapshot"]["current_xact_id"])
-            self.assertEqual(
-                outer_version["written_fields_by_record"],
-                {"discuss.channel": {channel.id: ["name", "write_date"]}},
             )

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -16,14 +16,14 @@ class TestDiscussTools(MailCase):
         """Test dict is present in result."""
         store = Store()
         store.add_model_values("key1", {"id": 1, "test": True})
-        self.assertEqual(store.get_result(), {"key1": [{"id": 1, "test": True}]})
+        self.assertEqual(store._build_result(), {"key1": [{"id": 1, "test": True}]})
 
     def test_011_store_dict_update_same_id(self):
         """Test dict update same id."""
         store = Store()
         store.add_model_values("key1", {"id": 1, "test": True})
         store.add_model_values("key1", {"id": 1, "test": False, "abc": 1})
-        self.assertEqual(store.get_result(), {"key1": [{"id": 1, "test": False, "abc": 1}]})
+        self.assertEqual(store._build_result(), {"key1": [{"id": 1, "test": False, "abc": 1}]})
 
     def test_012_store_dict_update_multiple_ids(self):
         """Test dict update multiple ids."""
@@ -32,7 +32,7 @@ class TestDiscussTools(MailCase):
         store.add_model_values("key1", {"id": 2, "test": True})
         store.add_model_values("key1", {"id": 2, "test": False, "abc": 1})
         self.assertEqual(
-            store.get_result(),
+            store._build_result(),
             {"key1": [{"id": 1, "test": True}, {"id": 2, "test": False, "abc": 1}]},
         )
 
@@ -41,27 +41,27 @@ class TestDiscussTools(MailCase):
         store = Store()
         store.add_model_values("key1", True)
         with self.assertRaises(TypeError):
-            store.get_result()
+            store._build_result()
 
     def test_042_store_invalid_missing_id(self):
         """Test Thread adding invalid list value."""
         store = Store()
         store.add_model_values("key1", {"test": True})
         with self.assertRaises(AssertionError):
-            store.get_result()
+            store._build_result()
 
     def test_060_store_data_empty_val(self):
         """Test empty values are not present in result."""
         store = Store()
         store.add_model_values("key1", {})
-        self.assertEqual(store.get_result(), {})
+        self.assertEqual(store._build_result(), {})
 
     def test_061_store_data_empty_not_empty(self):
         """Test mixing empty and non-empty values."""
         store = Store()
         store.add_model_values("key1", {})
         store.add_model_values("key2", {"id": 1})
-        self.assertEqual(store.get_result(), {"key2": [{"id": 1}]})
+        self.assertEqual(store._build_result(), {"key2": [{"id": 1}]})
 
     def test_075_store_same_related_field_twice(self):
         """Test adding the same related field twice combines their data"""
@@ -74,7 +74,7 @@ class TestDiscussTools(MailCase):
             ),
         )
         self.assertEqual(
-            store.get_result(),
+            store._build_result(),
             {
                 "res.partner": [
                     {
@@ -94,41 +94,41 @@ class TestDiscussTools(MailCase):
         """Test Store dict is present in result as a singleton."""
         store = Store()
         store.add_global_values(test=True)
-        self.assertEqual(store.get_result(), {"Store": {"test": True}})
+        self.assertEqual(store._build_result(), {"Store": {"test": True}})
 
     def test_111_store_store_dict_update(self):
         """Test Store dict update."""
         store = Store()
         store.add_global_values(test=True)
         store.add_global_values(test=False, abc=1)
-        self.assertEqual(store.get_result(), {"Store": {"test": False, "abc": 1}})
+        self.assertEqual(store._build_result(), {"Store": {"test": False, "abc": 1}})
 
     def test_140_store_store_invalid_bool(self):
         """Test Store adding invalid value."""
         store = Store()
         store.add_model_values("key1", True)
         with self.assertRaises(TypeError):
-            store.get_result()
+            store._build_result()
 
     def test_141_store_store_invalid_list(self):
         """Test adding invalid value."""
         store = Store()
         store.add_model_values("key1", [{"test": True}])
         with self.assertRaises(AssertionError):
-            store.get_result()
+            store._build_result()
 
     def test_160_store_store_data_empty_val(self):
         """Test Store empty values are not present in result."""
         store = Store()
         store.add_global_values()
-        self.assertEqual(store.get_result(), {})
+        self.assertEqual(store._build_result(), {})
 
     def test_161_store_store_data_empty_not_empty(self):
         """Test Store mixing empty and non-empty values."""
         store = Store()
         store.add_global_values()
         store.add_model_values("key2", {"id": 1})
-        self.assertEqual(store.get_result(), {"key2": [{"id": 1}]})
+        self.assertEqual(store._build_result(), {"key2": [{"id": 1}]})
 
     # 2xx Thread specific tests (dual id in ids_by_model)
 
@@ -137,7 +137,7 @@ class TestDiscussTools(MailCase):
         store = Store()
         store.add_model_values("mail.thread", {"id": 1, "model": "res.partner", "test": True})
         self.assertEqual(
-            store.get_result(), {"mail.thread": [{"id": 1, "model": "res.partner", "test": True}]}
+            store._build_result(), {"mail.thread": [{"id": 1, "model": "res.partner", "test": True}]}
         )
 
     def test_211_store_thread_dict_update_same_id(self):
@@ -146,7 +146,7 @@ class TestDiscussTools(MailCase):
         store.add_model_values("mail.thread", {"id": 1, "model": "res.partner", "test": True})
         store.add_model_values("mail.thread", {"id": 1, "model": "res.partner", "test": False, "abc": 1})
         self.assertEqual(
-            store.get_result(),
+            store._build_result(),
             {"mail.thread": [{"id": 1, "model": "res.partner", "test": False, "abc": 1}]},
         )
 
@@ -157,7 +157,7 @@ class TestDiscussTools(MailCase):
         store.add_model_values("mail.thread", {"id": 2, "model": "res.partner", "test": True})
         store.add_model_values("mail.thread", {"id": 2, "model": "res.partner", "test": False, "abc": 1})
         self.assertEqual(
-            store.get_result(),
+            store._build_result(),
             {
                 "mail.thread": [
                     {"id": 1, "model": "res.partner", "test": True},
@@ -175,7 +175,7 @@ class TestDiscussTools(MailCase):
         store.add_model_values("mail.thread", {"id": 2, "model": "discuss.channel", "test": False, "abc": 2})
         store.add_model_values("mail.thread", {"id": 1, "model": "res.partner", "test": False})
         self.assertEqual(
-            store.get_result(),
+            store._build_result(),
             {
                 "mail.thread": [
                     {"id": 1, "model": "res.partner", "test": False},
@@ -190,41 +190,41 @@ class TestDiscussTools(MailCase):
         store = Store()
         store.add_model_values("mail.thread", True)
         with self.assertRaises(TypeError):
-            store.get_result()
+            store._build_result()
 
     def test_241_store_thread_invalid_list(self):
         """Test Thread adding invalid list value."""
         store = Store()
         store.add_model_values("mail.thread", [True])
         with self.assertRaises(AttributeError):
-            store.get_result()
+            store._build_result()
 
     def test_242_store_thread_invalid_missing_id(self):
         """Test Thread adding invalid missing id."""
         store = Store()
         store.add_model_values("mail.thread", {"model": "res.partner"})
         with self.assertRaises(AssertionError):
-            store.get_result()
+            store._build_result()
 
     def test_243_store_thread_invalid_missing_model(self):
         """Test Thread adding invalid list value."""
         store = Store()
         store.add_model_values("mail.thread", {"id": 1})
         with self.assertRaises(AssertionError):
-            store.get_result()
+            store._build_result()
 
     def test_260_store_thread_data_empty_val(self):
         """Test Thread empty values are not present in result."""
         store = Store()
         store.add_model_values("mail.thread", {})
-        self.assertEqual(store.get_result(), {})
+        self.assertEqual(store._build_result(), {})
 
     def test_261_store_thread_data_empty_not_empty(self):
         """Test Thread mixing empty and non-empty values."""
         store = Store()
         store.add_model_values("key1", {})
         store.add_model_values("mail.thread", {"id": 1, "model": "res.partner"})
-        self.assertEqual(store.get_result(), {"mail.thread": [{"id": 1, "model": "res.partner"}]})
+        self.assertEqual(store._build_result(), {"mail.thread": [{"id": 1, "model": "res.partner"}]})
 
     # 3xx Tests with real models
 
@@ -241,7 +241,7 @@ class TestDiscussTools(MailCase):
                 ),
             ),
         )
-        self.assertEqual(store.get_result()["res.partner"][0]["email"], "test_user_350@example.com")
+        self.assertEqual(store._build_result()["res.partner"][0]["email"], "test_user_350@example.com")
 
     def test_355_single_extra_fields_copy_with_records(self):
         """Test that dynamic_fields apply individually to each record even when list extra fields are present."""
@@ -256,7 +256,7 @@ class TestDiscussTools(MailCase):
             user_a + user_b,
             lambda res: res.one("partner_id", lambda res: res.attr("name"), dynamic_fields=fields),
         )
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual(data["res.partner"][0]["email"], "test_user_355_a@example.com")
         self.assertNotIn("email", data["res.partner"][1])
 
@@ -371,11 +371,11 @@ class TestDiscussTools(MailCase):
         user_a = new_test_user(self.env, "test_user_390@example.com")
         store = Store()
         store.add(user_a, "_store_im_status_fields")
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual(data["res.partner"][0]["im_status"], "offline")
         self.env["mail.presence"]._update_presence(user_a)
         store.add(user_a, "_store_im_status_fields")
-        data2 = store.get_result()
+        data2 = store._build_result()
         self.assertEqual(data2["res.partner"][0]["im_status"], "online")
 
     def test_391_add_no_loop_callable_identity_obj(self):
@@ -388,18 +388,18 @@ class TestDiscussTools(MailCase):
             res.one("partner_id", _store_partner_test_fields)
 
         user = new_test_user(self.env, "test_user_391@example.com")
-        data = Store().add(user, _store_user_test_fields).get_result()
+        data = Store().add(user, _store_user_test_fields)._build_result()
         self.assertEqual(data["res.partner"][0]["test"], user.partner_id.id)
         self.assertEqual(data["res.users"][0]["test"], user.id)
 
     def test_393_delayed_add(self):
-        """Test that delayed store.add() postpones reading fields until get_result()."""
+        """Test that delayed store.add() postpones reading fields until _build_result()."""
         user_a = new_test_user(self.env, "test_user_390@example.com")
         store = Store()
         store.add(user_a, "_store_im_status_fields")
         self.assertEqual(user_a.partner_id.im_status, "offline")
         self.env["mail.presence"]._update_presence(user_a)
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual(data["res.partner"][0]["im_status"], "online")
 
     def test_395_delayed_add_ignores_deleted_record(self):
@@ -408,7 +408,7 @@ class TestDiscussTools(MailCase):
         store = Store()
         store.add(user_a, ["name"])
         user_a.unlink()
-        data = store.get_result()
+        data = store._build_result()
         self.assertFalse(data)
 
     def test_397_delayed_delete_keeps_deleted_record(self):
@@ -418,7 +418,7 @@ class TestDiscussTools(MailCase):
         user_a.unlink()
         store.add(user_a, ["name"])
         store.delete(user_a)
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual({"res.users": [{"id": user_a.id, "_DELETE": True}]}, data)
 
     # 4xx Tests many command modes
@@ -435,7 +435,7 @@ class TestDiscussTools(MailCase):
                 res.many("messages", [], value=general.message_ids[1], mode="REPLACE"),
             ),
         )
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual(data["discuss.channel"][0]["messages"], general.message_ids[1].ids)
 
     def test_460_replace_wrapped_into_command_when_multiple_commands_are_added(self):
@@ -448,7 +448,7 @@ class TestDiscussTools(MailCase):
             general,
             lambda res: res.many("messages", [], value=general.message_ids, mode="REPLACE"),
         )
-        data = store.get_result()
+        data = store._build_result()
         store = Store()
         self.assertEqual(data["discuss.channel"][0]["messages"], general.message_ids.ids)
         store.add(
@@ -458,7 +458,7 @@ class TestDiscussTools(MailCase):
                 res.many("messages", [], value=general.message_ids[2], mode="DELETE"),
             ),
         )
-        data = store.get_result()
+        data = store._build_result()
         self.assertEqual(
             data["discuss.channel"][0]["messages"],
             [("REPLACE", general.message_ids.ids), ("DELETE", general.message_ids[2].ids)],

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -123,14 +123,19 @@ class TestPartner(MailCommon):
             mail_new_test_user(self.env, login=f'{name}-{i}-internal-user', groups='base.group_user')
 
         # suggest portal user of this company in another company
-        suggested_partners = self.env["res.partner"].with_user(self.user_employee_c2).get_mention_suggestions("portal-user")
+        suggested_partners = (
+            self.env["res.partner"]
+            .with_user(self.user_employee_c2)
+            .get_mention_suggestions("portal-user")
+            ._build_result()
+        )
 
         porter_user_suggested = [
             p for p in suggested_partners['res.partner']
             if p["name"] == f'{name}-1-portal-user (base.group_portal)'
         ]
         self.assertEqual(len(porter_user_suggested), 1, "porter_user_suggested should contain one user")
-        store_data = self.env["res.partner"].get_mention_suggestions(name, limit=5)
+        store_data = self.env["res.partner"].get_mention_suggestions(name, limit=5)._build_result()
         partners_format = store_data["res.partner"]
         self.assertEqual(len(partners_format), 5, "should have found limit (5) partners")
         # return format for user is either a dict (there is a user and the dict is data) or a list of command (clear)

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -4,19 +4,23 @@ import base64
 import math
 import os
 from collections import UserList, defaultdict
+from contextlib import suppress
 from datetime import date, datetime
 from functools import partial, wraps
 from itertools import product
+from typing import Generic, TypeVar
 
 from markupsafe import Markup
 
 import odoo
-from odoo import _, models
+from odoo import models
 from odoo.exceptions import MissingError
-from odoo.http import Response, request, route
+from odoo.http import request, route
 from odoo.tools import OrderedSet, groupby
 
 from odoo.addons.bus.websocket import wsrequest
+
+T = TypeVar("T")
 
 
 def add_guest_to_context(func):
@@ -49,29 +53,24 @@ def add_guest_to_context(func):
 class StoreVersionInternal:
     """Internal state used by the `@store_version` decorator."""
     def __init__(self):
-        self._pending_bus_sends = []
-        self._snapshot_data = None
-        # Maps model names to record IDs to the set of updated field names.
-        self._written_fields_by_record = defaultdict(lambda: defaultdict(OrderedSet))
-
-    def enqueue_bus_notification(self, bus_channel, notification_type, payload):
-        """Enqueue a bus notification to be sent when the `@store_version` decorator
-        finishes, ensuring it includes the version metadata.
-        """
-        self._pending_bus_sends.append([bus_channel, notification_type, payload])
+        self.__version = None
+        self.__model_name_to_record_id_to_written_fnames = defaultdict(
+            lambda: defaultdict(OrderedSet)
+        )
 
     def mark_field_as_written(self, model_name, record_ids, fname):
         """Mark field as written for the given records. Done automatically when using the
         ORM, should be done manually otherwise.
         """
+        record_id_to_written_fnames = self.__model_name_to_record_id_to_written_fnames[model_name]
         for id_ in record_ids:
-            self._written_fields_by_record[model_name][id_].add(fname)
+            record_id_to_written_fnames[id_].add(fname)
 
-    def _get_formatted_version(self, env):
+    def get_formatted_version(self, env):
         """Get the version metadata, used by the client to determine if an incoming
         store insert is newer than what it already knows.
         """
-        if not self._snapshot_data:
+        if not self.__version:
             env.flush_all()  # Ensure TX id is assigned, if the DB was modified, before building the version.
             env.cr.execute("SELECT pg_current_snapshot(), pg_current_xact_id_if_assigned()")
             snapshot_str, current_xact_id = env.cr.fetchone()
@@ -83,59 +82,19 @@ class StoreVersionInternal:
             for x in xips:
                 offset = x - xmin
                 bitmap[offset // 8] |= 1 << (offset % 8)
-            self._snapshot_data = {
-                "xmin": str(xmin),
-                "xmax": str(xmax),
-                "xip_bitmap": base64.b64encode(bitmap).decode(),
-                "current_xact_id": current_xact_id,
+            self.__version = {
+                "snapshot": {
+                    "xmin": xmin_str,
+                    "xmax": xmax_str,
+                    "xip_bitmap": base64.b64encode(bitmap).decode(),
+                    "current_xact_id": current_xact_id,
+                },
+                "written_fields_by_record": {
+                    model: {record_id: list(fnames) for record_id, fnames in recs.items()}
+                    for model, recs in self.__model_name_to_record_id_to_written_fnames.items()
+                },
             }
-        elif not self._snapshot_data["current_xact_id"]:
-            env.flush_all()  # Ensure written fields are collected.
-            if self._written_fields_by_record:
-                # Snapshot was already fetched below in the stack, but fields have been
-                # updated since then. The snapshot is frozen at the beginning of the TX,
-                # but the current TX id is only assigned once the DB is modified. Update
-                # it now.
-                env.cr.execute("SELECT pg_current_xact_id_if_assigned()")
-                self._snapshot_data["current_xact_id"] = env.cr.fetchone()[0]
-        return {
-            "snapshot": self._snapshot_data.copy(),
-            "written_fields_by_record": {
-                model: {record_id: list(fnames) for record_id, fnames in recs.items()}
-                for model, recs in self._written_fields_by_record.items()
-            },
-        }
-
-    def _inject_version(self, version, payload):
-        """Add the version to the return value of `Store.get_result()`. Either the
-        payload itself, or one of the values of the payload.
-        """
-        if isinstance(payload, Store.Result) and "__store_version__" not in payload:
-            payload["__store_version__"] = version
-            return True
-        if isinstance(payload, dict):
-            return any(self._inject_version(version, v) for v in payload.values())
-        return False
-
-    def _add_version_to_response(self, version, response):
-        """Inject version metadata into the result returned by `Store.get_result()`,
-        which may be either an HTTP response from a controller or a dict returned by the
-        decorated function.
-        """
-        # Response is the result of `request.render()`, inject metadata inside the qweb context.
-        if isinstance(response, Response) and response.template:
-            self._inject_version(version, response.qcontext)
-        else:
-            self._inject_version(version, response)
-
-    def _send_bus_notifications(self, env, version):
-        """Send the notifications enqueued during the decorator method, alongside store
-        version metadata.
-        """
-        for target, n_type, msg in self._pending_bus_sends:
-            self._inject_version(version, msg)
-            env["bus.bus"].with_context(mail_store=None)._sendone(target, n_type, msg)
-        self._pending_bus_sends.clear()
+        return self.__version
 
 
 def store_version(func):
@@ -154,61 +113,44 @@ def store_version(func):
     write transaction. The combination of xmin, xmax, xip and the current transaction id
     is enough to deduce it.
 
-    This decorator injects version metadata into the return value of `Store.get_result()`,
-    both in the value returned by the decorated function and in any bus notifications
-    emitted during its execution.
-
+    This decorator injects the version helper into the context, allowing written fields to
+    be observed and `Store.as_dict` to inject version metadata into its result.
     """
     @wraps(func)
     def store_version__wrapper(self, *args, **kwargs):
-        manager = self.env.context.get("mail_store")
+        if self.env.context.get("store_version_ctx"):
+            return func(self, *args, **kwargs)
         should_cleanup = False
-        if not manager:
-            manager = StoreVersionInternal()
-            if isinstance(self, models.BaseModel):
-                self = self.with_context(mail_store=manager)
-            else:
-                # Clean up only if we inserted the manager in the request context;
-                # otherwise, the original decorator will handle it.
-                should_cleanup = True
-                req = request or wsrequest
-                req.update_context(mail_store=manager)
+        manager = StoreVersionInternal()
+        if isinstance(self, models.BaseModel):
+            self = self.with_context(store_version_ctx=manager)
+        else:
+            # Clean up only if we inserted the manager in the request context;
+            # otherwise, the original decorator will handle it.
+            should_cleanup = True
+            req = request or wsrequest
+            req.update_context(store_version_ctx=manager)
         response = func(self, *args, **kwargs)
-        version = manager._get_formatted_version(self.env)
-        manager._add_version_to_response(version, response)
-        manager._send_bus_notifications(self.env, version)
         if should_cleanup:
-            # Clean context to prevent side effects based on the presence of `mail_store`.
-            req.update_context(mail_store=None)
+            # Clean context to prevent side effects based on the presence of `store_version_ctx`.
+            req.update_context(store_version_ctx=None)
         return response
     return store_version__wrapper
 
 
 def mail_route(*route_args, **route_kwargs):
     """Thin wrapper around `route` that adds guest context and enables versioning.
-    HTTP route results that return a non-Response object will automatically be converted
-    into a proper HTTP JSON response using `request.make_json_response`.
 
     This decorator is equivalent to applying, in order:
         @route(*route_args, **route_kwargs)
         @store_version
         @add_guest_to_context
     """
-    if "type" not in route_kwargs:
-        raise TypeError(_("mail_route() must be called with the `type` keyword argument."))
 
     def decorator(func):
         wrapped_func = add_guest_to_context(func)
         wrapped_func = store_version(wrapped_func)
-
-        @wraps(func)
-        def mail_route__wrapper(*args, **kwargs):
-            result = wrapped_func(*args, **kwargs)
-            if route_kwargs["type"] == "http" and not isinstance(result, Response):
-                return request.make_json_response(result)  # nosemgrep: rules.requests-in-models
-            return result
-
-        return route(*route_args, **route_kwargs)(mail_route__wrapper)
+        return route(*route_args, **route_kwargs)(wrapped_func)
 
     return decorator
 
@@ -258,7 +200,7 @@ NO_VALUE = object()
 
 
 def store_enqueue(func):
-    """Wraps a Store method to postpone its execution until get_result()."""
+    """Wraps a Store method to postpone its execution until `Store._build_result()`."""
 
     @wraps(func)
     def store_enqueue__wrapper(store, *args, **kwargs):
@@ -276,7 +218,14 @@ class Store:
     """Helper to build a dict of data for sending to web client.
     It supports merging of data from multiple sources, either through list extend or dict update.
     The keys of data are the name of models as defined in mail JS code, and the values are any
-    format supported by store.insert() method (single dict or list of dict for each model name)."""
+    format supported by store.insert() method (single dict or list of dict for each model
+    name).
+
+    The store instance is then transformed to a dictionnary to be sent either by the HTTP
+    or the bus stack. If the store was created in the context of the `@store_version` decorator,
+    this dictionnary also includes information about the data version, which will be used
+    by the client to distinguish stale from new data.
+    """
 
     def __init__(self, bus_channel=None, bus_subchannel=None):
         self.add_depth = 0
@@ -289,6 +238,18 @@ class Store:
         self._internal_store = None
         if bus_channel and bus_channel._name == "discuss.channel" and bus_subchannel != "internal_users":
             self._internal_store = Store(bus_channel=bus_channel, bus_subchannel="internal_users")
+        self._env_with_version_ctx = None
+        self.__try_update_version_ctx_from_env(bus_channel)
+
+    def __try_update_version_ctx_from_env(self, records):
+        is_recordset = isinstance(records, models.Model)
+        assert not records or is_recordset, "Records must be a recordset or a falsy value."
+        if (
+            is_recordset
+            and not self._env_with_version_ctx
+            and records.env.context.get("store_version_ctx")
+        ):
+            self._env_with_version_ctx = records.env
 
     @store_enqueue
     def add(self, records, fields, *, as_thread=False, fields_params=None):
@@ -306,9 +267,9 @@ class Store:
 
         Use case: to add records and their fields to store. This is the preferred method.
         """
+        self.__try_update_version_ctx_from_env(records)
         if not records:
             return self
-        assert isinstance(records, models.Model)
         # call _format_fields before checking identifier to always compare the final shape
         field_list = self._format_fields(fields, records, fields_params)
         identifier = Store._deep_freeze((records.env, records, field_list, as_thread))
@@ -363,6 +324,7 @@ class Store:
         Use case: to add fields from inside _to_store() methods to avoid recursive code.
         Note: in all other cases, Store.add() should be called instead.
         """
+        self.__try_update_version_ctx_from_env(field_list.records)
         if field_list and field_list.records:
             for record, record_data_list in self._get_records_data_list(field_list).items():
                 for record_data in record_data_list:
@@ -394,9 +356,9 @@ class Store:
     @store_enqueue
     def delete(self, records, as_thread=False):
         """Delete records from the store."""
+        self.__try_update_version_ctx_from_env(records)
         if not records:
             return self
-        assert isinstance(records, models.Model)
         model_name = "mail.thread" if as_thread else records._name
         for record in records:
             values = (
@@ -412,15 +374,29 @@ class Store:
         """Gets client action to insert this store in the client."""
         return {
             "params": {
-                "store_values": self.get_result(),
+                "store_values": self,
                 "next_action": next_action,
             },
             "tag": "mail.store_insert",
             "type": "ir.actions.client",
         }
 
-    def get_result(self):
-        """Gets resulting data built from adding all data together."""
+    def as_dict(self):
+        """Hook for JSON serialization used by the `json_default` method. Do not call
+        directly. Returns a dictionary representing the aggregated result of all store
+        commands, versioned if the store was created within a `@store_version` context.
+        """
+        result = self._build_result()
+        if result and self._env_with_version_ctx:
+            store_version_ctx = self._env_with_version_ctx.context["store_version_ctx"]
+            result["__store_version__"] = store_version_ctx.get_formatted_version(
+                self._env_with_version_ctx,
+            )
+        return result
+
+    def _build_result(self):
+        """Do not call directly. Executes pending operations and returns the aggregated
+        result, automatically invoked by `as_dict()`."""
         self.is_executing_operation_queue = True
         try:
             for func in self.operation_queue:
@@ -428,7 +404,7 @@ class Store:
             self.operation_queue.clear()
         finally:
             self.is_executing_operation_queue = False
-        res = Store.Result()
+        res = {}
         for model_name, records in sorted(self.data.items()):
             if not ids_by_model[model_name]:  # singleton
                 res[model_name] = dict(sorted(records.items()))
@@ -440,8 +416,7 @@ class Store:
         assert self.target.channel is not None, (
             "Missing `bus_channel`. Pass it to the `Store` constructor to use `bus_send`."
         )
-        if res := self.get_result():
-            self.target.channel._bus_send(notification_type, res, subchannel=self.target.subchannel)
+        self.target.channel._bus_send(notification_type, self, subchannel=self.target.subchannel)
         if self._internal_store:
             self._internal_store.bus_send()
 
@@ -526,15 +501,11 @@ class Store:
 
     def _add_abstract_fields_value(self, abstract_fields, data_list, record=None):
         for field in abstract_fields:
-            if isinstance(field, dict):
-                data_list.append(field)
-            elif not field.predicate or field.predicate(record):
-                try:
-                    data_list.append(
-                        {field.field_name: field._get_value(record)},
-                    )
-                except MissingError:
-                    break
+            with suppress(MissingError):
+                if isinstance(field, dict):
+                    data_list.append(field)
+                elif not field.predicate or field.predicate(record):
+                    data_list.append({field.field_name: field._get_value(record)})
 
     def _get_record_index(self, model_name, data_list):
         # regroup indentifying fields into values as they might be spread accross data_list entries
@@ -571,6 +542,19 @@ class Store:
             return frozenset(Store._deep_freeze(i) for i in obj)
         return obj.__code__ if hasattr(obj, "__code__") else obj
 
+    class LazyValue(Generic[T]):  # noqa: OLS01001
+        def __init__(self, fn):
+            """Helper to lazily compute a recordset, shared across multiple consumers
+            (e.g., stores) while avoiding redundant queries.
+            """
+            self._fn = fn
+            self._value = None
+
+        def get(self, env) -> T:
+            if self._value is None:
+                self._value = self._fn()
+            return self._value.with_env(env)
+
     class Stores(dict[object | tuple, "Store"]):
         """Lazy mapping to manage a list of Store indexed by bus target.
         Store methods are forwarded to all contained Store instances."""
@@ -606,12 +590,6 @@ class Store:
             )
             self.channel = channel
             self.subchannel = subchannel
-
-    class Result(dict):
-        """Marker class for dictionaries returned by `Store.get_result()`.
-        Used to distinguish store results from arbitrary dicts so version
-        metadata can be added (see `store_version` decorator).
-        """
 
     class Attr:
         """Attribute to be added for each record. The value can be a static value or a function

--- a/addons/mail/views/discuss_public_templates.xml
+++ b/addons/mail/views/discuss_public_templates.xml
@@ -13,7 +13,7 @@
                         __session_info__: <t t-out="json.dumps(session_info)"/>,
                         csrf_token: "<t t-out="request.csrf_token(None)"/>",
                         debug: "<t t-out="debug"/>",
-                        discuss_data: <t t-out="json.dumps(data)"/>
+                        discuss_data: <t t-out="json.dumps(store_data)"/>
                     };
                 </script>
                 <t t-call-assets="mail.assets_public"/>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2154,7 +2154,7 @@ class ProjectTask(models.Model):
             Domain(self.env["res.partner"]._get_mention_suggestions_domain(search))
             & Domain("id", "in", followers.partner_id.ids)
         )
-        store = Store().add(
+        return Store().add(
             self.env["res.partner"].sudo()._search_mention_suggestions(domain, limit),
             lambda res: (
                 res.extend(["email", "name"]),
@@ -2162,7 +2162,6 @@ class ProjectTask(models.Model):
                 res.from_method("_store_mention_fields"),
             ),
         )
-        return store.get_result()
 
     @api.model
     def get_import_templates(self):

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -52,7 +52,11 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
         ])
 
     def test_mention_suggestions(self):
-        data = self.task_portal.with_user(self.user_portal).get_mention_suggestions(search="")
+        data = (
+            self.task_portal.with_user(self.user_portal)
+            .get_mention_suggestions(search="")
+            ._build_result()
+        )
         suggestion_ids = {partner.get("id") for partner in data.get("res.partner")}
         self.assertEqual(
             suggestion_ids,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -379,7 +379,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
 
         def test_fn():
             field_list = self.users[0].with_user(self.users[0])._store_init_global_fields
-            return Store().add_global_values(field_list).get_result()
+            return Store().add_global_values(field_list)._build_result()
 
         self._run_test(
             fn=test_fn,

--- a/addons/test_mail/tests/test_mail_management.py
+++ b/addons/test_mail/tests/test_mail_management.py
@@ -51,7 +51,7 @@ class TestMailManagement(MailCommon, TestRecipients):
             BusResult(
                 self.msg.author_id.user_ids,
                 "mail.record/insert",
-                Store().add(self.msg, "_store_notification_fields").get_result(),
+                Store().add(self.msg, "_store_notification_fields"),
             ),
         ]):
             self.test_record.with_user(self.user_employee).notify_cancel_by_type('email')

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -247,13 +247,13 @@ class TestMessageValues(MailCommon):
         self.env.flush_all()
         self.env.invalidate_all()
         store_1 = Store().add(message.with_user(self.user_employee), "_store_message_fields")
-        self.assertEqual(store_1.get_result()["mail.message"][0].get("record_name"), "Test1")
+        self.assertEqual(store_1._build_result()["mail.message"][0].get("record_name"), "Test1")
 
         record1.write({"name": "Test2"})
         self.env.flush_all()
         self.env.invalidate_all()
         store_2 = Store().add(message.with_user(self.user_employee), "_store_message_fields")
-        self.assertEqual(store_2.get_result()["mail.message"][0].get('record_name'), 'Test2')
+        self.assertEqual(store_2._build_result()["mail.message"][0].get('record_name'), 'Test2')
 
         # check model not inheriting from mail.thread -> should not crash
         record_nothread = self.env['mail.test.nothread'].create({'name': 'NoThread'})
@@ -261,7 +261,7 @@ class TestMessageValues(MailCommon):
             'model': record_nothread._name,
             'res_id': record_nothread.id,
         })
-        formatted = Store().add(message, "_store_message_fields").get_result()["mail.message"][0]
+        formatted = Store().add(message, "_store_message_fields")._build_result()["mail.message"][0]
         self.assertEqual(formatted['record_name'], record_nothread.name)
 
     def test_records_by_message(self):

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1390,13 +1390,13 @@ class TestNoThread(MailCommon, TestRecipients):
             'model': test_record._name,
             'res_id': test_record.id,
         })
-        formatted = Store().add(message, "_store_message_fields").get_result()["mail.message"][0]
+        formatted = Store().add(message, "_store_message_fields")._build_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], test_record.name)
         self.assertEqual(formatted['record_name'], test_record.name)
 
         test_record.write({'name': 'Just Test'})
         message.invalidate_recordset(['record_name'])
-        formatted = Store().add(message, "_store_message_fields").get_result()["mail.message"][0]
+        formatted = Store().add(message, "_store_message_fields")._build_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], 'Just Test')
         self.assertEqual(formatted['record_name'], 'Just Test')
 

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -549,14 +549,14 @@ class TestTrackingAPI(TestTrackingCommon):
             )
         # first record: tracking value should be hidden
         message_0 = records[0].message_ids[0]
-        formatted = Store().add(message_0, "_store_message_fields").get_result()["mail.message"][0]
+        formatted = Store().add(message_0, "_store_message_fields")._build_result()["mail.message"][0]
         self.assertEqual(formatted['trackingValues'], [], 'Hidden values should not be formatted')
         mail_render = records[0]._notify_by_email_prepare_rendering_context(message_0, {})
         self.assertEqual(mail_render['tracking_values'], [])
 
         # second record: all values displayed
         message_1 = records[1].message_ids[0]
-        formatted = Store().add(message_1, "_store_message_fields").get_result()["mail.message"][0]
+        formatted = Store().add(message_1, "_store_message_fields")._build_result()["mail.message"][0]
         self.assertEqual(len(formatted['trackingValues']), 1)
         self.assertDictEqual(
             formatted['trackingValues'][0],
@@ -1392,11 +1392,11 @@ class TestTrackingInternals(TestTrackingCommon):
         }]
         for user, exp_values in [(self.user_employee, []), (self.user_admin, formatted_tracking_values)]:
             self.env.transaction.reset()
-            msg_as_user = Store().add(track_msg.with_user(user), "_store_message_fields").get_result()
+            msg_as_user = Store().add(track_msg.with_user(user), "_store_message_fields")._build_result()
             self.assertEqual(
                 msg_as_user["mail.message"][0].get("trackingValues"), exp_values,
             )
-            msg_as_user = Store().add(track_msg.with_user(user).sudo(), "_store_message_fields").get_result()
+            msg_as_user = Store().add(track_msg.with_user(user).sudo(), "_store_message_fields")._build_result()
             self.assertEqual(
                 msg_as_user["mail.message"][0].get("trackingValues"),
                 formatted_tracking_values,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1571,7 +1571,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         messages_all = self.messages_all.with_env(self.env)
 
         with self.assertQueryCount(employee=27):  # tm 26
-            res = Store().add(messages_all, "_store_message_fields").get_result()
+            res = Store().add(messages_all, "_store_message_fields")._build_result()
 
         self.assertEqual(len(res["mail.message"]), 2 * 2)
         for message in res["mail.message"]:
@@ -1584,7 +1584,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         message = self.messages_all[0].with_env(self.env)
 
         with self.assertQueryCount(employee=27):  # tm 26
-            res = Store().add(message, "_store_message_fields").get_result()
+            res = Store().add(message, "_store_message_fields")._build_result()
 
         self.assertEqual(len(res["mail.message"]), 1)
         self.assertEqual(len(res["mail.message"][0]["attachment_ids"]), 2)
@@ -1605,14 +1605,14 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         } for record in records])
 
         with self.assertQueryCount(employee=5):
-            res = Store().add(messages, "_store_message_fields").get_result()
+            res = Store().add(messages, "_store_message_fields")._build_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
         with self.assertQueryCount(employee=16):  # tm: 15
-            res = Store().add(messages, "_store_message_fields").get_result()
+            res = Store().add(messages, "_store_message_fields")._build_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
     @warmup

--- a/addons/test_mail_sms/tests/test_sms_management.py
+++ b/addons/test_mail_sms/tests/test_sms_management.py
@@ -70,7 +70,7 @@ class TestSMSActionsCommon(SMSCommon, TestSMSRecipients):
             BusResult(
                 user,
                 "mail.record/insert",
-                Store().add(msg, "_store_notification_fields").get_result(),
+                Store().add(msg, "_store_notification_fields"),
             )
             for user in users
         ]

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -55,6 +55,6 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
         return request.render("im_livechat.chatbot_test_script_page", {
             'server_url': chatbot_script.get_base_url(),
             'chatbot_script': chatbot_script,
-            'chatbot_test_store': store.get_result(),
+            'chatbot_test_store': store.as_dict(),
             'title': self.env._("Test %s", chatbot_script.title),
         })

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -163,7 +163,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
         self.assertEqual(
-            Store().add(channel, "_store_channel_fields").get_result(),
+            Store().add(channel, "_store_channel_fields")._build_result(),
             {
                 "discuss.channel": self._filter_channels_fields(
                     {
@@ -337,7 +337,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         )
         channel_w_user = channel.with_user(self.user_public).with_context(guest=guest)
-        data = Store().add(channel_w_user, "_store_channel_fields").get_result()
+        data = Store().add(channel_w_user, "_store_channel_fields")._build_result()
         self.assertEqual(
             data["discuss.channel"],
             self._filter_channels_fields(


### PR DESCRIPTION
To feed data to the client, discuss uses the Store class, which eventually transforms collected data into a dict using `get_result`. The `@store_version` decorator then injects a version so the client can distinguish stale from new data.

This approach has several drawbacks. Each method expecting a versioned result must be decorated, but the version is only correct once all changes are flushed and assigned a transaction id. Returning the raw dict makes overrides cumbersome, and bus notifications require complex logic to enqueue and send them only once the version is available.

This commit solves these issues by implementing an `as_dict` method on Store. Both bus notifications and the HTTP stack use this method to convert objects into JSON. The version is now fetched once, at the very end, and the Store instance can be returned, making overrides easier and reducing boilerplate.

part of task-5242369

https://github.com/odoo/enterprise/pull/112159
