### PR TITLE
[FIX] base: add ir_sequence_date context key for prefix/suffix interpolation

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -267,7 +267,8 @@ class IrSequence(models.Model):
         seq_date = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '<=', dt), ('date_to', '>=', dt)], limit=1)
         if not seq_date:
             seq_date = self._create_date_range_seq(dt)
-        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from)._next()
+        ir_sequence_date = dt.date() if isinstance(dt, datetime) else dt
+        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from, ir_sequence_date=ir_sequence_date)._next()
 
     def next_by_id(self, sequence_date=None):
         """ Draw an interpolated string using the specified sequence."""

--- a/odoo/addons/base/tests/test_ir_sequence_date_range.py
+++ b/odoo/addons/base/tests/test_ir_sequence_date_range.py
@@ -3,6 +3,7 @@
 
 from datetime import date
 
+from odoo import Command
 from odoo.tests.common import SingleTransactionCase
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DATE_FORMAT
 
@@ -108,10 +109,31 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
         })
         self.assertTrue(seq)
 
+        seq = self.env['ir.sequence'].create({
+            'code': 'test_sequence_date_range_5',
+            'name': 'Test sequence',
+            'use_date_range': True,
+            'prefix': '%(month)s/',
+            'date_range_ids': [
+                Command.create({
+                    'date_from': '2025-01-01',
+                    'date_to': '2025-01-31',
+                    'number_next_actual': 15,
+                }),
+                Command.create({
+                    'date_from': '2025-02-01',
+                    'date_to': '2025-02-28',
+                    'number_next_actual': 1
+                })
+            ]
+        })
+        self.assertTrue(seq)
+
     def test_ir_sequence_date_range_2_use(self):
         """ Make some use of the sequences to create some subsequences """
         year = date.today().year - 1
         january = lambda d: date(year, 1, d)
+        february = lambda d: date(year, 2, d)  # noqa: E731
 
         seq = self.env['ir.sequence']
         seq16 = self.env['ir.sequence'].with_context({'ir_sequence_date': january(16)})
@@ -128,6 +150,12 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
         for i in range(1, 5):
             n = seq16.next_by_code('test_sequence_date_range_4')
             self.assertEqual(n, str(i))
+        for i in range(5):
+            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=january(16))
+            self.assertEqual(n, f'01/{i + 15}')
+        for i in range(1, 5):
+            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=february(16))
+            self.assertEqual(n, f'02/{i}')
 
     def test_ir_sequence_date_range_3_write(self):
         """swap the implementation method on both"""


### PR DESCRIPTION
## Issue
When using date_range in a `ir.sequence`, the placeholders `%(...)s` would be based on a different date than the sequence number.

## Steps to reproduce
This is one example among other use cases causing this issue.
1. Install *Sales* (`sale_management`)
2. In Settings > Technical > Sequences, select the `sale.order` sequence
    - Set the Prefix to something containing the current month (e.g. `S%(y)s/%(month)s/`)
    - Enable *Use subsequences per date_range* (`ir.sequence.use_date_range`)
    - Add a row for the current month, with *Next Number* set to 1
    - Add a row for the next month, with *Next Number* set to 5
3. Create a Sales Order:
    - Any Customer
    - Any Product
    - Set the *Quotation Date* to next month
    - Confirm
4. **The resulting Sales Order uses the sequence from next month (= its name ends with 5), but replace the `%(month)s` placeholder by the current month.**

<img width="541" height="130" alt="image" src="https://github.com/user-attachments/assets/6ace81f9-1ce2-4401-a9ba-383673a20981" />

The original issue reported by ticket 5950028 showed a similar issue with dropshipped Purchase Orders, which would use the date of delivery for the sequence number, and the current month for the placeholder in the prefix/suffix.

## Cause
When interpolating the prefix/suffix of a sequence, the date used by default is `datetime.now(self.env.tz)`. If provided, the context keys `ir_sequence_date` and `ir_sequence_date_range` are used instead.

https://github.com/odoo/odoo/blob/877289cf4d9725e12b355f482308150fe170e816/odoo/addons/base/models/ir_sequence.py#L211-L216

In the `IrSequence._next` method, the correct `ir.sequence.date_range` is chosen, based on the sequence date provided (which is the *Quotation Date* in our steps to reproduce) and the `ir_sequence_date_range` is passed as a context key to be used in the `_interpolation_dict` function later.

https://github.com/odoo/odoo/blob/98e6e929bf8e0c34ec77fb9d07ef253e0abf681c/odoo/addons/base/models/ir_sequence.py#L261-L270

**The `ir_sequence_date` is not passed as a context key, which will make `_interpolation_dict` use `datetime.now(...)` to interpolate the placeholders in the prefix/suffix.**

opw-5950028