### PR TITLE
[FIX] web: allow sorting grouped lists on date/datetime aggregate fields

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -518,10 +518,15 @@ class Base(models.AbstractModel):
                     groupby.remove(group)
                     order_spec.append(f"{group} {direction}")
                     break
-            for agg_spec in aggregates:
-                if agg_spec.startswith(f"{fname}:"):
-                    order_spec.append(f"{agg_spec} {direction}")
-                    break
+            else:
+                for agg_spec in aggregates:
+                    if agg_spec.startswith(f"{fname}:"):
+                        order_spec.append(f"{agg_spec} {direction}")
+                        break
+                else:
+                    field = self._fields.get(fname)
+                    if field and field.aggregator:
+                        order_spec.append(f"{fname}:{field.aggregator} {direction}")
 
         return ", ".join(order_spec + groupby)
 

--- a/odoo/addons/test_read_group/tests/test_web_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_web_read_group.py
@@ -1167,6 +1167,35 @@ class TestWebReadGroup(common.TransactionCase):
             },
         )
 
+    def test_order_field_aggregator_fallback(self):
+        """Ordering by a field not in aggregates should use the field's default aggregator.
+        Ordering with a non-default aggregator in aggregates should use that aggregator."""
+        Model = self.env["test_read_group.aggregate"]
+        Model.create([
+            {"key": 1, "value": 1},
+            {"key": 1, "value": 1},
+            {"key": 1, "value": 1},
+            {"key": 2, "value": 2},
+        ])
+
+        groups = Model.web_read_group(
+            domain=[],
+            groupby=["key"],
+            aggregates=["__count"],
+            order="value",
+        )["groups"]
+
+        self.assertEqual([g["key"] for g in groups], [2, 1])
+
+        groups = Model.web_read_group(
+            domain=[],
+            groupby=["key"],
+            aggregates=["value:max"],
+            order="value",
+        )["groups"]
+
+        self.assertEqual([g["key"] for g in groups], [1, 2])
+
     def test_read_extra_info_groupby_value(self):
         Model = self.env["test_read_group.aggregate"]
         partner_1, partner_2 = self.env["res.partner"].create(


### PR DESCRIPTION
Steps to reproduce
1. Open Accounting > Customers > Invoices and create an invoice with deferred dates.
2. Open the invoice and click the Deferred Entries smart button.
3. In the grouped list view, click the Date column header to sort.
4. Nothing happens.

Issue
The [IMP] web: Grouped kanban/list in a single RPC (https://github.com/odoo-dev/odoo/commit/26c37c9c070107f8bd753cb8a6d8343384fdd7bf) refactor
introduced a regression. _get_read_group_order() [1] iterated over the
provided aggregates list to build the ORDER BY clause. Fields with an
aggregator attribute that are not included in the aggregates list (e.g.
date fields, which getAggregateSpecifications() excludes) were silently
dropped from ORDER BY.

[1] https://github.com/odoo/odoo/blob/26c37c9c070107f8bd753cb8a6d8343384fdd7bf/addons/web/models/models.py#L496-L514

Solution
Add a fallback in _get_read_group_order() so that when fname is neither a
groupby field nor present in the provided aggregates list, the method checks
field.aggregator directly and appends `fname:aggregator direction` (e.g.
`date:min ASC`) to the ORDER BY string. The ORM's _read_group_orderby()
already accepts such specs in ORDER BY even without them being in SELECT.

opw-6044059