### PR TITLE
[FIX] website_sale: xml template issue with empty foreach on normalization

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -294,19 +294,16 @@
                                     <td style="width: 50%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">$ 10.00</td>
                                 </tr>
                             </table>
+                            <t t-if="object.tax_totals and object.tax_totals['subtotals']">
+                                <t t-set="all_tax_lines" t-value="[tax for line in object.tax_totals['subtotals'] for tax in line['tax_groups']]"/>
+                                <table width="100%" t-if="all_tax_lines" style="max-width: 590px; font-size: 14px; border-spacing: 0px; white-space: nowrap;" role="presentation">
+                                    <tr t-foreach="all_tax_lines" t-as="tax_line">
+                                        <td style="width: 20%; padding-bottom: 8px;" align="left"><span t-out="tax_line['group_name']"/></td>
+                                        <td style="width: 80%;" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
+                                    </tr>
+                                </table>
+                            </t>
                             <table width="100%" style="max-width: 590px; font-size: 14px; border-spacing: 0px; white-space: nowrap;" role="presentation">
-                                <tr>
-                                    <t t-if="object.tax_totals and object.tax_totals['subtotals']">
-                                        <t t-foreach="object.tax_totals['subtotals']" t-as="line">
-                                            <t t-foreach="line['tax_groups']" t-as="tax_line">
-                                                <tr>
-                                                    <td style="width: 20%; padding-bottom: 8px;" align="left"><span t-out="tax_line['group_name']"/></td>
-                                                    <td style="width: 80%;" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
-                                                </tr>
-                                            </t>
-                                        </t>
-                                    </t>
-                                </tr>
                                 <tr>
                                     <td style="width: 20%; padding-top: 4px; border-top: 1px solid #343a40; opacity: 0.9;" align="left"><strong>Total</strong></td>
                                     <td style="width: 80%; padding-top: 4px; border-top: 1px solid #343a40; font-weight: bold; " align="right">

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -188,18 +188,17 @@
                                 <td style="padding-top: 4px; color: #495057;">Subtotal</td>
                                 <td style="padding-top: 4px; text-align: right; color: #495057;" width="100px" align="right"><t t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">-</t></td>
                             </tr>
-                            <tr>
-                                <t t-if="object.tax_totals and object.tax_totals['subtotals']">
-                                        <t t-foreach="object.tax_totals['subtotals']" t-as="line">
-                                            <t t-foreach="line['tax_groups']" t-as="tax_line">
-                                                <tr>
-                                                    <td style="padding: 4px 0 8px 0; color: #495057;"><span t-out="tax_line['group_name']"/></td>
-                                                    <td style="padding: 4px 0 8px 0; text-align: right; color: #495057;" width="100px" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
-                                                </tr>
-                                            </t>
-                                        </t>
-                                    </t>
-                            </tr>
+                        </table>
+                        <t t-if="object.tax_totals and object.tax_totals['subtotals']">
+                            <t t-set="all_tax_lines" t-value="[tax for line in object.tax_totals['subtotals'] for tax in line['tax_groups']]"/>
+                            <table width="100%" t-if="all_tax_lines" style="font-size: 14px; border-collapse:collapse;" role="presentation">
+                                <tr t-foreach="all_tax_lines" t-as="tax_line">
+                                    <td style="padding: 4px 0 8px 0; color: #495057;"><span t-out="tax_line['group_name']"/></td>
+                                    <td style="padding: 4px 0 8px 0; text-align: right; color: #495057;" width="100px" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
+                                </tr>
+                            </table>
+                        </t>
+                        <table width="100%" role="presentation" style="font-size: 14px; border-collapse:collapse;">
                             <tr>
                                 <td style="padding-top: 8px; border-top: 1px solid #343a40;"><strong>Total</strong></td>
                                 <td style="padding-top: 8px; border-top: 1px solid #343a40; text-align: right" width="100px" align="right">

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2376,7 +2376,7 @@ class IrQweb(models.AbstractModel):
                     values[{expr_as + '_parity'!r}] = 'odd' if values[{expr_as + '_odd'!r}] else 'even'
             """, level))
 
-        code.extend(content_foreach or indent_code('continue', level + 1))
+        code.extend(content_foreach or [indent_code('continue', level + 1)])
         code.append(indent_code("attrs = None", level + 1))
 
         return code

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -892,6 +892,18 @@ class TestQWebBasic(TransactionCase):
         rendered = self.env['ir.qweb']._render(t.id)
         self.assertEqual(rendered.strip(), result.strip())
 
+    def test_empty_foreach(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="empty-for">
+                <t t-foreach="[1, 2]" t-as="v">
+                </t>
+            </t>'''
+        })
+        rendered = self.env['ir.qweb']._render(t.id)
+        self.assertEqual(rendered.strip(), "")
+
     def test_att_escaping_1(self):
         t = self.env['ir.ui.view'].create({
             'name': 'test',


### PR DESCRIPTION
**Steps to reproduce:**
- Install sale / website_sale
- In debug mode, go to Settings app
- Go to Technical > Email > Email Templates
- Try to edit and save "Sales: Order Confirmation" or "Ecommerce: Cart Recovery"
- QWebError is raised: 'IndentationError: unexpected indent'

**Issue:**
Before a `mail.template` is rendered in the html editor it must be valid html (even if they contains qweb elements) to avoid the browser silently moving elements around to match its specifications (and breaking template logic). This is also what happens with  `DOMParser.parseFromString` function.

e.g. the browser moves html elements out of the parent `<table>` if they are not the children of a `<tr>` `<td>`.
```xml
<table>
    <t t-foreach=...>
        <tr>
            <td>1</td>
        </tr>
    </t>
</table>
```
Becomes:
```xml
<t t-foreach=...>
</t>
<table>
    <tbody>
        <tr>
            <td>1</td>
        </tr>
    </tbody>
</table>
```

**Fix:**
The template is still working if not edited, but we need to ensure the template `body_html` is valid html to avoid the hierarchy modification.

related: https://github.com/odoo/odoo/commit/dbd8b879fd95f3e913e1c777cb8619c4e0673b03
similar issue: https://github.com/odoo/odoo/pull/259548

opw-6055026