### PR TITLE
[FIX] stock_landed_costs: use converting rate from invoice

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['expense'].id,
-                'price_unit': sign * l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
+                'price_unit': sign * l.company_currency_id.round(l.price_subtotal * l.currency_rate),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -364,6 +364,7 @@ class TestLandedCosts(TestStockLandedCostsCommon):
 
 @tagged('post_install', '-at_install')
 class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
+    @skip('Temporary to fast merge new valuation')
     def test_invoice_after_lc(self):
         self.env.company.anglo_saxon_accounting = True
         self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
@@ -439,8 +440,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         products = self.product1 | product2
         products.purchase_method = 'purchase'
         products.categ_id.write({
-            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
-            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
             'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
             'property_valuation': 'real_time',
             'property_cost_method': 'average',
@@ -494,6 +493,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         self.assertEqual(self.product1.standard_price, 1.5)
         self.assertEqual(product2.standard_price, 3.5)
 
+    @skip('Temporary to fast merge new valuation')
     def test_invoice_after_lc_amls(self):
         self.env.company.anglo_saxon_accounting = True
         self.landed_cost.landed_cost_ok = True
@@ -569,8 +569,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         self.env.company.anglo_saxon_accounting = True
         self.product1.purchase_method = 'purchase'
         self.product1.categ_id.write({
-            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
-            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
             'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
             'property_valuation': 'real_time',
             'property_cost_method': 'average',
@@ -621,6 +619,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         receipt2.button_validate()
         self.assertEqual(product.standard_price, 1.81)
 
+    @skip('Temporary to fast merge new valuation')
     def test_landed_costs_avco_invoice_before_receipt(self):
         """
         Test the application of landed costs on a product with average cost (AVCO) method
@@ -631,8 +630,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         self.env.company.anglo_saxon_accounting = True
         self.product1.purchase_method = 'purchase'
         self.product1.categ_id.write({
-            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
-            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
             'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
             'property_valuation': 'real_time',
             'property_cost_method': 'average',
@@ -675,6 +672,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         # 35 = Product price (10) + landed cost price (25)
         self.assertEqual(product.standard_price, 35)
 
+    @skip('Temporary to fast merge new valuation')
     def test_refund_landed_cost_creates_negative_valuation(self):
         """Ensure landed cost created from a vendor refund is negative and reduces valuation."""
         self.env.company.anglo_saxon_accounting = True
@@ -685,8 +683,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
             'categ_id': self.stock_account_product_categ.id,
         })
         product.categ_id.write({
-            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
-            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
             'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
             'property_valuation': 'real_time',
             'property_cost_method': 'average',
@@ -745,6 +741,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         self.assertEqual(lc.amount_total, -20)
         self.assertEqual(lc.stock_valuation_layer_ids.value, -20)
 
+    @skip('Temporary to fast merge new valuation')
     def test_landed_cost_avco_partial_bill_rounding(self):
         """Tests landed cost calculation for an AVCO product with partial
         billing and backorders, ensuring correct stock valuation and handling
@@ -758,8 +755,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         self.env.company.anglo_saxon_accounting = True
         self.product1.purchase_method = 'purchase'
         self.product1.categ_id.write({
-            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
-            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
             'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
             'property_valuation': 'real_time',
             'property_cost_method': 'average',
@@ -914,6 +909,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         po.action_create_invoice()
         bill = po.invoice_ids
         bill.invoice_date = fields.Date.today()
+        bill.invoice_currency_rate = 0.5
         bill.action_post()
 
         # create and validate the landed cost
@@ -926,10 +922,11 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         # check the amls
         bill_landed_cost_amls = bill.line_ids.filtered(lambda l: l.product_id == self.landed_cost)
         self.assertRecordValues(bill_landed_cost_amls, [
-            {'account_id': lc_expense_account.id, 'debit': 100.0, 'credit': 0.0},
+            {'account_id': lc_expense_account.id, 'debit': 200.0, 'credit': 0.0},
         ])
         landed_cost_amls = landed_cost.account_move_id.line_ids.sorted('credit')
         self.assertRecordValues(landed_cost_amls, [
-            {'account_id': lc_stock_valuation_account.id, 'debit':  70.0,   'credit':  0.0},
-            {'account_id': lc_expense_account.id,         'debit':   0.0,   'credit': 70.0},
+            {'account_id': lc_stock_valuation_account.id, 'debit':  35.0,   'credit':  0.0},
+            {'account_id': lc_expense_account.id,         'debit':   0.0,   'credit': 35.0},
         ])
+        self.assertEqual(bill.landed_costs_ids.cost_lines.price_unit, 50)

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -11,7 +11,6 @@ from freezegun import freeze_time
 import time
 
 
-@skip('Temporary to fast merge new valuation')
 class TestStockValuationLCCommon(TestStockLandedCostsCommon):
 
     @classmethod
@@ -142,6 +141,7 @@ class TestStockValuationLCCommon(TestStockLandedCostsCommon):
 
 
 @tagged('-at_install', 'post_install')
+@skip('Temporary to fast merge new valuation')
 class TestStockValuationLCFIFO(TestStockValuationLCCommon):
     @classmethod
     def setUpClass(cls):
@@ -273,6 +273,7 @@ class TestStockValuationLCFIFO(TestStockValuationLCCommon):
 
 
 @tagged('-at_install', 'post_install')
+@skip('Temporary to fast merge new valuation')
 class TestStockValuationLCAVCO(TestStockValuationLCCommon):
     @classmethod
     def setUpClass(cls):
@@ -360,6 +361,7 @@ class TestStockValuationLCAVCO(TestStockValuationLCCommon):
         self.assertEqual(product.standard_price, 15)
 
 @tagged('-at_install', 'post_install')
+@skip('Temporary to fast merge new valuation')
 class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
     @classmethod
     def setUpClass(cls):
@@ -668,6 +670,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
 
 
 @tagged('-at_install', 'post_install')
+@skip('Temporary to fast merge new valuation')
 class TestAccountInvoicingWithCOA(TestStockValuationLCCommon):
     def setUp(self):
         self.usd = self.env.ref('base.USD')


### PR DESCRIPTION
**Issue**:
Even if the currency rate is changed on the invoice, the today currency rate is used
while generating stock landed cost.

**Steps to reproduce**:
- Enable two currencies (ex: Dollar and Euro)
- Enable Landed Costs on the settings
- Create a service product
- Create a bill for that product for 100 dollar and click the Landed Costs check box
- Change the currency rating (ex: 1 USD = 0.5 euro) and confirm the bill
- Click on "Create Landed Costs"
-> The cost is not 200

**Cause**:
While creating the landed cost:
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/stock_landed_costs/models/account_move.py#L21
it uses `_convert` from the currency:
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/stock_landed_costs/models/account_move.py#L35
which gets the `conversion_rate` defined on the currency, regardless whether `is_invoicing` is true:
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/odoo/addons/base/models/res_currency.py#L294
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/account/models/account_move.py#L6350-L6351

**Solution**
It is safe to replace the `convert` calls by the `currency_rate` of the `Account.move.line` since:
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/account/models/account_move_line.py#L735-L747
`currency_rate` will be set as `_get_conversion_rate` when not invoicing.
Also add rounding since `_convert` is called with `round=True` by default.

opw-6047031