### PR TITLE
[FIX] base: add vat label for Mozambique

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1022,6 +1022,7 @@
             <field name="code">mz</field>
             <field name="currency_id" ref="MZN" />
             <field eval="258" name="phone_code" />
+            <field name="vat_label">NUIT</field>
         </record>
         <record id="na" model="res.country">
             <field name="name">Namibia</field>


### PR DESCRIPTION
Currently the "Tax ID" title used e.g. on sales orders, invoices, etc. was translated as "CPF/CNPJ" in Portuguese, which is the tax ID used in Brazil. However, in Mozambique, the tax ID is called "NUIT", and there is no language variant for Portuguese in Mozambique. This caused Mozambique users to see "CPF/CNPJ" instead of "NUIT" on their documents, which was wrong.

This commit adds a `vat_label` field for Mozambique to display the correct tax ID label.

Issue reported by functional support.