### PR TITLE
[FIX] core: normalize test setattr checker paths on Windows

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -973,7 +973,7 @@ class TransactionCase(BaseCase):
 
         def metamodel_setattr(model, key, value):
             caller = inspect.currentframe().f_back
-            filename = inspect.getsourcefile(caller)
+            filename = (inspect.getsourcefile(caller) or '').replace('\\', '/')
 
             # special case / fastpath because this does model alterations everywhere
             if filename.endswith('odoo/models.py'):


### PR DESCRIPTION
## Summary
Normalizes the path returned by `inspect.getsourcefile(caller)` in `odoo.tests.common.TransactionCase.setUpClass()` before the existing suffix checks are evaluated.

## Problem
The `MetaModel.__setattr__` test checker added in 18.0 compares `filename.endswith(...)` against slash-based suffixes such as `odoo/models.py` and entries in `SETATTR_SOURCES`.

On Windows, `inspect.getsourcefile()` returns backslash-separated paths, so legitimate internal calls can miss those allowlist checks and produce noisy false-positive logging during tests and cleanup.

## Fix
Normalize the inspected path once with:

```python
filename = (inspect.getsourcefile(caller) or '').replace('\\', '/')
```

This keeps the existing logic unchanged while making the suffix checks platform-neutral.

## Validation
- Reproduced the noisy Windows behavior locally on 18.0.
- Verified the one-line patch removes the false-positive teardown logging in local test runs.
- Syntax-checked the modified file with `py -3.12 -m py_compile odoo/tests/common.py`.
