### PR TITLE
[FIX] website_sale: Fix dynamically variant creation

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -605,8 +605,23 @@ class ProductTemplate(models.Model):
         """
         combination = self.env['product.template.attribute.value'].browse(
             product_template_attribute_value_ids)
+        if not combination:
+            # Some frontend actions (e.g. add to wishlist/compare from
+            # /shop) can call this route without explicit ids.
+            # In that case, use the first possible combination as a fallback
+            combination = self._get_first_possible_combination()
 
         return self._create_product_variant(combination, log_warning=True).id or 0
+
+    def _get_first_existing_variant_id(self):
+        """Return the first possible variant id if it already exists.
+
+        Unlike ``_get_first_possible_variant_id``, this method never creates a
+        variant for dynamic templates.
+        """
+        self.ensure_one()
+        combination = self._get_first_possible_combination()
+        return self._get_variant_for_combination(combination).id
 
     def _get_image_holder(self):
         """Returns the holder of the image to use as default representation.
@@ -619,7 +634,7 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         if self.image_128:
             return self
-        variant = self.env['product.product'].browse(self._get_first_possible_variant_id())
+        variant = self.env['product.product'].browse(self._get_first_existing_variant_id())
         # if the variant has no image anyway, spare some queries by using template
         return variant if variant.image_variant_128 else self
 

--- a/addons/website_sale/static/tests/tours/website_sale_dynamic_variant_not_created_on_ecommerce_view.js
+++ b/addons/website_sale/static/tests/tours/website_sale_dynamic_variant_not_created_on_ecommerce_view.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("website_sale_dynamic_variant_not_created_on_ecommerce_view", {
+    test: true,
+    url: "/shop?search=T-Shirt Dynamic Tour",
+    steps: () => [
+        {
+            content: "Open the dynamic product",
+            trigger: '.oe_product_cart a:containsExact("T-Shirt Dynamic Tour")',
+        },
+        {
+            content: "Select color red",
+            trigger: 'input[data-attribute_name="Test Color Dynamic"][data-value_name="Red"]',
+            run: "click",
+        },
+        {
+            content: "Check color red selected",
+            trigger: 'input[data-attribute_name="Test Color Dynamic"][data-value_name="Red"]:propChecked',
+            isCheck: true,
+        }
+    ],
+});

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -24,6 +24,7 @@ from . import test_website_sequence
 from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_visitor
 from . import test_website_sale_product
+from . import test_website_sale_product_variant_creation
 from . import test_website_editor
 from . import test_website_sale_reorder_from_portal
 from . import test_website_sale_snippets

--- a/addons/website_sale/tests/test_website_sale_product_variant_creation.py
+++ b/addons/website_sale/tests/test_website_sale_product_variant_creation.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleProductVariantCreation(HttpCaseWithUserDemo):
+
+    def test_dynamic_variant_not_created_on_ecommerce_view(self):
+        """Ensure browsing does not create dynamic variants before add-to-cart."""
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Test Color Dynamic',
+            'create_variant': 'dynamic',
+            'value_ids': [
+                Command.create({'name': 'Red'}),
+                Command.create({'name': 'Blue'}),
+            ],
+        })
+        color_red = color_attribute.value_ids.filtered(lambda value: value.name == 'Red')
+        color_blue = color_attribute.value_ids.filtered(lambda value: value.name == 'Blue')
+
+        product_template = self.env['product.template'].create({
+            'name': 'T-Shirt Dynamic Tour',
+            'type': 'consu',
+            'list_price': 50.0,
+            'is_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': color_attribute.id,
+                    'value_ids': [
+                        Command.link(color_red.id),
+                        Command.link(color_blue.id),
+                    ],
+                }),
+            ],
+        })
+
+        self.start_tour('/', 'website_sale_dynamic_variant_not_created_on_ecommerce_view', login='')
+
+        final_variant_count = len(product_template.product_variant_ids)
+        self.assertEqual(
+            final_variant_count,
+            0,
+            "Viewing the product page must not create variants.",
+        )

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -241,9 +241,9 @@
 
     <template id="products_add_to_cart" inherit_id="website_sale.products_item" active="False" name="Add to Cart">
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
-            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
+            <t t-set="product_variant_id" t-value="product._get_first_existing_variant_id()"/>
             <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
-            <t t-if="product_variant_id and template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
+            <t t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
                 <a t-if="product._website_show_quick_add()"
                    href="#" role="button" class="btn btn-primary a-submit" aria-label="Shopping cart" title="Shopping cart">
                     <span class="fa fa-shopping-cart"/>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -4,16 +4,18 @@
     <template id="add_to_compare" inherit_id="website_sale.products_item" name="Comparison List" priority="22">
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
-            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id and categories" type="button" role="button" class="d-none d-md-inline-block btn btn-outline-primary bg-white o_add_compare" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist"><span class="fa fa-exchange"></span></button>
+            <t t-set="product_variant_id" t-value="product._get_first_existing_variant_id()"/>
+            <button t-if="categories" type="button" role="button" class="d-none d-md-inline-block btn btn-outline-primary bg-white o_add_compare" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist"><span class="fa fa-exchange"></span></button>
         </xpath>
     </template>
 
     <template id="product_add_to_compare" name='Add to comparison in product page' inherit_id="website_sale.product" priority="8">
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
             <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
-            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id and categories"
+            <t t-set="first_possible_combination" t-value="product._get_first_possible_combination()"/>
+            <t t-set="is_combination_possible" t-value="product._is_combination_possible(first_possible_combination)"/>
+            <t t-set="product_variant_id" t-value="product._get_first_existing_variant_id()"/>
+            <button t-if="categories and is_combination_possible"
                 type="button"
                 role="button"
                 class="d-none d-md-block btn btn-link px-0 o_add_compare_dyn"

--- a/addons/website_sale_comparison_wishlist/views/templates.xml
+++ b/addons/website_sale_comparison_wishlist/views/templates.xml
@@ -3,9 +3,8 @@
     <template id="product_wishlist" inherit_id="website_sale_wishlist.product_wishlist">
         <xpath expr="//button[hasclass('o_wish_rm')]" position="after">
             <t t-set="categories" t-value="wish.product_id.product_tmpl_id.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
-            <t t-set="product_variant_id" t-value="wish.product_id.product_tmpl_id._get_first_possible_variant_id()"/>
             <button
-                t-if="is_view_active('website_sale_comparison.add_to_compare') and product_variant_id and categories"
+                t-if="is_view_active('website_sale_comparison.add_to_compare') and categories"
                 type="button"
                 class="btn btn-link o_add_to_compare no-decoration"
                 t-att-data-product-id='wish.product_id.id'>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -4,8 +4,10 @@
     <template id="add_to_wishlist" inherit_id="website_sale.products_item" name="Wishlist Button" priority="20">
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="in_wish" t-value="product in products_in_wishlist"/>
-            <t t-set="product_variant_id" t-value="in_wish or product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id"
+            <t t-set="first_possible_combination" t-value="product._get_first_possible_combination()"/>
+            <t t-set="is_combination_possible" t-value="product._is_combination_possible(first_possible_combination)"/>
+            <t t-set="product_variant_id" t-value="in_wish or product._get_first_existing_variant_id()"/>
+            <button t-if="is_combination_possible"
                     type="button"
                     role="button"
                     class="btn btn-outline-primary bg-white o_add_wishlist"
@@ -21,9 +23,13 @@
     <template id="product_add_to_wishlist" inherit_id="website_sale.product" name="Wishlist Button" priority="20">
         <xpath expr="//div[@id='product_option_block']" position="inside">
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">
-                <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
-                <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
-                <button t-if="product_variant" type="button" role="button" class="btn btn-link px-0 pe-3 o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Add to wishlist"><i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>Add to wishlist</button>
+                <t t-set="first_possible_combination" t-value="product._get_first_possible_combination()"/>
+                <t t-set="is_combination_possible" t-value="product._is_combination_possible(first_possible_combination)"/>
+                <t t-if="is_combination_possible">
+                    <t t-set="product_variant" t-value="product_variant or product.env['product.product'].browse(product._get_first_existing_variant_id())"/>
+                    <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
+                    <button type="button" role="button" class="btn btn-link px-0 pe-3 o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Add to wishlist"><i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>Add to wishlist</button>
+                </t>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
For now, when a product is created with a Dynamically attribute, a variant is automatically created when viewing the product on the eCommerce site. However, the Dynamically behavior is supposed to create a variant only when a Sales Order (SO) is created.

This PR fixes the issue by preventing the variant from being created when simply viewing the product on the eCommerce site.

opw-6060733