### PR TITLE
[IMP] core: show thread time in logs

### DIFF
--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -37,7 +37,7 @@ from odoo.modules.module import (
     initialize_sys_path,
 )
 from odoo.modules.registry import Registry
-from odoo.tools import config, file_path, profiler, real_time
+from odoo.tools import config, file_path, profiler, real_time, thread_time
 from odoo.tools.misc import submap
 
 if typing.TYPE_CHECKING:
@@ -246,7 +246,7 @@ class Application:
         current_thread = threading.current_thread()
         current_thread.query_count = 0
         current_thread.query_time = 0
-        current_thread.perf_t0 = real_time()
+        current_thread.perf_t0 = (thread_time(), real_time())
         current_thread.cursor_mode = None
         if hasattr(current_thread, 'dbname'):
             del current_thread.dbname

--- a/odoo/http/server_log.py
+++ b/odoo/http/server_log.py
@@ -24,7 +24,7 @@ from odoo.netsvc import (
     ColoredFormatter,
 )
 from odoo.tools import frozendict
-from odoo.tools.misc import real_time
+from odoo.tools.misc import real_time, thread_time
 
 from .requestlib import DEFAULT_MAX_CONTENT_LENGTH, MAX_FORM_SIZE
 
@@ -33,7 +33,7 @@ __all__ = (
     'reset_thread_info',
 )
 
-_HTTP_FORMAT = '%(remote_addr)s %(ident)s %(http_auth)s [%(date)s] "%(http_request_line)s" %(http_response_status)s %(http_response_body)s %(query_count)s %(query_time)s %(remaining_time)s %(cursor_mode)s'
+_HTTP_FORMAT = '%(remote_addr)s %(ident)s %(http_auth)s [%(date)s] "%(http_request_line)s" %(http_response_status)s %(http_response_body)s %(query_count)s %(query_time)s %(user_time)s %(wall_time)s %(cursor_mode)s'
 _HTTP_FORMAT_HEADERS = _HTTP_FORMAT + "\n%(http_headers)s"
 
 # All the fallback values for _HTTP_FORMAT(_HEADERS)?
@@ -47,7 +47,8 @@ _HTTP_EXTRA = frozendict({
     'http_response_body': '-',
     'query_count': 0,
     'query_time': 0.0,
-    'remaining_time': 0.0,  # total time - query time
+    'user_time': 0.0,
+    'wall_time': 0.0,
     'cursor_mode': '-',
     'http_headers': (),
 })
@@ -65,7 +66,7 @@ _NO_BODY_STATUS = {
 
 
 def reset_thread_info():
-    t0 = real_time()
+    t0 = (thread_time(), real_time())
     current_thread = threading.current_thread()
     current_thread.query_count = 0
     current_thread.query_time = 0
@@ -88,12 +89,15 @@ def http_log(
 
     now = time.time()
     real_now = real_time()
+    thread_now = thread_time()
     current_thread = threading.current_thread()
+    t0_user, t0_wall = current_thread.perf_t0
     extra = dict(
         _HTTP_EXTRA,
         query_count=current_thread.query_count,
         query_time=current_thread.query_time,
-        remaining_time=real_now - current_thread.perf_t0 - current_thread.query_time,
+        wall_time=real_now - t0_wall,
+        user_time=thread_now - t0_user,
         date=format_date_time(now),
     )
     if th_cursor_mode := current_thread.cursor_mode:
@@ -134,7 +138,8 @@ def http_log(
     if _has_color():
         extra['query_count'] = _colorize_query_count(extra['query_count'])
         extra['query_time'] = _colorize_query_time(extra['query_time'])
-        extra['remaining_time'] = _colorize_remaining_time(extra['remaining_time'])
+        extra['user_time'] = _colorize_user_time(extra['user_time'])
+        extra['wall_time'] = _colorize_wall_time(extra['wall_time'])
         if extra['http_response_status'] != '-':
             extra['http_request_line'] = _colorize_request_line(
                 extra['http_request_line'], extra['http_response_status'])
@@ -144,7 +149,8 @@ def http_log(
         extra['ident'] = _colorize_ident(extra['ident'])
     else:
         extra['query_time'] = round(extra['query_time'], 3)
-        extra['remaining_time'] = round(extra['remaining_time'], 3)
+        extra['user_time'] = round(extra['user_time'], 3)
+        extra['wall_time'] = round(extra['wall_time'], 3)
 
     if extra['http_headers'] and _logger_headers.isEnabledFor(logging.DEBUG):
         extra['http_headers'] = pprint.pformat(list(extra['http_headers']))
@@ -202,7 +208,8 @@ def _colorize_range(value: float, format: str, low: float, high: float) -> str:
 
 _colorize_query_count = functools.partial(_colorize_range, format='%d', low=100, high=1000)
 _colorize_query_time = functools.partial(_colorize_range, format='%.3f', low=.1, high=3)
-_colorize_remaining_time = functools.partial(_colorize_range, format='%.3f', low=1, high=5)
+_colorize_user_time = functools.partial(_colorize_range, format='%.3f', low=1, high=5)
+_colorize_wall_time = functools.partial(_colorize_range, format='%.3f', low=2, high=5)
 
 
 def _colorize_body_length(body_length: int | typing.Literal['-', 'stream']) -> str:

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -121,10 +121,11 @@ if os.environ.get('ODOO_PY_COLORS_NOPID'):
     TRUE_COLOR_PATTERN = f"\033[%dm%s{RESET_SEQ}"
     PID_COLORS = [0]
 
+
 class PerfFilter(logging.Filter):
 
-    def format_perf(self, query_count, query_time, remaining_time):
-        return (f"{query_count:d}", f"{query_time:.3f}", f"{remaining_time:.3f}")
+    def format_perf(self, query_count, query_time, user_time, wall_time):
+        return f"{query_count:d} {query_time:.3f} {user_time:.3f} {wall_time:.3f}"
 
     def format_cursor_mode(self, cursor_mode):
         return cursor_mode or '-'
@@ -133,9 +134,10 @@ class PerfFilter(logging.Filter):
         if hasattr(threading.current_thread(), "query_count"):
             query_count = threading.current_thread().query_count
             query_time = threading.current_thread().query_time
-            perf_t0 = threading.current_thread().perf_t0
-            remaining_time = tools.real_time() - perf_t0 - query_time
-            record.perf_info = '%s %s %s' % self.format_perf(query_count, query_time, remaining_time)
+            perf_u0, perf_w0 = threading.current_thread().perf_t0
+            user_time = tools.thread_time() - perf_u0
+            wall_time = tools.real_time() - perf_w0
+            record.perf_info = self.format_perf(query_count, query_time, user_time, wall_time)
             if tools.config['db_replica_host'] or 'replica' in tools.config['dev_mode']:
                 cursor_mode = threading.current_thread().cursor_mode
                 record.perf_info = f'{record.perf_info} {self.format_cursor_mode(cursor_mode)}'
@@ -146,19 +148,21 @@ class PerfFilter(logging.Filter):
             record.perf_info = "- - -"
         return True
 
+
 class ColoredPerfFilter(PerfFilter):
-    def format_perf(self, query_count, query_time, remaining_time):
+    def format_perf(self, query_count, query_time, user_time, wall_time):
         def colorize_time(time, format, low=1, high=5):
             if time > high:
                 return COLOR_PATTERN % (30 + RED, 40 + DEFAULT, format % time)
             if time > low:
                 return COLOR_PATTERN % (30 + YELLOW, 40 + DEFAULT, format % time)
             return format % time
-        return (
+        return ' '.join((
             colorize_time(query_count, "%d", 100, 1000),
             colorize_time(query_time, "%.3f", 0.1, 3),
-            colorize_time(remaining_time, "%.3f", 1, 5),
-            )
+            colorize_time(user_time, "%.3f", 1, 5),
+            colorize_time(wall_time, "%.3f", 1, 5),
+        ))
 
     def format_cursor_mode(self, cursor_mode):
         cursor_mode = super().format_cursor_mode(cursor_mode)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -95,6 +95,7 @@ __all__ = [
     'split_every',
     'str2bool',
     'street_split',
+    'thread_time',
     'topological_sort',
     'unique',
     'verify_hash_signed',
@@ -116,6 +117,7 @@ NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
 
 # ensure we have a non patched time for query times when using freezegun
 real_time = time.time.__call__  # type: ignore
+thread_time = time.thread_time
 
 
 class Sentinel(enum.Enum):
@@ -845,20 +847,23 @@ def dumpstacks(sig=None, frame=None, thread_idents=None, log_level=logging.INFO)
         if not thread_idents or threadId in thread_idents:
             thread_info = threads_info.get(threadId, {})
             query_time = thread_info.get('query_time')
-            perf_t0 = thread_info.get('perf_t0')
-            remaining_time = None
-            if query_time is not None and perf_t0:
-                remaining_time = '%.3f' % (real_time() - perf_t0 - query_time)
+            perf_u0, perf_w0 = thread_info.get('perf_t0', (0, 0))
+            user_time, wall_time = None, None
+            if query_time is not None and perf_w0:
+                user_time = '%.3f' % (thread_time() - perf_u0)
+                wall_time = '%.3f' % (real_time() - perf_w0)
                 query_time = '%.3f' % query_time
             # qc:query_count qt:query_time pt:python_time (aka remaining time)
-            code.append("\n# Thread: %s (db:%s) (uid:%s) (url:%s) (qc:%s qt:%s pt:%s)" %
+            code.append("\n# Thread: %s (db:%s) (uid:%s) (url:%s) (qc:%s qt:%s ut:%s, wt:%s)" %
                         (thread_info.get('repr', threadId),
                          thread_info.get('dbname', 'n/a'),
                          thread_info.get('uid', 'n/a'),
                          thread_info.get('url', 'n/a'),
                          thread_info.get('query_count', 'n/a'),
                          query_time or 'n/a',
-                         remaining_time or 'n/a'))
+                         user_time or 'n/a',
+                         wall_time or 'n/a',
+                         ))
 
             env = find_env(stack)
             if env:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -97,6 +97,7 @@ __all__ = [
     'split_every',
     'str2bool',
     'street_split',
+    'thread_time',
     'topological_sort',
     'unique',
     'verify_hash_signed',
@@ -118,6 +119,7 @@ NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
 
 # ensure we have a non patched time for query times when using freezegun
 real_time = time.time.__call__  # type: ignore
+thread_time = time.thread_time
 
 
 class Sentinel(enum.Enum):
@@ -854,20 +856,23 @@ def dumpstacks(sig=None, frame=None, thread_idents=None, log_level=logging.INFO)
         if not thread_idents or threadId in thread_idents:
             thread_info = threads_info.get(threadId, {})
             query_time = thread_info.get('query_time')
-            perf_t0 = thread_info.get('perf_t0')
-            remaining_time = None
-            if query_time is not None and perf_t0:
-                remaining_time = '%.3f' % (real_time() - perf_t0 - query_time)
+            perf_u0, perf_w0 = thread_info.get('perf_t0', (0, 0))
+            user_time, wall_time = None, None
+            if query_time is not None and perf_w0:
+                user_time = '%.3f' % (thread_time() - perf_u0)
+                wall_time = '%.3f' % (real_time() - perf_w0)
                 query_time = '%.3f' % query_time
-            # qc:query_count qt:query_time pt:python_time (aka remaining time)
-            code.append("\n# Thread: %s (db:%s) (uid:%s) (url:%s) (qc:%s qt:%s pt:%s)" %
+            # qc:query_count qt:query_time ut:user_time (aka python time) wt:wall_time (aka total time)
+            code.append("\n# Thread: %s (db:%s) (uid:%s) (url:%s) (qc:%s qt:%s ut:%s, wt:%s)" %
                         (thread_info.get('repr', threadId),
                          thread_info.get('dbname', 'n/a'),
                          thread_info.get('uid', 'n/a'),
                          thread_info.get('url', 'n/a'),
                          thread_info.get('query_count', 'n/a'),
                          query_time or 'n/a',
-                         remaining_time or 'n/a'))
+                         user_time or 'n/a',
+                         wall_time or 'n/a',
+                         ))
 
             env = find_env(stack)
             if env:


### PR DESCRIPTION
Problem statement
-----------------
Currently, the logged performance counters are:

- Query Count := Counts the number of times a query is issued to the
  database.
- Query Time := Time spent executing "SQL" queries. This include time
  includes:
    - Serialization of the query's body
    - Latency to the Postgres server over network
    - Execution of the query
    - Latency from sending back the result to the Application server
    - Deserialization of the result into Psycopg cursor object.
- Remaining Time := Total Time of the request (from start to finish
  aka the "Wall Time") minus Query Time

The issue lies in "Remaining Time" which is taught to people to be
assumed to be only "Python Time", but that's a **lie**.

Actually the remaining time includes stuff like:

- Any time spent waiting on IO, whether it's for the filesystem, or
  external requests over the network.
- Any time spent serializing/deserializing the HTTP request payload
- Any time spent "sleeping", in a context switch, or waiting for the
  GIL.

This leads to possible false conclusions:

- If the request had a high remaining time, what was slow, the python
  code, the request payload, was there an IO issue on the FS, or just
  high contention for a threaded server leading to a GIL contention ->
  It's impossible to know.
- Requests that server large payloads (like routes that server the
  assets bundle) have a higher than average "Remaining Time" but that's
  due to serving large payloads, not the Python processing it (or is it,
  actually we can't know for sure :S)

Proposition
-----------
We propose to rework the logged performance counters:

- Query Count (same as before)
- Query Time (same as before)
- User Time := via `time.thread_time()`which gives the CPU time for
  the current Python thread, which include **only** time spent 
  **actually** processing (User Space + Kernel Space). So this 
  number actually tells us the "real" Python Time.
- Wall Time := via `time.time()`, this gives the "total" time for a
  request from A-Z (everything).
- (inferrable value, not logged) "Remaining Time" := (`wall_time` -
  `user_time` - `query_time`) any time spent in some form of waiting,
  contention or serialization. This value usually is the one we care
  less about on average, therefor it's ok to be the "inferred" one.
  The "old" remaining time can still be inferred via `wall_time` -
  `query_time` if needed.

With the new User Time, we should be able to actually get an idea of 
"bad" python code that needs attention, with pretty high confidence that
it isn't due to some external factor unrelated to the code itself (like
server load/contention/slow external requests).
With the "new" remaining time, it's possible to do a post-mortem on
issues that were related to any form of IO or just general contention on
the GIL (for Threaded Server).

Commit msg
----------

For performance investigation, we want to know how much time was spent in the python thread. Currently, the remaining time is an approximation by taking the wall (real) time and substracting the time spent querying the database. We introduce the user time (thread time) to the logs and compare it with the wall time. The user time takes into account process interruptions and time spent processing the query on the python side.

Current logged numbers: `query_count, query_time, remaining_time`
New logged numbers:     `query_count, query_time, user_time, wall_time`
Where `remaining_time = wall_time - query_time`.

Reference
---------
task-6080214

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
