### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: avoid global discount from root AllowanceCharge

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -979,6 +979,13 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         })
         return partner_vals
 
+    def _import_document_allowance_charges(self, tree, record, tax_type, qty_factor=1):
+        # EXTENDS account.edi.xml.ubl_20
+        # UBL-TR does not use document-level allowance/charge nodes as global discounts.
+        # In practice, the AllowanceCharge found at the document root reflects the sum of
+        # line-level discounts, so importing it as a separate global discount would duplicate it.
+        return [], []
+
     def _import_fill_invoice(self, invoice, tree, qty_factor):
         # EXTENDS account.edi.xml.ubl_20
         logs = super()._import_fill_invoice(invoice, tree, qty_factor)

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -164,3 +164,17 @@ class TestUBLTR(TestUBLTRCommon):
             expected_xml = expected_xml_file.read()
 
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
+
+    def test_import_invoice_basic_sale_einvoice_discounts(self):
+        invoice = self.env["account.move"].create({"move_type": "out_invoice"})
+
+        with file_open("l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_einvoice.xml", "rb") as xml_file:
+            tree = self.get_xml_tree_from_string(xml_file.read())
+
+        self.env["account.edi.xml.ubl.tr"]._import_fill_invoice(invoice, tree, 1)
+
+        product_line = invoice.invoice_line_ids.filtered(lambda l: l.name == 'product_a')[:1]
+        global_discount_line = invoice.invoice_line_ids.filtered(lambda l: l.name == "Discount")[:1]
+
+        self.assertEqual(product_line.discount, 12.0)
+        self.assertFalse(global_discount_line, "Nilvera moves should not have any global discount line")


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Nilvera includes an **AllowanceCharge** node at the document root level in UBL-TR invoices. This node represents the aggregated sum of line-level discounts rather than a true document-level (global) discount.

The current implementation in the generic UBL parser interprets this node as a global discount, which leads to incorrect invoice data.

# Current behavior before PR:
During XML import, the root-level AllowanceCharge node is parsed as a global discount. This results in an additional discount line being created, effectively duplicating the discounts already present at the line level.

# Desired behavior after PR is merged:
The root-level AllowanceCharge node is ignored during import for UBL-TR documents. This prevents the creation of duplicate global discount lines and ensures that only the actual line-level discounts are reflected in the invoice.

## Note
This pr is a refactor of [242603](https://github.com/odoo/odoo/pull/242603) with very limited scope

taskId - 5079559
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
