### PR TITLE
[FIX] account: adjust hide composition column in PDF invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -339,12 +339,10 @@
                                                     t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                                     <span t-if="not hide_prices and not hide_details" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
                                                 </td>
-                                                <td name="td_price_unit_grouped" t-if="hide_details" colspan="1"/>
                                                 <td name="td_discount_grouped"
                                                     t-if="display_discount and (hide_details or grouped_line['display_type'] == 'product')"
                                                     colspan="1"
                                                     t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"/>
-                                                <td name="td_discount_grouped" t-if="hide_details" colspan="1"/>
                                                 <td name="td_taxes_grouped"
                                                     colspan="1"
                                                     t-if="display_taxes and (hide_details or grouped_line['display_type'] == 'product' or grouped_line.get('taxes'))"


### PR DESCRIPTION
Two fixes were r+ at the same time to correct the alignment

Issue:
Information displayed about sections with hidden composition are not align with the other lines.

Steps to reproduce:
- Create an invoice
- Add a product
- Add a section with any product.
- Hide the composition of the section (with the 3 dots on the right)
- Download the invoice PDF

Current behavior:
- Information on the hidden section compo are not align with other lines

opw-6017276
opw-6030372

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr