### PR TITLE
[FIX] mrp: don't delete group when not fully unlinked

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2552,7 +2552,12 @@ class MrpProduction(models.Model):
             production.action_confirm()
 
         self.with_context(skip_activity=True)._action_cancel()
-        self.sudo().production_group_id.unlink()
+        self_sudo = self.sudo()
+        groups = {production.production_group_id for production in self_sudo if production.production_group_id}
+        self_sudo.production_group_id = False
+        for group in groups:
+            if not group.production_ids:
+                group.unlink()
         # set the new deadline of origin moves (stock to pre prod)
         production.move_raw_ids.move_orig_ids.with_context(date_deadline_propagate_ids=set(production.move_raw_ids.ids)).write({'date_deadline': production.date_start})
         for p in self:

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -569,6 +569,37 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(mo.origin, expected_origin)
         self.assertEqual(mo.product_qty, 10)
 
+    def test_split_merge_production_group(self):
+        """ Ensure that splitting and then merging MO's properly unlinks and deletes the production groups.
+        The group should only be deleted when no MO's are associated to it anymore.
+        """
+        mo_1 = self.generate_mo(qty_final=12)[0]
+        mo_2 = mo_1.copy()
+        mo_2.action_confirm()
+        pg_1 = mo_1.production_group_id
+        pg_2 = mo_2.production_group_id
+        # Split into 4
+        action = mo_1.action_split()
+        wizard = Form.from_action(self.env, action)
+        wizard.max_batch_size = 3
+        action = wizard.save().action_split()
+        # Split into 2
+        action = mo_2.action_split()
+        wizard = Form.from_action(self.env, action)
+        wizard.max_batch_size = 6
+        action = wizard.save().action_split()
+
+        (pg_1.production_ids[0] + pg_2.production_ids[0]).action_merge()
+        self.assertEqual(len(pg_1.production_ids), 3)
+        self.assertEqual(len(pg_2.production_ids), 1)
+
+        (pg_1.production_ids[0] + pg_2.production_ids[0]).action_merge()
+        self.assertEqual(len(pg_1.production_ids), 2)
+        self.assertFalse(pg_2.exists())
+
+        (pg_1.production_ids[0] + pg_1.production_ids[1]).action_merge()
+        self.assertFalse(pg_1.exists())
+
     def test_reservation_method_w_mo(self):
         """ Create a MO for 2 units, Produce 1 and create a backorder.
         The MO and the backorder should be assigned according to the reservation method


### PR DESCRIPTION
# How to reproduce
- Create 2 MO's A & B, both having the same product_id & bom_id
- Split MO A into two MO's A1 & A2
- Merge MO's A1 & B

# The issue
MO A2 no longer has a production group (visible via Studio).
If the user tries to partially produce the MO and create a backorder, a traceback popup appears with :

"ValueError: max() iterable argument is empty"

# Cause
The traceback is triggered because we use the `max()` function on `self.production_group_id.production_ids` when creating the backorder, but `production_ids` is an empty recordset since `production_group_id` is also empty.

https://github.com/odoo/odoo/blob/0d8eaeeb971f2f670aebb1b72ed03f4a2d5e0105/addons/mrp/models/mrp_production.py#L1936

The production group is empty because when merging two MO's we delete it without paying attention to other remaining links.

https://github.com/odoo/odoo/blob/394a30f8a2814d460cfe220b5017e7ac95d8cddc/addons/mrp/models/mrp_production.py#L2555

Note : the production groups were introduced by this commit (https://github.com/odoo/odoo/commit/2713876dbc70d3984e584a9037a2206dcda4e84a)

# Proposed solution
When merging, we unlink the original MO's from their production group.
Then, we check every altered production group : if they are not linked to any MO anymore, we delete them.

opw-6055376

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
