### PR TITLE
[FIX] stock: restrict reference field to readonly, not writable by users

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -82,7 +82,7 @@ class StockMoveLine(models.Model):
     is_locked = fields.Boolean(related='move_id.is_locked', readonly=True)
     consume_line_ids = fields.Many2many('stock.move.line', 'stock_move_line_consume_rel', 'consume_line_id', 'produce_line_id')
     produce_line_ids = fields.Many2many('stock.move.line', 'stock_move_line_consume_rel', 'produce_line_id', 'consume_line_id')
-    reference = fields.Char(related='move_id.reference', readonly=False)
+    reference = fields.Char(related='move_id.reference')
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     origin = fields.Char(related='move_id.origin', string='Source')
     description_picking = fields.Text(string="Description picking")


### PR DESCRIPTION
### Issue before this commit:
Before this commit, the Reference field displayed on stock.move.line was editable in the user interface, even if the modification made by the user was not persisted. After saving and reloading the Move History view, the original value was restored.

### Steps to reproduce the issue:
1. Go to Move history in Inventory app
2. Try to change the name of a line and save
3. If you go back to the Move history you can see that the name is not changed

### Cause of the issue:
The issue was caused by a mismatch between the stock.move.line.reference field and its target field stock.move.reference. The field on stock.move.line is a related field that appears editable (readonly=False), but the underlying stock.move.reference field was not writable. As a result, user could edit the field but the modifications were ignored, preventing changes from being effectively saved.

### Reason to introduce the fix:
The fix ensures that the reference field in stock.move and in stock.move.line are readonly.

opw-6055708

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
