### PR TITLE
[IMP] base, mail: add support for Cc recipients in the mail composer

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -152,16 +152,12 @@ class ThreadController(http.Controller):
             # User input is HTML string, so it needs to be in a Markup.
             # It will be sanitized by the field itself when writing on it.
             res["body"] = Markup(post_data["body"]) if post_data["body"] else post_data["body"]
-        partner_ids = post_data.get("partner_ids")
-        partner_emails = post_data.get("partner_emails")
+        partners = request.env["res.partner"].browse(map(int, post_data.get("partner_ids", [])))
+        partners_cc = request.env["res.partner"].browse(map(int, post_data.get("partner_cc_ids", [])))
+        partner_emails = post_data.get("partner_emails", [])
+        partner_cc_emails = post_data.get("partner_cc_emails", [])
         role_ids = post_data.get("role_ids")
-        if partner_ids is not None or partner_emails is not None or role_ids is not None:
-            partners = request.env["res.partner"].browse(map(int, partner_ids or []))
-            if partner_emails:
-                partners |= thread._partner_find_from_emails_single(
-                    partner_emails,
-                    no_create=not request.env.user.has_group("base.group_partner_manager"),
-                )
+        if partners or partner_emails or partners_cc or partner_cc_emails or role_ids is not None:
             if role_ids:
                 # sudo - res.users: getting partners linked to the role is allowed.
                 partners |= (
@@ -170,17 +166,28 @@ class ThreadController(http.Controller):
                     .search_fetch([("role_ids", "in", role_ids)], ["partner_id"])
                     .partner_id
                 )
-            res["partner_ids"] = partners.filtered(
-                lambda p: (not self.env.user.share and p.has_access("read"))
-                or (
-                    verify_limited_field_access_token(
-                        p,
-                        "id",
-                        post_data.get("partner_ids_mention_token", {}).get(str(p.id), ""),
-                        scope="mail.message_mention",
-                    )
-                ),
-            ).ids
+            if partner_emails:
+                partners |= thread._partner_find_from_emails_single(
+                    partner_emails,
+                    no_create=not request.env.user.has_group("base.group_partner_manager"),
+                )
+            if partner_cc_emails:
+                partners_cc |= thread._partner_find_from_emails_single(
+                    partner_cc_emails,
+                    no_create=not request.env.user.has_group("base.group_partner_manager"),
+                )
+            for (source, target) in ((partners, 'partner_ids'), (partners_cc, 'partner_cc_ids')):
+                res[target] = source.filtered(
+                    lambda p: (not self.env.user.share and p.has_access("read"))
+                    or (
+                        verify_limited_field_access_token(
+                            p,
+                            "id",
+                            post_data.get("partner_ids_mention_token", {}).get(str(p.id), ""),
+                            scope="mail.message_mention",
+                        )
+                    ),
+                ).ids
         res.setdefault("message_type", "comment")
         return res
 

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -6,7 +6,7 @@ from ast import literal_eval
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Domain
-from odoo.tools import BinaryBytes
+from odoo.tools import BinaryBytes, email_normalize, unique
 from odoo.tools.safe_eval import safe_eval, time
 
 _logger = logging.getLogger(__name__)
@@ -482,20 +482,31 @@ class MailTemplate(models.Model):
         if find_or_create_partners:
             email_to_res_ids = {}
             records_emails = {}
+            emails_cc_by_res_id = {}
             for record in Model.browse(res_ids):
                 record_values = render_results.setdefault(record.id, {})
-                mails = tools.email_split(record_values.pop('email_to', '')) + \
-                        tools.email_split(record_values.pop('email_cc', ''))
+                emails_cc = tools.email_split(record_values.pop('email_cc', ''))
+                mails = tools.email_split(record_values.pop('email_to', '')) + emails_cc
                 records_emails[record] = mails
                 for mail in mails:
                     email_to_res_ids.setdefault(mail, []).append(record.id)
+                emails_cc_by_res_id[record.id] = [email_normalize(e) for e in emails_cc]
 
             if hasattr(Model, '_partner_find_from_emails'):
                 records_partners = Model.browse(res_ids)._partner_find_from_emails(records_emails)
             else:
                 records_partners = self.env['mail.thread']._partner_find_from_emails(records_emails)
+            all_partner_ids = list(unique(pid for p in records_partners.values() for pid in p.ids))
+            partner_by_email = {p.email_normalized: p for p in self.env['res.partner'].browse(all_partner_ids)}
             for res_id, partners in records_partners.items():
-                render_results[res_id].setdefault('partner_ids', []).extend(partners.ids)
+                emails_cc = emails_cc_by_res_id[res_id]
+                partners_cc_ids = [partner.id
+                                   for email in emails_cc
+                                   if (partner := partner_by_email[email]) in partners]
+                render_results[res_id].setdefault('partner_cc_ids', []).extend(partners_cc_ids)
+                partners_cc_ids_set = set(partners_cc_ids)
+                render_results[res_id].setdefault('partner_ids', []).extend(
+                    [partner.id for partner in partners if partner.id not in partners_cc_ids_set])
 
         # update 'partner_to' rendered value to 'partner_ids'
         all_partner_to = {
@@ -676,6 +687,17 @@ class MailTemplate(models.Model):
                 return None
         return [pid for pto in partner_to if (pid := to_id(pto))]
 
+    @api.model
+    def _get_adapted_rendered_no_partner_cc(self, rendered):
+        """ Convert rendered values from _generate_template for code not handling partner_cc_ids. """
+        if partner_cc_ids := rendered.get('partner_cc_ids', None):
+            # make partner_ids contains all the recipient (including the partner_cc_ids) and remove partner_cc_ids field
+            return {
+                **{k: v for k, v in rendered.items() if k not in ('partner_ids', 'partner_cc_ids')},
+                'partner_ids': rendered.get('partner_ids', []) + partner_cc_ids
+            }
+        return rendered
+
     # ------------------------------------------------------------
     # EMAIL
     # ------------------------------------------------------------
@@ -745,7 +767,7 @@ class MailTemplate(models.Model):
                  'subject',
                 )
             )
-            values_list = [res_ids_values[res_id] for res_id in res_ids_chunk]
+            values_list = [self._get_adapted_rendered_no_partner_cc(res_ids_values[res_id]) for res_id in res_ids_chunk]
 
             # get record in batch to use the prefetch
             prefetch_ids = [res_id for res_id in res_ids_chunk if res_id]  # avoid browsing False

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2219,6 +2219,7 @@ class MailThread(models.AbstractModel):
                      partner_ids=None, outgoing_email_to=False,
                      incoming_email_to=False, incoming_email_cc=False,
                      attachments=None, attachment_ids=None, body_is_html=False,
+                     partner_cc_ids=None,
                      **kwargs):
         """ Post a new message in an existing thread, returning the new mail.message.
 
@@ -2236,8 +2237,8 @@ class MailThread(models.AbstractModel):
           fetch, will force value of subtype_id;
         :param int subtype_id: subtype_id of the message, used mainly for followers
             notification mechanism;
-        :param list(int) partner_ids: partner_ids to notify in addition to partners
-            computed based on subtype / followers matching;
+        :param list(int) partner_ids: partner_ids to notify in addition to partner_cc_ids and
+            partners computed based on subtype / followers matching;
         :param str outgoing_email_to: comma-separated list of emails to notify in
             addition to partner_ids. Experimental support as of Odoo v19;
         :param str incoming_email_to: comma-separated list of emails, already notified
@@ -2252,6 +2253,8 @@ class MailThread(models.AbstractModel):
             composer will be attached to the related document.
         :param bool body_is_html: indicates body should be threated as HTML even if str
             to be used only for RPC calls
+        :param list(int) partner_cc_ids: partner_ids to notify in addition to partner_ids and
+            partners computed based on subtype / followers matching;
 
         Extra keyword arguments will be used either
           * as default column values for the new mail.message record if they match
@@ -2296,12 +2299,25 @@ class MailThread(models.AbstractModel):
                  )
             )
         partner_ids = list(partner_ids or [])
+        if partner_cc_ids and not is_list_of(partner_cc_ids, int):
+            raise ValueError(
+                _('Posting a message should receive copy carbon partners as a list of IDs (received %(pids)s)',
+                  pids=repr(partner_cc_ids),
+                 )
+            )
+        partner_cc_ids = list(partner_cc_ids or [])
 
         # split message additional values from notify additional values
         msg_kwargs = {key: val for key, val in kwargs.items()
                       if key in self.env['mail.message']._fields}
         notif_kwargs = {key: val for key, val in kwargs.items()
                         if key not in msg_kwargs}
+        if partner_cc_ids:
+            notif_kwargs['mail_headers'] = {
+                **notif_kwargs.get('mail_headers', {}),
+                'X-Msg-Cc-Force': ','.join(self.env['res.partner'].browse(
+                    partner_cc_ids).sudo().mapped('email_formatted')),
+            }
 
         # Add lang to context immediately since it will be useful in various flows later
         self = self._fallback_lang()
@@ -2351,7 +2367,7 @@ class MailThread(models.AbstractModel):
             'subject': subject or False,
             'subtype_id': subtype_id,
             # recipients
-            'partner_ids': partner_ids,
+            'partner_ids': partner_ids + partner_cc_ids,
             'incoming_email_to': incoming_email_to,
             'incoming_email_cc': incoming_email_cc,
             'outgoing_email_to': outgoing_email_to,

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -210,12 +210,15 @@ const chatterPatch = {
             partner_id: result.partner_id,
             name: result.name || result.email,
         }));
+        const excludePartnerIds = this.state.thread.suggestedRecipients.map(
+            (r) => r.partner_id
+        );
         this.state.thread.additionalRecipients = this.state.thread.additionalRecipients.filter(
-            (additionalRecipient) =>
-                this.state.thread.suggestedRecipients.every(
-                    (suggestedRecipient) =>
-                        suggestedRecipient.partner_id !== additionalRecipient.partner_id
-                )
+            (r) => !excludePartnerIds.includes(r.partner_id)
+        );
+        excludePartnerIds.push(...this.state.thread.additionalRecipients.map((r) => r.partner_id));
+        this.state.thread.additionalCcRecipients = this.state.thread.additionalCcRecipients.filter(
+            (r) => !excludePartnerIds.includes(r.partner_id)
         );
     },
 

--- a/addons/mail/static/src/chatter/web/composer_patch.js
+++ b/addons/mail/static/src/chatter/web/composer_patch.js
@@ -1,4 +1,5 @@
-import { useLayoutEffect, useRef } from "@web/owl2/utils";
+import { onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { useLayoutEffect, useRef, useState } from "@web/owl2/utils";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -47,6 +48,11 @@ patch(Composer.prototype, {
                 this.subjectInputRef?.el,
             ]
         );
+        this.chatterState = useState({
+            isCcEnabled: false,
+        });
+        onWillStart(() => this._updateIsCcEnabled(this.props));
+        onWillUpdateProps((nextProps) => this._updateIsCcEnabled(nextProps));
         return super.setup();
     },
 
@@ -63,10 +69,25 @@ patch(Composer.prototype, {
         if (this.subject) {
             postData.subject = this.subject;
         }
+        postData.isCcEnabled = this.chatterState.isCcEnabled;
         return postData;
     },
 
     get subject() {
         return this.subjectInputRef.el?.value;
+    },
+
+    _updateIsCcEnabled(props) {
+        if (props.thread?.additionalCcRecipients?.length) {
+            this.chatterState.isCcEnabled = true;
+        }
+    },
+
+    get isCcEnabled() {
+        return this.chatterState.isCcEnabled;
+    },
+
+    toggleIsCcEnabled() {
+        this.chatterState.isCcEnabled = !this.chatterState.isCcEnabled;
     },
 });

--- a/addons/mail/static/src/chatter/web/composer_patch.xml
+++ b/addons/mail/static/src/chatter/web/composer_patch.xml
@@ -5,7 +5,17 @@
             <div t-if="this.props.withMessageFields and this.props.type === 'message'" class="py-1">
                 <div class="d-flex">
                     <span class="flex-shrink-0 text-end fw-bold" style="width:55px">To: </span>
-                    <RecipientsInput thread="this.props.thread"/>
+                    <RecipientsInput thread="this.props.thread"
+                        threadFields="['suggestedRecipients', 'additionalRecipients']"
+                        placeholder.translate="Followers only"/>
+                    <button t-attf-class="btn btn-sm {{this.chatterState.isCcEnabled ? 'btn-primary' : 'btn-outline-primary'}}"
+                        t-on-click="() => this.toggleIsCcEnabled()">Cc</button>
+                </div>
+                <div t-if="this.chatterState.isCcEnabled" class="d-flex">
+                    <span class="flex-shrink-0 text-end fw-bold" style="width:55px">Cc: </span>
+                    <RecipientsInput thread="this.props.thread"
+                        threadFields="['additionalCcRecipients']"
+                        placeholder.translate="Cc recipients"/>
                 </div>
                 <div class="d-flex" t-if="this.props.thread.showSubjectInSmallComposer">
                     <span class="flex-shrink-0 text-end fw-bold me-1" style="width:55px">Subject: </span>

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -80,7 +80,9 @@ export class MailComposerFormRenderer extends formView.Renderer {
         };
 
         onCloseWizardModal(async () => {
-            const selectedPartnerIds = this.props.record.data.partner_ids.currentIds;
+            const selectedPartnerToIds = this.props.record.data.partner_ids.currentIds;
+            const selectedPartnerCcIds = this.props.record.data.partner_cc_ids.currentIds;
+            const selectedPartnerIds = [...selectedPartnerToIds, ...selectedPartnerCcIds];
             const selectedPartners = await this.orm.searchRead(
                 "res.partner",
                 [["id", "in", selectedPartnerIds]],
@@ -107,13 +109,6 @@ export class MailComposerFormRenderer extends formView.Renderer {
                 return recipient;
             };
 
-            /**
-             * @param {SuggestedRecipient} recipient
-             * @returns {boolean}
-             */
-            const isRecipientSelectedFromFullMailComposer = (recipient) =>
-                selectedPartnerIds.includes(recipient.partner_id);
-
             for (const thread of getActiveMailThreads()) {
                 // Update the recipient lists:
                 thread.suggestedRecipients = thread.suggestedRecipients.map(
@@ -122,23 +117,43 @@ export class MailComposerFormRenderer extends formView.Renderer {
                 thread.additionalRecipients = thread.additionalRecipients.map(
                     updateRecipientWithCorrespondingPartner
                 );
+                thread.additionalCcRecipients = thread.additionalCcRecipients.map(
+                    updateRecipientWithCorrespondingPartner
+                );
 
                 // Remove the recipients that got removed from the composer:
-                thread.suggestedRecipients = thread.suggestedRecipients.filter(
-                    isRecipientSelectedFromFullMailComposer
+                thread.suggestedRecipients = thread.suggestedRecipients.filter((r) =>
+                    selectedPartnerToIds.includes(r.partner_id)
                 );
-                thread.additionalRecipients = thread.additionalRecipients.filter(
-                    isRecipientSelectedFromFullMailComposer
+                thread.additionalRecipients = thread.additionalRecipients.filter((r) =>
+                    selectedPartnerToIds.includes(r.partner_id)
+                );
+                thread.additionalCcRecipients = thread.additionalRecipients.filter((r) =>
+                    selectedPartnerCcIds.includes(r.partner_id)
                 );
 
                 // Add the recipients that got added to the composer:
+                const currentToIds = [
+                    ...thread.suggestedRecipients.map((r) => r.partner_id),
+                    ...thread.additionalRecipients.map((r) => r.partner_id),
+                ];
+                const currentCcIds = thread.additionalCcRecipients.map((r) => r.partner_id);
                 for (const partner of selectedPartners) {
-                    const allRecipients = [
-                        ...thread.suggestedRecipients,
-                        ...thread.additionalRecipients,
-                    ];
-                    if (!allRecipients.some((recipient) => recipient.partner_id === partner.id)) {
-                        thread.additionalRecipients.push({
+                    const addTos = [];
+                    if (
+                        !currentCcIds.includes(partner.id) &&
+                        selectedPartnerCcIds.includes(partner.id)
+                    ) {
+                        addTos.push(thread.additionalCcRecipients);
+                    }
+                    if (
+                        !currentToIds.includes(partner.id) &&
+                        selectedPartnerToIds.includes(partner.id)
+                    ) {
+                        addTos.push(thread.additionalRecipients);
+                    }
+                    for (const addTo of addTos) {
+                        addTo.push({
                             display_name: partner.display_name,
                             email: partner.email,
                             lang: partner.lang,

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -670,9 +670,12 @@ export class Composer extends Component {
 
     async onClickFullComposerGetAction() {
         this.props.composer.restoredFromFullComposer = false;
-        const allRecipients = [...this.thread.suggestedRecipients];
+        const recipientsTo = [...this.thread.suggestedRecipients];
+        const recipientsCc = [];
         if (this.props.type !== "note") {
-            allRecipients.push(...this.thread.additionalRecipients);
+            recipientsTo.push(...this.thread.additionalRecipients);
+            recipientsCc.push(...this.thread.additionalCcRecipients);
+            const allRecipients = recipientsTo.concat(recipientsCc);
             // auto-create partners:
             const newPartners = allRecipients.filter((recipient) => !recipient.partner_id);
             if (newPartners.length !== 0) {
@@ -714,7 +717,11 @@ export class Composer extends Component {
             default_partner_ids:
                 this.props.type === "note"
                     ? []
-                    : allRecipients.map((recipient) => recipient.partner_id),
+                    : recipientsTo.map((recipient) => recipient.partner_id),
+            default_partner_cc_ids:
+                this.props.type === "note"
+                    ? []
+                    : recipientsCc.map((recipient) => recipient.partner_id),
             default_res_ids: [this.thread.id],
             default_subtype_xmlid: this.props.type === "note" ? "mail.mt_note" : "mail.mt_comment",
             clicked_on_full_composer: true,
@@ -841,6 +848,7 @@ export class Composer extends Component {
             const allRecipients = [
                 ...composer.thread.suggestedRecipients,
                 ...composer.thread.additionalRecipients,
+                ...composer.thread.additionalCcRecipients,
             ];
             if (allRecipients.some((recipient) => !recipient.email || !isEmail(recipient.email))) {
                 return;
@@ -932,6 +940,7 @@ export class Composer extends Component {
         this.props.composer.replyToMessage = undefined;
         this.props.composer.emailAddSignature = true;
         this.props.composer.thread.additionalRecipients = [];
+        this.props.composer.thread.additionalCcRecipients = [];
         return message;
     }
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -462,7 +462,7 @@ export class Store extends BaseStore {
 
     fillPartnersMentionToken(postData) {
         postData.partner_ids_mention_token ||= {};
-        for (const pid of postData.partner_ids) {
+        for (const pid of [...postData.partner_ids, ...(postData.partner_cc_ids || [])]) {
             const partner = this["res.partner"].get(pid);
             if (partner?.mention_token) {
                 postData.partner_ids_mention_token[pid] = partner.mention_token;
@@ -521,6 +521,7 @@ export class Store extends BaseStore {
             attachments,
             cannedResponseIds,
             emailAddSignature,
+            isCcEnabled,
             isNote,
             mentionedChannels,
             mentionedPartners,
@@ -534,21 +535,6 @@ export class Store extends BaseStore {
             mentionedRoles,
             thread,
         });
-        const partner_ids = validMentions?.partners.map((partner) => partner.id) ?? [];
-        const role_ids = validMentions?.roles.map((role) => role.id) ?? [];
-        const recipientEmails = [];
-        if (!isNote) {
-            const allRecipients = [...thread.suggestedRecipients, ...thread.additionalRecipients];
-            const recipientIds = allRecipients
-                .filter((recipient) => recipient.persona)
-                .map((recipient) => recipient.persona.id);
-            allRecipients
-                .filter((recipient) => !recipient.persona)
-                .forEach((recipient) => {
-                    recipientEmails.push(recipient.email);
-                });
-            partner_ids.push(...recipientIds);
-        }
         postData = {
             body: await generateEmojisOnHtml(body),
             email_add_signature: emailAddSignature,
@@ -556,15 +542,35 @@ export class Store extends BaseStore {
             subtype_xmlid: subtype,
             subject,
         };
+        postData.partner_ids = validMentions?.partners.map((partner) => partner.id) ?? [];
+        postData.partner_emails = [];
+        postData.partner_cc_ids = [];
+        postData.partner_cc_emails = [];
+        postData.role_ids = validMentions?.roles.map((role) => role.id) ?? [];
+        if (!isNote) {
+            for (const recipient of [
+                ...thread.suggestedRecipients,
+                ...thread.additionalRecipients,
+            ]) {
+                if (recipient.persona) {
+                    postData.partner_ids.push(recipient.persona.id);
+                } else {
+                    postData.partner_emails.push(recipient.email);
+                }
+            }
+            if (isCcEnabled) {
+                for (const recipient of thread.additionalCcRecipients) {
+                    if (recipient.persona) {
+                        postData.partner_cc_ids.push(recipient.persona.id);
+                    } else {
+                        postData.partner_cc_emails.push(recipient.email);
+                    }
+                }
+            }
+        }
+        this.fillPartnersMentionToken(postData);
         if (attachments.length) {
             postData.attachment_ids = attachments.map(({ id }) => id);
-        }
-        if (partner_ids.length) {
-            Object.assign(postData, { partner_ids });
-            this.fillPartnersMentionToken(postData);
-        }
-        if (role_ids.length) {
-            Object.assign(postData, { role_ids });
         }
         if (thread.channel && validMentions?.specialMentions.length) {
             postData.special_mentions = validMentions.specialMentions;
@@ -574,8 +580,18 @@ export class Store extends BaseStore {
                 (attachment) => attachment.ownership_token
             );
         }
-        if (recipientEmails.length) {
-            postData.partner_emails = recipientEmails;
+        // Clean empty fields
+        for (const field of [
+            "partner_ids",
+            "partner_ids_mention_token",
+            "partner_cc_ids",
+            "partner_emails",
+            "partner_cc_emails",
+            "role_ids",
+        ]) {
+            if (Object.prototype.hasOwnProperty.call(postData, field) && !postData[field].length) {
+                delete postData[field];
+            }
         }
         const params = {
             // Changed in 18.2+: finally get rid of autofollow, following should be done manually

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -212,6 +212,7 @@ export class Thread extends Record {
     /* The additional recipients are the recipients that are manually added
      * by the user by using the "To" field of the Chatter. */
     additionalRecipients = fields.Attr([]);
+    additionalCcRecipients = fields.Attr([]);
     /** @type {number|undefined} */
     recipients = fields.Many("mail.followers");
     recipientsCount = undefined;

--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -19,6 +19,9 @@ export class RecipientsInput extends Component {
     static components = { AutoComplete, RecipientTag };
     static props = {
         thread: { type: Object },
+        /** recipient init thread fields. threadFields.at(-1) will be updated with additional recipients. */
+        threadFields: { type: Array, element: String },
+        placeholder: { type: String },
     };
 
     setup() {
@@ -190,30 +193,24 @@ export class RecipientsInput extends Component {
                 tooltip,
                 onDelete: () => {
                     this.props.thread[recipientField] = this.props.thread[recipientField].filter(
-                        (additionalOrSuggestedRecipient) =>
-                            additionalOrSuggestedRecipient.partner_id !== recipient.partner_id ||
-                            additionalOrSuggestedRecipient.email !== recipient.email
+                        (r) => r.partner_id !== recipient.partner_id || r.email !== recipient.email
                     );
                 },
                 updateRecipient: this.updateRecipient.bind(this),
                 bus: this.recipientCheckerBus,
             });
         };
-        for (const recipient of this.props.thread.suggestedRecipients) {
-            createTagForRecipient(recipient, "suggestedRecipients");
-        }
-        for (const recipient of this.props.thread.additionalRecipients) {
-            createTagForRecipient(recipient, "additionalRecipients");
+        for (const threadField of this.props.threadFields) {
+            for (const recipient of this.props.thread[threadField]) {
+                createTagForRecipient(recipient, threadField);
+            }
         }
         return tags;
     }
 
     /** @return {Array[SuggestedRecipient]}*/
     getAllMailThreadRecipients() {
-        return [
-            ...this.props.thread.suggestedRecipients,
-            ...this.props.thread.additionalRecipients,
-        ];
+        return this.props.threadFields.map((field) => this.props.thread[field]).flat();
     }
 
     /**
@@ -236,14 +233,13 @@ export class RecipientsInput extends Component {
 
     /** @param {SuggestedRecipient} recipient */
     insertAdditionalRecipient(recipient) {
-        this.props.thread.additionalRecipients.push(recipient);
+        this.props.thread[this.props.threadFields.at(-1)].push(recipient);
     }
 
     /** @returns {string} */
     getPlaceholder() {
-        const hasRecipients =
-            this.props.thread.suggestedRecipients.length ||
-            this.props.thread.additionalRecipients.length;
-        return hasRecipients ? "" : _t("Followers only");
+        return this.props.threadFields.some((k) => this.props.thread[k].length)
+            ? ""
+            : this.props.placeholder;
     }
 }

--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -1,3 +1,4 @@
+import { deepEqual } from "@web/core/utils/objects";
 import { onWillRender } from "@web/owl2/utils";
 import { parseEmail } from "@mail/utils/common/format";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
@@ -204,6 +205,16 @@ export class RecipientsInput extends Component {
             for (const recipient of this.props.thread[threadField]) {
                 createTagForRecipient(recipient, threadField);
             }
+        }
+        // Avoid changing the reference if nothing as changed (except the id)
+        // to avoid useRecipientChecker to open emailSetterPopover multiple time on recipient without email.
+        if (
+            deepEqual(
+                tags.map((t) => ({ ...t, id: "tag_0" })),
+                this.tags.map((t) => ({ ...t, id: "tag_0" }))
+            )
+        ) {
+            return this.tags;
         }
         return tags;
     }

--- a/addons/mail/static/src/views/fields/mail_boolean_label/boolean_label_field.js
+++ b/addons/mail/static/src/views/fields/mail_boolean_label/boolean_label_field.js
@@ -1,0 +1,27 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class BooleanLabelField extends Component {
+    static template = "mail.BooleanLabelField";
+    static props = {
+        ...standardFieldProps,
+        label: { type: String },
+    };
+
+    update() {
+        this.props.record.update({ [this.props.name]: !this.props.record.data[this.props.name] });
+    }
+}
+
+export const booleanLabelField = {
+    component: BooleanLabelField,
+    displayName: _t("Boolean Label"),
+    supportedTypes: ["boolean"],
+    extractProps: ({ string }) => ({
+        label: string,
+    }),
+};
+
+registry.category("fields").add("mail_boolean_label", booleanLabelField);

--- a/addons/mail/static/src/views/fields/mail_boolean_label/boolean_label_field.xml
+++ b/addons/mail/static/src/views/fields/mail_boolean_label/boolean_label_field.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.BooleanLabelField">
+        <button t-attf-class="btn btn-sm {{this.props.record.data[this.props.name] ? 'btn-primary' : 'btn-outline-primary'}}"
+            t-att-data-tooltip="this.props.label" t-on-click.prevent.stop="this.update" data-available-offline=""
+            t-out="this.props.label"/>
+    </t>
+
+</templates>

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -113,6 +113,70 @@ test("can post a message on a record thread", async () => {
     await expect.waitForSteps(["/mail/message/post"]);
 });
 
+test("can post a message with cc on a record thread", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    let postCallN = 0;
+    onRpcBefore("/mail/message/post", (args) => {
+        expect.step("/mail/message/post");
+        const expected = {
+            context: args.context,
+            post_data: {
+                body: `hey${postCallN}`,
+                email_add_signature: true,
+                message_type: "comment",
+                partner_emails: ["new-partner@ex.com"],
+                partner_cc_emails: ["new-cc-partner@ex.com"],
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: partnerId,
+            thread_model: "res.partner",
+        };
+        if (postCallN === 1) {
+            // On the second call, the cc field is disabled and must not be sent to the server.
+            delete expected.post_data.partner_cc_emails;
+        }
+        expect(args).toEqual(expected);
+        postCallN++;
+    });
+    async function fillRecipients() {
+        await insertText(
+            ".o-mail-Chatter input[placeholder='Followers only']",
+            "new-partner@ex.com"
+        );
+        await click(".dropdown-item:text('Create new-partner@ex.com')");
+        await contains(".o_tag_badge_text:text('new-partner@ex.com')");
+
+        await click(".btn:text('Cc')");
+        await insertText(
+            ".o-mail-Chatter input[placeholder='Cc recipients']",
+            "new-cc-partner@ex.com"
+        );
+        await click(".dropdown-item:text('Create new-cc-partner@ex.com')");
+        await contains(".o_tag_badge_text:text('new-cc-partner@ex.com')");
+    }
+    await start();
+    await openFormView("res.partner", partnerId);
+    await contains("button:text('Send message')");
+    await contains(".o-mail-Composer", { count: 0 });
+    await click("button:text('Send message')");
+    await contains(".o-mail-Composer");
+    await insertText(".o-mail-Composer-input", "hey0");
+    await contains(".o-mail-Message", { count: 0 });
+    await fillRecipients();
+    await click(".o-mail-Composer button[aria-label='Send']:enabled");
+    await contains(".o-mail-Message .o-mail-Message-richBody:text('hey0')");
+
+    await click("button:text('Send message')");
+    await insertText(".o-mail-Composer-input", "hey1");
+    await fillRecipients();
+    await click(".btn:text('Cc')");
+    await click(".o-mail-Composer button[aria-label='Send']:enabled");
+    await contains(".o-mail-Message .o-mail-Message-richBody:text('hey1')");
+
+    await expect.waitForSteps(["/mail/message/post", "/mail/message/post"]);
+});
+
 test("can post a note on a record thread", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -157,10 +157,16 @@ class MailComposeMessage(models.TransientModel):
         string='Replies', compute='_compute_reply_to_mode', inverse='_inverse_reply_to_mode',
         help="Original Discussion: Answers go in the original document discussion thread. \n Another Email Address: Answers go to the email address mentioned in the tracking message-id instead of original document discussion thread. \n This has an impact on the generated message-id.")
     # recipients
+    partner_cc_enabled = fields.Boolean('Cc enabled', compute='_compute_partner_cc_enabled',
+                                        store=True, readonly=False)
     partner_ids = fields.Many2many(
         'res.partner', 'mail_compose_message_res_partner_rel',
         'wizard_id', 'partner_id', 'Additional Contacts',
-        compute='_compute_partner_ids', readonly=False, store=True)
+        compute='_compute_recipient_partners', readonly=False, store=True)
+    partner_cc_ids = fields.Many2many(
+        'res.partner', 'mail_compose_message_res_partner_cc_rel',
+        'wizard_id', 'partner_id', 'Additional Cc contacts',
+        compute='_compute_recipient_partners', readonly=False, store=True)
     partner_ids_all_have_email = fields.Boolean(compute="_compute_partner_ids_all_have_email")
     notified_bcc_contains_share = fields.Boolean(
         'Is an external partner follower of the document?',
@@ -200,6 +206,13 @@ class MailComposeMessage(models.TransientModel):
         """ Check res_ids is a valid list of integers (or Falsy). """
         for composer in self:
             composer._evaluate_res_ids()
+
+    @api.constrains('res_ids', 'partner_cc_enabled')
+    def _check_cc_disabled_on_batch(self):
+        """ Check res_ids is a valid list of integers (or Falsy). """
+        for composer in self:
+            if len(composer._evaluate_res_ids()) > 1 and composer.partner_cc_enabled:
+                raise ValidationError(_('Cc must be disabled in batch mode.'))
 
     @api.constrains('res_domain')
     def _check_res_domain(self):
@@ -500,9 +513,16 @@ class MailComposeMessage(models.TransientModel):
             if composer.reply_to_mode != 'new':
                 composer.reply_to = False
 
+    @api.depends('partner_cc_ids')
+    def _compute_partner_cc_enabled(self):
+        """ Display the cc field when a cc partner is modified and not empty (ex: when using a template). """
+        for composer in self:
+            if composer.partner_cc_ids:
+                composer.partner_cc_enabled = True
+
     @api.depends('composition_mode', 'model', 'parent_id', 'res_domain',
                  'res_ids', 'subtype_id', 'template_id')
-    def _compute_partner_ids(self):
+    def _compute_recipient_partners(self):
         """ Computation is coming either from template, either from context.
         When having a template it uses its 3 fields 'email_cc', 'email_to' and
         'partner_to', in monorecord comment mode. Emails are converted into
@@ -530,15 +550,18 @@ class MailComposeMessage(models.TransientModel):
                 )[res_ids[0]]
                 if rendered_values.get('partner_ids'):
                     composer.partner_ids = rendered_values['partner_ids']
+                if rendered_values.get('partner_cc_ids'):
+                    composer.partner_cc_ids = rendered_values['partner_cc_ids']
             elif composer.parent_id and composer.composition_mode == 'comment':
                 composer.partner_ids = composer.parent_id.partner_ids
             elif not composer.template_id:
                 composer.partner_ids = False
 
-    @api.depends('partner_ids')
+    @api.depends('partner_ids', 'partner_cc_ids')
     def _compute_partner_ids_all_have_email(self):
         for record in self:
-            record.partner_ids_all_have_email = all(record.partner_ids.mapped('email'))
+            record.partner_ids_all_have_email = (
+                    all(record.partner_ids.mapped('email')) and all(record.partner_cc_ids.mapped('email')))
 
     @api.depends('composition_batch', 'composition_mode', 'message_type',
                  'model', 'res_ids', 'subtype_id')
@@ -1179,7 +1202,9 @@ class MailComposeMessage(models.TransientModel):
             for res_id in res_ids:
                 # remove attachments from template values as they should not be rendered
                 template_values[res_id].pop('attachment_ids', None)
-                mail_values_all[res_id].update(template_values[res_id])
+                # email_cc is turned into partner_cc_ids which is only supported by message_post
+                tpl_mail_values = self.env['mail.template']._get_adapted_rendered_no_partner_cc(template_values[res_id])
+                mail_values_all[res_id].update(tpl_mail_values)
 
         # Handle recipients. Without template, if no partner_ids is given, update
         # recipients using default recipients to be sure to notify someone
@@ -1321,12 +1346,21 @@ class MailComposeMessage(models.TransientModel):
             new_attachment_ids.reverse()
             self.write({'attachment_ids': [Command.set(new_attachment_ids)]})
 
+        is_message_post = self.model and hasattr(self.env[self.model], 'message_post')
+        if is_message_post:
+            recipients = {
+                'partner_ids': self.partner_ids.ids,
+                'partner_cc_ids': self.partner_cc_ids.ids,
+            }
+        else:
+            # Only message_post supports partner_cc_ids
+            recipients = {'partner_ids': (self.partner_ids | self.partner_cc_ids).ids}
         return {
             res_id: {
                 'attachment_ids': [attach.id for attach in self.attachment_ids],
                 'body': self.body or '',
                 'email_from': self.email_from,
-                'partner_ids': self.partner_ids.ids,
+                **recipients,
                 'scheduled_date': self.scheduled_date,
                 'subject': self.subject or '',
                 **(

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -40,8 +40,10 @@
                         <!-- visible wizard -->
                         <field name="email_from"
                             invisible="composition_mode != 'mass_mail'"/>
-                        <label for="partner_ids" string="To" invisible="composition_mode != 'comment' or subtype_is_log"/>
-                        <div groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log" class="d-flex gap-3">
+                    </group>
+                    <group groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log">
+                        <label for="partner_ids" string="To"/>
+                        <div class="d-flex gap-3">
                             <field name="partner_ids" widget="many2many_tags_email" placeholder="Followers only" class="w-auto flex-grow-1"
                                 invisible="composition_comment_option == 'forward' or (composition_comment_option != 'reply_all' and not context.get('clicked_on_full_composer', False))"
                                 context="{'form_view_ref': 'base.view_partner_simple_form', 'show_email': True}"
@@ -51,7 +53,17 @@
                                 invisible="composition_comment_option != 'forward' and (context.get('clicked_on_full_composer', False) or composition_comment_option == 'reply_all' )"
                                 options="{'on_tag_click': 'open_form'}"
                                 context="{'force_email': True, 'show_email': True, 'form_view_ref': 'base.view_partner_simple_form', 'forward_mode': True}"/>
+                            <div class="d-flex gap-2">
+                                <field string="Cc" name="partner_cc_enabled" widget="mail_boolean_label" nolabel="1"/>
+                            </div>
                         </div>
+                        <label for="partner_cc_ids" string="Cc" invisible="not partner_cc_enabled"/>
+                        <div class="d-flex gap-3" invisible="not partner_cc_enabled">
+                            <field name="partner_cc_ids" widget="many2many_tags_email" placeholder="Add Cc recipients..."
+                                class="w-auto flex-grow-1"/>
+                        </div>
+                    </group>
+                    <group>
                         <field name="subject" placeholder="e.g. Welcome to MyCompany!" required="True"/>
                         <field name="reply_to" placeholder="e.g. info@company.com"
                             invisible="reply_to_mode == 'update'"
@@ -132,3 +144,4 @@
         </record>
     </data>
 </odoo>
+

--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -78,10 +78,11 @@ class MailTemplatePreview(models.TransientModel):
                 preview.error_msg = False
             else:
                 try:
-                    mail_values = mail_template.with_context(template_preview_lang=preview.lang)._generate_template(
-                        [preview.resource_ref.id],
-                        preview._MAIL_TEMPLATE_FIELDS
-                    )[preview.resource_ref.id]
+                    mail_values = self.env['mail.template']._get_adapted_rendered_no_partner_cc(
+                        mail_template.with_context(template_preview_lang=preview.lang)._generate_template(
+                            [preview.resource_ref.id],
+                            preview._MAIL_TEMPLATE_FIELDS
+                        )[preview.resource_ref.id])
 
                     if mail_template.email_layout_xmlid:
                         # Encapsulate body with layout

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -15,8 +15,8 @@ from odoo.addons.test_mail.models.mail_test_ticket import MailTestTicket
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.fields import Command, Datetime as FieldDatetime, Domain
 from odoo.exceptions import AccessError, UserError
-from odoo.tests import Form, tagged, users
-from odoo.tools import email_normalize, mute_logger, formataddr
+from odoo.tests import Form, RecordCapturer, tagged, users
+from odoo.tools import email_normalize, mute_logger, formataddr, email_normalize_all
 
 
 @tagged('mail_composer')
@@ -1033,7 +1033,7 @@ class TestComposerInternals(TestMailComposer):
                 self.assertEqual(self.test_record.message_partner_ids, self.partner_employee_2)
 
                 batch = bool(batch_mode)
-                test_records = self.test_records if batch else self.test_record
+                test_records = self.test_records.copy() if batch else self.test_record.copy()
                 ctx = {
                     'default_model': test_records._name,
                     'default_composition_mode': composition_mode,
@@ -1084,14 +1084,34 @@ class TestComposerInternals(TestMailComposer):
                 # values come from template
                 if composition_mode == 'comment' and not batch:
                     self.assertEqual(len(new_partners), 2)
-                    self.assertEqual(composer.partner_ids, self.partner_1 + new_partners, 'Template took customer_id as set on record')
+                    self.assertEqual(composer.partner_ids, self.partner_1, 'Template took customer_id as set on record')
+                    self.assertEqual(composer.partner_cc_ids, new_partners)
                     self.assertEqual(composer.reply_to, 'info@test.example.com', 'Template was rendered')
                     self.assertTrue(composer.reply_to_force_new)
                 else:
                     self.assertEqual(len(new_partners), 0)
                     self.assertEqual(composer.partner_ids, base_recipients, 'Mass mode: kept original values')
+                    self.assertFalse(composer.partner_cc_ids)
                     self.assertEqual(composer.reply_to, self.template.reply_to, 'Mass mode: raw template value')
                     self.assertTrue(composer.reply_to_force_new, 'Mass mode: reply_to -> consider this is for new threads')
+
+                # Check Cc recipients
+                with (self.mock_mail_gateway(),
+                      RecordCapturer(self.env['mail.message.schedule'].sudo()) as scheduled_messages):
+                    composer._action_send_mail()
+                if composition_mode == 'comment':
+                    mail_headers = [json.loads(p).get('mail_headers', {})
+                                    for p in scheduled_messages.records.mapped('notification_parameters')]
+                else:
+                    mail_headers = [literal_eval(h) for h in self._new_mails.mapped('headers')]
+                self.assertTrue(mail_headers)
+                if composition_mode == 'comment' and not batch:
+                    self.assertTrue(all(h.get('X-Msg-Cc-Force') for h in mail_headers))
+                    self.assertEqual(
+                        [set(email_normalize_all(h.get('X-Msg-Cc-Force'))) for h in mail_headers],
+                        [{p.email_normalized for p in new_partners} for _ in mail_headers])
+                else:
+                    self.assertFalse(any(h.get('X-Msg-Cc-Force') for h in mail_headers))
 
                 # manual values is kept over template
                 composer.write({'partner_ids': [(5, 0), (4, self.partner_admin.id)]})
@@ -1118,7 +1138,8 @@ class TestComposerInternals(TestMailComposer):
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.partner_ids, self.partner_1 + new_partners)
+                    self.assertEqual(composer.partner_ids, self.partner_1)
+                    self.assertEqual(composer.partner_cc_ids, new_partners)
                 else:
                     self.assertFalse(composer.partner_ids)
                 if composition_mode == 'comment' and not batch:
@@ -1136,7 +1157,8 @@ class TestComposerInternals(TestMailComposer):
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.partner_ids, self.partner_1 + new_partners)
+                    self.assertEqual(composer.partner_ids, self.partner_1)
+                    self.assertEqual(composer.partner_cc_ids, new_partners)
                 else:
                     self.assertFalse(composer.partner_ids)
                 if composition_mode == 'comment' and not batch:

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -478,7 +478,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=57, employee=57):  # tm 57/57
+        with self.assertQueryCount(admin=58, employee=58):  # tm 57/57
             composer._action_send_mail()
 
         # notifications
@@ -600,7 +600,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=54, employee=53):
+        with self.assertQueryCount(admin=55, employee=54):
             composer._action_send_mail()
 
         # notifications
@@ -630,7 +630,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=69, employee=69):
+        with self.assertQueryCount(admin=70, employee=69):
             composer._action_send_mail()
 
         # notifications

--- a/addons/website_slides/models/slide_channel_partner.py
+++ b/addons/website_slides/models/slide_channel_partner.py
@@ -229,7 +229,7 @@ class SlideChannelPartner(models.Model):
                 # attachments specific not supported currently, only attachment_ids
                 values.pop('attachments', False)
                 values['body'] = values.get('body_html')  # keep body copy in chatter
-                record_email_values[res_id] = values
+                record_email_values[res_id] = self.env['mail.template']._get_adapted_rendered_no_partner_cc(values)
 
         mail_mail_values = []
         for record in self:

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -739,18 +739,37 @@ class IrMail_Server(models.Model):
             message.replace_header('To', x_forge_to)
         # `To:` header extended, e.g. for adding "virtual" recipients, aka fake recipients
         # that do not impact SMTP To
-        elif x_msg_add_to := message['X-Msg-To-Add']:
+        else:
+            x_msg_add_to = message.get('X-Msg-To-Add', '')
+            x_msg_force_cc = message.get('X-Msg-Cc-Force', '')
+            x_msg_force_cc_normalized = set(tools.mail.email_normalize_all(x_msg_force_cc))
             to = message['To'] or ''
-            to_normalized = tools.mail.email_normalize_all(to)
-            message.replace_header(
-                'To', ', '.join([
-                    to,
-                    ', '.join(
-                        address for address in tools.mail.email_split_and_format(x_msg_add_to)
-                        if tools.mail.email_normalize(address, strict=False) not in to_normalized
-                    ),
-                ]
-                ))
+            cc = message.get('Cc') or ''
+
+            exclude_to_add = set(tools.mail.email_normalize_all(to))
+            new_to = ', '.join(
+                ([to] if to else []) +
+                [address for address in tools.mail.email_split_and_format(x_msg_add_to)
+                 if tools.mail.email_normalize(address, strict=False) not in exclude_to_add])
+            # As we only store in the headers whether recipients are in the "To" or "Cc" field,
+            # we change here the email from "To" to "Cc" for all the emails present in X-Msg-Cc-Force.
+            if common_emails := x_msg_force_cc_normalized.intersection(tools.mail.email_normalize_all(new_to)):
+                new_to = ', '.join(
+                    address for address in tools.mail.email_split_and_format(new_to)
+                    if tools.mail.email_normalize(address, strict=False) not in common_emails
+                )
+            message.replace_header('To', new_to)
+            # Add cc
+            exclude_cc_add = set(tools.mail.email_normalize_all(cc)) | set(tools.mail.email_normalize_all(new_to))
+            cc_value = ', '.join(
+                ([cc] if cc else []) +
+                [address for address in tools.mail.email_split_and_format(x_msg_force_cc)
+                 if tools.mail.email_normalize(address, strict=False) not in exclude_cc_add])
+            if cc_value:
+                try:
+                    message.replace_header('Cc', cc_value)
+                except KeyError:
+                    message.add_header('Cc', cc_value)
 
         if message['From'] != smtp_from:
             message.replace_header('From', smtp_from)
@@ -759,6 +778,7 @@ class IrMail_Server(models.Model):
         del message['Bcc']                   # see odoo/odoo@2445f9e3c22db810d61996afde883e4ca608f15b
         del message['X-Forge-To']
         del message['X-Msg-To-Add']
+        del message['X-Msg-Cc-Force']
         del message['X-Msg-To-Consolidate']
 
     @api.model

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -533,3 +533,69 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             raise AssertionError("Email with non-ASCII .eml attachment could not be serialized") from e
 
         self.assertIsInstance(serialized, bytes)
+
+    def test_mail_force_cc(self):
+        """Check that "To" recipients are turned into "Cc" recipients in the headers when present in X-Msg-Cc-Force."""
+        IrMailServer = self.env['ir.mail_server']
+        mail_from = 'specific_user@test.mycompany.com'
+
+        # Simple use-case to illustrate how it is used in the mail_compose_message wizard:
+        # The wizard adds both "to" and "cc" as partners recipients so they ends up both in the "to" and smtp_to_list.
+        # But configure X-Msg-Cc-Force to move the "cc" partners recipients into fake "cc" through headers.
+        with self.mock_smtplib_connection():
+            smtp_session = IrMailServer._connect__(smtp_from=mail_from)
+            message = self._build_email(
+                mail_from=mail_from,
+                # email_to includes the "cc" recipients
+                email_to=['test-to@ex.com', 'test-cc@ex.com'],
+                email_cc=['test-cc-std@ex.com'],
+                # force the "cc" recipient setup in the "to" to be moved into the "cc" recipient header
+                headers={'X-Msg-Cc-Force': 'test-cc@ex.com'},
+            )
+            IrMailServer.send_email(message, smtp_session=smtp_session)
+        self.assertSMTPEmailsSent(
+            smtp_from=mail_from,
+            message_from=mail_from,
+            mail_server=self.mail_server_user,
+            # Sent directly to the Cc recipient
+            smtp_to_list=['test-to@ex.com', 'test-cc@ex.com', 'test-cc-std@ex.com'],
+            # But the Cc recipient must not appear in the "To" header
+            msg_to_lst=['test-to@ex.com'],
+            # But well in the Cc header
+            msg_cc_lst=['test-cc-std@ex.com', 'test-cc@ex.com'],
+        )
+
+        # Additional checks
+        for (email_to, email_cc, email_cc_force), (expected_to, expected_msg_to, expected_msg_cc) in (
+            # Fake Cc (test-cc@ex.com is present in the headers but not in the smtp_to_list
+            ((['test-to@ex.com'], ['test-cc-std@ex.com'], 'test-cc@ex.com'),
+             (['test-to@ex.com', 'test-cc-std@ex.com'], ['test-to@ex.com'], ['test-cc-std@ex.com', 'test-cc@ex.com'])),
+            # Using formated emails (format of X-Msg-Cc-Force wins)
+            ((['"Formatted To" <test-to@ex.com>', '"Formatted Cc" <test-cc@ex.com>'],
+              ['"Formatted Cc std" <test-cc-std@ex.com>'],
+              '"Formatted Cc mod" <test-cc@ex.com>'),
+             (['test-to@ex.com', 'test-cc@ex.com', 'test-cc-std@ex.com'],
+              ['"Formatted To" <test-to@ex.com>'],
+              ['"Formatted Cc std" <test-cc-std@ex.com>', '"Formatted Cc mod" <test-cc@ex.com>'])),
+            # Multiple Cc forced (one of them not in the smtp_to_list)
+            ((['test-to@ex.com', 'test-cc2@ex.com'], ['test-cc-std@ex.com'], 'test-cc@ex.com, test-cc2@ex.com'),
+             (['test-to@ex.com', 'test-cc2@ex.com', 'test-cc-std@ex.com'],
+              ['test-to@ex.com'],
+              ['test-cc-std@ex.com', 'test-cc@ex.com', 'test-cc2@ex.com'])),
+            # Multiple Cc with format
+            ((['"Formatted To" <test-to@ex.com>', '"Formatted Cc2" <test-cc2@ex.com>'],
+              ['"Formated cc-std" <test-cc-std@ex.com>'],
+              '"Formated cc" <test-cc@ex.com>, test-cc2@ex.com'),
+             (['test-to@ex.com', 'test-cc2@ex.com', 'test-cc-std@ex.com'],
+              ['"Formatted To" <test-to@ex.com>'],
+              ['"Formated cc-std" <test-cc-std@ex.com>', '"Formated cc" <test-cc@ex.com>', 'test-cc2@ex.com'])),
+        ):
+            with self.subTest(email_to=email_to, email_cc=email_cc, email_cc_force=email_cc_force):
+                with self.mock_smtplib_connection():
+                    smtp_session = IrMailServer._connect__(smtp_from=mail_from)
+                    message = self._build_email(mail_from=mail_from, email_to=email_to, email_cc=email_cc,
+                                                headers={'X-Msg-Cc-Force': email_cc_force})
+                    IrMailServer.send_email(message, smtp_session=smtp_session)
+                self.assertSMTPEmailsSent(
+                    smtp_from=mail_from, message_from=mail_from, mail_server=self.mail_server_user,
+                    smtp_to_list=expected_to, msg_to_lst=expected_msg_to, msg_cc_lst=expected_msg_cc)


### PR DESCRIPTION
We add support for cc recipients in the composer for comment composition mode and also support the pre-fill of this value through template. Note that this is not supported when sending a mail directly from the chatter.

As we opted for a simplified implementation and migration (more details below), the information whether the recipient was in "To" or "Cc" is lost after sending the message (as solely stored in mail_mail.headers). So that information is not present when clicking on the small envelop in the chatter nor when doing a "Reply All".

How it works:
To avoid modifying mail.message/mail.mail, when sending mail with the composer, to and cc recipients are set as partner_ids for mail_message. So normally, those cc recipients will end up in the "To" headers.

To avoid that, we introduce a new pseudo headers X-Msg-Cc-Force. It is similar to X-Msg-To-Add in the sense that it doesn't modify the real recipients but only the headers to fake the Cc recipients (no additional recipient is injected in _prepare_smtp_to_list). The main difference is that it forces a recipient to be in "Cc" even if it was planned in "To".

When the composer send mail, it also configures that new header with the Cc recipient partners so that those added Cc recipients are handled like before (notification, black list, ...) but just before the mails are sent, the headers are modified so they appear to be sent in Cc.

Technical notes:
- To avoid modifying mail_mail/mail_message, we use the existing mail_mail.headers field to add the new header: X-Msg-Cc-Force that forces some recipients to be seen as cc recipient (even when sent directly to them). This new header is filled by the mail compose message wizard when _action_send_mail_comment is called.
- To avoid migration, we don't modify either the mail_notification to add a recipient_type on it (that could be filled during the sending by analysing the headers).
- In the mail compose message wizard, we have improved the compute for the recipient to also pre-fill the cc recipients based on the _generate_template_for_composer method. For that we add a new handle_partner_cc parameter that we propagate along the call chain to turn email_cc as cc recipient partners, if the find_or_create_partners parameter is enabled. Before, email_cc was just concatenated with email_to and the recipient types were lost. This is still the case when the new added parameter is not specified.
- We had to increase a bit the query count because partner_cc_ids are queried during mail_compose_message._action_send_mail. We could have spared a table and probably that extra query by using the existing linking table materialized by a new model with a field recipient_type, but the code was complicated and some issues remained in the interface.
- To test the new feature, we do it in 2 steps: first that the new header is well filled by the composer and finally that this new header is well interpreted when sending a mail.
- We had to add a new field widget because none of the existing boolean field widget allows to display a toggle button with translatable "Cc" label (we could have used the boolean icon field but there was no icon representing Cc and using a fake icon containing "Cc" wouldn't have been translatable).

[IMP] mail: add support for Cc recipients in the chat composer

After having added the support for Cc recipients in the mail composer, we add it in the mini composer of the chatter and configure the synchronization of the recipients between the mini composer and the full one.

[FIX] mail: fix email setter popover

The test "update email for the partner on the fly" was failing randomly because onWillRender is called twice causing RecipientsInput.tags to be updated twice. As the method create each time new ids for the tags even if the recipients haven't changed, it causes the emailSetterPopover to be opened twice which made the test fails when filling the email on the first popover. To avoid that, we don't change the reference of RecipientsInput.tags if the recipients haven't changed (thanks to a deepequals comparison).

Task-5910857