### PR TITLE
[IMP] project, hr_timesheet_attendance:  Hide reporting menus from non-admins

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -85,6 +85,7 @@
         <menuitem id="menu_hr_timesheet_attendance_report"
                   parent="hr_timesheet.menu_timesheets_reports"
                   action="action_hr_timesheet_attendance_report"
-                  name="Timesheets / Attendance Analysis"/>
+                  name="Timesheets / Attendance Analysis"
+                  groups="hr_timesheet.group_timesheet_manager"/>
     </data>
 </odoo>

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -13,13 +13,6 @@
         <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]"/>
     </record>
 
-    <record id="hr_timesheet_attendance_report_rule_approver" model="ir.rule">
-        <field name="name">Timesheet attendance Report: Approver</field>
-        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
-    </record>
-
     <record id="hr_timesheet_attendance_report_rule_manager" model="ir.rule">
         <field name="name">Timesheet attendance Report: Administrator</field>
         <field name="model_id" ref="model_hr_timesheet_attendance_report"/>

--- a/addons/hr_timesheet_attendance/security/ir.model.access.csv
+++ b/addons/hr_timesheet_attendance/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_hr_timesheet_attendance_report,access_hr_timesheet_attendance_report,model_hr_timesheet_attendance_report,hr_timesheet.group_hr_timesheet_user,1,0,0,0
+access_hr_timesheet_attendance_report,access_hr_timesheet_attendance_report,model_hr_timesheet_attendance_report,hr_timesheet.group_timesheet_manager,1,0,0,0

--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -9,8 +9,6 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if not self.env.user.has_group('project.group_project_manager'):
-            res.append(self.env.ref('project.rating_rating_menu_project').id)
         if self.env.user.has_group('project.group_project_stages'):
             res.append(self.env.ref('project.menu_projects').id)
             res.append(self.env.ref('project.menu_projects_config').id)

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -9,7 +9,6 @@ access_project_task_type_manager,project.task.type manager,model_project_task_ty
 access_project_task_type_portal,task_type_portal,project.model_project_task_type,base.group_portal,1,0,0,0
 access_project_task,project.task,model_project_task,project.group_project_user,1,1,1,1
 access_report_project_task_user,report.project.task.user,model_report_project_task_user,project.group_project_manager,1,0,0,0
-access_report_project_task_user_project_user,report.project.task.user.project.user,model_report_project_task_user,project.group_project_user,1,0,0,0
 access_partner_task_user,base.res.partner user,base.model_res_partner,project.group_project_user,1,0,0,0
 access_task_on_partner,project.task on partners,model_project_task,base.group_user,1,0,0,0
 access_task_portal,task_portal,project.model_project_task,base.group_portal,1,0,0,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -255,21 +255,6 @@
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
 
-    <record model="ir.rule" id="report_project_task_user_rule">
-        <field name="name">Tasks Analysis: project visibility User</field>
-        <field name="model_id" ref="model_report_project_task_user"/>
-        <field name="domain_force">[
-        '|',
-            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
-            '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                '|',
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('user_ids', 'in', user.id),
-        ]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
-    </record>
-
     <record model="ir.rule" id="report_project_task_manager_rule">
         <field name="name">Tasks Analysis: project visibility Manager</field>
         <field name="model_id" ref="model_report_project_task_user"/>

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -42,6 +42,7 @@
             name="Reporting"
             id="menu_project_report"
             sequence="99"
+            groups="project.group_project_manager"
         >
             <menuitem
                 name="Tasks Analysis"

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -476,7 +476,7 @@
                                         <h5 role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_user">
                                             <span>Reporting</span>
                                         </h5>
-                                        <div class="d-inline-block" role="menuitem" groups="project.group_project_user" name="task_analysis">
+                                        <div class="d-inline-block" role="menuitem" groups="project.group_project_manager" name="task_analysis">
                                             <a name="action_view_tasks_analysis" type="object">Tasks Analysis</a>
                                         </div>
                                         <div class="d-inline-block" role="menuitem" name="project_burndown_menu" groups="project.group_project_user">


### PR DESCRIPTION
Before this commit:
Currently, the `Tasks Analysis` report from the project module, and the
`Timesheets / Attendance Analysis` report (which becomes available in timesheets
after installing the hr_timesheet_attendance module) are accessible to non-admin
users. To manage data privacy and ensure users only see their own data, custom
Python overrides (like _load_menus_blacklist) and complex record rules (ir.rule)
were maintained to filter these reports.

After this commit:
project: Hide the parent `Reporting` menu directly by restricting it to the
`group_project_manager` group, since the `Tasks Analysis` report is its only
sub-menu item. Removed the custom `_load_menus_blacklist` Python override
and the obsolete `ir.rule` data filters in project_security.xml. Revoked base
read access in the `ir.model.access.csv` file for standard users to prevent
direct access via URL.

hr_timesheet_attendance: Explicitly restricted the
`Timesheets / Attendance Analysis` menu to the `group_timesheet_manager`group.
Removed the dead security filter rules in
`hr_timesheet_attendance_report_security.xml`. Updated the `ir.model.access.csv`
file to revoke read access from standard users, preventing access via direct URL
.

task-5119293