### PR TITLE
[REV] project: remove duplicate 'Comment' field in customer rating form

### DIFF
--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -51,12 +51,6 @@
             <field name="feedback" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
-            <xpath expr="//label[@for='publisher_comment']" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </xpath>
-            <xpath expr="//field[@name='publisher_comment']/parent::div" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </xpath>
             <field name="rated_on" position="after">
                 <field name="partner_id" position="move"/>
             </field>


### PR DESCRIPTION
This reverts commit 1f762031d8afdb0dcf019205c3b60bba6ab8279c because the publisher_comment field in `rating.rating` model is defined in `portal_rating` module and that module is not in the dependencies of project module.

task-5359052
