### PR TITLE
[FIX] sale{,_management}: move optional section discount line edit test

### DIFF
--- a/addons/sale/tests/test_sale_sections.py
+++ b/addons/sale/tests/test_sale_sections.py
@@ -189,30 +189,3 @@ class TestSaleSections(SaleCommon):
             self.sections_sale_order.order_line[7]._get_section_totals('price_subtotal'),
             sum(self.sections_sale_order.order_line[8:].mapped('price_subtotal')),
         )
-
-    def test_optional_section_discount_line_not_editable_on_portal(self):
-        so = self.env["sale.order"].create({
-            "partner_id": self.partner.id,
-            "order_line": [
-                Command.create({
-                    "name": "Optional Section",
-                    "display_type": "line_section",
-                    "is_optional": True,
-                }),
-                Command.create({"product_id": self.product.id, "price_unit": 200}),
-            ],
-        })
-        wizard = self.env["sale.order.discount"].create({
-            "sale_order_id": so.id,
-            "discount_type": "so_discount",
-            "discount_percentage": 0.1,
-        })
-        wizard.action_apply_discount()
-        self.assertTrue(
-            so.order_line[1]._can_be_edited_on_portal(),
-            "Optional section line should be editable on portal",
-        )
-        self.assertFalse(
-            so.order_line[2]._can_be_edited_on_portal(),
-            "Discount line on optional section should not be editable on portal",
-        )

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -522,3 +522,30 @@ class TestSaleOrder(SaleManagementCommon):
             self.assertTrue(sale_order_form.order_line)
             self.assertFalse(sale_order_form.show_update_pricelist)
             sale_order_form.partner_id = self.partner
+
+    def test_optional_section_discount_line_not_editable_on_portal(self):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "order_line": [
+                Command.create({
+                    "name": "Optional Section",
+                    "display_type": "line_section",
+                    "is_optional": True,
+                }),
+                Command.create({"product_id": self.product.id, "price_unit": 200}),
+            ],
+        })
+        wizard = self.env["sale.order.discount"].create({
+            "sale_order_id": so.id,
+            "discount_type": "so_discount",
+            "discount_percentage": 0.1,
+        })
+        wizard.action_apply_discount()
+        self.assertTrue(
+            so.order_line[1]._can_be_edited_on_portal(),
+            "Optional section line should be editable on portal",
+        )
+        self.assertFalse(
+            so.order_line[2]._can_be_edited_on_portal(),
+            "Discount line on optional section should not be editable on portal",
+        )


### PR DESCRIPTION
Issue:
---
`is_optional` does not exist in `sale` module, leading to runbot issue.
The test needs to be moved to `sale_management`.

runbot-242127
