### PR TITLE
[FIX] Spreadsheet: neutralize odoo links on freeze

### DIFF
--- a/addons/spreadsheet/__manifest__.py
+++ b/addons/spreadsheet/__manifest__.py
@@ -70,6 +70,7 @@
             'spreadsheet/static/src/o_spreadsheet/migration.js',
             'spreadsheet/static/src/o_spreadsheet/odoo_module.js',
             'spreadsheet/static/src/helpers/helpers.js',
+            'spreadsheet/static/src/helpers/neutralized_link.js',
             'spreadsheet/static/src/public_readonly_app/**/*.xml',
             'spreadsheet/static/src/public_readonly_app/**/*.scss',
             'spreadsheet/static/src/public_readonly_app/**/*',

--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -12,6 +12,7 @@ import {
     isMarkdownIrMenuIdUrl,
     isIrMenuXmlUrl,
 } from "@spreadsheet/ir_ui_menu/odoo_menu_link_cell";
+import { getNeutralizedLink } from "./neutralized_link";
 
 export async function fetchSpreadsheetModel(env, resModel, resId) {
     const { data, revisions } = await env.services.orm.call(resModel, "join_spreadsheet_session", [
@@ -91,7 +92,7 @@ export async function freezeOdooData(model) {
                 }
             }
             if (containsLinkToOdoo(evaluatedCell.link)) {
-                cell.content = evaluatedCell.link.label;
+                cell.content = `[${evaluatedCell.link.label}](${getNeutralizedLink()})`;
             }
         }
         for (const figure of sheet.figures) {

--- a/addons/spreadsheet/static/src/helpers/neutralized_link.js
+++ b/addons/spreadsheet/static/src/helpers/neutralized_link.js
@@ -1,0 +1,33 @@
+/** @odoo-module */
+
+import { registries } from "@odoo/o-spreadsheet";
+
+const { urlRegistry } = registries;
+const NEUTRALIZED_LINK = "neutralized:link";
+
+export function getNeutralizedLink() {
+    return NEUTRALIZED_LINK;
+}
+
+export function isNeutralizedLink(url) {
+    return url === NEUTRALIZED_LINK;
+}
+
+urlRegistry.add("neutralizedLink", {
+    sequence: 80,
+    match: isNeutralizedLink,
+    createLink(url, label) {
+        return {
+            url,
+            label: label,
+            isExternal: false,
+            isUrlEditable: false,
+        };
+    },
+    urlRepresentation(url) {
+        return "";
+    },
+    open(url) {
+        return;
+    },
+});

--- a/addons/spreadsheet/static/src/ir_ui_menu/index.js
+++ b/addons/spreadsheet/static/src/ir_ui_menu/index.js
@@ -67,12 +67,6 @@ export const spreadsheetLinkMenuCellService = {
                     const menu = env.services.menu.getMenu(menuId);
                     env.services.action.doAction(menu.actionID);
                 },
-                // createCell: (id, content, properties, sheetId, getters) => {
-                //     const { url } = parseMarkdownLink(content);
-                //     const menuId = parseIrMenuIdLink(url);
-                //     const menuName = env.services.menu.getMenu(menuId).name;
-                //     return new OdooMenuLinkCell(id, content, menuId, menuName, properties);
-                // },
             })
             .add("OdooMenuXmlLink", {
                 sequence: 66,

--- a/addons/spreadsheet/static/src/public_readonly_app/odoo_menu_fill.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/odoo_menu_fill.js
@@ -1,0 +1,11 @@
+/** @odoo-module **/
+
+import { registries } from "@odoo/o-spreadsheet";
+
+const { clickableCellRegistry } = registries;
+
+const currentlinkCell = clickableCellRegistry.get("link");
+currentlinkCell.condition = (position, env) => {
+    const evaluatedCell = env.model.getters.getEvaluatedCell(position);
+    return evaluatedCell.link && evaluatedCell.link.isExternal;
+};

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze_test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze_test.js
@@ -192,9 +192,9 @@ QUnit.module("freezing spreadsheet", {}, function () {
         assert.strictEqual(getEvaluatedCell(model, "A1").value, "");
         const frozenData = await freezeOdooData(model);
         assert.strictEqual(frozenData.sheets[0].cells.A1.content, '=""');
-    })
+    });
 
-    QUnit.test("odoo links are replaced with their label", async function (assert) {
+    QUnit.test("odoo links are replaced by a neutralized link", async function (assert) {
         const view = {
             name: "an odoo view",
             viewType: "list",
@@ -226,9 +226,9 @@ QUnit.module("freezing spreadsheet", {}, function () {
             serverData: getMenuServerData(),
         });
         const frozenData = await freezeOdooData(model);
-        assert.strictEqual(frozenData.sheets[0].cells.A1.content, "menu_xml");
-        assert.strictEqual(frozenData.sheets[0].cells.A2.content, "menu_id");
-        assert.strictEqual(frozenData.sheets[0].cells.A3.content, "odoo_view");
+        assert.strictEqual(frozenData.sheets[0].cells.A1.content, "[menu_xml](neutralized:link)");
+        assert.strictEqual(frozenData.sheets[0].cells.A2.content, "[menu_id](neutralized:link)");
+        assert.strictEqual(frozenData.sheets[0].cells.A3.content, "[odoo_view](neutralized:link)");
         assert.strictEqual(
             frozenData.sheets[0].cells.A4.content,
             "[external_link](https://odoo.com)"
@@ -261,27 +261,34 @@ QUnit.module("freezing spreadsheet", {}, function () {
         assert.deepEqual(data.styles[cells.B12.style], { bold: true }, "style is preserved");
     });
 
-    QUnit.test("empty values from spilled pivot table is exported as empty string", async function (assert) {
-        const { model } = await createSpreadsheetWithPivot();
-        setCellContent(model, "A10", "=ODOO.PIVOT.TABLE(1)");
-        assert.strictEqual(getEvaluatedCell(model, "B12").value, "");  // empty value
-        const data = await freezeOdooData(model);
-        const cells = data.sheets[0].cells;
-        assert.strictEqual(cells.B12.content, '=""');
-    });
+    QUnit.test(
+        "empty values from spilled pivot table is exported as empty string",
+        async function (assert) {
+            const { model } = await createSpreadsheetWithPivot();
+            setCellContent(model, "A10", "=ODOO.PIVOT.TABLE(1)");
+            assert.strictEqual(getEvaluatedCell(model, "B12").value, ""); // empty value
+            const data = await freezeOdooData(model);
+            const cells = data.sheets[0].cells;
+            assert.strictEqual(cells.B12.content, '=""');
+        }
+    );
 
     QUnit.test(
         "Text values that match a number representation are escaped",
         async function (assert) {
             const serverData = getBasicServerData();
             const names = [/*infinity*/ "23e99999", "23e76", "23e-76", "25z776", "12/12/2021"];
-            serverData.models.partner.records =
-                serverData.models.partner.records.map((record, i) => ({
+            serverData.models.partner.records = serverData.models.partner.records.map(
+                (record, i) => ({
                     ...record,
                     name: names[i],
-                }));
-            serverData.models.partner.records = names.map((name, index) => ({ ...serverData.models.partner.records[0], name, id: index +1 }));
-
+                })
+            );
+            serverData.models.partner.records = names.map((name, index) => ({
+                ...serverData.models.partner.records[0],
+                name,
+                id: index + 1,
+            }));
 
             const { model } = await createSpreadsheetWithList({
                 linesNumber: 5,

--- a/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet_test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet_test.js
@@ -5,6 +5,7 @@ import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/utils/global_filt
 import { addGlobalFilter } from "@spreadsheet/../tests/utils/commands";
 import { freezeOdooData } from "../../src/helpers/model";
 import { createModelWithDataSource } from "@spreadsheet/../tests/utils/model";
+import { setCellContent } from "../utils/commands";
 
 QUnit.module("Public spreadsheet", {}, function () {
     QUnit.test("show spreadsheet in readonly mode", async function (assert) {
@@ -59,4 +60,15 @@ QUnit.module("Public spreadsheet", {}, function () {
         assert.isVisible(fixture.querySelector(".o-public-spreadsheet-filter-button"));
         assert.equal(fixture.querySelector(".o-public-spreadsheet-filters"), null);
     });
+
+    QUnit.test(
+        "Internal links converted to neutralized are not clickable",
+        async function (assert) {
+            const model = await createModelWithDataSource();
+            setCellContent(model, "A1", "[label](odoo://ir_menu_xml_id/test_menu)");
+            const data = await freezeOdooData(model);
+            const fixture = await mountPublicSpreadsheet(data, "dashboardDataUrl", "dashboard");
+            assert.equal(fixture.querySelector(".o-dashboard-clickable-cell"), null);
+        }
+    );
 });


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/166843, we remove the odoo links entirely from the spreadsheet on `freeze and share`. While it is true that the link is not usable from a public page (and that we'd somehow leak internal views information in the links), cells with links benefit from a specific style that is not hardcoded on the cell but rather computed based on their content.
By removing the links from teh cells altogether, the greenish link style is lost on those cells and we actually rely on that style for our dashboards layout.

To preserve the intension of https://github.com/odoo/odoo/pull/166843, we introduce a new type of links `neutralized` which allows the cell to be recognized as a link (and benefit from the style) while disabling their behaviour (no click).

Task-6063301

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
