### PR TITLE
[FIX] account_peppol: Fix peppol Invoice period extra field

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -1648,7 +1648,7 @@ class AccountEdiUBL(models.AbstractModel):
         vals['document_node']['cbc:BuyerReference'] = {'_text': None}
 
     def _ubl_add_invoice_period_nodes(self, vals):
-        vals['document_node']['cac:InvoicePeriod'] = []
+        vals['document_node']['cac:InvoicePeriod'] = {}
 
     def _ubl_add_order_reference_node(self, vals):
         vals['document_node']['cac:OrderReference'] = {

--- a/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
+++ b/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
@@ -66,7 +66,7 @@ class AccountEdiXmlPint_Jp(models.AbstractModel):
 
         # [aligned-ibrp-052] An Invoice MUST have an invoice period (ibg-14) or an Invoice line period (ibg-26).
         if invoice and not nodes:
-            nodes.append({
+            nodes.update({
                 'cbc:StartDate': {'_text': invoice.invoice_date},
                 'cbc:EndDate': {'_text': invoice.invoice_date},
             })


### PR DESCRIPTION
When mapping the Invoice period extra field and updating the xml nodes, if the invoice period was originally empty, it would be initialized to an empty list not a dict which was breaking the mapping. 
task-6076624