### PR TITLE
[FIX] web: can display many2one property in list

### DIFF
--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -7,7 +7,7 @@
         <div class="d-flex align-items-center gap-1">
             <span class="o_avatar o_m2o_avatar">
                 <t t-if="value">
-                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128?unique={{value.write_date.toMillis()}}"/>
+                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128?unique={{value.write_date?.toMillis()}}"/>
                 </t>
                 <t t-elif="!props.readonly">
                     <span class="o_avatar_empty o_m2o_avatar_empty"/>

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -2972,3 +2972,32 @@ test("properties definition: test display and edit", async () => {
         message: "4 field value should be present : 1 for each definition.",
     });
 });
+
+test.tags("desktop");
+test("many2one property in list view", async () => {
+    ResCompany._records[0].definitions.push({
+        name: "m2o_property",
+        string: "My Many2one Property",
+        type: "many2one",
+        comodel: "res.users",
+    });
+    Partner._records[0].properties = {
+        m2o_property: [1, "Alice"],
+    };
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `
+            <list>
+                <field name="display_name"/>
+                <field name="properties"/>
+            </list>`,
+    });
+
+    expect(".o_list_table thead th").toHaveCount(3);
+    await contains(".o_optional_columns_dropdown_toggle").click();
+    await contains(".o-dropdown-item input[name='properties.m2o_property']").click();
+    expect(".o_list_table thead th").toHaveCount(4);
+    expect(queryAllTexts(".o_data_row:eq(0) .o_data_cell")).toEqual(["first partner", "Alice"]);
+    expect(".o_data_row:eq(0) .o_m2o_avatar img").toHaveCount(1);
+});


### PR DESCRIPTION
Since PR [1], there's a crash when trying to display a many2one property in a list view.

Steps to reproduce:
- in the task form view, add a property field of type many2one pointing to the res.partner (Contact) model
- go back to list, and in the optional fields dropdown, toggle the newly created property => crash

In that case, we do not know the write_date of the many2one value, but the Many2oneAvatarField assumed that the write_date was always known.

[1] https://github.com/odoo/odoo/pull/247548

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
