### PR TITLE
[FIX] l10n_es_edi_verifactu_pos:  fix qr code url

### DIFF
--- a/addons/l10n_es_edi_verifactu_pos/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/app/utils/printer/generate_printer_data.js
@@ -11,7 +11,7 @@ patch(GeneratePrinterData.prototype, {
         if (this.order.l10n_es_edi_verifactu_qr_code) {
             const baseUrl = this.order.config._base_url;
             data.image.l10n_es_edi_verifactu_qr_code = this.generateQrCode(
-                `${baseUrl}/${this.order.l10n_es_edi_verifactu_qr_code}`
+                `${baseUrl}${this.order.l10n_es_edi_verifactu_qr_code}`
             );
         }
 


### PR DESCRIPTION
Step to reproduce:
- install "l10n_es_edi_verifactu_pos"
- setup "ePOS printer" for a pos
- open pos and settle a order below 400$
- notice we get l10n_es_edi_verifactu_qr_code in our receipt
- click on "Print"

Observation:
- when you scan the qr code in invoice it contains `//` in it

cause:
- in recent commit [1]  a typo is introduced which prepends `/` before barcode url, while barcode url starts with `/report/barcode` .
https://github.com/odoo/odoo/blob/0d8eaeeb971f2f670aebb1b72ed03f4a2d5e0105/addons/l10n_es_edi_verifactu/models/verifactu_document.py#L293-L311



Fix:
- remove extra `/` , which fixes the typo

opw-6075474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
