### PR TITLE
[FIX] event: prevent error when accessing deleted attendee tickets

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -52,6 +52,8 @@ class EventController(Controller):
             raise NotFound()
 
         event_registrations_sudo = event_sudo.registration_ids.filtered(lambda reg: reg.id in registration_ids)
+        if not event_registrations_sudo:
+            raise NotFound()
         report_name_prefix = _("Ticket") if responsive_html else _("Badges") if badge_mode else _("Tickets")
         report_date = format_datetime(request.env, event_registrations_sudo[0].event_begin_date, tz=event_sudo.date_tz, dt_format='medium')
         report_name = f"{report_name_prefix} - {event_sudo.name} ({report_date})"


### PR DESCRIPTION
Currently, an error occurs when accessing the ticket link after the related attendee has been deleted.

**Steps to Reproduce:**
- Install the **Events** module.
- Create a new event.
- Create an attendee with a valid email ID.
- Make sure the email is sent successfully.
- Delete the attendee for the event.
- From the received email, try to click on the **"View Tickets"** link.

**Error:**
`IndexError - tuple index out of range`

**Cause:**
The controller filters registrations using the provided `registration_ids`, but when the attendee is deleted, the resulting recordset becomes empty. It raises an error when trying to access the first element of an empty recordset.

**Fix:**
This commit handles empty recordsets by returning early when no registrations are found.

sentry-7357927405