### PR TITLE
[FIX] web: one2many_field tests: make test more robust

### DIFF
--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -361,7 +361,7 @@ test("one2many in a list x2many editable use the right context", async () => {
     });
 
     await contains(".o_field_x2many_list .o_field_x2many_list_row_add a").click();
-    await contains("[name='trululu'] input").edit("new partner");
+    await contains("[name='trululu'] input").edit("new partner", { confirm: false });
     await selectFieldDropdownItem("trululu", 'Create "new partner"');
 
     expect.verifySteps(["name_create list"]);
@@ -12338,7 +12338,7 @@ test("existing record: receive more create commands than limit", async () => {
         { id: 2, name: "Initial Record 2" },
         { id: 3, name: "Initial Record 3" },
         { id: 4, name: "Initial Record 4" },
-    ]
+    ];
     Partner._onChanges = {
         int_field: function (obj) {
             if (obj.int_field === 16) {


### PR DESCRIPTION
This commit fixes a non deterministic one2many field test by ensuring that we don't quick create the record twice.

Before this commit, it might sometimes happen that the validation of the input ("Enter", by default) produced a second name_create. Note that in practice this is highly unlikely to happen as if the user presses Enter, the "Quick create" item in the dropdown only appears during a single frame, thus making impossible for the user to click on it.

runbot error~242204

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
