### PR TITLE
[FIX] stock_account,sale_stock_margin: compute cost on sale order dropshipped

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -18,7 +18,7 @@ class SaleOrderLine(models.Model):
             elif line.product_id and line.product_id.categ_id and line.product_id.categ_id.property_cost_method != 'standard':
                 # don't overwrite any existing value unless non-standard cost method
                 qty_from_delivery = line.qty_delivered
-                price_unit_from_delivery = line.move_ids.filtered(lambda m: m.state == 'done')._get_price_unit() if qty_from_delivery > 0 else 0
+                price_unit_from_delivery = line.move_ids.filtered(lambda m: m.state == 'done')._get_price_unit_delivery() if qty_from_delivery > 0 else 0
                 if qty_from_delivery <= 0:
                     purch_price = product.standard_price
                 else:

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -3,7 +3,7 @@
 import datetime
 from freezegun import freeze_time
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests import Form, tagged
 from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 
@@ -630,3 +630,40 @@ class TestSaleStockMargin(TestStockValuationCommon):
             # purchase_unit_from_delivery = line.move_ids(done)._get_price_unit = (2 * 32.5 + 1 * 32.5) / (2 + 1) = 32.5
             self.assertEqual(sol3.purchase_price, 32.5, "purchase_price = 2 * 32.5 + 1 * 32.5) / (2 + 1) = 32.5")
             self.assertEqual(sol3.margin, -32.5, "margin = SOL qty * sale price - purchase_price * qty_delivered = (0 - 32.5) * 1 = -32.5")
+
+    def test_dropship_fifo_purchase_price(self):
+        """ Check that when the product is dropshipped, the purchase_price used is based on the unit
+        price of the purchase order.
+        """
+        try:
+            dropship_route = self.env.ref('stock_dropshipping.route_drop_shipping')
+        except ValueError:
+            self.skipTest('This test requires the following module: stock_dropshipping')
+
+        self.product_fifo_auto.write({
+            'seller_ids': [Command.create({'partner_id': self.vendor.id, 'price': 20})],
+            'route_ids': [Command.link(dropship_route.id)]
+        })
+        # create and confirm SO and PO
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': self.product_fifo_auto.id,
+                'product_uom_qty': 1.0,
+            })],
+        })
+        so.action_confirm()
+        po = self.env['purchase.order'].search([
+            ('origin', '=', so.name),
+            ('partner_id', '=', self.vendor.id),
+        ], limit=1)
+        po.button_confirm()
+
+        # untill dropship validation, purchase price of the sale order line is the product's standard price
+        self.assertEqual(self.product_fifo_auto.standard_price, 10)
+        self.assertEqual(so.order_line.purchase_price, 10)
+
+        # after dropship validation, purchase price of the sale order line is the PO's unit cost
+        so.picking_ids.button_validate()
+        self.assertEqual(po.order_line.price_unit, 20)
+        self.assertEqual(so.order_line.purchase_price, 20)

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -649,3 +649,24 @@ class StockMove(models.Model):
 
     def _get_valued_consigned_qty(self):
         return sum(self.move_line_ids.filtered(lambda l: l._is_consigned_valued_line()).mapped('quantity_product_uom'))
+
+    def _get_price_unit_delivery(self):
+        """ Computes the unit price for a set of moves, using a weighted average between
+        dropshipped and non dropshipped moves.
+        """
+        dropship_moves = self.filtered(lambda m: m._is_dropshipped() or m._is_dropshipped_returned())
+        dropship_quantity = sum(m._get_valued_qty() for m in dropship_moves)
+        dropship_price_unit = dropship_moves._get_price_unit_dropshipped()
+        regular_moves = self - dropship_moves
+        regular_quantity = sum(m._get_valued_qty() for m in regular_moves)
+        regular_price_unit = regular_moves._get_price_unit()
+        total_quantity = dropship_quantity + regular_quantity
+        if not total_quantity:
+            return self._get_price_unit()
+        return (dropship_quantity * dropship_price_unit + regular_quantity * regular_price_unit) / total_quantity
+
+    def _get_price_unit_dropshipped(self):
+        """ Returns the unit price to value the dropshipped moves."""
+        total_value = sum(m._get_value() for m in self)
+        total_qty = sum(m._get_valued_qty() for m in self)
+        return total_value / total_qty if total_qty else 0


### PR DESCRIPTION
**Problem:**
The cost is not correctly computed on sale order 
line when the product is dropshipped.

**Steps to reproduce:**
- enable "margins" and "dropshipping" settings
- create a tracked, fifo product with dropship route
- add a vendor in the purchase tab
- confirm a sale order for 1 unit
- set a unit price of 10 in the PO and confirm it
- validate the dropship picking
- come back to the sale order and unhide de cost column

**Current behavior:**
the cost is 0

**Expected behavior:**
the cost should be 10 based on the unit price of the PO

**Cause of the issue:**
To compute the purchase price, when there is valued moves 
linked to the sale order line and the product is fifo/avco, 
we call _get_price_unit() on the moves.
https://github.com/odoo/odoo/blob/98e6e929bf8e0c34ec77fb9d07ef253e0abf681c/addons/sale_stock_margin/models/sale_order_line.py#L21
Which uses the value of the moves
https://github.com/odoo/odoo/blob/98e6e929bf8e0c34ec77fb9d07ef253e0abf681c/addons/stock_account/models/stock_move.py#L237-L243
But for dropshipped move the value on the moves is always 0.
So the return value will be 0 and purchase price will be 0.

**fix:**
- The idea of the fix is to use _get_value() instead of the move 
value for dropship moves. 
This approach is already used in the code inside 
_run_average_batch()
https://github.com/odoo/odoo/blob/98e6e929bf8e0c34ec77fb9d07ef253e0abf681c/addons/stock_account/models/product.py#L474-L475

- In case there is not only dropship moves we need to do 
a weighted average


opw-6051004