### PR TITLE
[IMP] account: install l10n and load coa when account installed on fly

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -728,6 +728,10 @@ class ResCompany(models.Model):
         locks.sort()
         return locks
 
+    def _check_existing_companies_needs_l10n(self):
+        res = super()._check_existing_companies_needs_l10n()
+        return res or not self.root_id._existing_accounting() and self.chart_template == 'generic_coa'
+
     def write(self, vals):
         self._validate_locks(vals)
 
@@ -968,7 +972,7 @@ class ResCompany(models.Model):
             env = self.env
             env.flush_all()
             env.transaction.reset()
-            for company in self.filtered(lambda c: c.country_id and not c.chart_template):
+            for company in self.filtered(lambda c: c.country_id and (not c.chart_template or (not c.root_id._existing_accounting() and c.chart_template == 'generic_coa'))):
                 template_code = company.parent_id.chart_template or self.env['account.chart.template']._guess_chart_template(company.country_id)
                 if template_code != 'generic_coa':
                     @self.env.cr.precommit.add

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -237,6 +237,10 @@ class ResCompany(models.Model):
             return uninstalled_modules.button_immediate_install()
         return is_ready_and_not_test
 
+    def _check_existing_companies_needs_l10n(self):
+        self.ensure_one()
+        return not self.country_id
+
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
         delegated_fnames = set(self._get_company_root_delegated_field_names())
@@ -353,7 +357,7 @@ class ResCompany(models.Model):
 
         companies_needs_l10n = (
             vals.get('country_id')
-            and self.filtered(lambda company: not company.country_id)
+            and self.filtered(lambda company: company._check_existing_companies_needs_l10n())
         ) or self.browse()
         if not invalidation_fields.isdisjoint(vals):
             self.env.registry.clear_cache()


### PR DESCRIPTION
When onboarding when the account is installed first before configuring the company, my defualt country changes to United States and Generic CoA is loaded. And that is done without consent of the user.

But after that if I change my country then the related l10n modules and CoA is not changed.

In this commit, we make sure if the Generic CoA is loaded and no existing account exists for that company then the l10n and CoA both should be reloaded


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
