### PR TITLE
[FIX] account_peppol,l10n_dk: avoid Access Error on webhook.

### DIFF
--- a/addons/account_peppol/controllers/webhooks.py
+++ b/addons/account_peppol/controllers/webhooks.py
@@ -12,7 +12,7 @@ class PeppolWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_new_message(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'account_peppol.ir_cron_peppol_get_new_documents',
@@ -31,7 +31,7 @@ class PeppolWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_message_update(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'account_peppol.ir_cron_peppol_get_message_status',
@@ -50,7 +50,7 @@ class PeppolWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_user_update(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'account_peppol.ir_cron_peppol_get_participant_status',

--- a/addons/l10n_dk_nemhandel/controllers/webhooks.py
+++ b/addons/l10n_dk_nemhandel/controllers/webhooks.py
@@ -12,7 +12,7 @@ class NemhandelWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_nemhandel_new_message(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_nemhandel_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_nemhandel_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'l10n_dk_nemhandel.ir_cron_nemhandel_get_new_documents',
@@ -31,7 +31,7 @@ class NemhandelWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_nemhandel_message_update(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_nemhandel_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_nemhandel_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'l10n_dk_nemhandel.ir_cron_nemhandel_get_message_status',
@@ -50,7 +50,7 @@ class NemhandelWebhookController(http.Controller):
         csrf=False,
     )
     def webhook_nemhandel_user_update(self, token):
-        edi_client = request.env['account_edi_proxy_client.user']._get_nemhandel_user_from_token(token, url=request.httprequest.url)
+        edi_client = request.env['account_edi_proxy_client.user'].sudo()._get_nemhandel_user_from_token(token, url=request.httprequest.url)
 
         cron = request.env.ref(
             'l10n_dk_nemhandel.ir_cron_nemhandel_get_participant_status',


### PR DESCRIPTION
- Register your user (on a db that allows webhook).
- On another registered account, send an invoice to the first one. 

=> A webhook call has been made, resulting into a 403 Forbidden. 
Following some changes on access rights checks, the webhook don't work.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
