### PR TITLE
[FIX] sale_stock,stock_account: use std price multi steps cogs partially done

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1585,3 +1585,22 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
             {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 60.0},
             {'account_id': self.account_expense.id, 'debit': 60.0, 'credit': 0.0},
         ])
+
+    def test_multi_steps_partially_delivered(self):
+        """Checks that when there is multi steps delivery, if one of the moves of the chain
+        is validated but not the other(s) we fallback on the standard price for the cogs.
+        """
+        self.warehouse.delivery_steps = 'pick_ship'
+        self._make_in_move(self.product_avco_auto, 1, 10)
+        # create a SO
+        sale_order = self._so_deliver(self.product_avco_auto, 1, 1, picking=False)
+        # validate only the first picking of the chain
+        sale_order.picking_ids.button_validate()
+        # validate invoice
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        cogs_aml = invoice.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(cogs_aml, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 10.0},
+            {'account_id': self.account_expense.id, 'debit': 10.0, 'credit': 0.0},
+        ])

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -249,13 +249,11 @@ class StockMove(models.Model):
         if len(self.product_id) > 1:
             return 0
         total_qty = sum(m._get_valued_qty() for m in self)
-        if not total_qty:
-            return 0
         valued_consigned_qty = self._get_valued_consigned_qty()
-        total_qty += valued_consigned_qty
-        if self.product_id.cost_method == 'fifo' or valued_consigned_qty or\
-            (self.product_id.lot_valuated and self.product_id.cost_method == 'average'):
-            return sum(self.mapped('value')) / total_qty
+        total_valued_qty = total_qty + valued_consigned_qty
+        if total_valued_qty and (self.product_id.cost_method == 'fifo' or valued_consigned_qty or
+            (self.product_id.lot_valuated and self.product_id.cost_method == 'average')):
+            return sum(self.mapped('value')) / total_valued_qty
         else:
             return self.product_id.standard_price
 

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -70,5 +70,5 @@ class StockMoveLine(models.Model):
         the _should_exclude_for_valuation criteria (.i.e the line would have been valued if it wasn't consigned)
         """
         return self.picked and self._should_exclude_for_valuation() and\
-            (self.move_id._is_in() and not self.location_id._should_be_valued() and self.location_dest_id._should_be_valued()
-            or self.move_id._is_out() and self.location_id._should_be_valued() and not self.location_dest_id._should_be_valued())
+            (not self.location_id._should_be_valued() and self.location_dest_id._should_be_valued()
+            or self.location_id._should_be_valued() and not self.location_dest_id._should_be_valued())


### PR DESCRIPTION
**Problem:**
cogs is 0 if the delivery is multi steps with only first 
picking validated. 

**Steps to reproduce:**
- set the warehouse as 2 steps delivery
- create a tracked product avco perpetual
- set a cost of 10$ and a positive quantity
- create and confirm a SO for 1 quantity
- validate only the first picking
- create and confirm the invoice

**Current behavior:**
there is no cogs lines in the invoice

**Expected behavior:**
there should be cogs line for a cost of 10$

**Cause of the issue:**
to compute the unit price of the cogs we use 
_get_cogs_value()
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/account_move.py#L122
Inside _get_cogs_value(), because there is done moves, 
we use _get_cogs_price_unit()
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/account_move_line.py#L67-L68
But because there is no valued quantity (because the done 
moves are internal), the return value will be 0.
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/stock_move.py#L251-L253
So the cogs will have an amount of 0 and no line will be created
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/account_move.py#L125-L126

**fix**
The fix for consigned products introduced by this PR https://github.com/odoo/odoo/pull/255043
was working for the wrong reasons. 
_get_valued_consigned_qty() only works if the 
moves are partially consigned. 
If the move is fully consigned, _is_consigned_value_line() 
will return False for every move line.
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/stock_move.py#L650-L651
That's because if the move is fully consigned, _is_in() 
and _is_out() will return False. 
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/stock_move_line.py#L72-L74
So it only works if the move is not fully consigned 
because _is_in() or _is_out() will be True thanks to 
the non consigned line.
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/stock_move.py#L511-L519

However, _get_cogs_price_unit() still worked fine for fully 
consigned moves because if the move is fully consigned, 
total_qty will be 0 and the return value will be 0
https://github.com/odoo/odoo/blob/5fd80a1fb8ef33cfa9261967cf14f6f0c421d45a/addons/stock_account/models/stock_move.py#L251-L253

But this was hacky and prevented us to address the issue of this PR. 
The logic should be:
If there is no quantity to value (consigned + not consigned) 
we fallback on the standard price (just as if there is no move).
This solves the issue of this PR because no moves were 
valued moves in our use case.
If there is a quantity to value (and we're in a case where we want
the average move value), we use the average move value (which 
will be 0 if all the moves are consigned)

opw-6001694