### PR TITLE
[FIX] hr_attendance: write date of undertime correctly

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -307,8 +307,14 @@ class HrAttendanceOvertimeRule(models.Model):
         employee = attendances.employee_id
         company = self.company_id or employee.company_id
         if company.absence_management and float_compare(overtime_amount, -self.employee_tolerance, 5) == -1:
-            last_attendance = sorted(intervals_attendance_by_attendance.keys(), key=lambda att: att.check_out)[-1]
-            return {}, {last_attendance: [(overtime_amount, self)]}
+            undertime_attendance_intervals = sorted(intervals_attendance_by_attendance.items(),
+                                                    # Sorting the attendance-intervals pair by the date of the last interval
+                                                    key=lambda x: x[1]._items[-1][1] if x[1]._items else datetime.min)
+            if not undertime_attendance_intervals:
+                return {}, {}
+
+            last_attendance, last_interval = undertime_attendance_intervals[-1]
+            return {}, {last_attendance: [(overtime_amount, last_interval._items[0][0].date(), self)]}
 
         if float_compare(overtime_amount, self.employer_tolerance, 5) != 1:
             return {}, {}
@@ -706,13 +712,12 @@ class HrAttendanceOvertimeRule(models.Model):
                 _add_overtime_val(attendance, duration_by_day_by_rules)
 
         for employee, intervals_by_attendance in undertimes.items():
-            tz = timezone(employee.sudo()._get_tz())
             for attendance, intervals in intervals_by_attendance.items():
-                date = attendance.check_in.astimezone(tz).date()
                 duration_by_day_by_rules = defaultdict(lambda: defaultdict(float))
-                min_duration_tuple = max(intervals, key=lambda x: x[0])
-                duration, rules = min_duration_tuple
-                duration_by_day_by_rules[date][rules] += duration
+                for undertime, date, rule in intervals:
+                    duration_by_day_by_rules[date][rule] += undertime
+                for date in duration_by_day_by_rules:
+                    duration_by_day_by_rules[date] = dict([max(duration_by_day_by_rules[date].items(), key=lambda x: x[1])])
                 _add_overtime_val(attendance, duration_by_day_by_rules)
         return vals
 

--- a/addons/hr_attendance/tests/test_hr_attendance_undertime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_undertime.py
@@ -555,3 +555,16 @@ class TestHrAttendanceUndertime(HttpCase):
 
         all_overtimes = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id)])
         self.assertEqual(len(all_overtimes), 1, 'There should be only 1 overtime record in total for that employee.')
+
+    def test_undertime_on_multiple_days(self):
+        """ Check that when an attendance spans over multiple days, the correct amount of undertime is computed for each day."""
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2021, 1, 6, 20, 0),
+            'check_out': datetime(2021, 1, 7, 4, 0),
+        })
+
+        overtime = attendance.linked_overtime_ids
+        self.assertEqual(len(overtime), 2, 'There should be 2 overtime records for that attendance.')
+        self.assertEqual(sorted(overtime.mapped('date')), [date(2021, 1, 6), date(2021, 1, 7)], 'The overtime records should be for the correct days.')
+        self.assertEqual(overtime.mapped('duration'), [-4, -4], 'There should be a total of 4 hours of undertime in both days.')


### PR DESCRIPTION
Create an attendance from Tuesday 20h till Wednesday 4am. You will have a single overtime record with -8 set on Tuesday. We want two overtime records, both of -4 hours one for Tuesday and the other for Wednesday.

task-6079675