### PR TITLE
[FIX] html_builder: ensure correct gradient preview in color picker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -177,13 +177,7 @@ export class BuilderColorPicker extends Component {
         }
         if (this.state.selectedColorCombination) {
             const colorCombination = this.state.selectedColorCombination.replace("_", "-");
-            const el = this.env.getEditingElement();
-            const style = el.ownerDocument.defaultView.getComputedStyle(el);
-            if (style.backgroundImage !== "none") {
-                return `background-image: ${style.backgroundImage}`;
-            } else {
-                return `background-color: var(--${colorCombination}-bg)`;
-            }
+            return `background-color: var(--hb-cp-${colorCombination}-bg); background-image: var(--hb-cp-${colorCombination}-bg-gradient);`;
         }
         return "";
     }

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -260,3 +260,33 @@ test("should open the last used tab", async () => {
     await contains(".we-bg-options-container .o_we_color_preview").click();
     expect(".theme-tab.active").toHaveCount(1);
 });
+
+test("should apply theme and update preview using CSS variables", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue() {
+                return "";
+            }
+            apply({ editingElement, value }) {
+                editingElement.classList.add("o_cc", value);
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderColorPicker action="'customAction'" defaultColor="''"/>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+
+    await contains(":iframe .test-options-target").click();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await contains(".o-overlay-item [data-color='o_cc1']").click();
+    expect(":iframe .test-options-target").toHaveClass("o_cc o_cc1");
+    expect(".we-bg-options-container .o_we_color_preview").toHaveAttribute(
+        "style",
+        "background-color: var(--hb-cp-o-cc1-bg); background-image: var(--hb-cp-o-cc1-bg-gradient);"
+    );
+});


### PR DESCRIPTION
### Issue:
Color picker preview not showing correctly when a theme with a
gradient background is applied to the header.

### Steps to reproduce:
1. Go to the Theme tab and open the color presets dropdown.
2. Select any preset and set its background to a gradient.
3. Apply this theme to the header.

### Reason:
- The color picker preview relies on `getComputedStyle` of the current
  editing element to determine what background to show.
- For the header, the targeted editing element is `#wrapwrap > header`,
  but the actual gradient styles are applied to its inner `<nav>`
  elements (e.g., via `customizeWebsiteColorAction`).
- Since the `background-image` property is never applied directly to the
  header element itself, computing its style does not capture the 
  gradient defined on its inner elements, resulting in an incorrect or
  missing preview.

### Fix:
- Avoid depending strictly on the computed style of the main editing
  element for generating the preview.
- Ensure the preview accurately reflects the applied styles by utilizing
  CSS variables, even when certain builder actions apply those styles to
  inner elements rather than the primary targeted element, as
  demonstrated in the header example with `customizeWebsiteColorAction`.
  
task-[6075788](https://www.odoo.com/odoo/project/974/tasks/6075788)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
