### PR TITLE
[FIX] l10n_es_edi_facturae: issue when sending invoice without tax to VeriFactu

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -498,9 +498,11 @@ class AccountMove(models.Model):
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, grouping_function_per_base_line_tax)
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
         for grouping_key, values in values_per_grouping_key.items():
-            tax_record = values['base_line_x_taxes_data'][0][1][0]['tax']
-            if not tax_record:
+            taxes_data = values['base_line_x_taxes_data']
+            if not taxes_data[0][1]:
                 continue
+
+            tax_record = taxes_data[0][1][0]['tax']
 
             is_withholding = values['grouping_key']['tax_rate'] < 0.0
             tax_data = self._l10n_es_edi_facturae_get_tax_node_from_tax_data({**values, 'grouping_key': tax_record}, round=True)

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -725,3 +725,16 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             with file_open("l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml", "rt") as f:
                 expected_xml = lxml.etree.fromstring(f.read().encode())
             self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)
+
+    @freeze_time('2023-01-01')
+    def test_out_invoice_no_tax(self):
+        """ Ensure no crash when generating a facturae XML for an invoice without taxes (opw-6067715) """
+        invoice = self.create_invoice(
+            partner_id=self.partner_a.id,
+            move_type='out_invoice',
+            invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': []}],
+        )
+        invoice.action_post()
+        generated_file, errors = invoice._l10n_es_edi_facturae_render_facturae()
+        self.assertFalse(errors)
+        self.assertTrue(generated_file)


### PR DESCRIPTION
Steps to reproduce:

1. Install l10n_es_edi_facturae.
2.  Switch to a Spanish company.
3. Create an invoice without any taxes.
4. Send the invoice to VeriFactu.

Issue:
A traceback occurs when sending an invoice without taxes: IndexError: list index out of range

Cause:
The code assumes the presence of tax data and directly accesses list elements without checking if base_line_x_taxes_data exists or contains values.

Fix:
Add proper checks to ensure tax data exists before accessing it, and skip processing when no tax data is available.

opw-6067715
co-authored by @bhra-odoo