### PR TITLE
[CLA] add individual CLA for RieveFireProt

### DIFF
--- a/doc/cla/individual/rievefireprot.md
+++ b/doc/cla/individual/rievefireprot.md
@@ -1,0 +1,11 @@
+United States, 2026-03-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Eric Rieve eric@rievefire.com https://github.com/RieveFireProt


### PR DESCRIPTION
Adds the individual contributor license agreement signature file for GitHub user `RieveFireProt` as described in Odoo's CLA contribution process.

Contributor details:
- Name: Eric Rieve
- Email: eric@rievefire.com
- GitHub: https://github.com/RieveFireProt
