### PR TITLE
[FIX] hr_holidays: correct search on member_of_department

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -258,7 +258,9 @@ class HrEmployee(models.Model):
         return [('id', 'in', holidays.employee_id.ids)]
 
     def _search_part_of_department(self, operator, value):
-        versions = self.env['hr.version'].sudo().search([('member_of_department', operator, value)])
+        versions = self.env['hr.version'].sudo().search([
+            ('member_of_department', operator, value),
+        ]).filtered(lambda v: v.is_current)
         return [('id', 'in', versions.employee_id.ids)]
 
     @api.model_create_multi

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -38,3 +38,4 @@ from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
 from . import test_timeoff_overview_my_department_tour
 from . import test_hr_leave_report
+from . import test_member_of_department

--- a/addons/hr_holidays/tests/test_member_of_department.py
+++ b/addons/hr_holidays/tests/test_member_of_department.py
@@ -1,0 +1,51 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from odoo import tests
+from odoo.tests import TransactionCase
+
+
+@tests.tagged('access_rights', 'post_install', '-at_install')
+class TestMemberOfDepartment(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.duck_guy = cls.env["res.users"].create({
+            'name': 'Duck Guy',
+            'login': 'duck_guy',
+            'group_ids': cls.env.ref('hr.group_hr_manager').ids,
+        })
+
+        cls.duck_department, cls.other_department = cls.env["hr.department"].create([
+            {"name": "DUCK"},
+            {"name": "OTHER"},
+        ])
+
+        cls.duck_guy_emp, cls.other_dep_emp = cls.env["hr.employee"].create([
+            {
+                "name": "DUCK GUY",
+                "department_id": cls.duck_department.id,
+                "date_version": date(2026, 1, 1),
+                "user_id": cls.duck_guy.id,
+            },
+            {
+                "name": "OTHER GUY",
+                "department_id": cls.duck_department.id,
+                "date_version": date(2026, 1, 1),
+            },
+        ])
+        cls.env["hr.version"].create({
+            "employee_id": cls.other_dep_emp.id,
+            "department_id": cls.other_department.id,
+            "date_version": date(2026, 2, 1),
+        })
+
+    @freeze_time('2026-03-01')
+    def test_other_dep_visibility(self):
+        dep_emps = self.env["hr.employee"].with_user(self.duck_guy).search([("member_of_department", "=", True)])
+        self.assertTrue(self.duck_guy_emp in dep_emps.employee_id)
+        self.assertFalse(self.other_dep_emp in dep_emps.employee_id)


### PR DESCRIPTION
Reproduce the issue:
- Create an employee linked to a user with department A
- Create a second employee with 2 versions:
  - a past one with department A
  - a current one with department B
- create a leave for both employees
- go to Time Off > Overview, keep the group by employee and select the filter "My department"
- both employee appear

Before this commit, the search on "member_of_department" was looking for all versions with a similar department (same or child of) regardless of the version validity.
This commit limits that search to current versions only

task-6076014