### PR TITLE
[FIX] payment_flutterwave: fix `invalid billToPhone` error

### DIFF
--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -2,6 +2,7 @@
 
 import logging
 import pprint
+import re
 
 from werkzeug import urls
 
@@ -58,7 +59,7 @@ class PaymentTransaction(models.Model):
             'customer': {
                 'email': self.partner_email,
                 'name': self.partner_name,
-                'phonenumber': self.partner_phone,
+                'phonenumber': re.sub(r"[^\d]", "", (self.partner_phone or "").replace("+", "00")),
             },
             'customizations': {
                 'title': self.company_id.name,


### PR DESCRIPTION
With are recently seeing an increasing number of payments that fail with an `invalid billToPhone` error.

It's unclear if it's a recent change of flutterwave API or of any intermediary payment processor, but the flutterwave v4.0.0-beta API now state to send the phone number "unformatted" - even if there is no such statement for the v3.0.0 API (that we are using), based on testing, sending the phone number "unformatted" do so seems do solve the issue.

So this commit, sanitize the phone number to send it unformatted.

opw-6074825



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
