### PR TITLE
[FIX] pos_loyalty: fix Buy X Get Y giving too many free items with multiple rewards

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -488,7 +488,12 @@ patch(Order.prototype, {
             }
 
             //If there is only one possible reward we try to claim the most possible out of it
-            if (claimedReward.reward.reward_product_ids?.length === 1) {
+            if (
+                claimedReward.reward.reward_product_ids?.length === 1 &&
+                allRewardsMerged.filter(
+                    (reward) => reward.reward.program_id.id === claimedReward.reward.program_id.id
+                ).length === 1
+            ) {
                 delete claimedReward.args["quantity"];
             }
             this._applyReward(claimedReward.reward, claimedReward.coupon_id, claimedReward.args);
@@ -532,6 +537,7 @@ patch(Order.prototype, {
             // Update point changes for those that exist
             for (let idx = 0; idx < Math.min(pointsAdded.length, oldChanges.length); idx++) {
                 Object.assign(oldChanges[idx], pointsAdded[idx]);
+                oldChanges[idx].appliedRules = pointsForProgramsCountedRules[program.id];
             }
             if (pointsAdded.length < oldChanges.length || !this._programIsApplicable(program)) {
                 const removedIds = oldChanges.map((pe) => pe.coupon_id);
@@ -1510,12 +1516,9 @@ patch(Order.prototype, {
                 this._isRewardProductPartOfRules(reward, product) &&
                 reward.program_id.applies_on !== "future"
             ) {
-                const line = this.get_orderlines().find(
-                    (line) => line.reward_product_id === product.id
-                );
                 // Compute the correction points once even if there are multiple reward lines.
                 // This is because _getPointsCorrection is taking into account all the lines already.
-                const claimedPoints = line ? this._getPointsCorrection(reward.program_id) : 0;
+                const claimedPoints = this._getPointsCorrection(reward.program_id);
                 return Math.floor((remainingPoints - claimedPoints) / reward.required_points) > 0
                 ? reward.reward_product_qty
                 : 0;

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyRewardButtonTour.js
@@ -3,6 +3,7 @@
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/PosLoyaltyTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
+import { negateStep } from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
@@ -257,5 +258,32 @@ registry.category("web_tour.tours").add("test_loyalty_on_order_with_fixed_tax", 
             ProductScreen.clickDisplayedProduct("Product A"),
             PosLoyalty.enterCode("563412"),
             PosLoyalty.hasRewardLine("10% on your order", "-1.50"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_multiple_reward_line_free_product", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10.00", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B").map(negateStep),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5.00", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10.00", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5.00", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10.00", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5.00", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-20.00", "2.00"),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2745,3 +2745,57 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_number_buffer_popup(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_number_buffer_popup', login="pos_user")
+
+    def test_multiple_reward_line_free_product(self):
+        """Test that multiple reward lines with free product are correctly applied
+        when the product is added to the cart."""
+        self.env['loyalty.program'].search([]).write({'active': False})
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'list_price': 10,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+        product_b = self.env['product.product'].create({
+            'name': 'Product B',
+            'type': 'product',
+            'list_price': 5,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        self.env['loyalty.program'].create({
+            'name': 'Buy 2 Take 1',
+            'program_type': 'buy_x_get_y',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'product_ids': (product_a | product_b).ids,
+                'reward_point_mode': 'unit',
+                'minimum_qty': 0,
+            })],
+            'reward_ids': [
+                (0, 0, {
+                    'reward_type': 'product',
+                    'reward_product_id': product_a.id,
+                    'reward_product_qty': 1,
+                    'required_points': 2,
+                }),
+                (0, 0, {
+                    'reward_type': 'product',
+                    'reward_product_id': product_b.id,
+                    'reward_product_qty': 1,
+                    'required_points': 2,
+                }),
+            ],
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "test_multiple_reward_line_free_product",
+            login="pos_user",
+        )


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a "Buy 2 Get 1 Free" program with 2 rules
   - rule 1: if min 2 items products A bought, grand 2 points
   - rule 2: if min 2 items products A bought, grand 2 points and add 2 rewards:
   - reward 1: Free product A in exchange of 2 points
   - reward 2: Free product B in exchange of 2 points
2. In PoS, add 2 products A and activate the reward 1 to get another free A -> All good, we got 3 A and 1 "Free A"
3. Add 2 products B, and activate the reward 2 to get another free B

We expect to end up with 3 A + 1 Free A (from step 2), and 2 B + 1 Free B (From step 3).

Instead, we end up with 3 A + 2 Free A, and 3 B + 2 Free B

The fix is to backport of 92c00eee0c49 from 18.0.
Also, sync `appliedRules` when updating coupon point changes.

opw-6037712
