### PR TITLE
[PERF] spreadsheet_account: OOM when using ODOO.ACCOUNT.GROUP with many accounts

### DIFF
--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -69,14 +69,19 @@ class AccountAccount(models.Model):
                     return default_domain
                 default_domain = Domain('account_type', 'in', ['liability_payable', 'asset_receivable'])
 
+            # ODOO.ACCOUNT.GROUP returns type tokens (e.g. "__type__income") instead of
+            # individual account codes to avoid passing thousands of codes to the server.
+            account_types = [c[len("__type__"):] for c in codes if c.startswith("__type__")]
+            codes = [c for c in codes if not c.startswith("__type__")]
+
             # It is more optimized to (like) search for code directly in account.account than in account_move_line
             code_domain = Domain.OR(
                 Domain("code", "=like", f"{code}%")
                 for code in codes
             )
-            account_domain = code_domain | default_domain
-            account_ids = self.env["account.account"].with_company(company_id).search(account_domain).ids
-            account_id_domain = [("account_id", "in", account_ids)]
+            type_domain = Domain("account_type", "in", account_types) if account_types else Domain.FALSE
+            account_domain = (code_domain | type_domain | default_domain) & Domain(self._check_company_domain(company))
+            account_id_domain = Domain("account_id", "any", account_domain)
         else:
             account_id_domain = Domain.FALSE
 
@@ -189,16 +194,11 @@ class AccountAccount(models.Model):
 
     @api.model
     def get_account_group(self, account_types):
-        data = self._read_group(
-            [
-                *self._check_company_domain(self.env.company),
-                ("account_type", "in", account_types),
-            ],
-            ['account_type'],
-            ['code:array_agg'],
-        )
-        mapped = dict(data)
-        return [mapped.get(account_type, []) for account_type in account_types]
+        # Return a lightweight type token for each requested type.
+        # The token is recognised by _build_spreadsheet_formula_domain and converted
+        # into an efficient account_id.account_type IN (...) condition, avoiding the
+        # need to fetch and round-trip thousands of individual account codes.
+        return [[f"__type__{account_type}"] for account_type in account_types]
 
     @api.model
     def spreadsheet_fetch_balance_tag(self, args_list):


### PR DESCRIPTION
**Problem:**
Opening the invoicing dashboard causes an out-of-memory error on databases with many account.account records

**Cause:**
The standard invoicing dashboard uses:
  =ODOO.BALANCE(ODOO.ACCOUNT.GROUP("income"), $B$4)

`ODOO.ACCOUNT.GROUP` calls `get_account_group` server-side, which fetches all individual account codes for the given type (e.g. 2000+ on a French COA). These codes are sent to the client then forwarded back as `codes: [2000 strings]` to `spreadsheet_fetch_debit_credit`.

The server then builds a domain with 2000 individual LIKE conditions:
  account_id IN (SELECT id FROM account_account
    WHERE code LIKE '701000%' OR code LIKE '701001%' OR ... -- 2000 times)

This is repeated for each formula cell in the batch, causing the OOM.

**Solution:**
`get_account_group` now returns a lightweight type token per requested type (e.g. `["__type__income"]`) instead of fetching all individual codes. `_build_spreadsheet_formula_domain` detects the `__type__` prefix and converts it into a single efficient condition:
  account_id IN (SELECT id FROM account_account
    WHERE account_type IN ('income')
    AND company_ids IN (...))

The company filter previously implicit via `with_company().search()` is preserved explicitly using `_check_company_domain` in the subquery domain.

Manually entered code prefixes (e.g. `ODOO.BALANCE("40,41", year)`) are unaffected and continue to use the existing LIKE-based path.

Benchmark:
||Before|After|
|-|-|-|
||Memory error|-|

Related ticket:
opw-5964940

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
