### PR TITLE
[FIX] account,account,edi_ubl_cii: Fix Peppol BR-S-08 fatal error

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -626,12 +626,12 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 'tax_category_percent': tax_category_vals['percent'],
                 '_tax_category_vals_': tax_category_vals,
                 'tax_amount_type': tax.amount_type,
-                'include_base_amount': tax.include_base_amount,
             }
             # If the tax is fixed, we want to have one group per tax
             # s.t. when the invoice is imported, we can try to guess the fixed taxes
             if tax.amount_type == 'fixed':
                 grouping_key['tax_name'] = tax.name
+                grouping_key['include_base_amount'] = tax.include_base_amount
             return grouping_key
 
         # Validate the structure of the taxes

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_S_08_tax_subtotal_taxable_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_S_08_tax_subtotal_taxable_amount.xml
@@ -1,0 +1,171 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>___ignore___</cbc:ID>
+	<cbc:IssueDate>___ignore___</cbc:IssueDate>
+	<cbc:DueDate>___ignore___</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cac:OrderReference>
+		<cbc:ID>___ignore___</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject filename="___ignore___" mimeCode="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
+				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+		<cac:DeliveryParty>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+		</cac:DeliveryParty>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>___ignore___</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>BE15001559627230</cbc:ID>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">38.88</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">185.15</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">38.88</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="EUR">185.14</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">185.14</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">224.02</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">224.02</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">101.25</cbc:LineExtensionAmount>
+		<cac:AllowanceCharge>
+			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+			<cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
+			<cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
+			<cbc:Amount currencyID="EUR">1.25</cbc:Amount>
+		</cac:AllowanceCharge>
+		<cac:Item>
+			<cbc:Description>product_a</cbc:Description>
+			<cbc:Name>product_a</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">100.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">83.89</cbc:LineExtensionAmount>
+		<cac:AllowanceCharge>
+			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+			<cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
+			<cbc:AllowanceChargeReason>AUVIBEL</cbc:AllowanceChargeReason>
+			<cbc:Amount currencyID="EUR">1.25</cbc:Amount>
+		</cac:AllowanceCharge>
+		<cac:Item>
+			<cbc:Description>product_b</cbc:Description>
+			<cbc:Name>product_b</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">82.64</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -137,6 +137,40 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_tax_reverse_charge')
 
+    def test_invoice_BR_S_08_tax_subtotal_taxable_amount(self):
+        """ [BR-S-08] For each different value of VAT category rate (BT-119) where the VAT category code (BT-118) is "Standard rated",
+        the VAT category taxable amount (BT-116) in a VAT breakdown (BG-23) shall equal the sum of Invoice line net amounts (BT-131)
+        plus the sum of document level charge amounts (BT-99) minus the sum of document level allowance amounts (BT-92)
+        where the VAT category code (BT-151, BT-102, BT-95) is "Standard rated" and the VAT rate (BT-152, BT-103, BT-96)
+        equals the VAT category rate (BT-119)
+
+        Note: There is a tolerance of 1 euro for the delta. This test is only producing a difference of 0.01 so,
+        technically, the xml is still valid.
+        """
+        tax_recupel = self.fixed_tax(1.254, name="RECUPEL", include_base_amount=True)
+        tax_auvibel = self.fixed_tax(1.254, name="AUVIBEL", include_base_amount=True)
+        tax_21 = self.percent_tax(21.0)
+        tax_21_service = self.percent_tax(21.0, price_include=True, include_base_amount=True)
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=100.0,
+                    tax_ids=tax_recupel + tax_21,
+                ),
+                self._prepare_invoice_line(
+                    product_id=self.product_b,
+                    price_unit=100.0,
+                    tax_ids=tax_auvibel + tax_21_service,
+                ),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_S_08_tax_subtotal_taxable_amount')
+
     def test_invoice_allowance_charge_fixed_tax_recycling_contribution(self):
         """ Ensure the recycling contribution taxes are turned into allowance/charges at the document line level. """
         tax_recupel = self.fixed_tax(1.0, name="RECUPEL", include_base_amount=True)


### PR DESCRIPTION
Peppol invoices are rejected with error `[BR-S-08]` when multiple taxes
with the same rate (e.g. 21%) are used on the same invoice.

Odoo generates separate `<cac:TaxSubtotal>`` blocks for them due to
technical differences (like `include_base_amount`), but the standard
requires a single consolidated block per rate.

Simplify the grouping key used during UBL export by removing
`include_base_amount`. This forces all taxes of the same category and
rate to be merged into a single subtotal block, ensuring mathematical
consistency and satisfying Peppol validation rules.

Peppol error:
```
The XML document did not pass the Schematron validation. Schematron
Validation failed with error: Fatal: [BR-S-08]-For each different value
of VAT category rate (BT-119) where the VAT category code (BT-118) is
"Standard rated", the VAT category taxable amount (BT-116) in a VAT
breakdown (BG-23) shall equal the sum of Invoice line net amounts
(BT-131) plus the sum of document level charge amounts (BT-99) minus the
sum of document level allowance amounts (BT-92) where the VAT category
code (BT-151, BT-102, BT-95) is "Standard rated" and the VAT rate
(BT-152, BT-103, BT-96) equals the VAT category rate (BT-119).
```
opw-5891685