### PR TITLE
[FIX] html_editor: allow opening links on non-editable icons

### DIFF
--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -111,9 +111,16 @@ export class MediaWebsitePlugin extends Plugin {
     openImageTooltip(mediaEl) {
         // Remove the displayed tooltip if any first.
         this.removeCurrentTooltip();
-        this.removeCurrentTooltip = this.popover.add(mediaEl, Tooltip, {
-            tooltip: _t("Double-click to edit"),
-        });
+        this.removeCurrentTooltip = this.popover.add(
+            mediaEl,
+            Tooltip,
+            {
+                tooltip: _t("Double-click to edit"),
+            },
+            {
+                sequence: 0,
+            }
+        );
         setTimeout(this.removeCurrentTooltip, 3000);
     }
 

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -223,6 +223,9 @@ export class SelectionPlugin extends Plugin {
             if (ev.detail && ev.detail % 3 === 0) {
                 this.onTripleClick(ev);
             }
+            if (!ev.detail || ev.detail === 1) {
+                this.onClick(ev);
+            }
         });
         this.addDomListener(this.editable, "keydown", (ev) => {
             const handled = [
@@ -287,6 +290,12 @@ export class SelectionPlugin extends Plugin {
 
     resetSelection() {
         this.activeSelection = this.makeActiveSelection();
+    }
+
+    onClick(ev) {
+        if (this.delegateTo("click_overrides", ev)) {
+            return;
+        }
     }
 
     onDoubleClick(ev) {

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -14,6 +14,7 @@ import {
     isProtecting,
     isVisible,
     isZwnbsp,
+    isContentEditable,
 } from "@html_editor/utils/dom_info";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { rpc } from "@web/core/network/rpc";
@@ -652,7 +653,9 @@ export class LinkPlugin extends Plugin {
             getAttachmentMetadata: this.getAttachmentMetadata,
             recordInfo: this.config.getRecordInfo?.() || {},
             canEdit:
-                !this.linkInDocument || !this.linkInDocument.classList.contains("o_link_readonly"),
+                (!this.linkInDocument ||
+                    !this.linkInDocument.classList.contains("o_link_readonly")) &&
+                isContentEditable(linkElement),
             canRemove:
                 this.linkInDocument &&
                 this.linkInDocument.parentElement.isContentEditable &&

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -3,8 +3,8 @@ import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
-import { ICON_SELECTOR, isElement } from "@html_editor/utils/dom_info";
-import { isIconElement, isZwnbsp } from "../../utils/dom_info";
+import { ICON_SELECTOR, isElement, isIconElement, isZwnbsp } from "@html_editor/utils/dom_info";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -68,7 +68,8 @@ export class IconPlugin extends Plugin {
                 // FEFF is directly adjacent to it.
                 const isIconRelatedNode = (node) => {
                     if (
-                        node.classList?.contains("fa") ||
+                        (node.classList?.contains("fa") &&
+                            this.dependencies.selection.isNodeEditable(node)) ||
                         node.parentElement?.classList.contains("fa")
                     ) {
                         return true;
@@ -141,7 +142,21 @@ export class IconPlugin extends Plugin {
                 text: _t("Replace"),
             },
         ],
+        click_overrides: this.onClickIcon.bind(this),
     };
+
+    onClickIcon(ev) {
+        const node = ev.target;
+        if (
+            isIconElement(closestElement(node)) &&
+            !this.dependencies.selection.isNodeEditable(node)
+        ) {
+            // We select around an icon inside non editable.
+            // This might, in case icon inside link, show the link
+            // popover to be able to open link.
+            this.dependencies.selection.selectElement(node);
+        }
+    }
 
     getTargetedIcon() {
         const targetedNodes = this.dependencies.selection.getTargetedNodes();

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1994,3 +1994,24 @@ test("Should properly show the preview if fetching metadata fails", async () => 
     await waitFor(".o-we-linkpopover");
     expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="/contactus">a[]b</a></p>');
 });
+
+test("Should should show link popover without edit", async () => {
+    const id = Math.random().toString();
+    onRpc("/html_editor/link_preview_internal", () => Promise.reject(new Error(`No data ${id}`)));
+    const originalConsoleWarn = console.warn.bind(console);
+    patchWithCleanup(console, {
+        warn: (msg, error, ...args) => {
+            if (!error?.message?.includes?.(id)) {
+                originalConsoleWarn(msg, error, ...args);
+            }
+        },
+    });
+    const { el } = await setupEditor(
+        '<p contenteditable="false"><a href="#"><i class="fa"></i></a></p>'
+    );
+    await animationFrame();
+    await click(el.querySelector(".fa"));
+    // Should open the link popover without edit button
+    expectElementCount(".o-we-linkpopover", 1);
+    expectElementCount(".o_we_edit_link", 0);
+});

--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -26,6 +26,7 @@ export class MenuDataPlugin extends Plugin {
                     ),
                 getProps: (props) => ({
                     ...props,
+                    canEdit: props.canEdit || this.isMenuLink(props.linkElement),
                     onClickEditLink: (elem, callback) => {
                         const menuEl = elem.props.linkElement.querySelector("[data-oe-id]");
                         this.services.dialog.add(MenuDialog, {

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -46,6 +46,16 @@ async function testSocialSnippetOptions(snippetName, containerTitle, iconName) {
         ];
     });
 
+    onRpc(`${location.origin}/website/social/facebook`, () => ({
+        title: "title",
+        description: "description",
+    }));
+
+    onRpc(`/html_editor/link_preview_internal`, () => ({
+        title: "title",
+        description: "description",
+    }));
+
     const core = await setupWebsiteBuilderWithSnippet(snippetName, {
         styleContent: `.${snippetName}.no_icon_color a {
             color: inherit !important;


### PR DESCRIPTION
Problem:
When the website editor is enabled and icons inside links are marked as non-editable, it becomes impossible to open those links.

Solution:
Enable the link popover when clicking on non-editable icons inside links so the link can still be accessed.

Steps to reproduce:
- In the website editor, drop a "Social Media" inner snippet anywhere inside the header.
- Click on one of the social media icons.
- Observe that the link popover does not open, making it impossible to test the link.

task-6009319

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
