### PR TITLE
[FIX] point_of_sale: display correct rounding when over paying

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -125,14 +125,20 @@ export class PosOrderAccounting extends Base {
     }
     get appliedRounding() {
         const total = this.prices.taxDetails.total_amount_no_rounding;
-        const isNegative = this.amountPaid > total;
         const remaining = this.currency.round(total - this.amountPaid);
-        const amount =
+        const signedRemaining = total < 0 ? -remaining : remaining;
+        const isDone =
             this.orderIsRounded &&
-            this.config.rounding_method.asymmetricRound(total < 0 ? -remaining : remaining) == 0
-                ? Math.abs(remaining)
-                : 0;
-        return isNegative ? this.currency.round(amount) : this.currency.round(-amount);
+            (signedRemaining <= 0 ||
+                this.config.rounding_method.asymmetricRound(signedRemaining) === 0);
+        if (!isDone) {
+            return 0;
+        }
+
+        const roundedRemaining = this.config.rounding_method.asymmetricRound(signedRemaining);
+        const diff =
+            total < 0 ? signedRemaining - roundedRemaining : roundedRemaining - signedRemaining;
+        return this.currency.round(diff);
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -113,8 +113,16 @@ export class PosOrderAccounting extends Base {
     }
     get appliedRounding() {
         const total = this.prices.taxDetails.total_amount_no_rounding;
-        const isNegative = this.amountPaid > total;
-        const remaining = total - this.amountPaid;
+        const roundedOverpaid =
+            Math.abs(this.amountPaid) > Math.abs(total) &&
+            this.orderIsRounded &&
+            this.config.rounding_method.round(this.amountPaid) !==
+                this.config.rounding_method.round(total)
+                ? this.amountPaid - this.config.rounding_method.round(total)
+                : 0;
+        const effectivePaid = this.amountPaid - roundedOverpaid;
+        const isNegative = effectivePaid > total;
+        const remaining = total - effectivePaid;
         const amount =
             this.orderIsRounded &&
             this.config.rounding_method.asymmetricRound(total < 0 ? -remaining : remaining) == 0

--- a/addons/point_of_sale/static/tests/unit/accounting/old_tour.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/old_tour.test.js
@@ -286,7 +286,7 @@ test("[Old Tour] test_cash_rounding_with_change", async () => {
     order.addPaymentline(cardPm);
     order.payment_ids[0].setAmount(20);
     expect(order.amountPaid).toBe(20);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(-0.02);
     expect(order.change).toBe(-4.3);
 
     const order2 = store.addNewOrder();
@@ -299,7 +299,7 @@ test("[Old Tour] test_cash_rounding_with_change", async () => {
     order2.addPaymentline(cardPm);
     order2.payment_ids[0].setAmount(-20);
     expect(order2.amountPaid).toBe(-20);
-    expect(order2.appliedRounding).toBe(0);
+    expect(order2.appliedRounding).toBe(0.02);
     expect(order2.change).toBe(4.3);
 });
 
@@ -317,7 +317,7 @@ test("[Old Tour] test_cash_rounding_only_cash_method_with_change", async () => {
     order.addPaymentline(cashPm);
     order.payment_ids[0].setAmount(20);
     expect(order.amountPaid).toBe(20);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(-0.02);
     expect(order.change).toBe(-4.3);
 
     const order2 = store.addNewOrder();
@@ -330,7 +330,7 @@ test("[Old Tour] test_cash_rounding_only_cash_method_with_change", async () => {
     order2.addPaymentline(cashPm);
     order2.payment_ids[0].setAmount(-20);
     expect(order2.amountPaid).toBe(-20);
-    expect(order2.appliedRounding).toBe(0);
+    expect(order2.appliedRounding).toBe(0.02);
     expect(order2.change).toBe(4.3);
 });
 

--- a/addons/point_of_sale/static/tests/unit/accounting/old_tour.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/old_tour.test.js
@@ -251,8 +251,8 @@ test("[Old Tour] test_cash_rounding_halfup_add_invoice_line_only_round_cash_meth
     order.addPaymentline(cashPm);
     expect(order.payment_ids[1].amount).toBe(15.05);
     expect(order.amountPaid).toBe(15.73);
-    expect(order.appliedRounding).toBe(0.01);
-    expect(order.change).toBe(0.0);
+    expect(order.appliedRounding).toBe(-0.02);
+    expect(order.change).toBe(-0.05);
 
     const order2 = store.addNewOrder();
     order2.pricelist_id = false;
@@ -268,8 +268,8 @@ test("[Old Tour] test_cash_rounding_halfup_add_invoice_line_only_round_cash_meth
     order2.addPaymentline(cashPm);
     expect(order2.payment_ids[1].amount).toBe(-15.05);
     expect(order2.amountPaid).toBe(-15.73);
-    expect(order2.appliedRounding).toBe(-0.01);
-    expect(order2.change).toBe(0.0);
+    expect(order2.appliedRounding).toBe(0.02);
+    expect(order2.change).toBe(0.05);
 });
 
 test("[Old Tour] test_cash_rounding_with_change", async () => {
@@ -286,7 +286,7 @@ test("[Old Tour] test_cash_rounding_with_change", async () => {
     order.addPaymentline(cardPm);
     order.payment_ids[0].setAmount(20);
     expect(order.amountPaid).toBe(20);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(-0.02);
     expect(order.change).toBe(-4.3);
 
     const order2 = store.addNewOrder();
@@ -299,7 +299,7 @@ test("[Old Tour] test_cash_rounding_with_change", async () => {
     order2.addPaymentline(cardPm);
     order2.payment_ids[0].setAmount(-20);
     expect(order2.amountPaid).toBe(-20);
-    expect(order2.appliedRounding).toBe(0);
+    expect(order2.appliedRounding).toBe(0.02);
     expect(order2.change).toBe(4.3);
 });
 
@@ -317,7 +317,7 @@ test("[Old Tour] test_cash_rounding_only_cash_method_with_change", async () => {
     order.addPaymentline(cashPm);
     order.payment_ids[0].setAmount(20);
     expect(order.amountPaid).toBe(20);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(-0.02);
     expect(order.change).toBe(-4.3);
 
     const order2 = store.addNewOrder();
@@ -330,7 +330,7 @@ test("[Old Tour] test_cash_rounding_only_cash_method_with_change", async () => {
     order2.addPaymentline(cashPm);
     order2.payment_ids[0].setAmount(-20);
     expect(order2.amountPaid).toBe(-20);
-    expect(order2.appliedRounding).toBe(0);
+    expect(order2.appliedRounding).toBe(0.02);
     expect(order2.change).toBe(4.3);
 });
 

--- a/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
@@ -106,7 +106,7 @@ test("Rounding sale UP 10 (all methods)", async () => {
     order.payment_ids[0].setAmount(70);
     expect(order.payment_ids[0].amount).toBe(70);
     expect(order.canBeValidated()).toBe(true);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(7.46);
     expect(order.change).toBe(-10);
 });
 
@@ -137,7 +137,7 @@ test("Rounding sale DOWN 10 (all methods)", async () => {
     order.payment_ids[0].setAmount(70);
     expect(order.payment_ids[0].amount).toBe(70);
     expect(order.canBeValidated()).toBe(true);
-    expect(order.appliedRounding).toBe(0);
+    expect(order.appliedRounding).toBe(-2.54);
     expect(order.change).toBe(-20);
 });
 
@@ -373,4 +373,22 @@ test("Rouding sale HALF-UP 0.05 with two payment method", async () => {
     expect(order.canBeValidated()).toBe(true);
     expect(order.appliedRounding).toBe(0);
     expect(order.change).toBe(0);
+});
+test("Applied rounding when overpaying", async () => {
+    const store = await setupPosEnv();
+    const cashPm = prepareRoundingVals(store, 0.05, "HALF-UP", false);
+    const order = store.addNewOrder();
+    const product = store.models["product.template"].get(1);
+    store.models["product.product"].get(1).lst_price = 4.99;
+    order.pricelist_id = false;
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: product,
+            qty: 1,
+        },
+        order
+    );
+    const paymentLine = order.addPaymentline(cashPm);
+    paymentLine.data.setAmount(10);
+    expect(order.appliedRounding).toBe(0.01);
 });


### PR DESCRIPTION
**Steps to reproduce:**
- Make a rounding method, Nearest and 0.05 of rounding
- Make a product that costs $4.99, don't set a tax
- Go to the PoS
- Order the product
- Before paying click the +10 button, then pay
- The rounding line is not present on the ticket

**Why the fix:**

When making a normal rounded purchase, by just clicking the "Cash" button, the rounding line will be displayed.

This is because we do not try to apply the rounding if the rounding of the remaining is not equal to zero.
https://github.com/odoo/odoo/blob/995629db3231de944710751c3184bf1b8b1355c7/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js#L118-L123

When we try to over pay, the remaining will be negative by the amount we overpay, so the amount will be set to zero, and the rounding will not be set.

We now take the amount we overpay into account, and deduct it from the amount we paid to then correctly compute the remaining amount without having to deal with the amount overpaid.

Some tests were not taking the rounding as it was not working correctly, so it has now been changed now that it works as it should.

opw-6025807