### PR TITLE
[FIX] mrp_account: fix rounding in manufacturing cost calculation

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -95,7 +95,7 @@ class MrpProduction(models.Model):
                 work_center_cost += work_order._cal_cost(times=time_lines)
                 time_lines.write({'cost_already_recorded': True})
             qty_done = finished_move.product_uom._compute_quantity(
-                finished_move.quantity_done, finished_move.product_id.uom_id)
+                finished_move.quantity_done, finished_move.product_id.uom_id, rounding_method='HALF-UP')
             extra_cost = self.extra_cost * qty_done
             total_cost = - sum(consumed_moves.sudo().stock_valuation_layer_ids.mapped('value')) + work_center_cost + extra_cost
             byproduct_moves = self.move_byproduct_ids.filtered(lambda m: m.state not in ('done', 'cancel') and m.quantity_done > 0)


### PR DESCRIPTION
**Impacted versions:**
16.0

**Steps to reproduce:**
- Create a Manufacturing Order (MO) with raw materials
- Produce a quantity that results in floating-point precision issues (e.g., quantities with many decimal places)
- Confirm and validate the MO
- Check the stock valuation layers for raw materials and finished products

**Current behavior:**
The `qty_done` calculation in `_cal_price()` does not specify a rounding method, causing floating-point precision errors. The finished product's stock valuation may not exactly match the total manufacturing cost (raw materials + work center + extra costs), resulting in unbalanced journal entries.

**Expected behavior:**
The `qty_done` should use `HALF-UP` rounding method, consistent with how the parent module handles quantity_done in `_post_inventory()` (mrp/models/mrp_production.py:1587). This ensures the finished product valuation exactly equals the total manufacturing cost, keeping journal entries balanced.

**Attachment**
- (Image 1) is sample uom that will produce floating-point
- (Image 2) is sample manufcaturing that produced
- (Image 3) is result journal with different valuation amount
<img width="1280" height="745" alt="(Image 1) Screenshot 2026-03-30 at 10 13 16" src="https://github.com/user-attachments/assets/26b4ae5f-2e11-4129-b27e-5019efd0298c" />
<img width="1286" height="778" alt="(Image 2) Screenshot 2026-03-30 at 10 14 43" src="https://github.com/user-attachments/assets/adcb8b13-228a-40bd-bf50-bc778e0a39e5" />
<img width="1288" height="576" alt="(Image 3) Screenshot 2026-03-30 at 10 15 24" src="https://github.com/user-attachments/assets/9796ec02-df4a-4ff9-933b-7765b1b73dd1" />

----------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
