### PR TITLE
[FIX] account: correct dynamic report filename when sending email 

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -35,6 +35,7 @@ from odoo.tools import (
     create_index,
     StackMap,
 )
+from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -4769,10 +4770,17 @@ class AccountMove(models.Model):
         pdf_name = self._get_invoice_report_filename() if len(self) == 1 else "Invoices.pdf"
         return pdf_content, pdf_name
 
-    def _get_invoice_report_filename(self, extension='pdf'):
+    def _get_invoice_report_filename(self, extension='pdf', report=None):
         """ Get the filename of the generated invoice report with extension file. """
         self.ensure_one()
-        return f"{self.name.replace('/', '_')}.{extension}"
+        if report:
+            if report.print_report_name and isinstance(report.print_report_name, str):
+                file_name = safe_eval(report.print_report_name, {'object': self})
+            else:
+                file_name = f"{report.name.lower()}_{self.name}"
+        else:
+            file_name = self.name
+        return f"{file_name.replace('/', '_')}.{extension}"
 
     def _get_invoice_proforma_pdf_report_filename(self):
         """ Get the filename of the generated proforma PDF invoice report. """

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -450,6 +450,45 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             },
         )
 
+    def test_move_composer_with_dynamic_report_print_report_name(self):
+        """
+        Additional dynamic report with custom print_report_name,
+        uses its own filename instead of reusing the invoice PDF filename.
+        """
+        test_move = self.test_account_moves[0].with_env(self.env)
+        test_customer = self.test_customers[0].with_env(self.env)
+        move_template = self.move_template.with_env(self.env)
+
+        extra_dynamic_report = self.env.ref('account.action_account_original_vendor_bill').copy({
+            'name': 'Invoice PDF 2',
+            'print_report_name': "'CUSTOM_DYNAMIC_REPORT'",
+        })
+        move_template.report_template_ids += extra_dynamic_report
+
+        composer = self.env['account.move.send']\
+            .with_context(active_model='account.move', active_ids=test_move.ids)\
+            .create({'mail_template_id': move_template.id})
+
+        with self.mock_mail_gateway(mail_unlink_sent=False), \
+                self.mock_mail_app():
+            composer.action_send_and_print()
+            self.env.cr.flush()
+
+        self.assertMailMail(
+            test_customer,
+            'sent',
+            author=self.user_account_other.partner_id,
+            content=f'TemplateBody for {test_move.name}',
+            email_values={
+                'attachments_info': [
+                    {'name': 'AttFileName_00.txt', 'raw': b'AttContent_00', 'type': 'text/plain'},
+                    {'name': 'AttFileName_01.txt', 'raw': b'AttContent_01', 'type': 'text/plain'},
+                    {'name': f'{test_move.name}.pdf'},
+                    {'name': 'CUSTOM_DYNAMIC_REPORT.pdf'},
+                ],
+            },
+        )
+
     def test_invoice_sent_to_additional_partner(self):
         """
         Make sure that when an invoice is sent to a partner who is not

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -203,16 +203,17 @@ class AccountMoveSend(models.TransientModel):
     def _get_placeholder_mail_template_dynamic_attachments_data(self, move, mail_template):
         invoice_template = self.env.ref('account.account_invoices')
         extra_mail_templates = mail_template.report_template_ids - invoice_template
-        filename = move._get_invoice_report_filename()
-        return [
-            {
+        attachments = []
+        for extra_mail_template in extra_mail_templates:
+            filename = move._get_invoice_report_filename(report=extra_mail_template)
+            attachments.append({
                 'id': f'placeholder_{extra_mail_template.name.lower()}_{filename}',
-                'name': f'{extra_mail_template.name.lower()}_{filename}',
+                'name': filename,
                 'mimetype': 'application/pdf',
                 'placeholder': True,
                 'dynamic_report': extra_mail_template.report_name,
-            } for extra_mail_template in extra_mail_templates
-        ]
+            })
+        return attachments
 
     @api.model
     def _get_invoice_extra_attachments(self, move):

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -265,10 +265,10 @@ class AccountMove(models.Model):
             return self.with_context(l10n_sa_file_format=False).env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(self)
         return super()._get_report_base_filename()
 
-    def _get_invoice_report_filename(self, extension='pdf'):
+    def _get_invoice_report_filename(self, extension='pdf', report=None):
         if self._is_l10n_sa_eligibile_invoice():
             return self.with_context(l10n_sa_file_format=extension).env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(self)
-        return super()._get_invoice_report_filename(extension)
+        return super()._get_invoice_report_filename(extension=extension, report=report)
 
     def _l10n_sa_is_in_chain(self):
         """


### PR DESCRIPTION
When sending an invoice by email template, the generated PDF attachment does not use the configured Printed Report Name. Instead, it falls back to a default naming pattern (e.g. report action name + invoice number).

This is due to a difference in flow: sales use the standard mail.compose.message wizard, which correctly applies each report’s print_report_name, while invoices use the dedicated account.move.send wizard. In the invoice flow,
_get_placeholder_mail_template_dynamic_attachments_data uses the invoice report context instead of the actual dynamic report.

To fix this, the send flow is updated so
_get_placeholder_mail_template_dynamic_attachments_data computes the filename from extra_mail_template.

Additionally, _get_invoice_report_filename needs to be extended in 17.0 to optionally accept a report and use its print_report_name like in the newer versions while preserving fallback behavior. 

The safe_eval is taken from code used in the future version's code, and is needed as the field accepts python expressions.

This naming issue occurs from 17.0 to current master, and the fix will ensure extra dynamic reports follow their configured printed name. 

Steps to reproduce:
Go to Settings > Technical > Reporting > Reports and duplicate the standard Invoice report. In the duplicated report, set a custom value in Printed Report Name (e.g. 'CUSTOM_NAME_TEST'). Go to Settings > Technical > Email > Templates and open “Invoice: Send my email”. Add the duplicated report under Dynamic Reports.
Create a customer invoice and confirm it.
Click Send (or Send & Print) to open the email preview.

Related Ticket:
opw-6058716