### PR TITLE
[FIX] account: include all expense/income types in account name_search

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -822,8 +822,8 @@ class AccountAccount(models.Model):
             domain = Domain.AND([search_domain, domain])
         else:
             move_type_accounts = {
-                'out': ['income'],
-                'in': ['expense', 'asset_fixed'],
+                'out': ['income', 'income_other'],
+                'in': ['expense', 'expense_direct_cost', 'expense_depreciation', 'expense_other', 'asset_fixed'],
             }
             allowed_account_types = move_type_accounts.get(move_type.split('_')[0])
             type_domain = [('account_type', 'in', allowed_account_types)] if allowed_account_types else []


### PR DESCRIPTION
When searching accounts by name on invoices/bills, the name_search method filters by account_type to show relevant accounts. However, the type lists were incomplete. Vendor bills only matched 'expense' and 'asset_fixed', excluding valid types like 'expense_direct_cost' (Cost of Revenue), 'expense_depreciation', and 'expense_other'. Similarly, customer invoices excluded 'income_other'.

This caused accounts of those types to not appear when searching by name, while searching by code (which bypasses the type filter) worked fine.

## Steps to reproduce

   1. Create a Vendor Bill
   2. On a bill line, click the Account field
   3. Search for an account name that has type "Cost of Revenue" (e.g. `expense_direct_cost`)
   4. Odoo suggests creating a new account instead of finding the existing one
   5. Search for the same account by its code: it appears correctly


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
