### PR TITLE
[FIX] iap: show correct balance on save

### DIFF
--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -50,12 +50,8 @@ class IapAccount(models.Model):
                 ))
 
     def web_read(self, *args, **kwargs):
-        if not self.env.context.get('disable_iap_fetch'):
-            self._get_account_information_from_iap()
+        self._get_account_information_from_iap()
         return super().web_read(*args, **kwargs)
-
-    def web_save(self, *args, **kwargs):
-        return super(IapAccount, self.with_context(disable_iap_fetch=True)).web_save(*args, **kwargs)
 
     def write(self, values):
         res = super().write(values)


### PR DESCRIPTION
Before this commit:
When creating an `iap.account`, selecting a service(`service_id`) showed the correct balance.
However, as soon as the record was saved, the balance would reset to 0, and users had to
refresh the page to see the real value.

With this fix, the balance now stays accurate after saving the record.

Task [link](https://www.odoo.com/odoo/project.task/6004546)
task-6004546