### PR TITLE
[FIX] hr-employee: force refresh when new contract created

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.js
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.js
@@ -58,6 +58,7 @@ export class ButtonNewContractWidget extends Component {
                 version_id: version_id,
             },
         });
+        await window.location.reload();
     }
 }
 


### PR DESCRIPTION
Reproducing procedure:
- Open any one of the employee profile and create new contract using New Contract button in the payroll section
- when you switch the contract to the previous using timeline_widget, newly created contract is dissapeared.
- In the backend the data is persisted

Why:
- it's mainly because of the inconsistence data transfer between widgets.

It's resolved by force refresh.

task-6067998
