### PR TITLE
[FIX] base: Allow to not raise when creating a document from attachment

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -474,7 +474,7 @@ class IrAttachment(models.Model):
                 if not self.env.is_system():
                     if not res_id and create_uid != self.env.uid:
                         raise AccessError(_("Sorry, you are not allowed to access this document."))
-                    if res_field:
+                    if res_model and res_field:
                         field = self.env[res_model]._fields[res_field]
                         if not field.is_accessible(self.env):
                             raise AccessError(_("Sorry, you are not allowed to access this document."))


### PR DESCRIPTION
Current behavior before PR:

When uploading an UBL file in journal kanban view in accounting **with a non admin user**, an exception raises

Desired behavior after PR is merged:

Allow to upload files in journal kanaban view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
