### PR TITLE
[FIX] point_of_sale: do not swap accounts for outbound payments

### DIFF
--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -33,3 +33,15 @@ class AccountPayment(models.Model):
             if sepa_ct and 'pos_payment' in self.env.context and sepa_ct.code not in res:
                 res.append(sepa_ct.code)
         return res
+
+    def _prepare_move_counterpart_lines(self, default_values):
+        [res] = super()._prepare_move_counterpart_lines(default_values)
+        if self.pos_session_id and self.payment_type == 'outbound':
+            res['account_id'] = self.outstanding_account_id.id
+        return [res]
+
+    def _prepare_move_liquidity_lines(self, default_values):
+        [res] = super()._prepare_move_liquidity_lines(default_values)
+        if self.pos_session_id and self.payment_type == 'outbound':
+            res['account_id'] = self.destination_account_id.id
+        return [res]

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1087,18 +1087,14 @@ class PosSession(models.Model):
     def _ensure_payment_outstanding_account(self, payment, payment_amount):
         # In community the outstanding account is computed on the creation of account.payment records
         if not payment.outstanding_account_id and self.env['account.move']._get_invoice_in_payment_state() == 'in_payment':
-            payment.outstanding_account_id = payment._get_outstanding_account(payment.payment_type)
-
-        if float_compare(payment_amount, 0, precision_rounding=self.currency_id.rounding) < 0:
-            payment.write({
-                'force_outstanding_account_id': payment.destination_account_id,
-                'destination_account_id': payment.outstanding_account_id,
-                'payment_type': 'outbound',
-            })
+            payment.force_outstanding_account_id = payment._get_outstanding_account(payment.payment_type)
 
     def _create_combine_account_payment(self, payment_method, amounts, diff_amount):
         outstanding_account = payment_method.outstanding_account_id
         destination_account = self._get_receivable_account(payment_method)
+        payment_type = "inbound"
+        if self.currency_id.compare_amounts(amounts['amount'], 0) < 0:
+            payment_type = 'outbound'
 
         account_payment = self.env['account.payment'].with_context(pos_payment=True).create({
             'amount': abs(amounts['amount']),
@@ -1109,6 +1105,7 @@ class PosSession(models.Model):
             'pos_payment_method_id': payment_method.id,
             'pos_session_id': self.id,
             'company_id': self.company_id.id,
+            'payment_type': payment_type,
         })
 
         self._ensure_payment_outstanding_account(account_payment, amounts['amount'])
@@ -1150,6 +1147,9 @@ class PosSession(models.Model):
         outstanding_account = payment_method.outstanding_account_id
         accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
         destination_account = accounting_partner.property_account_receivable_id
+        payment_type = "inbound"
+        if self.currency_id.compare_amounts(amounts['amount'], 0) < 0:
+            payment_type = 'outbound'
 
         account_payment = self.env['account.payment'].create({
             'amount': abs(amounts['amount']),
@@ -1160,6 +1160,7 @@ class PosSession(models.Model):
             'memo': _('%(payment_method)s POS payment of %(partner)s in %(session)s', payment_method=payment_method.name, partner=payment.partner_id.display_name, session=self.name),
             'pos_payment_method_id': payment_method.id,
             'pos_session_id': self.id,
+            'payment_type': payment_type,
         })
 
         self._ensure_payment_outstanding_account(account_payment, amounts['amount'])

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -3040,7 +3040,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(order_balance + payment_balance, 0)
 
     def test_pos_payment_direction_and_accounts(self):
-        """Ensure POS payments create correct inbound/outbound payments and accounts."""
+        """Ensure POS payments create correct inbound/outbound payments and accounts and related journal items"""
 
         def _do_pos_transaction(amount, split, index):
             self.bank_payment_method.write({'split_transactions': split})
@@ -3079,8 +3079,9 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             _do_pos_transaction(amount, split, idx).id
             for idx, (amount, split) in enumerate([(100, False), (-100, False), (100, True), (-100, True)])
         ]
+        payments = self.env['account.payment'].search([('pos_session_id', 'in', session_ids)], order='id')
         self.assertRecordValues(
-            self.env['account.payment'].search([('pos_session_id', 'in', session_ids)], order='id'),
+            payments,
             [
                 {
                     "payment_type": "inbound",
@@ -3089,8 +3090,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 },
                 {
                     "payment_type": "outbound",
-                    "outstanding_account_id": self.bank_payment_method.receivable_account_id.id,
-                    "destination_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "outstanding_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "destination_account_id": self.bank_payment_method.receivable_account_id.id,
                 },
                 {
                     "payment_type": "inbound",
@@ -3099,8 +3100,21 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 },
                 {
                     "payment_type": "outbound",
-                    "outstanding_account_id": self.bank_payment_method.receivable_account_id.id,
-                    "destination_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "outstanding_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "destination_account_id": self.bank_payment_method.receivable_account_id.id,
                 },
             ],
         )
+
+        for payment in payments:
+            move_lines = payment.move_id.line_ids.sorted('balance')
+            if payment.payment_type == "inbound":
+                self.assertRecordValues(move_lines, [
+                    {'account_id': self.bank_payment_method.receivable_account_id.id},
+                    {'account_id': self.bank_payment_method.outstanding_account_id.id},
+                ])
+            else:
+                self.assertRecordValues(move_lines, [
+                    {'account_id': self.bank_payment_method.outstanding_account_id.id},
+                    {'account_id': self.bank_payment_method.receivable_account_id.id},
+                ])

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -3040,7 +3040,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(order_balance + payment_balance, 0)
 
     def test_pos_payment_direction_and_accounts(self):
-        """Ensure POS payments create correct inbound/outbound payments and accounts."""
+        """Ensure POS payments create correct inbound/outbound payments and accounts and related journal items"""
 
         def _do_pos_transaction(amount, split, index):
             self.bank_payment_method.write({'split_transactions': split})
@@ -3079,8 +3079,9 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             _do_pos_transaction(amount, split, idx).id
             for idx, (amount, split) in enumerate([(100, False), (-100, False), (100, True), (-100, True)])
         ]
+        payments = self.env['account.payment'].search([('pos_session_id', 'in', session_ids)], order='id')
         self.assertRecordValues(
-            self.env['account.payment'].search([('pos_session_id', 'in', session_ids)], order='id'),
+            payments,
             [
                 {
                     "payment_type": "inbound",
@@ -3104,3 +3105,19 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 },
             ],
         )
+
+        def get_credit_debit_line(lines):
+            credit_line = lines.filtered(lambda line: line.credit > 0)
+            debit_line = lines - credit_line
+            self.assertEqual(len(debit_line), 1)
+            self.assertEqual(len(credit_line), 1)
+            return credit_line, debit_line
+
+        for payment in payments:
+            credit, debit = get_credit_debit_line(payment.move_id.line_ids)
+            if payment.payment_type == "inbound":
+                self.assertEqual(credit.account_id, self.bank_payment_method.receivable_account_id)
+                self.assertEqual(debit.account_id, self.bank_payment_method.outstanding_account_id)
+            else:
+                self.assertEqual(debit.account_id, self.bank_payment_method.receivable_account_id)
+                self.assertEqual(credit.account_id, self.bank_payment_method.outstanding_account_id)


### PR DESCRIPTION
Step to reproduce:
- we need a session, where in total, we gave out money (when we refund)
- for this, start a pos session, do a order, pay using bank and close session
- restart the pos, refund the order, and pay using bank, close it.
- go to accounting > customer > payment
- open payment for both session

Observation:
- in journal entries for both payment, amount is credit into
`account_receivable` and debit from `outstanding account`

Cause:
- commit[1] swaps accounts when we have outbound payments, which is functionally
incorrect and lead to this issue.
[1] https://github.com/odoo/odoo/commit/844d2960af6b2cdd8620eb1681bda03dd48a97e4

Fix:
- do not swap accounts between `outstanding` and `destination` accounts.

Expected after fix:
- Inbound and outbound payments use the same accounts
- Journal entries are correct:
- Inbound: debit outstanding, credit account_receivable
- Outbound: reverse of inbound entries

opw-6044883