### PR TITLE
[FIX] account: Check archived accounts for unaffected earnings

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -803,7 +803,7 @@ class ResCompany(models.Model):
         # Do not assume '999999' doesn't exist since the user might have created such an account
         # manually.
         code = 999999
-        while self.env['account.account'].with_company(self).search_count([
+        while self.env['account.account'].with_company(self).with_context(active_test=False).search_count([
             *self.env['account.account']._check_company_domain(self),
             ('code', '=', str(code)),
         ], limit=1):


### PR DESCRIPTION
Archived accounts are also searched when looking for duplicate codes since https://github.com/odoo/odoo/commit/cd8d9718427e48aaa79be21f9a08e89b79b573f9

We need to check archived accounts as well when creating the unaffected earnings account, to avoid triggering the validation if an archived account has the same code.

This is failing on upgrades with `l10n_sa` installed where the account `sa_account_999999` has been archived.