### PR TITLE
[FIX] html_editor: remove empty toggle block on enter

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -453,6 +453,10 @@ export class ToggleBlockPlugin extends Plugin {
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
                 baseContainer.appendChild(this.document.createElement("br"));
                 toggle.replaceWith(baseContainer);
+                const dir = toggle.getAttribute("dir");
+                if (dir) {
+                    baseContainer.setAttribute("dir", dir);
+                }
                 this.dependencies.selection.setCursorStart(baseContainer);
                 return true;
             }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -445,7 +445,7 @@ export class ToggleBlockPlugin extends Plugin {
         const { toggle, title, content } = this.getClosestToggleTitleInfo(targetNode);
         if (title) {
             const selection = this.dependencies.selection.getEditableSelection();
-            if (isEmptyBlock(selection.anchorNode)) {
+            if (isEmptyBlock(closestBlock(selection.anchorNode))) {
                 const contentChildren = children(content);
                 if (contentChildren.length !== 1 || !isEmptyBlock(contentChildren[0])) {
                     toggle.after(...children(content));

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -629,6 +629,32 @@ describe("Enter applied to toggle title", () => {
             `)
         );
     });
+    test("empty title with inline elements: should explode toggle", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "false");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p><strong>[]\u200B</strong></p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p><br></p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        splitBlock(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+            `)
+        );
+    });
 });
 describe("Tab applied to toggle title", () => {
     test("toggle closed, should move inside previous toggle", async () => {

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -655,6 +655,32 @@ describe("Enter applied to toggle title", () => {
             `)
         );
     });
+    test("empty title with rtl: should preserve direction", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "false");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" dir="rtl" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>[]<br></p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p><br></p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        splitBlock(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p dir="rtl" placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+            `)
+        );
+    });
 });
 describe("Tab applied to toggle title", () => {
     test("toggle closed, should move inside previous toggle", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce issue:

- Create a toggle list.
- Apply some formattings e.g. bold and italic to title.
- Press Enter.

Instead of removing the toggle, another toggle list is created.

**Desired behavior after PR is merged:**

Now, if there is a empty toggle block title having some formattings in it, pressing enter removes the empty toggle and exit the list.

task-6075014





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
