### PR TITLE
[FIX] web,sale: make dialog active-element focus configurable

### DIFF
--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductConfiguratorDialog">
-        <Dialog size="props.size" title="title" contentClass="'o_sale_product_configurator_dialog'">
+        <Dialog size="props.size" title="title" contentClass="'o_sale_product_configurator_dialog'" setActiveElement="!this.env.isSmall">
             <ProductList t-if="this.state.products.length" products="this.state.products"/>
             <ProductList
                 t-if="this.state.optionalProducts.length"

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -55,6 +55,7 @@ export class Dialog extends Component {
         },
         withBodyPadding: { type: Boolean, optional: true },
         onExpand: { type: Function, optional: true },
+        setActiveElement: { type: Boolean, optional: true },
     };
     static defaultProps = {
         contentClass: "",
@@ -66,11 +67,14 @@ export class Dialog extends Component {
         technical: true,
         title: "Odoo",
         withBodyPadding: true,
+        setActiveElement: true,
     };
 
     setup() {
         this.modalRef = useForwardRefToParent("modalRef");
-        useActiveElement("modalRef");
+        if(this.props.setActiveElement){
+            useActiveElement("modalRef");
+        }
         this.data = useState(this.env.dialogData);
         useHotkey("escape", () => this.onEscape());
         useHotkey(


### PR DESCRIPTION
The dialog component currently enforces automatic focus on the first
focusable element using the useActiveElement hook. While this improves
accessibility, it causes poor UX on mobile devices where focusing an
input (e.g. quantity field) triggers the virtual keyboard and hides
important UI elements.

This commit introduces a configurable approach to control autofocus
behavior.

web changes:
- Add new optional prop `setActiveElement` on Dialog component.
- Default value is set to true to preserve existing behavior.
- Conditionally call useActiveElement based on this prop.

sale changes:
- Forward `setActiveElement` prop from ProductConfiguratorDialog.
- Disable autofocus on small screens using env.isSmall to prevent
  unwanted keyboard popup in product configurator dialog.

opw-5970020