### PR TITLE
[ADD] setup: add Firejail sandboxing for Claude Code and VSCode

### DIFF
--- a/setup/sandboxing/README.md
+++ b/setup/sandboxing/README.md
@@ -1,5 +1,8 @@
 # Sandboxing AI Coding Assistants
 
+tldr; if you are using VSCode / VSCodium and with the Claude Code integration, Firejail is
+probably the simplest approach.
+
 We advise running AI coding assistants in a sandbox for better security and privacy.
 These scripts and configurations allow you to run popular AI coding assistants with
 filesystem isolation, so the assistant can only access the files it needs to work
@@ -14,6 +17,92 @@ AI assistants are powerful tools that can execute code, read and write files, an
 the network. Running them without isolation can lead to accidental data leaks or malicious
 code execution if the assistant is compromised. By using sandboxing, you can mitigate
 these risks while still benefiting from the assistant's capabilities.
+
+## Firejail
+
+[Firejail](https://firejail.wordpress.com/) allows a process to have their own private
+of the system resources. It ships with a built-in profile for VSCode
+(`/etc/firejail/code.profile`) that sandboxes the editor but still gives it access
+to the entire home directory.
+The `code.local` provided here tightens this by activating whitelist mode: only
+explicitly listed directories (Odoo workspace, editor config, AI assistants) are
+accessible, everything else in `$HOME` is hidden.
+
+Running your editor under firejail means **the entire editor is sandboxed**:
+all extensions
+(including [Claude Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code)),
+the integrated terminal, and any process spawned from it only see the whitelisted paths.
+
+An alternative to Claude is
+[Kilo Code](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code)
+which can be used with many providers, including OpenRouter.
+
+### Prerequisites
+
+An up-to-date `.deb` is provided on the
+[official project repository](https://github.com/netblue30/firejail/releases).
+
+You can also install Firejail with your package manager. Be aware that official
+repositories may contain an outdated Firejail version. To install on Debian/Ubuntu:
+
+```sh
+sudo apt install firejail
+```
+
+Copy the provided files to Firejail's configuration directories:
+
+```sh
+mkdir -p ~/.config/firejail
+cp setup/sandboxing/firejail/* ~/.config/firejail/
+```
+
+`code.local` whitelists `~/src` by default. Edit it to point to where you keep
+your coding projects.
+
+### Running your editor in the sandbox
+
+Launch your editor with firejail:
+
+```sh
+# VSCode (uses code.profile automatically, which includes code.local)
+firejail code
+
+# VSCodium (specify the profile explicitly since there is no codium.profile)
+firejail --profile=/etc/firejail/code.profile codium
+
+# Cursor (specify the profile explicitly)
+firejail --profile=/etc/firejail/code.profile cursor
+```
+
+The editor and everything inside it (extensions, terminal, AI agents) will run
+within the sandbox. You can use Claude Code from the integrated terminal or the
+Claude Code VSCode extension as usual: it will only have access to the
+whitelisted directories.
+
+### Running Claude Code standalone
+
+The `claude.profile` can also be used to run Claude Code directly in the
+terminal, outside of an editor:
+
+Install Claude Code as recommended by the documentation:
+```sh
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Then run it using the profile in the source directory:
+
+```sh
+cd ~/src/odoo
+firejail --profile=~/.config/firejail/claude.profile --whitelist=$PWD claude
+```
+
+**Note:** Auto-updates will not work correctly under the sandbox.
+See [Claude auto-updates break the symlink](#claude-auto-updates-break-the-symlink).
+
+**Limitation:** Firejail always creates a PID namespace, which prevents VSCode
+IDE integration (`claude /ide`). Use `bwrap-claude.sh` if you need this
+feature. This limitation does not apply when running the editor itself under
+Firejail, as the Claude extension communicates with the editor directly.
 
 ## Bubblewrap
 
@@ -112,6 +201,9 @@ If VSCode is started, it should appear in the Claude CLI output.
 
 See the script header for the full sandbox layout.
 
+**Note:** Auto-updates will not work correctly under the sandbox.
+See [Claude auto-updates break the symlink](#claude-auto-updates-break-the-symlink).
+
 #### Using OpenRouter
 
 To use [OpenRouter](https://openrouter.ai/) as a proxy for Claude API calls, set the
@@ -146,7 +238,7 @@ export ANTHROPIC_DEFAULT_OPUS_MODEL="minimax/minimax-m2.7"
 bwrap-claude.sh --openrouter
 ```
 
-### Example: Running Odoo tests
+## Example: Running Odoo tests
 
 Here is an example of prompt to run the CRM tests (Python and JavaScript tours):
 
@@ -164,10 +256,30 @@ Can you do this for me?
 ```
 
 You can follow the logs in the file `~/src/odoo/log/pouet.log`.
+At the time of writing, it should work fine with Bubblewrap but still faces minor
+errors with Firejail.
 
-### Troubleshooting
+## Troubleshooting
 
-1. If you get the following error:
+### Claude auto-updates break the symlink
+
+`~/.local/bin/claude` is a symlink pointing to the active version under
+`~/.local/share/claude/versions/<version>`. When Claude auto-updates, it downloads
+the new binary into `versions/` but cannot update the symlink because the sandbox
+only exposes the symlink itself, not its parent directory `~/.local/bin/`.
+
+Old binaries are automatically garbage-collected, so after some time the symlink
+will point to a non-existing executable and Claude will fail to start.
+
+To fix the issue, re-install Claude **outside the sandbox** (no data will be lost):
+
+```sh
+rm -f ~/.local/bin/claude && curl -fsSL https://claude.ai/install.sh | bash
+```
+
+### bwrap: setting up uid map: Permission denied
+
+If you get the following error:
 
 ```
 bwrap: setting up uid map: Permission denied

--- a/setup/sandboxing/bwrap/bwrap-claude.sh
+++ b/setup/sandboxing/bwrap/bwrap-claude.sh
@@ -103,12 +103,22 @@
 #   bind-mounted into the sandbox so `claude /ide` can connect to the editor.
 
 set -e
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "Do not run this script as root" >&2
+  exit 1
+fi
+
 HOME="${HOME:-/home/$(whoami)}"
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 
 # Pre-check: ensure Claude binary exists
 if [[ ! -x "$CLAUDE_BIN" ]]; then
   echo "Claude Code not found at $CLAUDE_BIN" >&2
+  echo "In all likelihood, the Claude executable has been garbage-collected but the" >&2
+  echo "symlink was not updated because of sandboxing restrictions." >&2
+  echo "You can fix the issue by re-installing Claude (no data will be lost):" >&2
+  echo "rm -f $HOME/.local/bin/claude && curl -fsSL https://claude.ai/install.sh | bash" >&2
   exit 1
 fi
 
@@ -152,9 +162,14 @@ while [[ $# -gt 0 ]]; do
   fi
 done
 
-BRAP=(
+BWRAP=(
   # Read-write bin (needed for Claude auto-updates). These 2 must already exists since they
   # contain the binaries.
+  # NOTE: ~/.local/bin/claude is a symlink to ~/.local/share/claude/versions/<version>.
+  # Claude auto-updates download a new binary under versions/ but cannot update the symlink
+  # because only the symlink itself is bind-mounted, not the parent ~/.local/bin/ directory.
+  # After an update, fix the symlink manually:
+  #   ln -sf ~/.local/share/claude/versions/<new-version> ~/.local/bin/claude
   --bind "$HOME/.local/bin/claude" "$HOME/.local/bin/claude"
   --bind "$HOME/.local/share/claude" "$HOME/.local/share/claude"
   --ro-bind-try "$HOME/.vscode" "$HOME/.vscode"
@@ -182,6 +197,7 @@ BRAP=(
   --unshare-cgroup
   --die-with-parent
   --new-session
+  --hostname dev-sandbox
   # Odoo: filestore and PostgreSQL socket, passwd necessary for PostgreSQL auth
   --bind-try "$HOME/.local/share/Odoo" "$HOME/.local/share/Odoo"
   --bind-try /var/run/postgresql /var/run/postgresql
@@ -206,17 +222,17 @@ BRAP=(
 
 # Bind Claude config and cache files
 for path in "${CLAUDE_DIRS[@]}" "${CLAUDE_FILES[@]}"; do
-  BRAP+=(--bind "$path" "$path")
+  BWRAP+=(--bind "$path" "$path")
 done
 
 # Bind allowed directories
 for path in "${ALLOW_DIRS[@]}"; do
-  BRAP+=(--bind "$path" "$path")
+  BWRAP+=(--bind "$path" "$path")
 done
 
 # Bind VSCode sockets from XDG_RUNTIME_DIR for IDE integration
 for sock in "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"/vscode-*.sock; do
-  [[ -S "$sock" ]] && BRAP+=(--bind "$sock" "$sock")
+  [[ -S "$sock" ]] && BWRAP+=(--bind "$sock" "$sock")
 done
 
 # Pass --add-dir for each allowed dir so Claude's tool access matches the sandbox
@@ -246,5 +262,19 @@ if [[ "$USE_OPENROUTER" == true ]]; then
   )
 fi
 
-echo "Running: bwrap ${BRAP[@]} ${BWRAP_ENV[@]} -- $CLAUDE_BIN ${CLAUDE_CMD[@]}" >&2
-exec bwrap "${BRAP[@]}" "${BWRAP_ENV[@]}" -- "$CLAUDE_BIN" "${CLAUDE_CMD[@]}"
+echo "Running: bwrap ${BWRAP[@]} ${BWRAP_ENV[@]} -- $CLAUDE_BIN ${CLAUDE_CMD[@]}" >&2
+
+# Last check before execution: make sure some common $HOME directories are not accessible.
+# This could happen if one sets ODOO_BASE as $HOME or $PWD for example.
+FORBIDDEN_DIRS=(
+  "$HOME/.ssh"
+  "$HOME/.gnupg"
+)
+for dir in "${FORBIDDEN_DIRS[@]}"; do
+  if bwrap "${BWRAP[@]}" -- ls "$dir" >/dev/null 2>&1; then
+    echo "FAIL: $dir is readable inside the sandbox. Check allowed directories!" >&2
+    exit 1
+  fi
+done
+
+exec bwrap "${BWRAP[@]}" "${BWRAP_ENV[@]}" -- "$CLAUDE_BIN" "${CLAUDE_CMD[@]}"

--- a/setup/sandboxing/bwrap/bwrap-opencode.sh
+++ b/setup/sandboxing/bwrap/bwrap-opencode.sh
@@ -76,6 +76,12 @@
 #   of lines of test output in stdout won't render well in Opencode's TUI.
 
 set -e
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "Do not run this script as root" >&2
+  exit 1
+fi
+
 HOME="${HOME:-/home/$(whoami)}"
 OPENCODE_BIN="${OPENCODE_BIN:-$HOME/.opencode/bin/opencode}"
 
@@ -136,6 +142,7 @@ BWRAP=(
   --share-net
   --die-with-parent
   --new-session
+  --hostname dev-sandbox
   # Odoo: filestore and PostgreSQL socket, passwd necessary for PostgreSQL auth
   --bind-try "$HOME/.local/share/Odoo" "$HOME/.local/share/Odoo"
   --bind-try /var/run/postgresql /var/run/postgresql
@@ -169,4 +176,18 @@ for path in "${ALLOW_DIRS[@]}"; do
 done
 
 echo "Running: bwrap ${BWRAP[@]} -- $OPENCODE_BIN ${OPENCODE_ARGS[@]}" >&2
+
+# Last check before execution: make sure some common $HOME directories are not accessible.
+# This could happen if one sets ODOO_BASE as $HOME or $PWD for example.
+FORBIDDEN_DIRS=(
+  "$HOME/.ssh"
+  "$HOME/.gnupg"
+)
+for dir in "${FORBIDDEN_DIRS[@]}"; do
+  if bwrap "${BWRAP[@]}" -- ls "$dir" >/dev/null 2>&1; then
+    echo "FAIL: $dir is readable inside the sandbox. Check allowed directories!" >&2
+    exit 1
+  fi
+done
+
 exec bwrap "${BWRAP[@]}" -- "$OPENCODE_BIN" "${OPENCODE_ARGS[@]}"

--- a/setup/sandboxing/firejail/claude.profile
+++ b/setup/sandboxing/firejail/claude.profile
@@ -1,0 +1,95 @@
+# Copy this file to ~/.config/firejail
+#
+# Firejail profile for Claude Code.
+#
+# Provides filesystem isolation so Claude can only access explicitly
+# whitelisted directories. It is intended to run Claude in standalone.
+#
+# Usage:
+#   firejail --profile=claude.profile --whitelist=~/src/odoo claude
+#
+# LIMITATIONS
+#   Firejail always creates a PID namespace, which prevents VSCode IDE
+#   integration (`claude /ide`).
+#   Use bwrap-claude.sh or the provided code.local if you need the feature.
+#
+#   ~/.local/bin/claude is a symlink to ~/.local/share/claude/versions/<version>.
+#   Auto-updates cannot update the symlink because of the sandboxing. Old
+#   binaries are automatically garbage-collected, so after some time the symlink
+#   will point to a non-existing executable. To fix the issue, re-install Claude
+#   outside of the sandbox:
+#     rm -f ~/.local/bin/claude && curl -fsSL https://claude.ai/install.sh | bash
+
+
+# ============================================================================
+# SECURITY HARDENING
+# ============================================================================
+
+# Drop capabilities and protocols
+# unix is necessary for commnication with postgres through the socket
+caps.drop all
+nonewprivs
+noroot
+seccomp
+restrict-namespaces
+protocol unix,inet,inet6
+
+# No need for this
+nodvd
+nosound
+no3d
+notv
+nou2f
+novideo
+nogroups
+
+# Avoid fingerprinting
+machine-id
+hostname claude-sandbox
+
+# ============================================================================
+# FILESYSTEM ISOLATION
+# ============================================================================
+
+# Override blacklists from the includes below for paths we need.
+# noblacklist must appear before the include that would blacklist the path.
+noblacklist ${HOME}/.cache/claude
+noblacklist ${HOME}/.cache/claude-cli-nodejs
+noblacklist ${HOME}/.claude
+noblacklist ${HOME}/.claude.json
+noblacklist ${HOME}/.local/bin/claude
+noblacklist ${HOME}/.local/share/claude
+noblacklist ${HOME}/.local/state/claude
+
+include disable-common.inc
+include disable-programs.inc
+
+private-tmp
+private-dev
+private-etc @network,@tls-ca
+
+disable-mnt
+
+# ============================================================================
+# WHITELIST - WRITABLE PATHS
+# ============================================================================
+
+mkdir ${HOME}/.cache/claude
+mkdir ${HOME}/.cache/claude-cli-nodejs
+mkdir ${HOME}/.claude
+mkdir ${HOME}/.local/state/claude
+
+whitelist ${HOME}/.cache/claude
+whitelist ${HOME}/.cache/claude-cli-nodejs
+whitelist ${HOME}/.claude
+whitelist ${HOME}/.claude.json
+whitelist ${HOME}/.local/bin/claude
+whitelist ${HOME}/.local/share/claude
+whitelist ${HOME}/.local/state/claude
+
+# ============================================================================
+# D-BUS
+# ============================================================================
+
+dbus-user none
+dbus-system none

--- a/setup/sandboxing/firejail/code.local
+++ b/setup/sandboxing/firejail/code.local
@@ -1,0 +1,59 @@
+# Copy this file to ~/.config/firejail
+# IMPORTANT: Change this to point to where you keep your coding projects!
+# You can add multiple folders here if needed.
+whitelist ${HOME}/src
+
+# Allow read-write access ONLY to VS Code's own configuration directories
+# Also supports knows forks (VSCodium, Cursor)
+whitelist ${HOME}/.config/Code
+whitelist ${HOME}/.config/Code - OSS
+whitelist ${HOME}/.config/Cursor
+whitelist ${HOME}/.vscode
+whitelist ${HOME}/.vscode-oss
+whitelist ${HOME}/.cursor
+
+# Allow access to shell configuration for the integrated terminal to work properly.
+# Needs to be defined as whitelist and read-only.
+whitelist ${HOME}/.zshrc
+whitelist ${HOME}/.bashrc
+whitelist ${HOME}/.oh-my-zsh
+whitelist ${HOME}/.config/fish
+whitelist ${HOME}/.profile
+read-only ${HOME}/.zshrc
+read-only ${HOME}/.bashrc
+read-only ${HOME}/.oh-my-zsh
+read-only ${HOME}/.config/fish
+read-only ${HOME}/.profile
+
+# IBus input method: the daemon's Unix socket lives at ~/.cache/ibus/dbus-*
+# (see IBUS_ADDRESS in firejail --debug output). Whitelist mode hides it,
+# causing Electron to fail silently on input. Also need to override
+# private-cache from blink-common.profile, which would mount a fresh tmpfs
+# over ~/.cache and hide the socket again.
+ignore private-cache
+whitelist ${HOME}/.cache/ibus
+
+# Support for AI agents -- they can be run in the integrated terminal
+# Claude
+mkdir ${HOME}/.cache/claude
+mkdir ${HOME}/.cache/claude-cli-nodejs
+mkdir ${HOME}/.claude
+mkdir ${HOME}/.local/state/claude
+whitelist ${HOME}/.cache/claude
+whitelist ${HOME}/.cache/claude-cli-nodejs
+whitelist ${HOME}/.claude
+whitelist ${HOME}/.claude.json
+whitelist ${HOME}/.local/bin/claude
+whitelist ${HOME}/.local/share/claude
+whitelist ${HOME}/.local/state/claude
+
+# Opencode
+# For some unknown reason: Opencode does not start
+#mkdir ${HOME}/.cache/opencode
+#mkdir ${HOME}/.config/opencode
+#mkdir ${HOME}/.local/share/opencode
+#mkdir ${HOME}/.opencode
+#whitelist ${HOME}/.cache/opencode
+#whitelist ${HOME}/.config/opencode
+#whitelist ${HOME}/.local/share/opencode
+#whitelist ${HOME}/.opencode


### PR DESCRIPTION
Add Firejail profiles and documentation for sandboxing Claude Code and
VSCode/VSCodium:

- claude.profile: runs Claude Code CLI in a whitelisted sandbox with
  security hardening (caps.drop, seccomp, noroot, private-tmp/dev/etc)
- code.local: tightens the built-in code.profile by activating whitelist
  mode, restricting access to the Odoo workspace, editor config, and AI
  assistant directories only

Document installation steps, usage for VSCode, VSCodium, Cursor, and
standalone Claude Code.