### PR TITLE
[FIX] stock: handle mutliple and partial returns on stock.lot.report

### DIFF
--- a/addons/stock/report/stock_lot_customer.py
+++ b/addons/stock/report/stock_lot_customer.py
@@ -84,8 +84,7 @@ class StockLotReport(models.Model):
             partner.street2,
             sml.quantity,
             sml.product_uom_id,
-            picking.date_done,
-            sml_return.id
+            picking.date_done
         """
 
     def _query(self):

--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.fields import Command
 from odoo.tests import Form
+
 
 class TestReturnPicking(TestStockCommon):
 
@@ -253,55 +255,75 @@ class TestReturnPicking(TestStockCommon):
         """
         wh_stock = self.env['stock.location'].browse(self.stock_location)
         partner = self.env['res.partner'].create({'name': 'Test Customer'})
-
         product_serial = self.env['product.product'].create({
             'name': 'Tracked by SN',
             'is_storable': True,
             'tracking': 'serial',
         })
-
-        serial_1 = self.env['stock.lot'].create({'name': 'SN1', 'product_id': product_serial.id})
-        serial_2 = self.env['stock.lot'].create({'name': 'SN2', 'product_id': product_serial.id})
-
+        serial_1, serial_2, serial_3 = self.env['stock.lot'].create([
+            {'name': 'SN1', 'product_id': product_serial.id},
+            {'name': 'SN2', 'product_id': product_serial.id},
+            {'name': 'SN3', 'product_id': product_serial.id},
+        ])
         self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial_1)
         self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial_2)
-
+        self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial_3)
         picking = self.PickingObj.create({
             'partner_id': partner.id,
             'picking_type_id': self.picking_type_out,
             'location_id': self.stock_location,
             'location_dest_id': self.customer_location,
-            'move_ids': [(0, 0, {
-                'name': 'Move SN',
-                'product_id': product_serial.id,
-                'product_uom_qty': 2,
-                'product_uom': product_serial.uom_id.id,
-                'location_id': self.stock_location,
-                'location_dest_id': self.customer_location,
-            })],
+            'move_ids': [
+                Command.create({
+                    'name': 'Move SN',
+                    'product_id': product_serial.id,
+                    'product_uom_qty': 3,
+                    'product_uom': product_serial.uom_id.id,
+                    'location_id': self.stock_location,
+                    'location_dest_id': self.customer_location,
+                }),
+            ],
         })
-
         picking.action_confirm()
         picking.action_assign()
         picking.move_ids.picked = True
         picking.button_validate()
 
+        # return only one of the three SN of product_serial
         return_wizard = self.env['stock.return.picking'].with_context(active_id=picking.id, active_model='stock.picking').create({})
         return_wizard.product_return_moves.quantity = 1
         res = return_wizard.action_create_returns()
         return_picking = self.PickingObj.browse(res["res_id"])
-
         return_picking.action_confirm()
-        return_picking.move_ids.picked = True
         return_picking.button_validate()
-        self.env['stock.move.line'].flush_model()
 
+        self.env['stock.move.line'].flush_model()
         lot_report = self.env['stock.lot.report'].search([
             ('partner_id', '=', partner.id),
         ], order='id')
         self.assertRecordValues(lot_report, [
             {'lot_id': serial_1.id, 'has_return': True},
             {'lot_id': serial_2.id, 'has_return': False},
+            {'lot_id': serial_3.id, 'has_return': False},
+        ])
+
+        # return the other unit
+        return_wizard = self.env['stock.return.picking'].with_context(active_id=picking.id, active_model='stock.picking').create({})
+        return_wizard.product_return_moves.quantity = 1
+        res = return_wizard.action_create_returns()
+        return_picking_2 = self.PickingObj.browse(res["res_id"])
+        return_picking_2.action_confirm()
+        return_picking_2.button_validate()
+
+        self.env['stock.move.line'].flush_model()
+        lot_report.invalidate_recordset(['has_return'], flush=False)
+        lot_report = self.env['stock.lot.report'].search([
+            ('partner_id', '=', partner.id),
+        ], order='id')
+        self.assertRecordValues(lot_report, [
+            {'lot_id': serial_1.id, 'has_return': True},
+            {'lot_id': serial_2.id, 'has_return': True},
+            {'lot_id': serial_3.id, 'has_return': False},
         ])
 
     def test_product_quantities_in_return_for_exchange(self):


### PR DESCRIPTION
### Issues:

The customer stock.lot.report is not well behaved with respect to multiple partial returns which can lead to returned lots that are not correctly flagged as returned and to duplicate records.

### Steps to reproduce:

- Create a product tracked by SN and put 3 units in stock SN1, SN2, SN3
- Create, confirm and validate a delivery for these two units for Bob.
- Click Return, return 1 unit and validate the return for the SN1
- Click Return, return 1 unit and validate the return for the SN2
- Open the contact form of Bob > Lots serial numbers smart button
#### > There are two lines referring to SN2 both are flagged as un-returned

### Cause of the issue:

In order to determine if a lot has been returned the `stock.lot.report` joins the stock_move_line table with it self based on picking and returns of these:
https://github.com/odoo/odoo/blob/109f829c2b461b14167e9227e42d096d4410a3b3/addons/stock/report/stock_lot_customer.py#L48-L71 Records are then grouped to represent single move lines and a move line is expected to be returned to be returned if it is related to at least one move line on a return of its picking sharing the same lot related data (see the definition of `has_return`):
https://github.com/odoo/odoo/blob/109f829c2b461b14167e9227e42d096d4410a3b3/addons/stock/report/stock_lot_customer.py#L22-L34 Now the issue is that the group by close actually group records based on the `sml_return.id`:
https://github.com/odoo/odoo/blob/109f829c2b461b14167e9227e42d096d4410a3b3/addons/stock/report/stock_lot_customer.py#L73-L89 which does not make sense since we expect to aggregate `sml_return.id`'s to compute the `has_return` field and since we do not want a move line of the original delivery to appear twice simply because it is linked to two returns one with and one without returned move line.

opw-5974155

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
