### PR TITLE
[FIX] l10n_sg_ubl_pint: enable UBL import for SG PINT invoices

### DIFF
--- a/addons/l10n_sg_ubl_pint/__init__.py
+++ b/addons/l10n_sg_ubl_pint/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
+from . import tests

--- a/addons/l10n_sg_ubl_pint/models/account_move.py
+++ b/addons/l10n_sg_ubl_pint/models/account_move.py
@@ -1,6 +1,6 @@
 import uuid
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
@@ -13,3 +13,10 @@ class AccountMove(models.Model):
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
         guid = uuid.uuid5(namespace=uuid.UUID(dbuuid), name=str(self.id))
         return str(guid)
+
+    @api.model
+    def _get_ubl_cii_builder_from_xml_tree(self, tree):
+        customization_id = tree.find('{*}CustomizationID')
+        if customization_id is not None and customization_id.text == 'urn:peppol:pint:billing-1@sg-1':
+            return self.env['account.edi.xml.pint_sg']
+        return super()._get_ubl_cii_builder_from_xml_tree(tree)

--- a/addons/l10n_sg_ubl_pint/tests/__init__.py
+++ b/addons/l10n_sg_ubl_pint/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sg_ubl_pint

--- a/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
@@ -1,0 +1,152 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@sg-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SGD</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>SGD</cbc:ID>
+    <cbc:DocumentTypeCode>sgdtotal-excl-gst</cbc:DocumentTypeCode>
+    <cbc:DocumentDescription>1000.0</cbc:DocumentDescription>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>SGD</cbc:ID>
+    <cbc:DocumentTypeCode>sgdtotal-incl-gst</cbc:DocumentTypeCode>
+    <cbc:DocumentDescription>1090.0</cbc:DocumentDescription>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0195">201131415A</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Tyersall Avenue</cbc:StreetName>
+        <cbc:CityName>Central Singapore</cbc:CityName>
+        <cbc:PostalZone>248048</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+65 9123 4567</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0195">301131415A</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+65 9123 4589</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">180.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">180.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>9.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SGD">90.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2180.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">2180.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>9.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
+++ b/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import file_open
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestSgUBLPint(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='sg'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.env.ref('base.EUR').active = True
+
+    def test_invoice_import(self):
+        with file_open('l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml', 'rb') as f:
+            xml_content = f.read()
+
+        attachment = self.env['ir.attachment'].create({
+            'name': 'invoice.xml',
+            'datas': base64.encodebytes(xml_content),
+            'mimetype': 'application/xml',
+        })
+
+        journal = self.company_data['default_journal_purchase']
+        invoice = journal._create_document_from_attachment(attachment.ids)
+
+        self.assertTrue(invoice)
+        self.assertRecordValues(invoice, [{
+            'move_type': 'in_invoice',
+            'currency_id': self.env.ref('base.EUR').id,
+            'amount_untaxed': 2000.0,
+            'amount_tax': 180.0,
+            'amount_total': 2180.0,
+        }])


### PR DESCRIPTION
The UBL module wasn't able to import PINT documents because there was no logic to detect the type of UBL document for SG PINT invoices (urn:peppol:pint:billing-1@sg-1).

This commit adds the method to detect SG PINT document and provide appropriate EDI builder.