### PR TITLE
[FIX] portal: fix add billing address

### DIFF
--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -28,10 +28,7 @@
                     <t t-set="addresses" t-value="delivery_addresses"/>
                 </t>
                 <t t-set="address_type" t-valuef="billing"/>
-                <t
-                        t-set="new_address_url"
-                        t-valuef="{{address_url}}?address_type={{address_type}}&amp;use_delivery_as_billing={{use_delivery_as_billing}}"
-                />
+                <t t-set="new_address_url" t-valuef="{{address_url}}?address_type={{address_type}}"/>
                 <div class="d-flex justify-content-between align-items-start gap-3 mt-4 pt-2">
                     <h5 class="mb-0">Billing address</h5>
                     <a


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
- Log in on the portal
- Go to "My Account"
- Go to "Addresses"
- In the billing section uncheck "Same as delivery address"
- In the billing section click "Add Address"
- Fill in address details
- Click "Save Address"

Issue
-----
The newly added address is visible in both the delivery and billing sections, and in the backend the address has type "other" instead of "invoice".

Cause
-----
This happens because the "Add Address" url in the billing section contains the parameter `use_delivery_as_billing=True`, which supersedes the parameter `address_type=billing`, creating an address with type "other". This is because the "Add Address" url in the billing section is not dynamically updated when the "Same as delivery address" toggle is toggled like with the url in the delivery section.

Solution
--------
The `use_delivery_as_billing` is completely removed from the url in the billing section, because the button only appears when the toggle is unchecked (i.e. when `use_delivery_as_billing=false`). And by not sending the parameter, it defaults to false in the backend.

opw-5880430
