### PR TITLE
[IMP] project: show the subtask when showing the task activities

### DIFF
--- a/addons/project/static/src/core/web/activity_menu_patch.js
+++ b/addons/project/static/src/core/web/activity_menu_patch.js
@@ -1,0 +1,15 @@
+import { ActivityMenu } from "@mail/core/web/activity_menu";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ActivityMenu.prototype, {
+    /**
+     * Show the sub-task when clicking on the task activities menu.
+     */
+    async executeActivityAction(group, domain, views, context, newWindow) {
+        if (group.model === "project.task") {
+            context.activity_action = true;
+        }
+        return super.executeActivityAction(...arguments);
+    },
+});

--- a/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.js
+++ b/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.js
@@ -13,7 +13,11 @@ export class ProjectTaskControlPanel extends ControlPanel {
 
     get showTaskOptions() {
         const context = this.env.searchModel.globalContext;
-        return !context.my_tasks && (!('show_task_options' in context) || context.show_task_options);
+        return (
+            !context.my_tasks &&
+            !context.activity_action &&
+            (!("show_task_options" in context) || context.show_task_options)
+        );
     }
 
     get taskOptionsTitle() {

--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -3,8 +3,8 @@ import { Domain } from "@web/core/domain";
 
 export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends T {
     _processSearchDomain(domain) {
-        const { my_tasks, subtask_action } = this.env.searchModel.globalContext;
-        const showSubtasks = my_tasks || subtask_action || JSON.parse(browser.localStorage.getItem("showSubtasks"));
+        const { my_tasks, subtask_action, activity_action } = this.env.searchModel.globalContext;
+        const showSubtasks = my_tasks || subtask_action || activity_action || JSON.parse(browser.localStorage.getItem("showSubtasks"));
         if (!showSubtasks) {
             domain = Domain.and([
                 domain,

--- a/addons/project_todo/static/tests/tours/project_task_activities_split.js
+++ b/addons/project_todo/static/tests/tours/project_task_activities_split.js
@@ -14,14 +14,6 @@ registry.category("web_tour.tours").add('project_task_activities_split', {
             content: 'Task "New Task!" is listed in the activity view',
             trigger: 'td.o_data_cell:contains("New Task!")',
         }, {
-            trigger: ".o_control_panel_navigation button i.fa-sliders",
-            content: "Open embedded actions dropdown",
-            run: "click",
-        }, {
-            content: 'Click on `Show Sub-Tasks` button to see sub-tasks in the main view',
-            trigger: "span.o-dropdown-item:contains('Show Sub-Tasks')",
-            run: 'click',
-        }, {
             content: 'Task "New Sub-Task!" is listed in the activity view',
             trigger: 'td.o_data_cell:contains("New Sub-Task!")',
             run: () => {


### PR DESCRIPTION
Purpose
=======
When clicking on the task activities menu, we might have activities on subtask, and if the user doesn't have "show subtask" activated, then he won't see them.

This commit force the activation of the subtask when coming from the activity menu.

Task-6071691