### PR TITLE
[FIX] test_website, website: keep homepage url setting at url change

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -406,3 +406,31 @@ registerWebsitePreviewTour(
         ...clickOnSaveButtonStep,
     ]
 );
+
+registerWebsitePreviewTour(
+    "set_homepage_and_change_page_url",
+    {
+        url: "/",
+    },
+    () => [
+        ...openPagePropertiesDialog,
+        {
+            content: "Set as homepage",
+            trigger: "#is_homepage_0",
+            run: "check",
+        },
+        {
+            content: "Change url to /cool-page",
+            trigger: "#url_0",
+            run: `edit cool-page && press Enter`,
+        },
+        {
+            content: "Check that the 'Redirect Old URL' appeared",
+            trigger: "[name='redirect_old_url']",
+        },
+        {
+            content: "Check that the page is still set as the homepage",
+            trigger: "#is_homepage_0:checked",
+        },
+    ]
+);

--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -380,3 +380,29 @@ registerWebsitePreviewTour(
         ...testWebsitePageProperties().finalize(),
     ],
 );
+
+registerWebsitePreviewTour(
+    "change_page_url_and_set_as_homepage",
+    {
+        url: "/",
+    },
+    () => [
+        ...openPagePropertiesDialog,
+        {
+            content: "Unset as homepage",
+            trigger: "#is_homepage_0",
+            run: "uncheck",
+        },
+        {
+            content: "Change url to /cool-page",
+            trigger: "#url_0",
+            run: `edit cool-page && press Enter`,
+        },
+        {
+            content: "Set as homepage",
+            trigger: "#is_homepage_0",
+            run: "check",
+        },
+        ...clickOnSaveButtonStep,
+    ]
+);

--- a/addons/test_website/tests/test_website_page_properties.py
+++ b/addons/test_website/tests/test_website_page_properties.py
@@ -25,3 +25,6 @@ class TestWebsitePageProperties(HttpCase):
         })
 
         self.start_tour('/', 'website_page_properties_website_page', login='admin')
+
+    def test_change_page_url_and_set_as_homepage(self):
+        self.start_tour('/', 'change_page_url_and_set_as_homepage', login='admin')

--- a/addons/test_website/tests/test_website_page_properties.py
+++ b/addons/test_website/tests/test_website_page_properties.py
@@ -28,3 +28,6 @@ class TestWebsitePageProperties(HttpCase):
 
     def test_change_page_url_and_set_as_homepage(self):
         self.start_tour('/', 'change_page_url_and_set_as_homepage', login='admin')
+
+    def test_set_homepage_and_change_page_url(self):
+        self.start_tour('/test_view', 'set_homepage_and_change_page_url', login='admin')

--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -157,6 +157,7 @@ class WebsitePageProperties(models.TransientModel):
     visibility_password_display = fields.Char(related='target_model_id.visibility_password_display', readonly=False)
     group_ids = fields.Many2many(related='target_model_id.group_ids', readonly=False)
     is_new_page_template = fields.Boolean(related='target_model_id.is_new_page_template', readonly=False)
+    is_homepage = fields.Boolean(related='target_model_id.is_homepage', inverse='_inverse_is_homepage', string='Homepage')
 
     old_url = fields.Char()
     redirect_old_url = fields.Boolean(default=False, store=False)
@@ -169,17 +170,6 @@ class WebsitePageProperties(models.TransientModel):
         store=False,
         required=True,
     )
-
-    @api.depends('url', 'website_id.homepage_url')
-    def _compute_is_homepage(self):
-        """
-        Don't match is_homepage when url is '/' as this model's url is not the
-        accessed route's url.
-        """
-        for record in self:
-            url = record.url
-            current_homepage_url = record.website_id.homepage_url or '/'
-            record.is_homepage = url == current_homepage_url
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Steps to reproduce the problem:
- Create a page.
- Go on "Site" > "This Page" > "Properties".
- Click on "Is Homepage".
- Change the page url.

-> The "Is Homepage" setting is deactivated.

Since [1], accessing page properties creates a transient record: either `website.page.properties.base` or `website.page.properties`, depending on whether the properties belong to a page or a route. The issue arises for pages: the `is_homepage` field is computed based on the URL, so it changes whenever the URL is updated. However, for a page, `is_homepage` should instead reflect the value defined on the corresponding `website.page` record.

[1]: https://github.com/odoo/odoo/commit/d6c8177824be3f62f97ff82e4e27e9621be60dd3

task-6075339

