### PR TITLE
[FIX] project: correct dependency

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -14,6 +14,7 @@
         'mail',
         'portal',
         'rating',
+        'portal_rating',
         'resource',
         'web',
         'web_tour',


### PR DESCRIPTION
The `project` module's `rating_rating_views.xml` references the `publisher_comment` field (defined by `portal_rating`) via xpath. Since `project` already depends on `portal` and `rating` (`portal_rating`'s own dependencies), declaring `portal_rating` explicitly just makes the implicit dependency explicit and ensures correct load order.

```yml
2026-03-27 21:26:26,093 2235 INFO odoo odoo.modules.loading: Loading module project (47/79) 
2026-03-27 21:26:26,197 2235 INFO odoo odoo.registry: module project: creating or updating database tables 
2026-03-27 21:26:27,601 2235 INFO odoo odoo.modules.loading: loading project/security/project_security.xml 
2026-03-27 21:26:27,820 2235 INFO odoo odoo.modules.loading: loading project/security/ir.model.access.csv 
2026-03-27 21:26:27,859 2235 INFO odoo odoo.modules.loading: loading project/security/ir.model.access.xml 
2026-03-27 21:26:27,864 2235 INFO odoo odoo.modules.loading: loading project/data/digest_data.xml 
2026-03-27 21:26:27,877 2235 INFO odoo odoo.modules.loading: loading project/report/project_task_burndown_chart_report_views.xml 
2026-03-27 21:26:27,898 2235 INFO odoo odoo.modules.loading: loading project/views/account_analytic_account_views.xml 
2026-03-27 21:26:27,929 2235 INFO odoo odoo.modules.loading: loading project/views/digest_digest_views.xml 
2026-03-27 21:26:27,947 2235 INFO odoo odoo.modules.loading: loading project/views/rating_rating_views.xml 
2026-03-27 21:26:27,983 2235 WARNING odoo odoo.modules.loading: Transient module states were reset 
2026-03-27 21:26:27,986 2235 ERROR odoo odoo.registry: Failed to load registry 
2026-03-27 21:26:27,986 2235 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1544, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
  File "/opt/odoo/odoo/tools/func.py", line 88, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/odoo/orm/registry.py", line 199, in new
    load_modules(
  File "/opt/odoo/odoo/modules/loading.py", line 464, in load_modules
    load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 217, in load_module_graph
    load_data(env, idref, 'init', kind='data', package=package)
  File "/opt/odoo/odoo/modules/loading.py", line 59, in load_data
    convert_file(env, package.name, filename, idref, mode, noupdate=kind == 'demo')
  File "/opt/odoo/odoo/tools/convert.py", line 693, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "/opt/odoo/odoo/tools/convert.py", line 792, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/odoo/tools/convert.py", line 663, in parse
    self._tag_root(de)
  File "/opt/odoo/odoo/tools/convert.py", line 616, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /opt/odoo/addons/project/views/rating_rating_views.xml:22
Error while parsing or validating view:
Element '<xpath expr="//label[@for=&#39;publisher_comment&#39;]">' cannot be located in parent view
View error context:
{'file': '/opt/odoo/addons/project/views/rating_rating_views.xml',
 'line': 1,
 'name': 'rating.rating.form.project',
 'view': ir.ui.view(922,),
 'view.model': 'rating.rating',
 'view.parent': ir.ui.view(594,),
 'xmlid': 'rating_rating_view_form_project'}
2026-03-27 21:26:27,987 2235 INFO odoo odoo.service.server: Initiating shutdown 
```

This PR fixes https://github.com/odoo/odoo/pull/256203. I didn't remove `portal` and `rating` dependencies to avoid possible stable policy issue.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr