### PR TITLE
[IMP] resource: Add ensure_one

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -570,6 +570,8 @@ class ResourceCalendar(models.Model):
         with them so this method merely calculates the proportion that is
         covered by the intervals.
         """
+        if self:
+            self.ensure_one()
         day_hours = defaultdict(float)
         day_days = defaultdict(float)
         for start, stop, _ in attendance_intervals:
@@ -750,6 +752,7 @@ class ResourceCalendar(models.Model):
             Returns a dict {'days': n, 'hours': h} containing the
             quantity of working time expressed as days and as hours.
         """
+        self.ensure_one()
         # naive datetimes are made explicit in UTC
         from_datetime = localized(from_datetime)
         to_datetime = localized(to_datetime)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
These two methods in resource_calendar are not ensure_one : _get_attendance_intervals_days_data and get_work_duration_data but they don't handle multi-records; they return only 1 dictionary and not a dictionary by calendar. If you look to the code you can see that these methods are always used with only one calendar so they should be ensure_one()

Current behavior before PR:

Desired behavior after PR is merged:
. Add ensure_one() for _get_attendance_intervals_days_data() & get_work_duration_data() methods

task-6079899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
