### PR TITLE
[FIX] account: include archived accounts in COA code search

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -339,7 +339,7 @@ class AccountAccount(models.Model):
             record.code = record_root.code_store
 
     def _search_code(self, operator, value):
-        return [('id', 'in', self.with_company(self.env.company.root_id).sudo()._search([('code_store', operator, value)]))]
+        return [('id', 'in', self.with_company(self.env.company.root_id).with_context(active_test=False).sudo()._search([('code_store', operator, value)]))]
 
     def _inverse_code(self):
         for record, record_root in zip(self, self.with_company(self.env.company.root_id).sudo()):


### PR DESCRIPTION
The _search_code method used to search code_store without setting active_test=False, so filtering on inactive accounts and then searching by code returned no results. The inner query only matched active records while the outer domain required active=False.

 The same fix has already been applied to sibling methods in this file:                                                                                                             
  - `_search_new_account_code` (#253753)
  - `_constrains_code` (#248559)  

Steps to reproduce:
  1. Open Chart of Accounts
  2. Activate the "Inactive Accounts" filter
  3. Search for an account code that exists among archived accounts                                                                                                             
  4. Expected: matching archived accounts shown
  5. Actual: no results

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
