### PR TITLE
[18.0][FIX] hr_attendance: Add hr.group_hr_user to attendance_manager_id field

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -14,7 +14,7 @@ class HrEmployee(models.Model):
     attendance_manager_id = fields.Many2one(
         'res.users', store=True, readonly=False,
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
-        groups="hr_attendance.group_hr_attendance_officer",
+        groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user",
         help="The user set in Attendance will access the attendance of the employee through the dedicated app and will be able to edit them.")
     attendance_ids = fields.One2many(
         'hr.attendance', 'employee_id', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")


### PR DESCRIPTION
The `attendance_manager_id` field is missing the `hr.group_hr_user` group, causing inconsistency with other fields in the same model such as attendance_ids, last_attendance_id, last_check_in, etc., which already have both `hr_attendance.group_hr_attendance_officer` and `hr.group_hr_user` groups assigned.

This can lead to access errors when the field is accessed by users with` hr.group_hr_user` who don't have `hr_attendance.group_hr_attendance_officer`.

@qrtl QT6380