### PR TITLE
[FIX] website: better text generation for foreign languages

### DIFF
--- a/addons/website/models/html_text_processor.py
+++ b/addons/website/models/html_text_processor.py
@@ -185,15 +185,15 @@ class WebsiteHTMLTextProcessor(models.AbstractModel):
         :rtype: float
         """
         text_must_be_translated_for_openai = self.env.context.get('html_text_must_be_translated_for_openai', False)
-        if text_must_be_translated_for_openai:
-            nb_terms_translated = len([k for k, v in translated_content.items() if k != v])
-            nb_terms_total = len(translated_content)
-        else:
-            nb_terms_translated = len(generated_content)
-            nb_terms_total = len(generated_content)
 
-        translated_ratio = nb_terms_translated / nb_terms_total if nb_terms_total > 0 else 0
-        _logger.debug("Ratio of translated content: %s%% (%s/%s)", translated_ratio * 100, nb_terms_translated, nb_terms_total)
+        if text_must_be_translated_for_openai:
+            weight_terms_translated = sum(len(k) for k, v in translated_content.items() if k != v)
+            weight_terms_total = sum(len(k) for k, v in translated_content.items())
+        else:
+            weight_terms_translated = len(generated_content)
+            weight_terms_total = len(generated_content)
+
+        translated_ratio = weight_terms_translated / weight_terms_total if weight_terms_total > 0 else 0
         return translated_ratio
 
     @api.model

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -941,7 +941,7 @@ class Website(models.CachedModel):
                     generated_content[placeholder] = ''
 
         translated_ratio = html_text_processor._calculate_translation_ratio(generated_content, translated_content)
-        if translated_ratio > 0.8:
+        if translated_ratio > 0.5:
             try:
                 database_id = self.env['ir.config_parameter'].sudo().get_str('database.uuid')
                 response = self._OLG_api_rpc('/api/olg/1/generate_placeholder', {


### PR DESCRIPTION
**Problem:**
After creating a website via the website builder in a non English language, the texts displayed on the website was sometimes not linked to the selected industry.

**Steps to reproduce:**
- Add French in settings
- Create a new website with French as a main language
- Choose as an industry "martial art school"
- Choose the first theme
- After the loading, the website content is not linked to martial art

**Why:**
The generation of in context content was dependant of the amount of translated text. The threshold was set to 80% translated, so some themes with a lot of city and monument names that don't have a translation between English and French could have a ratio lower than 80%.

**Fix:**
- Lowered the ratio threshold to 50%
- Changed how we calculate this ratio
	- from counting the number of translated text elements
	- to summing the length of all translated texts