### PR TITLE
[FIX] pos_sale: fix error while open POS session after uninstalling sale_stock

### DIFF
--- a/addons/pos_sale/__manifest__.py
+++ b/addons/pos_sale/__manifest__.py
@@ -11,7 +11,7 @@
 
 This module adds a custom Sales Team for the Point of Sale. This enables you to view and manage your point of sale sales with more ease.
 """,
-    'depends': ['point_of_sale', 'sale_management'],
+    'depends': ['point_of_sale', 'sale_management', 'sale_stock'],
     'data': [
         'data/pos_sale_data.xml',
         'security/pos_sale_security.xml',


### PR DESCRIPTION
Currently an error is generated when a user tries to open a POS session after uninstalling the sale_stock module.

Steps to produce an error:
- Install `pos_sale` with demo data
- Uninstall the sale_stock module
- Go to `Point of Sale` > Click `Open Register` on any POS Shop
- An error occurs while opening a POS session.

This issue occurs because the `pos_sale` module uses several fields such as `picking_id` (see code ref [1] and [2]) and `move_ids` (see code ref [3] and 4), while these fields are actually defined in the `sale_stock` module. Additionally, multiple other fields used in the test cases are also defined in the `sale_stock` module.

However, `sale_stock` is not declared as a dependency of `pos_sale`. As a result, when the `sale_stock` module is not installed, these fields are not available, leading to undefined field errors and test failures.

This commit will fix the above issue by adding `sale_stock` as a dependency of `pos_sale` to ensure availability of fields like `picking_id`, `move_ids`, and others used in code and tests.

[1]: https://github.com/odoo/odoo/blob/0cbe84b6b3155b5652949e4b76874ea3071faa10/addons/pos_sale/models/sale_order.py#L29
[2]: https://github.com/odoo/odoo/blob/0cbe84b6b3155b5652949e4b76874ea3071faa10/addons/sale_stock/models/sale_order.py#L25
[3]: https://github.com/odoo/odoo/blob/0cbe84b6b3155b5652949e4b76874ea3071faa10/addons/pos_sale/models/stock_picking.py#L18
[4]: https://github.com/odoo/odoo/blob/0cbe84b6b3155b5652949e4b76874ea3071faa10/addons/sale_stock/models/sale_order_line.py#L17

sentry-7357831436