### PR TITLE
[FIX] stock: incorrect sequence if adding a product manually in picking

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -453,6 +453,7 @@
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_raw" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                     </control>
+                                    <field name="sequence" widget="handle"/>
                                     <field name="product_id" force_save="1" context="{'default_is_storable': True}" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)" domain="[('type', '=', 'consu')]"/>
                                     <field name="forecast_availability" column_invisible="parent.state in ['done', 'cancel']" string="" widget="forecast_widget"/>
                                     <field name="location_id" string="From" readonly="1" force_save="1" groups="stock.group_stock_multi_locations" optional="hide"/>
@@ -525,6 +526,7 @@
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_byproduct" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                     </control>
+                                    <field name="sequence" widget="handle"/>
                                     <field name="product_id" context="{'default_is_storable': True}" domain="[('type', '=', 'consu')]" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)"/>
                                     <field name="location_dest_id" string="To" readonly="1" force_save="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="company_id" column_invisible="True"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -148,6 +148,7 @@
                                     <create string="Add a line"/>
                                     <button name="action_add_from_catalog_repair" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                 </control>
+                                <field name="sequence" widget="handle"/>
                                 <field name="company_id" column_invisible="True"/>
                                 <field name="state" column_invisible="True"/>
                                 <field name="picking_type_id" column_invisible="True"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -273,6 +273,7 @@
                                     <control>
                                         <create string="Add a Product" hotkey="shift+p"/>
                                     </control>
+                                    <field name="sequence" widget="handle"/>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>
                                     <field name="picking_type_id" column_invisible="True"/>


### PR DESCRIPTION
Steps to reproduce
- Create three storable products: P1, P2 and P3
- Create a sale order with 1 unit of P1 and 1 unit of P2
- Confirm the sale order
- Open the generated picking
- Manually add 1 unit of P3

Problem:
After adding the new line manually, the sequence becomes:
- P1 → P3 → P2 instead of:
- P1 → P2 → P3

Explanation

The sale order line view uses the "handle" widget on the `sequence` field:
https://github.com/odoo/odoo/blob/57132f17bd15b593d16c68732a7cfd01c371ac0c/addons/sale/views/sale_order_views.xml#L381

Because of this, the first line starts with the default value defined in Python (`sequence = 10`), and each new line increments the sequence by 1:

- P1 → sequence = 10
- P2 → sequence = 11

When the sale order is confirmed, the `stock moves` are created with the same sequence values (10 and 11):
https://github.com/odoo/odoo/blob/b9fefd44cb7b9fe6245797416063df7930e7aca0/addons/sale_stock/models/sale_order_line.py#L250

However, the stock move tree view does NOT use the "handle" widget. As a result, when a new move line is added manually, it always receives the default value (`sequence = 10`) instead of the next logical value (12).

https://github.com/odoo/odoo/blob/cb486d7eb6353a66eea2cb3610141b4f3a778791/addons/stock/models/stock_move.py#L27

This causes the new line (P3) to appear between the existing lines instead of being added at the end.

opw-6061307
