### PR TITLE
[FIX] core: keep translations in cache for related fields when onchange

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1846,6 +1846,7 @@ class RelatedTranslation2(models.Model):
     name = fields.Char('Name Related', related='related_id.name', readonly=False)
     html = fields.Html('HTML Related', related='related_id.html', readonly=False)
     computed_name = fields.Char('Name Computed', compute='_compute_name')
+    name_en = fields.Char('Name EN', compute='_compute_name_en')
     computed_html = fields.Char('HTML Computed', compute='_compute_html')
 
     @api.depends_context('lang')
@@ -1853,6 +1854,11 @@ class RelatedTranslation2(models.Model):
     def _compute_name(self):
         for record in self:
             record.computed_name = record.related_id.name
+
+    @api.depends('name')
+    def _compute_name_en(self):
+        for record in self.with_context(lang='en_US'):
+            record.name_en = record.name
 
     @api.depends_context('lang')
     @api.depends('related_id.html')

--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -332,6 +332,16 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(child_fr.computed_name, 'fr')
         self.assertEqual(child_en.computed_name, 'en')
 
+        record_real = self.env['test_new_api.related_translation_1'].create({'name': 'en'})
+        record_real.with_context(lang='fr_FR').name = 'fr'
+        result = self.env['test_new_api.related_translation_2'].with_context(lang='fr_FR').onchange({
+            'name': 'new fr',  # updated from 'fr' to 'new fr'
+            'related_id': record_real.id,
+            'computed_name': 'fr',
+            'name_en': 'en',
+        }, ['name'], child_en._get_fields_spec())
+        self.assertEqual(result['value'], {})
+
     def test_new_records_html(self):
         model = self.env['test_new_api.related_translation_1']
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1822,7 +1822,7 @@ class _String(Field):
 
         # not dirty fields
         if not dirty:
-            if self.compute and self.inverse:
+            if self.compute and self.inverse and any(records._ids):
                 # invalidate the values in other languages to force their recomputation
                 lang = self._lang(records.env)
                 values = [{lang: cache_value} for _id in records._ids]


### PR DESCRIPTION
when related translated field (field_x) is changed when onchange, if another computed fields which depends on the field_x is recomputed but using another language value of the field_x. The orm should keep the existing translations in the cache but not drop them.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
