### PR TITLE
[IMP] website_sale_loyalty: add promotion progress bar on cart

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -354,13 +354,17 @@ class Cart(PaymentPortal):
             },
         )
         values["website_sale.total"] = IrUiView._render_template(
-            "website_sale.total", {"website_sale_order": order_sudo}
+            "website_sale.total", {"website_sale_order": order_sudo, **self._total_values()}
         )
         values["website_sale.quick_reorder_history"] = IrUiView._render_template(
             "website_sale.quick_reorder_history",
             {"website_sale_order": order_sudo, **self._prepare_order_history()},
         )
         return values
+
+    def _total_values(self):
+        """Pass additional values when rendering the 'website_sale.total' template."""
+        return {}
 
     def _prepare_order_history(self):
         """Prepare the order history of the current user.

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -478,7 +478,7 @@
                     </td>
                 </tr>
                 <!-- Tax included view -->
-                <t t-if="tax_included" t-call="website_sale.order_tax_lines"/>
+                <t t-if="tax_included" t-call="website_sale.order_tax_lines" name="tax_included_order_tax_lines"/>
             </table>
         </div>
     </template>

--- a/addons/website_sale_loyalty/controllers/cart.py
+++ b/addons/website_sale_loyalty/controllers/cart.py
@@ -13,8 +13,42 @@ class Cart(WebsiteSaleCart):
             order_sudo._auto_apply_rewards()
         return super().cart(**post)
 
+    def _cart_values(self, **post):
+        values = super()._cart_values(**post)
+        if order_sudo := request.cart:
+            values["promotion_progress_bars"] = order_sudo._get_promotion_progress_bars()
+        return values
+
+    def _total_values(self):
+        values = super()._total_values()
+        if order_sudo := request.cart:
+            values["promotion_progress_bars"] = order_sudo._get_promotion_progress_bars()
+        return values
+
     @route("/wallet/top_up", type="http", auth="user", website=True, sitemap=False)
     def wallet_top_up(self, **kwargs):
         product = self.env["product.product"].browse(int(kwargs["trigger_product_id"]))
         self.add_to_cart(product.product_tmpl_id.id, product.id, 1)
         return request.redirect("/shop/cart")
+
+    @route()
+    def add_to_cart(self, *args, **kwargs):
+        applied_before = (
+            {p.id for p in request.cart._get_applied_programs()} if request.cart else set()
+        )
+
+        result = super().add_to_cart(*args, **kwargs)
+
+        order_sudo = request.cart
+        if order_sudo:
+            bars = [
+                bar
+                for bar in order_sudo._get_promotion_progress_bars()
+                if bar["progress"] < 100 or bar["program_id"] not in applied_before
+            ]
+            if bars:
+                for notif in result.get("notifications", []):
+                    if notif["type"] == "item_added":
+                        notif["data"]["promotion_progress_bars"] = bars
+                        break
+        return result

--- a/addons/website_sale_loyalty/data/product_demo.xml
+++ b/addons/website_sale_loyalty/data/product_demo.xml
@@ -3,4 +3,21 @@
     <record id="loyalty.gift_card_product_50" model="product.product">
         <field name="is_published" eval="True"/>
     </record>
+    <!-- Free Shipping promotion -->
+    <record id="free_shipping_promotion" model="loyalty.program">
+        <field name="name">Free Shipping</field>
+        <field name="program_type">promotion</field>
+        <field name="trigger">auto</field>
+    </record>
+
+    <record id="free_shipping_promotion_rule" model="loyalty.rule">
+        <field name="minimum_amount">1000</field>
+        <field name="product_category_id" ref="product.product_category_furniture"/>
+        <field name="program_id" ref="free_shipping_promotion"/>
+    </record>
+
+    <record id="free_shipping_promotion_reward" model="loyalty.reward">
+        <field name="reward_type">shipping</field>
+        <field name="program_id" ref="free_shipping_promotion"/>
+    </record>
 </odoo>

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -276,3 +276,141 @@ class SaleOrder(models.Model):
         self._update_programs_and_rewards()
         self._auto_apply_rewards()
         super()._recompute_cart()
+
+    def _get_promotion_progress_bars(self):
+        """Return progress data for auto-applied promotion programs whose only unmatched
+        condition is the minimum purchase amount.
+
+        A progress bar is shown when all other rule conditions (product, quantity) are
+        satisfied but the order total hasn't yet reached the rule's minimum amount threshold.
+        Already-applied programs are included as completed bars (progress=100) so the bar
+        persists after the promotion is claimed.
+
+        :return: A list of dicts with the following shape:
+
+            [{
+                "program_id": int,
+                "reward_name": str,       # e.g. "Free delivery"
+                "minimum_amount": float,  # required threshold in order currency
+                "progress": float,        # 0..100 (100 means the promotion is applied)
+            }]
+        :rtype: list[dict]
+        """
+        self.ensure_one()
+        if not self.website_id:
+            return []
+
+        programs = (
+            self
+            .env["loyalty.program"]
+            .search(
+                Domain.AND([
+                    self._get_program_domain(),
+                    [
+                        ("program_type", "=", "promotion"),
+                        ("trigger", "=", "auto"),
+                        ("rule_ids.mode", "=", "auto"),
+                    ],
+                ])
+            )
+            .filtered(lambda p: not p.limit_usage or p.total_order_count < p.max_usage)
+        )
+        if not programs:
+            return []
+
+        applied_programs = self._get_applied_programs()
+        unapplied_programs = programs - applied_programs
+        progress_bars = []
+
+        for program in programs & applied_programs:
+            for rule in program.rule_ids.sorted("minimum_amount"):
+                rule_amount = rule._compute_amount(self.currency_id)
+                if rule_amount:
+                    progress_bars.append({
+                        "program_id": program.id,
+                        # Use the actual reward that was claimed on this order
+                        "reward_name": (
+                            self.order_line
+                            .filtered(lambda line: line.reward_id.program_id == program)
+                            .reward_id[:1]
+                            .description
+                            or program.name
+                        ),
+                        "minimum_amount": rule_amount,
+                        "progress": 100,
+                    })
+                    break
+
+        if not unapplied_programs:
+            return progress_bars
+
+        # --- Compute order-line data only for unapplied programs ---
+        # Mirrors the logic in _program_check_compute_points.
+        order_lines = self._get_not_rewarded_order_lines().filtered(
+            lambda line: not line.combo_item_id
+        )
+        products = order_lines.product_id
+        products_qties = dict.fromkeys(products, 0)
+        for line in order_lines:
+            products_qties[line.product_id] += line.product_uom_id._compute_quantity(
+                line.product_uom_qty, line.product_id.uom_id
+            )
+        products_per_rule = unapplied_programs._get_valid_products(products)
+
+        # Build per-rule line sets for amount computation, excluding lines that shouldn't
+        # count toward the threshold (discounts from auto programs, combo items).
+        so_products_per_rule = unapplied_programs._get_valid_products(self.order_line.product_id)
+        lines_per_rule = defaultdict(lambda: self.env["sale.order.line"])
+        for line in self.order_line - self._get_no_effect_on_threshold_lines():
+            is_discount = line.reward_id.reward_type == "discount"
+            reward_program = line.reward_id.program_id
+            if (is_discount and reward_program.trigger == "auto") or line.combo_item_id:
+                continue
+            for program in unapplied_programs:
+                if is_discount and reward_program == program:
+                    continue
+                for rule in program.rule_ids:
+                    if line.product_id in so_products_per_rule.get(rule, []):
+                        lines_per_rule[rule] |= line._get_lines_with_price()
+
+        # For each unapplied program, find the first rule (sorted by minimum_amount) where
+        # product/qty conditions pass but the amount condition doesn't.
+        for program in unapplied_programs:
+            bar = None
+            for rule in program.rule_ids.sorted("minimum_amount"):
+                if not products_per_rule.get(rule):
+                    continue
+                if sum(products_qties[p] for p in products_per_rule[rule]) < rule.minimum_qty:
+                    continue
+
+                rule_amount = rule._compute_amount(self.currency_id)
+                if not rule_amount:
+                    continue
+
+                untaxed = sum(lines_per_rule[rule].mapped("price_subtotal"))
+                tax = sum(lines_per_rule[rule].mapped("price_tax"))
+                current_amount = (
+                    (untaxed + tax) if rule.minimum_amount_tax_mode == "incl" else untaxed
+                )
+
+                if current_amount >= rule_amount:
+                    break
+
+                bar = {
+                    "program_id": program.id,
+                    # Fallback to program name if there are multiple rewards since we don't know
+                    # which one will be applied
+                    "reward_name": (
+                        program.reward_ids.description
+                        if len(program.reward_ids) == 1
+                        else program.name
+                    ),
+                    "minimum_amount": rule_amount,
+                    "progress": current_amount / rule_amount * 100,
+                }
+                break
+
+            if bar is not None:
+                progress_bars.append(bar)
+
+        return progress_bars

--- a/addons/website_sale_loyalty/static/src/js/cart_notification/item_added_notification/item_added_notification.js
+++ b/addons/website_sale_loyalty/static/src/js/cart_notification/item_added_notification/item_added_notification.js
@@ -1,0 +1,13 @@
+import { patch } from "@web/core/utils/patch";
+import { ItemAddedNotification } from
+    "@website_sale/js/cart_notification/item_added_notification/item_added_notification";
+import { PromotionProgressBar } from
+    "@website_sale_loyalty/js/promotion_progress_bar/promotion_progress_bar";
+
+patch(ItemAddedNotification, {
+    components: { ...ItemAddedNotification.components, PromotionProgressBar },
+    props: {
+        ...ItemAddedNotification.props,
+        promotion_progress_bars: { type: Array, optional: true },
+    },
+});

--- a/addons/website_sale_loyalty/static/src/js/cart_notification/item_added_notification/item_added_notification.xml
+++ b/addons/website_sale_loyalty/static/src/js/cart_notification/item_added_notification/item_added_notification.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t
+        t-inherit="website_sale.ItemAddedNotification"
+        t-inherit-mode="extension"
+    >
+        <xpath expr="//a[@href='/shop/cart']" position="after">
+            <t t-if="props.promotion_progress_bars?.length">
+                <t t-foreach="props.promotion_progress_bars" t-as="bar" t-key="bar.program_id">
+                    <PromotionProgressBar
+                        reward_name="bar.reward_name"
+                        minimum_amount="bar.minimum_amount"
+                        progress="bar.progress"
+                        currency_id="props.currency_id"
+                    />
+                </t>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/website_sale_loyalty/static/src/js/promotion_progress_bar/promotion_progress_bar.js
+++ b/addons/website_sale_loyalty/static/src/js/promotion_progress_bar/promotion_progress_bar.js
@@ -1,0 +1,16 @@
+import { Component } from "@odoo/owl";
+import { formatCurrency } from "@web/core/currency";
+
+export class PromotionProgressBar extends Component {
+    static template = "website_sale_loyalty.PromotionProgressBar";
+    static props = {
+        reward_name: String,
+        minimum_amount: Number,
+        progress: Number,
+        currency_id: Number,
+    };
+
+    getFormattedMinAmount() {
+        return formatCurrency(this.props.minimum_amount, this.props.currency_id);
+    }
+}

--- a/addons/website_sale_loyalty/static/src/js/promotion_progress_bar/promotion_progress_bar.xml
+++ b/addons/website_sale_loyalty/static/src/js/promotion_progress_bar/promotion_progress_bar.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_sale_loyalty.PromotionProgressBar">
+        <div class="pb-2 mt-2">
+            <div class="d-flex justify-content-between mb-1">
+                <small
+                    t-attf-class="fw-bold #{props.progress === 100 ? 'text-success' : ''}"
+                    t-out="props.reward_name"
+                />
+                <small t-out="getFormattedMinAmount()"/>
+            </div>
+            <div class="progress" style="height: 8px; border-radius: var(--btn-border-radius);">
+                <div
+                    t-attf-class="progress-bar #{props.progress === 100 ? 'bg-success' : ''}"
+                    role="progressbar"
+                    t-attf-style="width: #{props.progress}%; border-radius: inherit; #{props.progress === 100 ? '' : 'color: inherit; background-color: currentColor;'}"
+                    t-att-aria-valuenow="props.progress"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                />
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -220,4 +220,39 @@
             <t t-call="sale_loyalty.sale_purchased_gift_card"/>
         </xpath>
     </template>
+
+    <template
+        id="website_sale_loyalty.promotion_progress_bar"
+        inherit_id="website_sale.total"
+        name="Promotion Progress Bar"
+    >
+        <t name="tax_included_order_tax_lines" position="after">
+            <tr t-if="promotion_progress_bars">
+                <td colspan="3" class="border-0 p-0 pt-2">
+                    <t t-foreach="promotion_progress_bars" t-as="bar">
+                        <div class="d-flex justify-content-between mb-1">
+                            <small
+                                t-attf-class="fw-bold #{bar['progress'] == 100 and 'text-success' or ''}"
+                                t-out="bar['reward_name']"
+                            />
+                            <small
+                                t-out="bar['minimum_amount']"
+                                t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                            />
+                        </div>
+                        <div class="progress mb-3" style="height: 8px; border-radius: var(--btn-border-radius);" >
+                            <div
+                                t-attf-class="progress-bar #{bar['progress'] == 100 and 'bg-success' or ''}"
+                                role="progressbar"
+                                t-attf-style="width: #{bar['progress']}%; border-radius: inherit; #{bar['progress'] == 100 and '' or 'color: inherit; background-color: currentColor;'}"
+                                t-att-aria-valuenow="bar['progress']"
+                                aria-valuemin="0"
+                                aria-valuemax="100"
+                            />
+                        </div>
+                    </t>
+                </td>
+            </tr>
+        </t>
+    </template>
 </odoo>


### PR DESCRIPTION
Display a progress bar showing how close the customer is to unlocking auto-applied promotions that have a minimum purchase amount condition.

The bar appears in two contexts:
- In the add-to-cart popup notification, showing current progress or a success state when the specific add-to-cart action crosses the threshold.
- On the cart page sidebar, persisting as long as the promotion is relevant.

A promotion is eligible for the progress bar only when it is of type 'promotion', auto-triggered, and the minimum purchase amount is the sole unmatched condition (product, quantity, and code conditions must already be satisfied).

The implementation reuses the same amount computation logic as _program_check_compute_points to ensure consistency between what the progress bar shows and when the promotion actually triggers.

task-6059696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
