### PR TITLE
[FIX] web: hoot: cleanup various event listeners

### DIFF
--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -204,6 +204,10 @@ function getWatchedEventTargets(view) {
         EventBus.prototype,
         MockEventTarget.prototype,
         view.MediaDevices.prototype,
+        view.MediaStreamTrack.prototype,
+        view.RTCPeerConnection.prototype,
+        view.RTCDataChannel.prototype,
+        view.BaseAudioContext.prototype,
     ];
 }
 

--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -203,6 +203,7 @@ function getWatchedEventTargets(view) {
         // Other event targets
         EventBus.prototype,
         MockEventTarget.prototype,
+        view.MediaDevices.prototype,
     ];
 }
 


### PR DESCRIPTION
This commit fixes a memory leak in the test_unit_desktop suite, in the voip tests. The voip AudioManager registers event listeners on `navigator.mediaDevices`, but those listeners were never removed. As a consequence, audio managers and a bunch of other voip stuff, services, components... were leaking.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
