### PR TITLE
[FIX] website_sale: fix ecommerce product rating acl check

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -24,7 +24,7 @@
                         </a>
                         <div class="mt-2">
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
                         </div>
@@ -70,7 +70,7 @@
                         <div class="card-text flex-grow-1 text-muted h6" t-field="record.description_sale"/>
                         <div class="mt-2">
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
                         </div>
@@ -120,7 +120,7 @@
                     <div class="o_carousel_product_card_body mt-2 d-flex justify-content-between">
                         <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
                             <t t-set="rating_style_compressed" t-value="true"/>
-                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                            <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                             <t t-set="rating_count" t-value="record.rating_count"/>
                         </t>
                         <div class="ms-auto">
@@ -147,7 +147,7 @@
                     <div class="h6 text-center mt-2 p-2" t-out="data.get('display_name')"/>
                     <div class="text-center">
                         <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                            <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                             <t t-set="rating_count" t-value="record.rating_count"/>
                         </t>
                     </div>
@@ -178,7 +178,7 @@
                             <div class="h6 mb-0">
                                 <t t-if="is_view_active('website_sale.product_comment')">
                                     <t t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </t>
@@ -214,7 +214,7 @@
                         <div class="h6 card-title" t-out="data.get('display_name')"/>
                         <div>
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
                             <div class="mt-2">
@@ -250,7 +250,7 @@
                                 <t t-if="is_view_active('website_sale.product_comment')">
                                     <t t-call="portal_rating.rating_widget_stars_static">
                                         <t t-set="rating_style_compressed" t-value="true"/>
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </t>
@@ -303,7 +303,7 @@
                                         <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                                     </div>
                                     <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </div>
@@ -364,7 +364,7 @@
                             <div>
                                 <div class="mb-1">
                                     <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </div>
@@ -418,7 +418,7 @@
                         <div class="mb-3">
                             <div class="card-title h5" t-out="data.get('display_name')"/>
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                    <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                    <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                     <t t-set="rating_count" t-value="record.rating_count"/>
                                 </t>
                         </div>
@@ -471,7 +471,7 @@
                                         <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                                     </div>
                                     <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_avg" t-value="record.sudo().rating_avg"/>
                                         <t t-set="rating_count" t-value="record.rating_count"/>
                                     </t>
                                 </div>


### PR DESCRIPTION
**Steps to produce:**
- Install the `Ecommerce` module.
- Create a product.
- In the Sales tab, set an alternative product and ensure both are published.
- Open the product page on the website and enable `reviews` from the editor.
- Open the same product page in incognito mode.

**Issue:**
```
AccessError: You do not have enough rights to access the field "rating_avg"
on Product Variant (product.product).
```

Root cause:
---
- Currently, product records in dynamic snippets to be fetched without
  superuser privileges. Since the `rating_avg` field is restricted to
  internal users, public visitors encounter an `AccessError` when
  viewing snippets with ratings enabled.
- Similar approach used [here].

[here]: https://github.com/odoo/odoo/commit/12bb994da4c3222e8c7fb2df95c202a6c45a28b0

opw-6065319
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
