### PR TITLE
[FIX] account: added an SQL constraint for label in report columns

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -880,6 +880,14 @@ class AccountReportColumn(models.Model):
     blank_if_zero = fields.Boolean(string="Blank if Zero", help="When checked, 0 values will not show in this column.")
     custom_audit_action_id = fields.Many2one(string="Custom Audit Action", comodel_name="ir.actions.act_window")
 
+    _sql_constraints = [
+        (
+            "expression_label_uniq",
+            "unique(report_id, expression_label)",
+            "A Expression label with the same name already exists."
+        ),
+    ]
+
 
 class AccountReportExternalValue(models.Model):
     _name = "account.report.external.value"


### PR DESCRIPTION
Currently, an error occurs when user tries to open a report with two or more columns that have same expression labels.

Steps to replicate:
- Install `accountant`.
- Open `Accounting > Reporting > Balance Sheet`.
- Turn on debug mode and click on the button with gear icon in the header.
- Go to Columns tab > add new column with expression label as `balance` > save.
- Now try to open the report Executive Summary.

Error:
```
ValueError: Expected singleton: account.report.column(10, 137)
```

Cause:
- As the user made a new column with label `balance` we get two records from the result of `filtered()` and when we try to access its `figure_type` we get error from [here].

Solution:
- Added an SQL constraint that restricts user from making new columns with label same as an existing column in a report.

[here]: https://github.com/odoo/enterprise/blob/317890e8af3a9f9de086769a2871fcc28a03c783/account_reports/models/account_report.py#L3443-L3444

sentry-7356996739
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
