### PR TITLE
[FIX] website_sale: improve attribute fetching on shop page

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -461,9 +461,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductAttribute = request.env['product.attribute']
         if products:
             # get all products without limit
+            search_term = fuzzy_search_term if fuzzy_search_term else search
+            product_query = request.env['product.template']._search(
+                self._get_shop_domain(search_term, category, attribute_value_dict)
+            )
             attributes_grouped = request.env['product.template.attribute.line']._read_group(
                 domain=[
-                    ('product_tmpl_id', 'in', search_product.ids),
+                    ('product_tmpl_id', 'in', product_query),
                     ('attribute_id.visibility', '=', 'visible'),
                 ],
                 groupby=['attribute_id'],


### PR DESCRIPTION
Before this commit, fetching product template attributes was slow and memory-intensive when handling a large number of products. The domain included IDs of all fetched products, leading to high memory usage and slow performance.

To fix this, use the product domain directly instead of passing product IDs.

Below is the performance comparison for the read_group used for attribute fetching:

| Products | Before (Memory) | Before (Time) | After (Time) |
| -------- | --------------- | ------------- | ------------ |
| 900K     | 113MB           | 2.5s          | 2ms          |
| 2M       | 200MB           | 7s            | 2.5ms        |
| 9M       | OOM             | +15s (OOM)    | 11ms         |

opw-5949132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
