### PR TITLE
[FIX] l10n_sg_ubl_pint: enable UBL import for SG PINT invoices

### DIFF
--- a/addons/l10n_sg_ubl_pint/models/account_move.py
+++ b/addons/l10n_sg_ubl_pint/models/account_move.py
@@ -13,3 +13,12 @@ class AccountMove(models.Model):
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
         guid = uuid.uuid5(namespace=uuid.UUID(dbuuid), name=str(self.id))
         return str(guid)
+
+    def _get_import_file_type(self, file_data):
+        """ Identify PINT SG files. """
+        # EXTENDS 'account_edi_ubl_cii'
+        tree = file_data['xml_tree']
+        if tree is not None and tree.findtext('{*}CustomizationID') == 'urn:peppol:pint:billing-1@sg-1':
+            return 'account.edi.xml.pint_sg'
+
+        return super()._get_import_file_type(file_data)

--- a/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
+++ b/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
@@ -62,3 +62,31 @@ class TestSgUBLPint(AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(actual_xml),
             self.get_xml_tree_from_string(expected_xml),
         )
+
+    def test_invoice_import(self):
+        with file_open('l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml', 'rb') as f:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_invoice.xml',
+                'raw': f.read(),
+            })
+
+        imported_invoice = self.env['account.move'] \
+            .with_context(default_move_type='out_invoice') \
+            ._create_records_from_attachments(xml_attachment)
+
+        self.assertEqual(imported_invoice.move_type, 'out_invoice')
+        self.assertEqual(imported_invoice.partner_id, self.partner_a)
+        self.assertEqual(imported_invoice.currency_id, self.other_currency)
+        self.assertEqual(
+            imported_invoice.invoice_date.strftime("%Y-%m-%d"),
+            "2019-01-01",
+        )
+        self.assertRecordValues(
+            imported_invoice,
+            [{
+                'amount_untaxed': 2000.0,
+                'amount_tax': 180.0,
+                'amount_total': 2180.0,
+            }],
+        )


### PR DESCRIPTION
The UBL module wasn't able to import PINT documents because there was no logic to detect the type of UBL document for SG PINT invoices (urn:peppol:pint:billing-1@sg-1).

This commit adds the method to detect SG PINT document and provide appropriate EDI model name.