### PR TITLE
[FIX] l10n_ar,l10n_latam_check: unreconcile check from invoice on voiding

### DIFF
--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -115,9 +115,20 @@ class L10n_LatamCheck(models.Model):
 
     def action_void(self):
         for rec in self.filtered('outstanding_line_id'):
+            # Unreconcile the payment from its mactched invoice before voiding
+            payment_line = rec.payment_id.move_id.line_ids.filtered(
+                lambda l: l.account_id.account_type in ('asset_receivable', 'liability_payable')
+            )
+            if payment_line:
+                payment_line.remove_move_reconcile()
+
+            # Create and post reversal move to cancel original payment entry
             void_move = rec.env['account.move'].create(rec._prepare_void_move_vals())
             void_move.action_post()
+
+            # Reconcile the void move with the check and the outstanding debit on invoice
             (void_move.line_ids[1] + rec.outstanding_line_id).reconcile()
+            (void_move.line_ids[0] + payment_line).reconcile()
 
     def _get_last_operation(self):
         self.ensure_one()

--- a/addons/l10n_latam_check/tests/test_own_checks.py
+++ b/addons/l10n_latam_check/tests/test_own_checks.py
@@ -92,3 +92,44 @@ class TestOwnChecks(L10nLatamCheckTest):
         })
         payment.action_post()
         self.assertEqual(payment.amount, 120)
+
+    def test_invoice_status_after_voided_check(self):
+        invoice = self._create_invoice(
+            company_id=self.company_data_3['company'].id,
+            partner_id=self.partner_a.id,
+            invoice_line_ids=[self._prepare_invoice_line(price_unit=100, product_id=self.product_a)],
+            move_type='in_invoice',
+            l10n_latam_document_type_id=self.env.ref('l10n_ar.dc_liq_uci_a'),
+            l10n_latam_document_number="001-00001",
+            post=True
+        )
+
+        payment_method_line = self.bank_journal._get_available_payment_method_lines('outbound').filtered_domain([('code', '=', 'own_checks')])[:1]
+        action = invoice.action_register_payment()
+        wizard = self.env[action['res_model']].with_context(action['context']).create({
+            'journal_id': self.bank_journal.id,
+            'payment_method_line_id': payment_method_line.id,
+            'l10n_latam_new_check_ids': [
+                Command.create({
+                    'name': '0000001',
+                    'payment_date': fields.Date.today(),
+                    'amount': invoice.amount_total,
+                })
+            ],
+        })
+        action = wizard.action_create_payments()
+
+        payment = self.env['account.payment'].browse(action['res_id'])
+        check = payment.l10n_latam_new_check_ids
+        self.assertEqual(check.issue_state, 'handed', 'Own check should be in handed state after payment')
+
+        # invoice status is not_paid -> original payment unreconciled, but still appears as outstanding debit on invoice
+        # payment_line is reconciled -> payment now linked with void move and doesn't appear as outstanding debit
+        check.action_void()
+        self.assertEqual(check.issue_state, 'voided', 'Own check should be voided after action_void()')
+        self.assertEqual(invoice.payment_state, 'not_paid', 'Invoice should return to not_paid after the check is voided')
+
+        payment_line = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id.account_type in ('asset_receivable', 'liability_payable')
+        )
+        self.assertTrue(payment_line.reconciled, "Original payment line should be reconciled with the void move")


### PR DESCRIPTION
Steps to reproduce:
1- Install l10n_ar and l10n_latam_check modules
2- Switch company to (AR) Responsable Inscripto
3- Go to [Accounting -> Configuration -> Journals -> Bank] and make sure 'outstanding payments account' is set in outgoing payments for own checks and manual payment
4- Go to [Accounting -> Vendors -> Bills] and create a new bill
5- Create an own check payment for the full amount
6- Go to the check and void it

Description of issue:
When you view the invoice after voiding the check, it's payment state will be shown as 'Paid'

Expected behavior:
Invoice payment state should go back to 'not_paid'

Why this happens:
When the check is voided, it's `amount_residual` attribute becomes 0. This causes `pay.is_matched` to be True, and as a result `all_payments_matched` attribute is also True. This turns the invoice payment state to paid.

opw-6016394