### PR TITLE
[IMP] hr_work_entry: regeneration of worked days on payslip line

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -98,6 +98,9 @@ class HrVersion(models.Model):
         self.ensure_one()
         if 'work_entry_type_id' in interval[2] and interval[2].work_entry_type_id[:1]:
             return interval[2].work_entry_type_id[:1]
+        interval[2]._compute_work_entry_type_id()
+        if 'work_entry_type_id' in interval[2] and interval[2].work_entry_type_id[:1]:
+            return interval[2].work_entry_type_id[:1]
         return self.env['hr.work.entry.type'].browse(self._get_default_work_entry_type_id())
 
     def _get_valid_leave_intervals(self, attendances, interval):


### PR DESCRIPTION
[IMP] hr_work_entry: regeneration of worked days on payslip line

When we have a calendar (e.g., 40h/week), it shows the attendance line when you create the payslip (22 days/march) Then, try to update the calendar, add saturday and sunday's as well and create the payslip again (there are two difference attendance lines, 9 days for weekends and 22 days for previous one)

The purpose is combining both in the single attendance payslip line.

The problem was in function _get_interval_work_entry_type, it was checking whether the resource.calendar.attendance has work entry type or not. Normally the default calendar's attendance's do not have it. But when we add Saturday-Sunday or affect the calendar the function "_compute_work_entry_type_id" is triggered and it assigns the default work entry type for that company.

As a solution, if it has not work entry type yet, then I'm calling that "_compute_work_entry_type_id" function to assign the default work entry type for unassigned days as well.

Finally, their work entry types are all same and thus there is one attendance payslip line in the Worked days.

task - 6051499

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
