### PR TITLE
[FIX] account, *: peppol multi-file embed access

### DIFF
--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -122,7 +122,7 @@ class AccountInvoiceSend(models.TransientModel):
         super()._compute_attachments_not_supported()
         for wizard in self:
             if wizard.display_attachment_fields and wizard.checkbox_send_peppol:
-                xml_attachment_name = wizard.peppol_invoice_ids._get_peppol_document().attachment_id.name
+                xml_attachment_name = wizard.peppol_invoice_ids._get_peppol_document().sudo().attachment_id.name
                 _attachments_to_embed, attachments_not_supported = wizard._get_peppol_available_attachments(
                     wizard.peppol_invoice_ids,
                     wizard.attachment_ids.filtered(lambda attachment: attachment.name != xml_attachment_name),


### PR DESCRIPTION
Field `attachment_id` in `account.edi.document` is restricted to groups `base.group_system`. Method `_compute_attachments_not_supported` reads this field to determine unsupported attachments.

Before this commit, non-admin users sending an invoice and embedding multiple files ran into an access error trying to read the `attachment_id.name` in the aforementioned method.

After this commit, then same field is read in sudo mode, avoiding the access rights check.

Task-[5103539](https://www.odoo.com/odoo/all-tasks/5103539)
See 237cd53af27762a874ff0a3bf7f7228d06d42118

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
