### PR TITLE
[FIX] stock_account: missing super call

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -356,6 +356,7 @@ class ResCompany(models.Model):
         self.env['ir.config_parameter'].sudo().set_param(key, ','.join(ids))
 
     def _set_category_defaults(self):
+        super()._set_category_defaults()
         for company in self:
             self.env['ir.default'].set('product.category', 'property_valuation', company.inventory_valuation, company_id=company.id)
             self.env['ir.default'].set('product.category', 'property_cost_method', company.cost_method, company_id=company.id)

--- a/doc/cla/corporate/scalizer.md
+++ b/doc/cla/corporate/scalizer.md
@@ -1,0 +1,16 @@
+France, 2026-03-27
+
+Scalizer SAS agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+David Halgand david@scalizer.fr https://github.com/halgandd
+
+List of contributors:
+
+David Halgand david@scalizer.fr https://github.com/halgandd
+Julien Hémono julien@scalizer.fr https://github.com/jhemono


### PR DESCRIPTION
- **[CLA] Corporate signature for Scalizer SAS**
- **[FIX] stock_account: missing super call**

Description of the issue/feature this PR addresses:
The super call was missing in the override of res.company._set_category_defaults() in stock_account.

Current behavior before PR:
When stock_account is installed, changing income and expense accounts in the settings *isn't* reflected on the product category fallback values.

Desired behavior after PR is merged:
When stock_account is installed, changing income and expense accounts in the settings **is** reflected on the product category fallback values.
No migration is added: an existing database's settings aren't fixed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
