### PR TITLE
[FIX] web: Display page & topage in one line in external_layout_folder

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -632,7 +632,7 @@
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}">
             <div class="o_footer_content d-flex border-top pt-2">
                 <div class="flex-grow-1 me-2 text-start" t-field="company.report_footer"/>
-                <div class="text-end text-muted">
+                <div class="text-end text-muted text-nowrap">
                     <div t-if="report_type == 'pdf' and display_name_in_footer" t-out="o.name">(document name)</div>
                     <div t-if="report_type == 'pdf'">Page <span class="page"/> / <span class="topage"/></div>
                 </div>


### PR DESCRIPTION
Steps:
- Install accountant
- Configure Document layout
- Set folder layout
- Set Montserrat text font
- Try to print an invoice pdf it displays
```
Page 1/
       1
```

This commit use text-nowrap to displays page numbers in one line to have
```
Page 1/1
```

opw-6006148