### PR TITLE
[FIX] sale_management: align section behavior between sale order and templates

### DIFF
--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -284,8 +284,10 @@ patch(SaleOrderLineListRenderer.prototype, {
             super.resetOnResequence(record, parentSection)
             || (
                 this.isSubSection(record)
-                && parentSection?.data.is_optional
                 && (
+                    parentSection?.data.is_optional
+                    || parentSection?.data.collapse_composition
+                ) && (
                     record.data.collapse_composition
                     || record.data.collapse_prices
                     || record.data.is_optional

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
@@ -16,8 +16,32 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
         this.copyFields.push('is_optional');
     }
 
+    /**
+     * Disable "Hide Composition" and "Hide Prices" buttons for optional sections and their
+     * subsections.
+     */
+    get disableCompositionButton() {
+        return (
+            super.disableCompositionButton || this.shouldCollapse(this.record, "is_optional", true)
+        );
+    }
+
+    get disablePricesButton() {
+        return super.disablePricesButton || this.shouldCollapse(this.record, "is_optional", true);
+    }
+
+    /**
+     * Disable "Set Optional" button if
+     *  - Parent section is optional
+     *  - Parent section hides prices or composition
+     *  - Section itself hides prices or composition
+     */
     get disableOptionalButton() {
-        return this.shouldCollapse(this.record, 'is_optional');
+        return (
+            this.shouldCollapse(this.record, "is_optional")
+            || this.shouldCollapse(this.record, "collapse_prices", true)
+            || this.shouldCollapse(this.record, "collapse_composition", true)
+        );
     }
 
     get isCurrentSectionOptional() {
@@ -70,6 +94,37 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
         return rowClasses;
     }
 
+    /**
+     * @override
+     * This override resets optional state of subsections when their parent sections is collapsed
+     */
+    async toggleCollapse(record, fieldName) {
+        await super.toggleCollapse(record, fieldName);
+
+        if (this.isTopSection(record) && record.data[fieldName]) {
+            const commands = [];
+
+            for (const sectionRecord of getSectionRecords(this.props.list, record)) {
+                if (this.isSubSection(sectionRecord)) {
+                    commands.push(
+                        x2ManyCommands.update(sectionRecord.resId || sectionRecord._virtualId, {
+                            is_optional: false,
+                        })
+                    );
+                }
+            }
+
+            if (commands.length) {
+                await this.props.list.applyCommands(commands, { sort: true });
+            }
+        }
+    }
+
+    /**
+     * Toggles optional state on a section:
+     * - Product lines → qty = 0 when set optional, reset to 1 when unset.
+     * - Subsections → force hide composition/prices to false.
+     */
     async toggleIsOptional(record) {
         const setOptional = !record.data.is_optional;
 
@@ -84,6 +139,11 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
                 changes = setOptional
                     ? { product_uom_qty: 0 }
                     : { product_uom_qty: sectionRecord.data.product_uom_qty || 1 };
+            } else if (this.isSubSection(sectionRecord)) {
+                changes = setOptional && {
+                    collapse_composition: false,
+                    collapse_prices: false,
+                };
             }
 
             if (Object.keys(changes).length) {
@@ -212,6 +272,31 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
         await this.props.list.applyCommands(commands, { sort: true });
     }
 
+    /**
+     * @override
+     * Reset fields when a subsection is moved under an optional section,
+     * since optional sections cannot contain hidden subsections or hidden prices.
+     */
+    resetOnResequence(record, parentSection) {
+        return (
+            super.resetOnResequence(record, parentSection)
+            || (
+                this.isSubSection(record)
+                && (
+                    parentSection?.data.is_optional
+                    || parentSection?.data.collapse_composition
+                ) && (
+                    record.data.collapse_composition
+                    || record.data.collapse_prices
+                    || record.data.is_optional
+                )
+            )
+        );
+    }
+
+    fieldsToReset() {
+        return { ...super.fieldsToReset(), is_optional: false };
+    }
 }
 export class SaleOrderTemplateLineOne2Many extends SectionAndNoteFieldOne2Many {
     static components = {

--- a/addons/sale_management/static/tests/sale_order_line_field.test.js
+++ b/addons/sale_management/static/tests/sale_order_line_field.test.js
@@ -379,3 +379,33 @@ test("Moving Optional Sections to exclude some lines should set quantity to 1", 
     await clickSave();
     await expect.verifySteps(['web_save']);
 })
+
+test("Drag and drop optional subsection under hidden section resets its optional state", async () => {
+    SaleOrderLine._records[7].is_optional = true;
+
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+
+        expect(args[1].order_line.find((commands) => commands[1] === 8)[2].is_optional).toBe(
+            false,
+            {
+                message: "is_optional should reset to false for subsection Sec3-sub1",
+            }
+        );
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_data_row .o_list_text")).toEqual(EXPECTED_LINE_RECORDS);
+
+    await contains(".o_data_row:contains(Sec3-sub1):first .o_row_handle").dragAndDrop(
+        ".o_data_row:contains(Sec3):first"
+    );
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});

--- a/addons/sale_management/static/tests/sale_order_template_line_field.test.js
+++ b/addons/sale_management/static/tests/sale_order_template_line_field.test.js
@@ -24,6 +24,7 @@ class SaleOrderTemplateLine extends models.ServerModel {
             sequence: 3,
             display_type: 'line_section',
             product_uom_qty: 0,
+            collapse_prices: true,
         },
         {
             id: 4,
@@ -31,6 +32,7 @@ class SaleOrderTemplateLine extends models.ServerModel {
             sequence: 4,
             display_type: 'line_section',
             product_uom_qty: 0,
+            collapse_composition: true,
         },
         {
             id: 5,
@@ -71,6 +73,8 @@ class SaleOrderTemplateLine extends models.ServerModel {
             sequence: 14,
             display_type: 'line_subsection',
             product_uom_qty: 0,
+            collapse_composition: true,
+            collapse_prices: true,
         },
         { id: 15, name: "Sec4-sub1-r1", sequence: 15 },
     ];
@@ -91,7 +95,7 @@ class SaleOrderTemplate extends models.ServerModel {
                 <field
                     name="sale_order_template_line_ids"
                     widget="so_template_line_o2m"
-                    options="{'subsections': True}"
+                    options="{'subsections': True, 'hide_prices': True, 'hide_composition': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -104,6 +108,8 @@ class SaleOrderTemplate extends models.ServerModel {
                         <field name="product_uom_qty"/>
                         <field name="display_type" column_invisible="1"/>
                         <field name="is_optional" column_invisible="1"/>
+                        <field name="collapse_prices" column_invisible="1"/>
+                        <field name="collapse_composition" column_invisible="1"/>
                     </list>
                 </field>
             </form>
@@ -270,3 +276,152 @@ test("Moving Optional Sections to exclude some template lines should set quantit
     await clickSave();
     await expect.verifySteps(['web_save']);
 })
+
+test("Can't mark section hidden if optional and vice versa", async () => {
+    await mountView({
+        type: "form",
+        resModel: "sale.order.template",
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_data_row .o_list_text")).toEqual(EXPECTED_LINE_RECORDS);
+
+    await contains(".o_data_row:contains(Sec1) .o_list_section_options button").click();
+    expect(".o-dropdown-item:contains(Set Optional)").toHaveClass("disabled", {
+        message: "Section with hidden prices can't be optional",
+    });
+
+    await contains(".o_data_row:contains(Sec2) .o_list_section_options button").click();
+    expect(".o-dropdown-item:contains(Set Optional)").toHaveClass("disabled", {
+        message: "Hidden section can't be optional",
+    });
+});
+
+test("Setting section optional should reset some fields", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+        expect(args[1]).toEqual(
+            {
+                sale_order_template_line_ids: [
+                    [1, 10, { collapse_composition: false, collapse_prices: false }],
+                    [1, 8, { collapse_composition: false, collapse_prices: false }],
+                    [1, 5, { is_optional: true }],
+                    [1, 6, { product_uom_qty: 0 }],
+                    [1, 7, { product_uom_qty: 0 }],
+                    [1, 9, { product_uom_qty: 0 }],
+                    [1, 11, { product_uom_qty: 0 }],
+                ],
+            },
+            {
+                message:
+                    "Subsections reset collapse_* fields' value and product lines reset qty/price when section becomes optional",
+            }
+        );
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "sale.order.template",
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_data_row .o_list_text")).toEqual(EXPECTED_LINE_RECORDS);
+
+    await contains(".o_data_row:contains(Sec3-sub2) .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Hide Composition)").click();
+
+    await contains(".o_data_row:contains(Sec3-sub1) .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Hide Prices)").click();
+
+    await contains(".o_data_row:contains(Sec3) .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Set Optional)").click();
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});
+
+test("Unsetting optional section should reset some fields", async () => {
+    SaleOrderTemplateLine._records.find((record) => record.name === "Sec3").is_optional = true;
+    SaleOrderTemplateLine._records.find((record) => record.name === "Sec3-r1").product_uom_qty = 0;
+    SaleOrderTemplateLine._records.find((record) => record.name === "Sec3-r2").product_uom_qty = 0;
+    SaleOrderTemplateLine._records.find(
+        (record) => record.name === "Sec3-sub1-r1"
+    ).product_uom_qty = 0;
+    // This line should not be reset
+    SaleOrderTemplateLine._records.find(
+        (record) => record.name === "Sec3-sub2-r1"
+    ).product_uom_qty = 5;
+
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+        expect(args[1]).toEqual(
+            {
+                sale_order_template_line_ids: [
+                    [1, 5, { is_optional: false }],
+                    [1, 6, { product_uom_qty: 1 }],
+                    [1, 7, { product_uom_qty: 1 }],
+                    [1, 9, { product_uom_qty: 1 }],
+                    [1, 11, { product_uom_qty: 5 }],
+                ],
+            },
+            {
+                message:
+                    "The subsections should reset products lines with 0 quantity with 1 as soon as section becomes non optional",
+            }
+        );
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "sale.order.template",
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_data_row .o_list_text")).toEqual(EXPECTED_LINE_RECORDS);
+
+    expect(".o_data_row:contains(Sec3-r1)").toHaveClass("text-primary", {
+        message: "Line under optional section should be text-primary",
+    });
+    expect(".o_data_row:contains(Sec3-sub1)").toHaveClass("text-primary", {
+        message: "Subsection under optional section should be text-primary",
+    });
+    expect(".o_data_row:contains(Sec3-sub1-r1)").toHaveClass("text-primary", {
+        message: "Line under subsection(which is under optional section) should be text-primary",
+    });
+
+    await contains(".o_data_row:contains(Sec3) .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Unset Optional)").click();
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});
+
+test("Drag and drop optional subsection under hidden section resets its optional state", async () => {
+    SaleOrderTemplateLine._records[7].is_optional = true;
+
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+
+        expect(
+            args[1].sale_order_template_line_ids.find((commands) => commands[1] === 8)[2]
+                .is_optional
+        ).toBe(false, {
+            message: "is_optional should reset to false for subsection Sec3-sub1",
+        });
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "sale.order.template",
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_data_row .o_list_text")).toEqual(EXPECTED_LINE_RECORDS);
+
+    await contains(".o_data_row:contains(Sec3-sub1):first .o_row_handle").dragAndDrop(
+        ".o_data_row:contains(Sec3):first"
+    );
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});


### PR DESCRIPTION
This commit fixes inconsistencies between section behavior in sale orders and sale order templates.

In sale orders:

* A section cannot be marked as optional if it is hidden, and vice versa.
* Moving an optional subsection into a hidden section resets its optional state.
* Enabling 'hide composition' on a section resets the optional state of its subsections.

These rules were not consistently enforced in sale order templates, leading to mismatched behavior.

This commit aligns template logic with sale order behavior to ensure consistency across both.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
