### PR TITLE
[18.0][IMP] pos_sale: avoid rpc call for each so line at settleSO

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -180,3 +180,6 @@ class SaleOrderLine(models.Model):
         return super()._get_downpayment_line_price_unit(invoices) + sum(
             pol.price_unit for pol in self.sudo().pos_order_line_ids
         )
+
+    def has_valued_move_ids_batch(self):
+        return {rec.id: rec.has_valued_move_ids() for rec in self}

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -197,3 +197,6 @@ class SaleOrderLine(models.Model):
         return super()._get_downpayment_line_price_unit(invoices) + sum(
             pol.price_unit for pol in self.sudo().pos_order_line_ids
         )
+
+    def has_valued_move_ids_batch(self):
+        return {rec.id: rec.has_valued_move_ids() for rec in self}

--- a/addons/pos_sale/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_order_line.js
@@ -60,13 +60,13 @@ patch(PosOrderline.prototype, {
         if (saleOrderLine.is_downpayment) {
             // Down payment lines carry their amount as a negative `qty_to_invoice`
             this.set_quantity(saleOrderLine.qty_to_invoice);
-        } else if (!saleOrderLine.has_valued_move_ids) {
-            this.set_quantity(saleOrderLine.product_uom_qty);
         } else if (
             this.product_id.type === "service" &&
             !["sent", "draft"].includes(this.sale_order_origin_id.state)
         ) {
             this.set_quantity(saleOrderLine.qty_to_invoice);
+        } else if (!saleOrderLine.has_valued_move_ids) {
+            this.set_quantity(saleOrderLine.product_uom_qty);
         } else {
             this.set_quantity(
                 saleOrderLine.product_uom_qty -

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -87,7 +87,11 @@ patch(PosStore.prototype, {
         const converted_lines = await this.data.call("sale.order.line", "read_converted", [
             sale_order.order_line.map((l) => l.id),
         ]);
-
+        const valuedMoveMap = await this.data.call(
+            "sale.order.line",
+            "has_valued_move_ids_batch",
+            [converted_lines.map((l) => l.id)]
+        );
         for (const line of sale_order.order_line) {
             if (line.display_type === "line_note") {
                 if (previousProductLine) {
@@ -145,11 +149,7 @@ patch(PosStore.prototype, {
                 }
             }
 
-            converted_line.has_valued_move_ids = await this.data.call(
-                "sale.order.line",
-                "has_valued_move_ids",
-                [converted_line.id]
-            );
+            converted_line.has_valued_move_ids = !!valuedMoveMap[converted_line.id];
             newLine.setQuantityFromSOL(converted_line);
             newLine.set_unit_price(converted_line.price_unit);
             newLine.set_discount(line.discount);

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -100,6 +100,11 @@ patch(PosStore.prototype, {
             const converted_lines = await this.data.call("sale.order.line", "read_converted", [
                 sale_order.order_line.map((l) => l.id),
             ]);
+            const hasValuedMovePerSOL = await this.data.call(
+                "sale.order.line",
+                "has_valued_move_ids_batch",
+                [converted_lines.map((l) => l.id)]
+            );
 
             for (const line of sale_order.order_line) {
                 if (line.display_type === "line_note") {
@@ -177,6 +182,7 @@ patch(PosStore.prototype, {
                     }
                 }
 
+                converted_line.has_valued_move_ids = !!hasValuedMovePerSOL[converted_line.id];
                 newLine.setQuantityFromSOL(converted_line);
                 newLine.set_unit_price(converted_line.price_unit);
                 newLine.set_discount(line.discount);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When loading a large sale order in the POS, the settleSO method performs a RPC call (has_valued_move_ids) for each order line. This results in a significant number of sequential RPC calls, degrading performance and increasing the loading time

Desired behavior after PR is merged:

- Replace per-line RPC calls with a single batch RPC call
- Retrieve all has_valued_move_ids values in one request and map them locally


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
