### PR TITLE
[FIX] hr_holidays: ensure work entry type visibility via country and date context

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -479,9 +479,9 @@ class HrLeave(models.Model):
 
     @api.depends('employee_id', 'request_date_from', 'request_date_to')
     def _compute_work_entry_type_id(self):
-        local_work_entry_types = self.env['hr.work.entry.type'].search([('country_id', 'in', self.employee_id.country_id.ids + [False])])
-        all_valid_work_entry_types = local_work_entry_types.filtered_domain([('has_valid_allocation', '=', True)])
-        no_allocation_required_work_entry_types = local_work_entry_types.filtered_domain([('requires_allocation', '=', False)])
+        local_work_entry_types = self.env['hr.work.entry.type'].with_context(default_date_from=self.request_date_from, default_date_to=self.request_date_to).search([('country_id', 'in', [self.employee_id.country_id.id or self.employee_id.company_id.country_id.id] + [False])])
+        all_valid_work_entry_types = local_work_entry_types.with_context(default_date_from=self.request_date_from, default_date_to=self.request_date_to).filtered_domain([('has_valid_allocation', '=', True)])
+        no_allocation_required_work_entry_types = local_work_entry_types.with_context(default_date_from=self.request_date_from, default_date_to=self.request_date_to).filtered_domain([('requires_allocation', '=', False)])
         for holiday in self:
             if not holiday.work_entry_type_id.requires_allocation:
                 continue

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -271,7 +271,7 @@ class HrWorkEntryType(models.Model):
         target_date = self.env.context.get('leave_date_from') or self.env.context.get('default_date_from')
         data_days = self.get_allocation_data(employee, target_date)[employee]
         for work_entry_type in self:
-            result = [item for item in data_days if item[0] == work_entry_type.name]
+            result = [item for item in data_days if item[3] == work_entry_type.id]
             work_entry_type_tuple = result[0] if result else ('', {})
             work_entry_type.max_leaves = work_entry_type_tuple[1].get('max_leaves', 0)
             work_entry_type.leaves_taken = work_entry_type_tuple[1].get('leaves_taken', 0)


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open Time Off -> Management -> Allocations
2. Create a new  allocation with validity period in the past (Jan 1, 2025 to Dec 31, 2025) and Country(Eg: USA)  and validate it.
3. Open Managements -> Time Off
4. Create a time off with date, say Jan 10, 2025
5. You will not see the allocation type you created earlier

**Bug cause:**
When an employee profile lacked a 'country_id', they were unable to see  country-specific leave types because the search was incorrectly filtering for 'Global' types only.

Additionally, the dropdown was failing to show valid allocations for previous or future years because the compute context was losing the user-selected dates, falling back to 'today' and returning 0 balances.

**Solution:**
- Work entry type searches now fall back to the Company's country if  the Employee's country is not set.
- Explicit date context (default_date_from/to) is passed through filtered_domain to ensure allocations are evaluated for the requested period rather than the current date.
- The '_compute_leaves' logic now matches allocations by record ID instead of name string to avoid choosing generic types when country specific type is available.

**Task:** 6067425
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
