### PR TITLE
[FIX] pos_restaurant: show all lines on reprint after table transfer/merge

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -207,6 +207,8 @@ patch(PosStore.prototype, {
     async _mergeOrders(sourceOrder, destOrder) {
         const mergedCourses = this.mergeCourses(sourceOrder, destOrder);
 
+        const sourceLastPrint = sourceOrder.uiState.lastPrints.at(-1);
+
         // Sum the guest counts from both orders
         const totalGuests = sourceOrder.getCustomerCount() + destOrder.getCustomerCount();
         destOrder.setCustomerCount(totalGuests);
@@ -248,6 +250,32 @@ patch(PosStore.prototype, {
                     }
                 });
             }
+        }
+        const destLastPrint = destOrder.uiState.lastPrints.at(-1);
+        const combinedPrint = {
+            new: [...(destLastPrint?.new || []), ...(sourceLastPrint?.new || [])],
+            cancelled: [...(destLastPrint?.cancelled || []), ...(sourceLastPrint?.cancelled || [])],
+            noteUpdate: [
+                ...(destLastPrint?.noteUpdate || []),
+                ...(sourceLastPrint?.noteUpdate || []),
+            ],
+        };
+        if (destLastPrint?.internal_note || sourceLastPrint?.internal_note) {
+            combinedPrint.internal_note =
+                destLastPrint?.internal_note || sourceLastPrint?.internal_note;
+        }
+        if (destLastPrint?.general_customer_note || sourceLastPrint?.general_customer_note) {
+            combinedPrint.general_customer_note =
+                destLastPrint?.general_customer_note || sourceLastPrint?.general_customer_note;
+        }
+        if (
+            combinedPrint.new.length ||
+            combinedPrint.cancelled.length ||
+            combinedPrint.noteUpdate.length ||
+            combinedPrint.internal_note ||
+            combinedPrint.general_customer_note
+        ) {
+            destOrder.uiState.lastPrints.push(combinedPrint);
         }
     },
     async mergeOrders(sourceOrder, destOrder) {

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -241,6 +241,17 @@ patch(PosStore.prototype, {
             }
         }
 
+        const consolidatedLines = Object.values(destOrder.last_order_preparation_change.lines).map(
+            (line) => ({ ...line })
+        );
+        if (consolidatedLines.length) {
+            destOrder.uiState.lastPrints.push({
+                new: consolidatedLines,
+                cancelled: [],
+                noteUpdate: [],
+            });
+        }
+
         if (typeof destOrder.id === "number") {
             await this.syncAllOrders({ orders: [destOrder] });
         }

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -417,6 +417,46 @@ describe("restaurant pos_store.js", () => {
         const line2 = await store.addLineToOrder({ product_tmpl_id: product2, qty: 2 }, order2);
         line2.course_id = course2;
         course2.line_ids = [line2];
+        order1.last_order_preparation_change.lines[line1.preparationKey] = {
+            uuid: line1.uuid,
+            product_id: product1.id,
+            name: "Starter 1",
+            quantity: 1,
+        };
+        order2.last_order_preparation_change.lines[line2.preparationKey] = {
+            uuid: line2.uuid,
+            product_id: product2.id,
+            name: "Starter 2",
+            quantity: 2,
+        };
+        const table1InternalNote = '[{"text":"Table 1 kitchen note","colorIndex":0}]';
+        const table2InternalNote = '[{"text":"Table 2 kitchen note","colorIndex":0}]';
+        order1.uiState.lastPrints.push(
+            {
+                new: [{ product_id: 99, name: "Drink 1", quantity: 1 }],
+                cancelled: [],
+                noteUpdate: [],
+            },
+            {
+                new: [],
+                cancelled: [{ product_id: product1.id, name: "Starter 1", quantity: 1 }],
+                noteUpdate: [],
+                internal_note: table1InternalNote,
+            }
+        );
+        order2.uiState.lastPrints.push(
+            {
+                new: [{ product_id: 100, name: "Drink 2", quantity: 1 }],
+                cancelled: [],
+                noteUpdate: [],
+            },
+            {
+                new: [{ product_id: product2.id, name: "Starter 2", quantity: 2 }],
+                cancelled: [],
+                noteUpdate: [],
+                internal_note: table2InternalNote,
+            }
+        );
         await store.mergeOrders(order1, order2);
         expect(order2.lines.length).toBe(2);
         expect(order1.lines.length).toBe(0);
@@ -424,6 +464,13 @@ describe("restaurant pos_store.js", () => {
         expect(order2.table_id.id).toBe(table2.id);
         expect(order2.course_ids.length).toBe(1);
         expect(line2.course_id.id).toBe(course2.id);
+        const lastPrint = order2.uiState.lastPrints.at(-1);
+        expect(lastPrint).not.toBe(undefined);
+        expect(lastPrint.new.length).toBe(1);
+        expect(lastPrint.new[0].product_id).toBe(product2.id);
+        expect(lastPrint.cancelled.length).toBe(1);
+        expect(lastPrint.cancelled[0].product_id).toBe(product1.id);
+        expect(lastPrint.internal_note).toBe(table2InternalNote);
     });
 
     test("mergeOrders sums guest counts", async () => {

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -417,6 +417,18 @@ describe("restaurant pos_store.js", () => {
         const line2 = await store.addLineToOrder({ product_tmpl_id: product2, qty: 2 }, order2);
         line2.course_id = course2;
         course2.line_ids = [line2];
+        order1.last_order_preparation_change.lines[line1.preparationKey] = {
+            uuid: line1.uuid,
+            product_id: product1.id,
+            name: "Product 1",
+            quantity: 1,
+        };
+        order2.last_order_preparation_change.lines[line2.preparationKey] = {
+            uuid: line2.uuid,
+            product_id: product2.id,
+            name: "Product 2",
+            quantity: 2,
+        };
         await store.mergeOrders(order1, order2);
         expect(order2.lines.length).toBe(2);
         expect(order1.lines.length).toBe(0);
@@ -424,6 +436,11 @@ describe("restaurant pos_store.js", () => {
         expect(order2.table_id.id).toBe(table2.id);
         expect(order2.course_ids.length).toBe(1);
         expect(line2.course_id.id).toBe(course2.id);
+        const lastPrint = order2.uiState.lastPrints.at(-1);
+        expect(lastPrint).not.toBe(undefined);
+        expect(lastPrint.new.length).toBe(2);
+        const productIds = lastPrint.new.map((l) => l.product_id).sort();
+        expect(productIds).toEqual([product1.id, product2.id].sort());
     });
 
     test("mergeOrders sums guest counts", async () => {


### PR DESCRIPTION
When moving an order (Order A) to a table that already has an order (Order B), the merged order only reprints Order B's products. The products from Order A are missing from the preparation reprint.

Steps to reproduce:
-------------------
* Open a POS session on a Restaurant POS
* Create an order (Order A) for Table 1
* Create a second order (Order B) for Table 2
* Transfer/Merge Order A to Table 2
* Reprint the preparation order

> Observation:
Only the products that were already on Table 2 (Order B) appear on the reprint. Products from Order A are missing.

Why the fix:
------------
mergeOrders correctly transfers kitchen history
(last_order_preparation_change.lines) via handlePreparationHistory, but does not update uiState.lastPrints on the destination order. The reprint button uses lastPrints.at(-1) when there are no pending changes, so it only shows the destination order's last print batch — ignoring the merged lines entirely.

Implementation:
After the merge loop, build a consolidated lastPrints entry from the destination order's last_order_preparation_change.lines (which now contains lines from both orders) and push it onto
destOrder.uiState.lastPrints so that reprint reflects the full merged state.

opw-6060684