### PR TITLE
[FIX] purchase: fix deprecated product_uom field ref

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -620,7 +620,7 @@ class PurchaseOrder(models.Model):
                 if seller:
                     supplierinfo['product_name'] = seller.product_name
                     supplierinfo['product_code'] = seller.product_code
-                    supplierinfo['product_uom_id'] = line.product_uom.id
+                    supplierinfo['product_uom_id'] = line.product_uom_id.id
                 vals = {
                     'seller_ids': [(0, 0, supplierinfo)],
                 }


### PR DESCRIPTION
A big refactor of UOM in saas-18.1 (https://github.com/odoo/odoo/pull/184131) accidentally left a reference to the `product_uom` field on `purchase.order.line`.

But that field was renamed to `product_uom_id` in https://github.com/odoo/odoo/pull/186250.

In rare edge-cases, if we it `supplierinfo['product_uom_id'] = line.product_uom.id` while confirming a purchase order, it will block it because of a traceback:

```
supplierinfo['product_uom_id'] = line.product_uom.id
^^^^^^^^^^^^^^^^
AttributeError: 'purchase.order.line' object has no attribute 'product_uom'. Did you mean: 'product_id'?
```

This PR fixes the issues by accounting for the field rename.

OPW-6068125


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
