### PR TITLE
[IMP] http: use contextvars instead of thread locals

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -1,5 +1,6 @@
 import base64
 import bisect
+import contextvars
 import functools
 import hashlib
 import logging
@@ -23,7 +24,7 @@ import psycopg2
 from psycopg2.pool import PoolError
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
-from werkzeug.local import LocalStack
+from werkzeug.local import LocalProxy
 
 import odoo
 from odoo import api, modules
@@ -922,8 +923,8 @@ class TimeoutManager:
 # ------------------------------------------------------
 
 
-_wsrequest_stack = LocalStack()
-wsrequest = _wsrequest_stack()
+wsrequest_var = contextvars.ContextVar('wsrequest')
+wsrequest = LocalProxy(wsrequest_var, unbound_message='wsrequest is not bound')
 
 
 class WebsocketRequest:
@@ -932,13 +933,6 @@ class WebsocketRequest:
         self.httprequest = httprequest
         self.session = None
         self.ws = websocket
-
-    def __enter__(self):
-        _wsrequest_stack.push(self)
-        return self
-
-    def __exit__(self, *args):
-        _wsrequest_stack.pop()
 
     def serve_websocket_message(self, message):
         try:
@@ -1156,8 +1150,6 @@ class WebsocketConnectionHandler:
         """
         Process incoming messages and dispatch them to the application.
         """
-        current_thread = threading.current_thread()
-        current_thread.type = 'websocket'
         if httprequest.user_agent and version != cls._VERSION:
             # Close the connection from an outdated worker. We can't use a
             # custom close code because the connection is considered successful,
@@ -1173,15 +1165,18 @@ class WebsocketConnectionHandler:
             if message == b'\x00':
                 # Ignore internal sentinel message used to detect dead/idle connections.
                 continue
-            with WebsocketRequest(db, httprequest, websocket) as req:
-                try:
-                    req.serve_websocket_message(message)
-                except SessionExpiredException:
-                    websocket.close(CloseCode.SESSION_EXPIRED)
-                except PoolError:
-                    websocket.close(CloseCode.TRY_LATER)
-                except Exception:
-                    _logger.exception("Exception occurred during websocket request handling")
+            req = WebsocketRequest(db, httprequest, websocket)
+            req_reset = wsrequest_var.set(req)
+            try:
+                req.serve_websocket_message(message)
+            except SessionExpiredException:
+                websocket.close(CloseCode.SESSION_EXPIRED)
+            except PoolError:
+                websocket.close(CloseCode.TRY_LATER)
+            except Exception:
+                _logger.exception("Exception occurred during websocket request handling")
+            finally:
+                wsrequest_var.reset(req_reset)
 
 
 def _kick_all(code=CloseCode.GOING_AWAY):

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -1,5 +1,6 @@
 import base64
 import bisect
+import contextvars
 import functools
 import hashlib
 import logging
@@ -23,7 +24,7 @@ import psycopg2
 from psycopg2.pool import PoolError
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
-from werkzeug.local import LocalStack
+from werkzeug.local import LocalProxy
 
 import odoo
 from odoo import modules
@@ -887,8 +888,9 @@ class TimeoutManager:
 # ------------------------------------------------------
 
 
-_wsrequest_stack = LocalStack()
-wsrequest = _wsrequest_stack()
+wsrequest_var = contextvars.ContextVar('wsrequest')
+wsrequest = LocalProxy(wsrequest_var, unbound_message='wsrequest is not bound')
+
 
 class WebsocketRequest:
     def __init__(self, db, httprequest, websocket):
@@ -896,13 +898,6 @@ class WebsocketRequest:
         self.httprequest = httprequest
         self.session = None
         self.ws = websocket
-
-    def __enter__(self):
-        _wsrequest_stack.push(self)
-        return self
-
-    def __exit__(self, *args):
-        _wsrequest_stack.pop()
 
     def serve_websocket_message(self, message):
         try:
@@ -1115,8 +1110,6 @@ class WebsocketConnectionHandler:
         """
         Process incoming messages and dispatch them to the application.
         """
-        current_thread = threading.current_thread()
-        current_thread.type = 'websocket'
         if httprequest.user_agent and version != cls._VERSION:
             # Close the connection from an outdated worker. We can't use a
             # custom close code because the connection is considered successful,
@@ -1132,15 +1125,18 @@ class WebsocketConnectionHandler:
             if message == b'\x00':
                 # Ignore internal sentinel message used to detect dead/idle connections.
                 continue
-            with WebsocketRequest(db, httprequest, websocket) as req:
-                try:
-                    req.serve_websocket_message(message)
-                except SessionExpiredException:
-                    websocket.close(CloseCode.SESSION_EXPIRED)
-                except PoolError:
-                    websocket.close(CloseCode.TRY_LATER)
-                except Exception:
-                    _logger.exception("Exception occurred during websocket request handling")
+            req = WebsocketRequest(db, httprequest, websocket)
+            req_reset = wsrequest_var.set(req)
+            try:
+                req.serve_websocket_message(message)
+            except SessionExpiredException:
+                websocket.close(CloseCode.SESSION_EXPIRED)
+            except PoolError:
+                websocket.close(CloseCode.TRY_LATER)
+            except Exception:
+                _logger.exception("Exception occurred during websocket request handling")
+            finally:
+                wsrequest_var.reset(req_reset)
 
 
 def _kick_all(code=CloseCode.GOING_AWAY):

--- a/addons/http_routing/models/ir_qweb.py
+++ b/addons/http_routing/models/ir_qweb.py
@@ -26,8 +26,8 @@ Then:
 
 Failure to meet this expectation can lead to downstream problems, e.g.
 here inside of http_routing's ir.qweb. Solutions vary, the one used
-inside of #99667 is to use the request.borrow_request context manager to
-temporary hide the incoming http request.
+inside of #99667 is to use a new Context to temporary hide the incoming http
+request.
 """
 
 

--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -121,8 +121,8 @@ def MockRequest(
     request.update_context = update_context
 
     with contextlib.ExitStack() as s:
-        odoo.http.requestlib._request_stack.push(request)
-        s.callback(odoo.http.requestlib._request_stack.pop)
+        request_reset = odoo.http.request_var.set(request)
+        s.callback(odoo.http.request_var.reset, request_reset)
         s.enter_context(patch('odoo.http.router.root.get_db_router', router))
 
         yield request

--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -103,8 +103,8 @@ def MockRequest(
     request.update_context = update_context
 
     with contextlib.ExitStack() as s:
-        odoo.http.requestlib._request_stack.push(request)
-        s.callback(odoo.http.requestlib._request_stack.pop)
+        request_reset = odoo.http.request_var.set(request)
+        s.callback(odoo.http.request_var.reset, request_reset)
         s.enter_context(patch('odoo.http.router.root.get_db_router', router))
 
         yield request

--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -5,7 +5,7 @@ import time
 
 import odoo
 from odoo.exceptions import AccessDenied, AccessError
-from odoo.http.requestlib import _request_stack
+from odoo.http import request_var
 from odoo.service import common as auth
 from odoo.service import model
 from odoo.tests import common, tagged
@@ -210,8 +210,8 @@ class TestAPIKeys(common.HttpCase):
             'geoip': {},
             'get_json_data': get_json_data,
         })
-        _request_stack.push(fake_req)
-        self.addCleanup(_request_stack.pop)
+        request_reset = request_var.set(fake_req)
+        self.addCleanup(request_var.reset, request_reset)
 
     def test_trivial(self):
         uid = auth.dispatch('authenticate', [self.env.cr.dbname, 'byl', 'ananananan', {}])

--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -1,8 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import threading
-import unicodedata
 
-from odoo.tests.common import tagged, BaseCase
+from odoo.tests.common import get_db_name, BaseCase
 from odoo.modules.registry import Registry
 
 
@@ -30,7 +28,7 @@ class TestSlugUnslug(BaseCase):
             'foo-1#anchor': ('foo', 1),
         }
 
-        unslug = Registry(threading.current_thread().dbname)['ir.http']._unslug
+        unslug = Registry(get_db_name())['ir.http']._unslug
 
         for slug, expected in tests.items():
             self.assertEqual(unslug(slug), expected, "%r case failed" % slug)
@@ -43,7 +41,7 @@ class TestSlugUnslug(BaseCase):
             '1-2': (2, '1'),
         }
 
-        slug = Registry(threading.current_thread().dbname)['ir.http']._slug
+        slug = Registry(get_db_name())['ir.http']._slug
 
         for expected, value in tests.items():
             self.assertEqual(slug(value), expected, "%r case failed" % (value,))
@@ -56,8 +54,8 @@ class TestTitleToSlug(BaseCase):
     """
 
     def _slugify(self, value):
-        _slugify = Registry(threading.current_thread().dbname)['ir.http']._slugify
-        return _slugify(value)
+        slugify = Registry(get_db_name())['ir.http']._slugify
+        return slugify(value)
 
     def test_spaces(self):
         self.assertEqual(

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -236,7 +236,8 @@ class IrCron(models.Model):
             _logger.debug("job %s acquired", job_id)
             # take into account overridings of _process_job() on that database
             registry = Registry(db_name).check_signaling()
-            registry[IrCron._name]._process_job(cron_cr, job)
+            # run each job in an insolated context from other jobs
+            contextvars.copy_context().run(registry[IrCron._name]._process_job, cron_cr, job)
             cron_cr.commit()
             _logger.debug("job %s updated and released", job_id)
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import re
-import threading
 import time
 import typing
 import unicodedata
@@ -45,7 +44,6 @@ from odoo.http.session import (
     get_session_max_inactivity,
     session_store,
 )
-from odoo.modules.registry import Registry
 from odoo.tools.json import json_default
 from odoo.tools.misc import get_lang, submap
 from odoo.tools.translate import code_translations
@@ -111,17 +109,14 @@ class ModelConverter(werkzeug.routing.BaseConverter):
         super().__init__(url_map)
         self.model = model
 
-        IrHttp = Registry(threading.current_thread().dbname)['ir.http']
-        self.slug = IrHttp._slug
-        self.unslug = IrHttp._unslug
-
     def to_python(self, value: str) -> models.BaseModel:
         uid = RequestUID(value=value, converter=self)
         env = api.Environment(request.env.cr, uid, request.env.context)
-        return env[self.model].browse(self.unslug(value)[1])
+        unslug = env['ir.http']._unslug
+        return env[self.model].browse(unslug(value)[1])
 
     def to_url(self, value: models.BaseModel) -> str:
-        return self.slug(value)
+        return value.env['ir.http']._slug(value)
 
 
 class ModelsConverter(werkzeug.routing.BaseConverter):
@@ -448,7 +443,7 @@ class IrHttp(models.AbstractModel):
     @tools.ormcache('key', cache='routing')
     def routing_map(self, key=None):
         _logger.info("Generating routing map for key %s", key)
-        registry = Registry(threading.current_thread().dbname)
+        registry = self.env.registry
         installed = registry._init_modules.union(odoo.tools.config['server_wide_modules'])
         mods = sorted(installed)
         # Note : when routing map is generated, we put it on the class `cls`

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command
-from odoo.http.requestlib import _request_stack
+from odoo.http import request_var
 from odoo.tests import (
     Form,
     HttpCase,
@@ -705,8 +705,8 @@ class TestUsersIdentitycheck(HttpCase):
 
         # Push a fake request to the request stack, because @check_identity requires a request.
         # Use the first session created above, used to invalid other sessions than itself.
-        _request_stack.push(SimpleNamespace(session=session, env=self.env))
-        self.addCleanup(_request_stack.pop)
+        request_reset = request_var.set(SimpleNamespace(session=session, env=self.env))
+        self.addCleanup(request_var.reset, request_reset)
         # The user clicks the button logout from all devices from his profile
         action = self.env.user.action_revoke_all_devices()
         # The form of the check identity wizard opens

--- a/odoo/http/__init__.py
+++ b/odoo/http/__init__.py
@@ -2,14 +2,16 @@
 import odoo.init  # noqa: I001
 
 # Initialize the global `request`
+import contextvars
 import typing
-from werkzeug.local import LocalStack
-_request_stack = LocalStack()
 if typing.TYPE_CHECKING:
     from .requestlib import Request
+    request_var: contextvars.ContextVar[Request]
     request: Request
 else:
-    request = _request_stack()
+    from werkzeug.local import LocalProxy
+    request_var = contextvars.ContextVar('request')
+    request = LocalProxy(request_var, unbound_message="request not bound")
 
 
 from .response import Response  # noqa: I001

--- a/odoo/http/__init__.py
+++ b/odoo/http/__init__.py
@@ -1,6 +1,19 @@
+# ruff: noqa: E402, I001, RUF067
 import odoo.init  # noqa: I001
 
-from .response import Response  # noqa: I001
+# Initialize the global `request`
+import typing
+from werkzeug.local import LocalStack
+_request_stack = LocalStack()
+if typing.TYPE_CHECKING:
+    from .requestlib import Request
+    request: Request
+else:
+    request = _request_stack()
 
-from .requestlib import request
+
+from .response import Response  # noqa: I001
+from . import requestlib
 from .routing_map import Controller, route
+# import all sub-modules
+from . import dispatcher, geoip, retrying, router, session, stream

--- a/odoo/http/dispatcher.py
+++ b/odoo/http/dispatcher.py
@@ -22,6 +22,16 @@ from werkzeug.exceptions import default_exceptions as werkzeug_default_exception
 from odoo.exceptions import UserError
 from odoo.tools import exception_to_unicode
 
+from .response import Response
+from .session import (
+    CheckIdentityException,
+    SessionExpiredException,
+    get_session_max_inactivity,
+    logout,
+    save_session,
+    session_store,
+)
+
 if typing.TYPE_CHECKING:
     from collections.abc import Collection
 
@@ -153,6 +163,7 @@ class Dispatcher(ABC):
         """
         save_session(self.request)
         response.headers.extend(self.request.future_response.headers)
+        from .router import root  # noqa: PLC0415
         root.set_csp(response)
 
     @abstractmethod
@@ -410,16 +421,3 @@ class Json2Dispatcher(Dispatcher):
             body = serialize_exception(exc)
 
         return self.request.make_json_response(body, headers=headers, status=status)
-
-
-# ruff: noqa: E402
-from .response import Response
-from .router import root
-from .session import (
-    CheckIdentityException,
-    SessionExpiredException,
-    get_session_max_inactivity,
-    logout,
-    save_session,
-    session_store,
-)

--- a/odoo/http/requestlib.py
+++ b/odoo/http/requestlib.py
@@ -24,7 +24,7 @@ from werkzeug.utils import redirect
 
 from odoo.tools import consteq, json_default
 
-from . import _request_stack, request
+from . import request
 from .dispatcher import HttpDispatcher
 from .geoip import GeoIP
 from .response import FutureResponse, Response
@@ -54,12 +54,14 @@ CSRF_TOKEN_SALT = 60 * 60 * 24 * 365  # 1 year
 @contextmanager
 def borrow_request():
     """ Get the current request and unexpose it from the local stack. """
-    req = _request_stack.pop()
-    assert req is not None
+    warnings.warn("Use Context().run() to reset the context", DeprecationWarning, stacklevel=2)
+    from . import request_var  # noqa: PLC0415
+    req = request_var.get()
+    token = request_var.set(None)
     try:
         yield req
     finally:
-        _request_stack.push(req)
+        request_var.reset(token)
 
 
 def is_cors_preflight(request: Request, endpoint: Endpoint) -> bool:

--- a/odoo/http/requestlib.py
+++ b/odoo/http/requestlib.py
@@ -19,30 +19,29 @@ from werkzeug.datastructures import (
     MultiDict,
 )
 from werkzeug.exceptions import NotFound
-from werkzeug.local import LocalStack
 from werkzeug.urls import URL, url_encode, url_parse
 from werkzeug.utils import redirect
 
 from odoo.tools import consteq, json_default
 
+from . import request, _request_stack
+from .dispatcher import HttpDispatcher
+from .geoip import GeoIP
+from .response import FutureResponse, Response
+from .session import DEFAULT_LANG, STORED_SESSION_BYTES, get_default_session
+
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
-
-    import werkzeug.routing
 
     from odoo.api import Environment
     from odoo.models import BaseModel
     from odoo.modules.registry import Registry
 
-    from .response import Response
     from .routing_map import Endpoint
 
     HeaderType = Mapping[str, str | Iterable[str]] | Iterable[tuple[str, str]]
 
 _logger = logging.getLogger('odoo.http')
-
-_request_stack = LocalStack()
-request: Request = _request_stack()  # type: ignore[assignment]
 
 CSRF_TOKEN_SALT = 60 * 60 * 24 * 365  # 1 year
 """ The default csrf token lifetime, a salt against BREACH. """
@@ -364,13 +363,9 @@ class Request:
         self.httprequest = httprequest
 
 
-# ruff: noqa: E402
 if typing.TYPE_CHECKING:
+    import werkzeug.wrappers
     HTTPRequest = werkzeug.wrappers.Request
     from ._facade import DEFAULT_MAX_CONTENT_LENGTH
 else:
     from ._facade import DEFAULT_MAX_CONTENT_LENGTH, HTTPRequest  # noqa: F401
-from .dispatcher import HttpDispatcher
-from .geoip import GeoIP
-from .response import FutureResponse, Response
-from .session import DEFAULT_LANG, STORED_SESSION_BYTES, get_default_session

--- a/odoo/http/requestlib.py
+++ b/odoo/http/requestlib.py
@@ -24,7 +24,7 @@ from werkzeug.utils import redirect
 
 from odoo.tools import consteq, json_default
 
-from . import request, _request_stack
+from . import request
 from .dispatcher import HttpDispatcher
 from .geoip import GeoIP
 from .response import FutureResponse, Response
@@ -50,12 +50,14 @@ CSRF_TOKEN_SALT = 60 * 60 * 24 * 365  # 1 year
 @contextmanager
 def borrow_request():
     """ Get the current request and unexpose it from the local stack. """
-    req = _request_stack.pop()
-    assert req is not None
+    warnings.warn("Use Context().run() to reset the context", DeprecationWarning, stacklevel=2)
+    from . import request_var  # noqa: PLC0415
+    req = request_var.get()
+    token = request_var.set(None)
     try:
         yield req
     finally:
-        _request_stack.push(req)
+        request_var.reset(token)
 
 
 def is_cors_preflight(request: Request, endpoint: Endpoint) -> bool:

--- a/odoo/http/response.py
+++ b/odoo/http/response.py
@@ -9,6 +9,8 @@ import werkzeug.datastructures
 import werkzeug.exceptions
 import werkzeug.wrappers
 
+from . import request
+
 _logger = logging.getLogger('odoo.http')
 
 
@@ -143,7 +145,3 @@ class FutureResponse:
         if request.db and not request.env['ir.http']._is_allowed_cookie(cookie_type):
             max_age = 0
         werkzeug.Response.set_cookie(self, key, value=value, max_age=max_age, expires=expires, path=path, domain=domain, secure=secure, httponly=httponly, samesite=samesite)
-
-
-# ruff: noqa: E402
-from .requestlib import request

--- a/odoo/http/retrying.py
+++ b/odoo/http/retrying.py
@@ -11,6 +11,8 @@ import psycopg2.errorcodes
 from odoo.exceptions import ConcurrencyError, ValidationError
 from odoo.sql_db import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 
+from . import request
+
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
     from odoo.api import Environment
@@ -67,6 +69,7 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
                     # We need to reset the `session` attribute of `request`
                     # which may have been modified during the transaction.
                     # The `dbname` remains the same (consistent with the session).
+                    from .router import _set_session_and_dbname  # noqa: PLC0415
                     _set_session_and_dbname(request)
                     # Rewind files in case of failure
                     for filename, file in request.httprequest.files.items():
@@ -114,7 +117,3 @@ def retrying[T](func: Callable[[], T], env: Environment) -> T:
         env.cr.commit()  # effectively commits and execute post-commits
     env.registry.signal_changes()
     return result
-
-
-# ruff: noqa: E402
-from .router import _set_session_and_dbname, request

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -40,7 +40,7 @@ from odoo.modules.registry import Registry
 from odoo.tools import config, file_open, file_path, profiler
 from odoo.tools.misc import submap
 
-from . import request, _request_stack
+from . import request, request_var
 from .dispatcher import HttpDispatcher, JsonRPCDispatcher, _dispatchers
 from .response import Response
 from .retrying import retrying
@@ -49,7 +49,6 @@ from .stream import STATIC_CACHE, Stream
 from .requestlib import (
     HTTPRequest,
     Request,
-    borrow_request,
     is_cors_preflight,
 )
 from .session import SessionExpiredException, get_default_session, logout, session_store
@@ -136,11 +135,14 @@ def dispatch_rpc(service_name: str, method: str, params: Mapping[str, typing.Any
     else:
         raise ValueError(f"Invalid service name: {service_name}")
 
-    with borrow_request():
+    # Remove the request to simulate that the call does not come from HTTP
+    request_reset = request_var.set(None)
+    try:
         threading.current_thread().uid = None
         threading.current_thread().dbname = None
-
         return dispatch(method, params)
+    finally:
+        request_var.reset(request_reset)
 
 
 class RegistryError(RuntimeError):
@@ -258,8 +260,7 @@ class Application:
 
         with HTTPRequest(environ) as httprequest:
             request = Request(httprequest)
-            _request_stack.push(request)
-
+            request_reset = request_var.set(request)
             try:
                 _set_session_and_dbname(request)
                 threading.current_thread().url = httprequest.url
@@ -312,7 +313,7 @@ class Application:
                 return exc.error_response(environ, start_response)
 
             finally:
-                _request_stack.pop()
+                request_var.reset(request_reset)
 
 
 root = Application()

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -40,7 +40,7 @@ from odoo.modules.registry import Registry
 from odoo.tools import config, file_path, profiler, real_time
 from odoo.tools.misc import submap
 
-from . import request, _request_stack
+from . import request, request_var
 from .dispatcher import HttpDispatcher, JsonRPCDispatcher, _dispatchers
 from .response import Response
 from .retrying import retrying
@@ -49,7 +49,6 @@ from .stream import STATIC_CACHE, Stream
 from .requestlib import (
     HTTPRequest,
     Request,
-    borrow_request,
     is_cors_preflight,
 )
 from .session import SessionExpiredException, get_default_session, logout, session_store
@@ -146,11 +145,14 @@ def dispatch_rpc(service_name: str, method: str, params: Mapping[str, typing.Any
     else:
         raise ValueError(f"Invalid service name: {service_name}")
 
-    with borrow_request():
+    # Remove the request to simulate that the call does not come from HTTP
+    request_reset = request_var.set(None)
+    try:
         threading.current_thread().uid = None
         threading.current_thread().dbname = None
-
         return dispatch(method, params)
+    finally:
+        request_var.reset(request_reset)
 
 
 class RegistryError(RuntimeError):
@@ -277,8 +279,7 @@ class Application:
 
         with HTTPRequest(environ) as httprequest:
             request = Request(httprequest)
-            _request_stack.push(request)
-
+            request_reset = request_var.set(request)
             try:
                 _set_session_and_dbname(request)
                 current_thread.url = httprequest.url
@@ -331,7 +332,7 @@ class Application:
                 return exc.error_response(environ, start_response)
 
             finally:
-                _request_stack.pop()
+                request_var.reset(request_reset)
 
 
 root = Application()

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -40,12 +40,24 @@ from odoo.modules.registry import Registry
 from odoo.tools import config, file_path, profiler, real_time
 from odoo.tools.misc import submap
 
+from . import request, _request_stack
+from .dispatcher import HttpDispatcher, JsonRPCDispatcher, _dispatchers
+from .response import Response
+from .retrying import retrying
+from .routing_map import ROUTING_KEYS, _generate_routing_rules
+from .stream import STATIC_CACHE, Stream
+from .requestlib import (
+    HTTPRequest,
+    Request,
+    borrow_request,
+    is_cors_preflight,
+)
+from .session import SessionExpiredException, get_default_session, logout, session_store
+
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from wsgiref.types import StartResponse, WSGIEnvironment
 
-    from .requestlib import Request
-    from .response import Response
     from .routing_map import Endpoint
 
 _logger = logging.getLogger('odoo.http')
@@ -593,20 +605,3 @@ def serve_ir_http(request: Request, rule: werkzeug.routing.Rule, args) -> Respon
     response = request.dispatcher.dispatch(rule.endpoint, args)
     request.registry['ir.http']._post_dispatch(response)
     return response
-
-
-# ruff: noqa: E402
-from .dispatcher import HttpDispatcher, JsonRPCDispatcher, _dispatchers
-from .requestlib import (
-    HTTPRequest,
-    Request,
-    _request_stack,
-    borrow_request,
-    is_cors_preflight,
-    request,
-)
-from .response import Response
-from .retrying import retrying
-from .routing_map import ROUTING_KEYS, _generate_routing_rules
-from .session import SessionExpiredException, get_default_session, logout, session_store
-from .stream import STATIC_CACHE, Stream

--- a/odoo/http/routing_map.py
+++ b/odoo/http/routing_map.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from odoo.tools import unique
 from odoo.tools.func import filter_kwargs
 
+from . import request
 from .dispatcher import _dispatchers
 
 _logger = logging.getLogger('odoo.http')
@@ -352,7 +353,3 @@ def _check_and_complete_route_definition(controller_cls: type[Controller], subme
             'readonly' if parent_readonly else 'read/write',
         )
         submethod.original_routing['readonly'] = False
-
-
-# ruff: noqa: E402
-from .requestlib import request

--- a/odoo/http/session.py
+++ b/odoo/http/session.py
@@ -19,11 +19,13 @@ from zlib import adler32
 from odoo.api import Environment
 from odoo.tools import config, consteq, get_lang
 
+from . import request
+from .geoip import GeoIP
+
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
     from .requestlib import Request
-
 
 _logger = logging.getLogger('odoo.http')
 
@@ -643,8 +645,3 @@ def save_session(request: Request, env: Environment | None = None) -> None:
             max_age=get_session_max_inactivity(env),
             httponly=True,
         )
-
-
-# ruff: noqa: E402
-from .geoip import GeoIP
-from .requestlib import request

--- a/odoo/http/stream.py
+++ b/odoo/http/stream.py
@@ -14,11 +14,12 @@ from werkzeug.utils import send_file as _send_file
 
 from odoo.tools import config, file_path
 
+from . import request
+from .response import Response
+
 if typing.TYPE_CHECKING:
     from datetime import datetime
     from typing import Self
-
-    from .response import Response
 
 STATIC_CACHE = 60 * 60 * 24 * 7  # 1 week
 """ The cache duration for static content from the filesystem. """
@@ -222,8 +223,3 @@ class Stream:
             res.cache_control['immutable'] = None  # None sets the directive
 
         return res
-
-
-# ruff: noqa: E402
-from .requestlib import request
-from .response import Response

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------
 import collections
 import contextlib
+import contextvars
 import errno
 import logging
 import os
@@ -1475,7 +1476,7 @@ class WorkerHTTP(Worker):
     def process_work(self):
         try:
             client, addr = self.multi.socket.accept()
-            self.process_request(client, addr)
+            contextvars.Context().run(self.process_request, client, addr)
         except OSError as e:
             if e.errno not in (errno.EAGAIN, errno.ECONNABORTED):
                 raise
@@ -1546,7 +1547,7 @@ class WorkerCron(Worker):
         self.setproctitle(db_name)
 
         from odoo.addons.base.models.ir_cron import IrCron  # noqa: PLC0415
-        IrCron._process_jobs(db_name)
+        contextvars.Context().run(IrCron._process_jobs, db_name)
 
         # dont keep cursors in multi database mode
         if self.db_count > 1:

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -58,7 +58,8 @@ import odoo.orm.registry
 from odoo import api
 from odoo.exceptions import AccessError
 from odoo.fields import Command
-from odoo.http.requestlib import Request, _request_stack, request
+from odoo.http import request, request_var
+from odoo.http.requestlib import Request
 from odoo.http.session import (
     DEFAULT_LANG,
     get_default_session,
@@ -752,16 +753,19 @@ class BaseCase(case.TestCase):
             env=self.env,
             session=DotDict(get_default_session(), debug='1', sid=''),
         )
+        reset_req = None
         try:
             self.env.flush_all()
             self.env.invalidate_all()
-            _request_stack.push(request)
+            reset_req = request_var.set(request)
             yield
             self.env.flush_all()
             self.env.invalidate_all()
         finally:
-            popped_request = _request_stack.pop()
-            if popped_request is not request:
+            current_request = request_var.get()
+            if reset_req is not None:
+                request_var.reset(reset_req)
+            if current_request is not request:
                 raise Exception('Wrong request stack cleanup.')
 
     @contextmanager

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -61,7 +61,8 @@ import odoo.orm.registry
 from odoo import api
 from odoo.exceptions import AccessError
 from odoo.fields import Command
-from odoo.http.requestlib import Request, _request_stack, request
+from odoo.http import request, request_var
+from odoo.http.requestlib import Request
 from odoo.http.session import (
     DEFAULT_LANG,
     get_default_session,
@@ -757,16 +758,19 @@ class BaseCase(case.TestCase):
             env=self.env,
             session=DotDict(get_default_session(), debug='1', sid=''),
         )
+        reset_req = None
         try:
             self.env.flush_all()
             self.env.invalidate_all()
-            _request_stack.push(request)
+            reset_req = request_var.set(request)
             yield
             self.env.flush_all()
             self.env.invalidate_all()
         finally:
-            popped_request = _request_stack.pop()
-            if popped_request is not request:
+            current_request = request_var.get()
+            if reset_req is not None:
+                request_var.reset(reset_req)
+            if current_request is not request:
                 raise Exception('Wrong request stack cleanup.')
 
     @contextmanager


### PR DESCRIPTION
- Refactor http to avoid most circular imports.
- Manage correctly the context for `contextvars`.
- Use `LocalProxy` instead of `LocalStack` for request.

https://github.com/odoo/enterprise/pull/112460


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
