### PR TITLE
[IMP] l10n_fr: add adjustment for line 25

### DIFF
--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -2300,8 +2300,14 @@
                             <record id="tax_report_25_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">box_23.balance - box_16.balance</field>
+                                <field name="formula">box_23.balance - box_16.balance + box_25.adjustment</field>
                                 <field name="subformula">if_above(EUR(0))</field>
+                            </record>
+                            <record id="tax_report_25_adjustment" model="account.report.expression">
+                                <field name="label">adjustment</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">editable;rounding=0</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
This commit will add the possibility to do an adjustment on the line 25. Useful when you start using Odoo but have a VAT credit carried forward from the previous month (which should appear in box 25 of your return).

task-6072474




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
