### PR TITLE
[FIX] hr_holidays: make sure refused time off are striked in calendar

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -17,6 +17,7 @@
                 <field name="name"/>
                 <field name="employee_id" filters="1" invisible="1"/>
                 <field name="is_hatched" invisible="1"/>
+                <field name="is_striked" invisible="1"/>
             </calendar>
         </field>
     </record>


### PR DESCRIPTION
Before this commit, the calendar view in Overview menu does not strike the time off refused. The reason is because `is_strike` field is not fetched inside that view.

This commit adds the field in the view to make sure the time off refused are striked as it is the case in the other menus.

Closes #248868
