### PR TITLE
[IMP] hr: only one company possible per job position

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -78,7 +78,6 @@
         <!-- Jobs -->
         <record id="job_cto" model="hr.job">
             <field name="name">Chief Technical Officer</field>
-            <field name="company_id" eval="False"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="description">You will take part in the consulting services we provide to our partners and customers: design, analysis, development, testing, project management, support/coaching. You will work autonomously as well as coordinate and supervise small distributed development teams for some projects. Optionally, you will deliver Odoo training sessions to partners and customers (8-10 people/session). You will report to the Head of Professional Services and work closely with all developers and consultants.
 
@@ -105,7 +104,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
 
         <record id="job_consultant" model="hr.job">
             <field name="name">Consultant</field>
-            <field name="company_id" eval="False"/>
             <field name="department_id" ref="dep_ps"/>
             <field name="no_of_recruitment">5</field>
             <field name="employee_type_id" ref="contract_type_interim"/>
@@ -117,7 +115,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
 
         <record id="job_developer" model="hr.job">
             <field name="name">Experienced Developer</field>
-            <field name="company_id" eval="False"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="no_of_recruitment">5</field>
             <field name="employee_type_id" ref="contract_type_employee"/>
@@ -130,7 +127,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
 
         <record id="job_hrm" model="hr.job">
             <field name="name">Human Resources Manager</field>
-            <field name="company_id" eval="False"/>
             <field name="department_id" ref="dep_administration"/>
             <field name="description">
                 A Human Resources (HR) Manager is responsible for overseeing an organization's workforce and ensuring
@@ -146,7 +142,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
 
         <record id="job_marketing" model="hr.job">
             <field name="name">Marketing and Community Manager</field>
-            <field name="company_id" eval="False"/>
             <field name="department_id" ref="dep_sales"/>
             <field name="description">
                 The Marketing Manager defines the mid- to long-term marketing strategy for his covered market segments
@@ -158,7 +153,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
 
         <record id="job_trainee" model="hr.job">
             <field name="name">Trainee</field>
-            <field name="company_id" eval="False"/>
             <field name="description">You participate to the update of our tutorial tools and pre-sales tools after the launch of a new version of Odoo. Indeed, any new version of the software brings significant improvements in terms of functionalities, ergonomics and configuration.
 You will have to become familiar with the existing tools (books, class supports, Odoo presentation’s slides, commercial tools),
 to participate to the update of those tools in order to make them appropriate for the new version of the software and, for sure,

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -41,7 +41,7 @@ class HrJob(models.Model):
             position. The Recruiter is automatically added to all meetings with the Applicant.",
     )
     department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True, index='btree_not_null')
-    company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True)
+    company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True, required=True)
     employee_type_id = fields.Many2one('hr.employee.type', string='Employee Type', tracking=True)
     company_country_code = fields.Char(related='company_id.country_id.code', depends=["company_id.country_id"])
 

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -30,7 +30,7 @@
                                         </div>
                                     </group>
                                     <group name="job" string="Job">
-                                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" placeholder="Visible to all"/>
+                                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                                         <field name="department_id"/>
                                     </group>
                                     <group name="contract" string="Contract">


### PR DESCRIPTION
Purpose
A job position cannot be linked to multiple company. 1 JP = 1 company Specifications
Remove the "Visible to all" possibility On Jon position At creation set the current company
Adapt runbot data: All empty company must be My Company (San Fransisco)

Task-6064945