### PR TITLE
[FIX] website: rollback transaction on IntegrityError during form submit

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -99,6 +99,7 @@ class WebsiteForm(http.Controller):
         # Ex: crm.lead.probability which is a float between 0 and 1
         # TODO: How to get the name of the erroneous field ?
         except IntegrityError:
+            request.env.cr.rollback()
             return json.dumps(False)
 
         request.session['form_builder_model_model'] = model_record.model


### PR DESCRIPTION
Currently an exception is generated when the user submits the custom
website form after following the below steps:

- Install `web_studio`, `website` and `crm`
- Go to the website > Open the website editor > Add a form to the website
- Configure the form as below:
      Action: Click `More models` > select `crm.tead`
      Field: add any custom
- Save the form
- Now an error is generated in the backend when the user submits the form.

The error was caused by submitting a form without a required field, leading
to a `NotNullViolation` during insertion at code line [1]. This was caught as
an `IntegrityError` at code line [2], but since the transaction was not rolled
back (broken transaction), it remained in a failed state. Consequently, a
subsequent operation triggered an `InFailedSqlTransaction` error when
attempting to close the savepoint at code line [3].

This commit will solve the above issue by rolling back the cursor when
the `IntegrityError` error occurs while submitting the form.

[1]: https://github.com/odoo/odoo/blob/c21c481eecf11a2e6e8bb21aa907e0aee870e3da/addons/website/controllers/form.py#L77
[2]: https://github.com/odoo/odoo/blob/c21c481eecf11a2e6e8bb21aa907e0aee870e3da/addons/website/controllers/form.py#L98
[3]: https://github.com/odoo/odoo/blob/c21c481eecf11a2e6e8bb21aa907e0aee870e3da/addons/website/controllers/form.py#L53

Sentry-7260662088,7327198011