### PR TITLE
[FIX] mail: close avatar card popover on “View Profile” button click

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -79,6 +79,7 @@ export class AvatarCardPopover extends Component {
 
     async onClickViewProfile(newWindow) {
         const action = await this.getProfileAction();
+        this.props.close();
         if (!action) {
             return;
         }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1706,7 +1706,7 @@ test("Partner's avatar card should be opened after clicking on their mention", a
     });
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
-    await openFormView("res.partner", partnerId);
+    await openFormView("res.partner", serverState.partnerId);
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@Te");
     await click(".o-mail-Composer-suggestion strong", { text: "Test Partner" });
@@ -1714,6 +1714,10 @@ test("Partner's avatar card should be opened after clicking on their mention", a
     await click(".o-mail-Composer-send:enabled");
     await click(".o_mail_redirect");
     await contains(".o_avatar_card:contains('Test Partner')");
+    // Ensure clicking the button closes the popover
+    await click(".o_avatar_card_buttons button:text('View Profile')");
+    await contains(".o_last_breadcrumb_item:text('Test Partner')");
+    await contains(".o_avatar_card", { count: 0 });
 });
 
 test("Channel should be opened after clicking on its mention", async () => {


### PR DESCRIPTION
**Current behavior before PR:**
Clicking on a partner mention opens the avatar card popover. When the **View Profile** button is clicked, the partner form view opens, but the popover remains visible.

This happens because the popover opened via `onClickPartnerMention` uses the popover service directly, instead of the `usePopover` hook, which automatically closes the popover when the component is unmounted.

**Desired behavior after PR is merged:**
Clicking the **View Profile** button opens the partner form view and closes the avatar card popover.

task-[6063906](https://www.odoo.com/odoo/project/1519/tasks/6063906)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
