### PR TITLE
[FIX] l10n_es_edi_sii: include REAGYP amount in CuotaDeducible

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -118,7 +118,7 @@ class AccountEdiFormat(models.Model):
 
             else:
                 # Vendor bills
-                if tax_values['l10n_es_type'] in ('sujeto', 'sujeto_isp', 'no_sujeto', 'no_sujeto_loc', 'dua'):
+                if tax_values['l10n_es_type'] in ('sujeto', 'sujeto_isp', 'no_sujeto', 'no_sujeto_loc', 'dua', 'sujeto_agricultura'):
                     tax_amount_deductible += tax_values['tax_amount']
                 elif tax_values['l10n_es_type'] == 'retencion':
                     tax_amount_retention += tax_values['tax_amount']

--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -1269,7 +1269,7 @@ class TestEdiXmls(TestEsEdiCommon):
                             ]
                         }
                     },
-                    'CuotaDeducible': 0.0
+                    'CuotaDeducible': 24.0
                 },
                 'PeriodoLiquidacion': {'Periodo': '01', 'Ejercicio': '2019'}
             })


### PR DESCRIPTION
Currently, the deducible amount for REAGYP is not passing through to the AEAT. This happens because the REAGYP compensation amount (ImporteCompensacionREAGYP) was missing from the total deductible quota calculation in the SII JSON payload.

To fix this, we add 'sujeto_agricultura' to the list that cheks if the tax value for l10n_es is in the list

task-6072773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
