### PR TITLE
[FIX] spreadsheet_account: support company_id in ODOO.ACCOUNT.GROUP

### DIFF
--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -195,3 +195,31 @@ class AccountMove(models.Model):
         )
         mapped = dict(data)
         return [mapped.get(account_type, []) for account_type in account_types]
+
+    @api.model
+    def get_account_group_for_company(self, args_list):
+        """Like get_account_group but accepts a company_id parameter.
+
+        Used by ODOO.ACCOUNT.GROUP(type, company_id) to resolve account
+        codes for a specific company in multi-company spreadsheets.
+
+        The input list looks like this::
+
+            [{"account_type": "income", "company_id": 2}, ...]
+        """
+        results = []
+        for args in args_list:
+            account_type = args["account_type"]
+            company_id = args.get("company_id") or self.env.company.id
+            company = self.env["res.company"].browse(company_id)
+            data = self.with_company(company)._read_group(
+                [
+                    *self._check_company_domain(company),
+                    ("account_type", "in", [account_type]),
+                ],
+                ['account_type'],
+                ['code:array_agg'],
+            )
+            mapped = dict(data)
+            results.append(mapped.get(account_type, []))
+        return results

--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -350,11 +350,13 @@ functionRegistry.add("ODOO.ACCOUNT.GROUP", {
             "type (string)",
             _t("The technical account type (possible values are: %s).", ACCOUNT_TYPES.join(", "))
         ),
+        COMPANY_ARG,
     ],
     category: "Odoo",
     returns: ["NUMBER"],
-    compute: function (accountType) {
-        const accountTypes = this.getters.getAccountGroupCodes(toString(accountType));
+    compute: function (accountType, companyId = { value: null }) {
+        const _companyId = companyId?.value;
+        const accountTypes = this.getters.getAccountGroupCodes(toString(accountType), _companyId);
         return accountTypes.join(",");
     },
 });

--- a/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
+++ b/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
@@ -88,9 +88,20 @@ export class AccountingPlugin extends OdooUIPlugin {
 
     /**
      * @param {string} accountType
+     * @param {number | null} companyId specific company to target
      * @returns {string[]}
      */
-    getAccountGroupCodes(accountType) {
+    getAccountGroupCodes(accountType, companyId = null) {
+        if (companyId) {
+            // When targeting a specific company, use a separate fetch since
+            // the default batch system flattens args and cannot distinguish
+            // per-company requests.
+            return this.serverData.batch.get(
+                "account.account",
+                "get_account_group_for_company",
+                { account_type: accountType, company_id: companyId }
+            );
+        }
         return this.serverData.batch.get("account.account", "get_account_group", accountType);
     }
 


### PR DESCRIPTION
## Description

In multi-company environments, `ODOO.ACCOUNT.GROUP()` returns account codes for the **current user's company** only (`self.env.company`). When combined with `ODOO.BALANCE`'s `company_id` parameter, the resolved codes may not match the target company's chart of accounts.

This is because Odoo 18 stores per-company account codes in `code_store` (jsonb), so company 1's income codes (e.g., `"410301"`) differ from company 2's (e.g., `"47900"`).

### Example of the bug

```
=ODOO.BALANCE(ODOO.ACCOUNT.GROUP("income"), "2025", 0, 2)
```

1. `ODOO.ACCOUNT.GROUP("income")` resolves using company 1's codes → `"410301,410302"`
2. `ODOO.BALANCE("410301,410302", "2025", 0, 2)` searches company 2 for `410301%` → **no match** → returns `$0.00`

### Fix

Add an optional `company_id` parameter to `ODOO.ACCOUNT.GROUP`:

```
=ODOO.BALANCE(ODOO.ACCOUNT.GROUP("income", 2), "2025", 0, 2)
```

Now `ODOO.ACCOUNT.GROUP("income", 2)` resolves company 2's income codes → `"47900"` → correct result.

### Implementation

- **Python**: New `get_account_group_for_company()` method using the `args_list` pattern (compatible with the spreadsheet batch RPC system). The original `get_account_group()` is unchanged.
- **JS function**: `ODOO.ACCOUNT.GROUP` gains optional `company_id` arg (reuses existing `COMPANY_ARG`)
- **JS plugin**: Routes company-specific requests to the new endpoint; default batch path unchanged for the common case

### Backward compatibility

Fully backward compatible — existing formulas without `company_id` continue to work unchanged using `env.company`. The new parameter is optional.

### Testing

Tested on a multi-company Odoo 18 CE instance with 4 companies, each with different chart of accounts codes. Spreadsheet with `ODOO.BALANCE(ODOO.ACCOUNT.GROUP("income", N), ...)` formulas resolves correctly for all companies.