### PR TITLE
[IMP] core: Explanation cures AI hallucination

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -35,6 +35,7 @@ class AccountJournalGroup(models.Model):
 class AccountJournal(models.Model):
     _name = 'account.journal'
     _description = "Journal"
+    _explanation = "Groups financial transactions. Every accounting entry must be posted in a specific journal. Controls default accounts and transaction sequencing."
     _order = 'sequence, type, code'
     _inherit = ['portal.mixin',
                 'mail.alias.mixin.optional',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -79,6 +79,7 @@ BYPASS_LOCK_CHECK = object()
 
 class AccountMove(models.Model):
     _name = 'account.move'
+    _explanation = "The core model for financial accounting (journal entries, invoices, bills). Each record represents a transaction between the company and another party, or internal financial adjustments."
     _inherit = ['portal.mixin', 'mail.thread.main.attachment', 'mail.activity.mixin', 'sequence.mixin', 'product.catalog.mixin', 'account.document.import.mixin']
     _description = "Journal Entry"
     _order = 'date desc, name desc, invoice_date desc, id desc'

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -25,6 +25,7 @@ class AccountMoveLine(models.Model):
         "mail.track.mixin",
     ]
     _description = "Journal Item"
+    _explanation = "An individual line item within an account.move. Used to detail specific debits, credits, taxes, and products on invoices and journal entries."
     _order = "date desc, move_name desc, id"
     _check_company_auto = True
     _rec_names_search = ['name', 'move_id', 'product_id']

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -8,6 +8,7 @@ class AccountPayment(models.Model):
     _name = 'account.payment'
     _inherit = ['mail.thread.main.attachment', 'mail.activity.mixin']
     _description = "Payment"
+    _explanation = "Represents incoming (customer) or outgoing (vendor) payments. It handles the actual transfer of money and is used to reconcile open invoices or bills."
     _order = "date desc, name desc"
     _check_company_auto = True
 

--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -142,6 +142,7 @@ class DocController(http.Controller):
             {
                 'model': ir_model.model,
                 'name': ir_model.name,
+                'doc': ir_model.explanation,
                 'fields': {
                     field.name: {'string': field.field_description}
                     for field in ir_model.field_id
@@ -218,7 +219,7 @@ class DocController(http.Controller):
         result = {
             'model': model_name,
             'name': ir_model.name,
-            'doc': None,  # TODO
+            'doc': ir_model.explanation,
             'fields': {
                 field['name']: dict(
                     field,

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -4,6 +4,9 @@
 <t t-name="web.DocModel">
     <div t-if="!this.state.error" class="o-doc-model position-relative d-flex flex-nowrap flex-fill flex-column p-3">
         <h2 class="w-100 mb-2 mt-2" t-out="this.state.model?.name ?? ''"></h2>
+        <p t-if="this.state.model?.doc" class="mb-3" title="Derived from _explanation attribute">
+            <strong>Explanation: </strong><span class="text-muted" t-out="this.state.model.doc"/>
+        </p>
         <DocTable data="this.state.modelData"/>
 
         <h3 class="mt-3 mb-2" id="fields">Fields</h3>

--- a/addons/api_doc/static/src/components/doc_sidebar.xml
+++ b/addons/api_doc/static/src/components/doc_sidebar.xml
@@ -30,6 +30,7 @@
                         >
                             <div t-out="model.name"></div>
                             <small class="d-block" t-out="model.model"></small>
+                            <small t-if="model.doc" class="d-block text-muted text-truncate" t-out="model.doc"></small>
                         </a>
                     </t>
                 </div>

--- a/addons/api_doc/tests/test_doc.py
+++ b/addons/api_doc/tests/test_doc.py
@@ -80,6 +80,7 @@ class TestDoc(HttpCaseWithUserDemo):
         self.assertTrue(res_partner, "res.partner not found in json['models']")
         res_partner_fields = res_partner.pop('fields')
         res_partner_methods = res_partner.pop('methods')
+        self.assertIsInstance(res_partner.pop('doc', None), str)
         self.assertEqual(res_partner, {'name': "Contact", 'model': 'res.partner'})
         self.assertGreater(set(res_partner_methods), {'search'})
         self.assertGreater(set(res_partner_fields), {'id', 'create_uid', 'lang', 'tz'})
@@ -102,11 +103,11 @@ class TestDoc(HttpCaseWithUserDemo):
         json = res.json()
         fields = json.pop('fields', None)
         methods = json.pop('methods', None)
+        self.assertIsInstance(json.pop('doc', None), str)
         self.maxDiff = None
         self.assertEqual(json, {
             'model': 'res.partner',
             'name': 'Contact',
-            'doc': None,
         })
         self.assertGreater(set(fields), {'id', 'create_uid', 'lang', 'tz'})
         fields['id'].pop('ai', None)

--- a/addons/contacts/views/contact_views.xml
+++ b/addons/contacts/views/contact_views.xml
@@ -2,6 +2,7 @@
 <odoo>
     <record id="action_contacts" model="ir.actions.act_window">
         <field name="name">Contacts</field>
+        <field name="explanation">Opens the global Contacts directory. Use this as a general fallback for finding individuals or companies if a more specific action (like Customers or Vendors) is not requested.</field>
         <field name="path">contacts</field>
         <field name="res_model">res.partner</field>
         <field name="view_mode">list,kanban,form,activity</field>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -84,6 +84,7 @@ PLS_UPDATE_BATCH_STEP = 5000
 class CrmLead(models.Model):
     _name = 'crm.lead'
     _description = "Lead"
+    _explanation = "Represents a potential sales opportunity or lead. Use this to track interactions, estimated revenue, and the progress of a potential sale through different stages of your sales pipeline."
     _order = "priority desc, id desc"
     _inherit = [
                 'mail.thread.subject.suggested',

--- a/addons/crm/models/crm_lost_reason.py
+++ b/addons/crm/models/crm_lost_reason.py
@@ -7,6 +7,7 @@ from odoo import fields, models, _
 class CrmLostReason(models.Model):
     _name = 'crm.lost.reason'
     _description = 'Opp. Lost Reason'
+    _explanation = "Defines the standard reasons why a sales opportunity or lead was marked as lost. Used for reporting and analyzing sales failures."
 
     name = fields.Char('Description', required=True, translate=True)
     active = fields.Boolean('Active', default=True)

--- a/addons/crm/models/crm_recurring_plan.py
+++ b/addons/crm/models/crm_recurring_plan.py
@@ -7,6 +7,7 @@ from odoo import fields, models
 class CrmRecurringPlan(models.Model):
     _name = 'crm.recurring.plan'
     _description = "CRM Recurring Revenue Plan"
+    _explanation = "Defines billing intervals for recurring revenues (e.g., Monthly, Yearly). Applied to leads/opportunities to estimate future subscription income."
     _order = "sequence"
 
     name = fields.Char('Plan Name', required=True, translate=True)

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -19,6 +19,7 @@ class CrmStage(models.Model):
     """
     _name = 'crm.stage'
     _description = "CRM Stage"
+    _explanation = "Represents a step in the sales pipeline (e.g., New, Qualified, Proposition, Won). Used to organize and track the progress of crm.lead records."
     _rec_name = 'name'
     _order = "sequence, name, id"
 

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -20,6 +20,7 @@ class CrmTeam(models.Model):
     _name = 'crm.team'
     _inherit = ['mail.alias.mixin', 'crm.team']
     _description = 'Sales Team'
+    _explanation = "Represents a group of salespeople. It handles the assignment of leads/opportunities and can have its own pipeline stages and goals."
 
     use_leads = fields.Boolean('Leads', help="Check this box to filter and qualify incoming requests as leads before converting them into opportunities and assigning them to a salesperson.")
     use_opportunities = fields.Boolean('Pipeline', default=True, help="Check this box to manage a presales process with opportunities.")

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1004,6 +1004,7 @@
         <!-- Lead Menu -->
         <record model="ir.actions.act_window" id="crm_lead_all_leads">
             <field name="name">Leads</field>
+            <field name="explanation">Opens the pipeline view for CRM Leads and Opportunities. Use this when the user wants to see sales prospects, track deal stages, or analyze their sales pipeline.</field>
             <field name="res_model">crm.lead</field>
             <field name="view_mode">list,kanban,graph,pivot,form,activity</field>
             <field name="domain">['|', ('type','=','lead'), ('type','=',False)]</field>

--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -7,6 +7,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
+    _explanation = "In the HR context, partners also represent employees."
 
     employee_ids = fields.One2many(
         'hr.employee', 'work_contact_id', string='Employees', groups="hr.group_hr_user",

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -807,6 +807,7 @@
 
         <record id="open_view_employee_list_my" model="ir.actions.act_window">
             <field name="name">Employees</field>
+            <field name="explanation">Displays the main directory of employees. Use this action when the user wants to manage staff, view org charts, or look up internal HR profiles.</field>
             <field name="path">employees</field>
             <field name="res_model">hr.employee</field>
             <field name="view_mode">kanban,list,form,activity,graph,pivot</field>

--- a/addons/im_livechat/models/discuss_call_history.py
+++ b/addons/im_livechat/models/discuss_call_history.py
@@ -5,5 +5,6 @@ from odoo import models, fields
 
 class DiscussCallHistory(models.Model):
     _inherit = "discuss.call.history"
+    _explanation = "In the Livechat context, we extend call history to track participants (operators and visitors) involved in the call."
 
     livechat_participant_history_ids = fields.Many2many("im_livechat.channel.member.history")

--- a/addons/mail/models/discuss/discuss_call_history.py
+++ b/addons/mail/models/discuss/discuss_call_history.py
@@ -7,6 +7,7 @@ class DiscussCallHistory(models.Model):
     _name = "discuss.call.history"
     _order = "start_dt DESC, id DESC"
     _description = "Keep the call history"
+    _explanation = "Stores the history of internal discuss calls (audio/video), tracking the start time, end time, duration, and the associated channel."
 
     channel_id = fields.Many2one("discuss.channel", index=True, required=True, ondelete="cascade")
     duration_hour = fields.Float(compute="_compute_duration_hour")

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -14,6 +14,7 @@ class ResPartner(models.Model):
        to restrict usage of automatic email templates. """
     _name = 'res.partner'
     _inherit = ['mail.thread.blacklist', 'res.partner', 'mail.activity.mixin']
+    _explanation = "Adds communication and activity management to contacts. It enables the chatter (message history), email blacklisting, and the ability to schedule activities."
     _mail_flat_thread = False
     _mail_post_access = 'read'
 

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -14,6 +14,7 @@ from odoo.tools.misc import unique
 class ProductProduct(models.Model):
     _name = 'product.product'
     _description = "Product Variant"
+    _explanation = "A specific variant of a product.template (e.g., T-Shirt in size Large and color Red). This is the actual item that is bought, sold, and tracked in inventory."
     _inherits = {'product.template': 'product_tmpl_id'}
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'default_code, name, id'

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -18,6 +18,7 @@ class ProductTemplate(models.Model):
     _name = 'product.template'
     _inherit = ['mail.thread', 'mail.activity.mixin', 'image.mixin']
     _description = "Product"
+    _explanation = "The abstract base representation of a product. It defines the generic properties (name, category, price) that apply to all its variants. If a product has no variations (like size/color), this acts as the main product record."
     _order = "is_favorite desc, name"
     _check_company_auto = True
     _check_company_domain = models.check_company_domain_parent_of

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -22,6 +22,7 @@ _lt = LazyTranslate(__name__)
 class ProjectProject(models.Model):
     _name = 'project.project'
     _description = "Project"
+    _explanation = "A top-level container used to organize and track a group of related project.tasks. Provides a high-level overview of progress, budget, and time spent on a specific initiative or client."
     _inherit = [
         'portal.mixin',
         'mail.alias.mixin',

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -90,6 +90,7 @@ CLOSED_STATES = {
 class ProjectTask(models.Model):
     _name = 'project.task'
     _description = "Task"
+    _explanation = "A specific piece of work to be completed within a project. Tasks can be assigned to employees, tracked through stages (e.g., In Progress, Done), and have logged timesheets."
     _date_name = "date_assign"
     _inherit = [
         'portal.mixin',

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -6,6 +6,7 @@ from odoo.fields import Domain
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
+    _explanation = "In the Sales context, partners represent Customers. Use this to track sales history, credit limits, and pricing lists specific to the customer's relationship with the company."
 
     sale_order_count = fields.Integer(
         string="Sale Order Count",

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -32,6 +32,7 @@ SALE_ORDER_STATE = [
 
 class SaleOrder(models.Model):
     _name = "sale.order"
+    _explanation = "Represents a customer quotation that can be converted into a sales order. Used to manage pricing, product quantities, and status"
     _inherit = [
         "account.document.import.mixin",
         "mail.activity.mixin",

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -127,6 +127,7 @@
 
     <record id="product_template_action" model="ir.actions.act_window">
         <field name="name">Products</field>
+        <field name="explanation">Shows the product catalog available for sale. Use this when the user wants to update item pricing, inventory details, or product descriptions.</field>
         <field name="res_model">product.template</field>
         <field name="path">products</field>
         <field name="view_ids" eval="[Command.clear(),

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -17,6 +17,7 @@ PROCUREMENT_PRIORITIES = [('0', 'Normal'), ('1', 'Urgent')]
 class StockMove(models.Model):
     _name = 'stock.move'
     _description = "Stock Move"
+    _explanation = "Represents a request or a completed action to move a specific quantity of a product from a source location to a destination location. These are the lines that make up a stock.picking."
     _order = 'sequence, id'
     _rec_name = 'reference'
 

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -18,6 +18,7 @@ from odoo.tools.misc import clean_context
 class StockPickingType(models.Model):
     _name = 'stock.picking.type'
     _description = "Picking Type"
+    _explanation = "Defines the type of stock operation (e.g., Receipts, Deliveries, Internal Transfers) and contains configuration for how these operations should behave in the warehouse."
     _order = 'is_favorite desc, sequence, id'
     _rec_names_search = ['name', 'warehouse_id.name']
     _check_company_auto = True
@@ -531,6 +532,7 @@ class StockPicking(models.Model):
     _name = 'stock.picking'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = "Transfer"
+    _explanation = "Represents a physical movement of goods, such as receiving a shipment, sending out a delivery, or moving stock internally within a warehouse. Contains multiple stock.move lines."
     _order = "priority desc, scheduled_date asc, id desc"
     _priority_field = 'priority'
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -19,6 +19,7 @@ _logger = logging.getLogger(__name__)
 class StockQuant(models.Model):
     _name = 'stock.quant'
     _description = 'Quant'
+    _explanation = "The actual, current inventory on hand. A quant tracks how much of a specific product is currently sitting in a specific location (down to the lot/serial number or package)."
     _rec_name = 'product_id'
     _rec_names_search = ['location_id', 'lot_id', 'package_id', 'owner_id']
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -70,6 +70,7 @@ class IrActionsActions(models.Model):
     help = fields.Html(string='Action Description',
                        help='Optional help text for the users with a description of the target view, such as its usage and purpose.',
                        translate=True)
+    explanation = fields.Text(string='Explanation', help='Verbose description of what this action actually does')
     binding_model_id = fields.Many2one('ir.model', ondelete='cascade',
                                        help="Setting a value makes this action available in the sidebar for the given model.")
     binding_type = fields.Selection([('action', 'Action'),

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import random
 import re
+import textwrap
 import psycopg2
 import typing
 from ast import literal_eval
@@ -225,6 +226,7 @@ class IrModel(models.Model):
     order = fields.Char(string='Order', default='id', required=True,
                         help='SQL expression for ordering records in the model; e.g. "x_sequence asc, id desc"')
     info = fields.Text(string='Information')
+    explanation = fields.Text(string='Explanation', help='Verbose description of what is this model for')
     field_id = fields.One2many('ir.model.fields', 'model_id', string='Fields', required=True, copy=True,
                                default=_default_field_id)
     inherited_model_ids = fields.Many2many('ir.model', compute='_inherited_models', string="Inherited models",
@@ -457,9 +459,18 @@ class IrModel(models.Model):
 
     def _reflect_model_params(self, model):
         """ Return the values to write to the database for the given model. """
+        explanations = []
+        for cls in reversed(type(model).mro()):
+            # Use __dict__ to only capture explanations explicitly defined on this class.
+            explanation = cls.__dict__.get('_explanation')
+            # Only include if it matches the target model's name (ignores mixins).
+            if explanation and getattr(cls, '_name', None) == model._name:
+                explanations.append(textwrap.dedent(explanation).strip())
+
         return {
             'model': model._name,
             'name': model._description,
+            'explanation': "\n\n".join(explanations) if explanations else False,
             'order': model._order,
             'info': next(cls.__doc__ for cls in self.env.registry[model._name].mro() if cls.__doc__),
             'state': 'manual' if model._custom else 'base',

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -58,6 +58,7 @@ def company_default_for(fname, target_model, target_fname):
 class ResCompany(models.CachedModel):
     _name = 'res.company'
     _description = 'Company'
+    _explanation = "Represents a legal entity within the Odoo database. Odoo supports multi-company environments where each company has its own settings, chart of accounts, and business data."
     _order = 'sequence, name'
     _inherit = ['format.address.mixin', 'format.vat.label.mixin']
     _parent_store = True

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -31,6 +31,7 @@ NO_FLAG_COUNTRIES = [
 class ResCountry(models.CachedModel):
     _name = 'res.country'
     _description = 'Country'
+    _explanation = "Represents a nation or territory. Used for addressing, tax rules (fiscal positions), and localization settings."
     _order = 'name, id'
     _rec_names_search = ['name', 'code']
     _cached_data_fields = ('code', 'currency_id', 'phone_code')
@@ -192,6 +193,7 @@ class ResCountryGroup(models.Model):
 class ResCountryState(models.Model):
     _name = 'res.country.state'
     _description = "Country state"
+    _explanation = "Represents a sub-division of a country, such as a state, province, or region."
     _order = 'code, id'
     _rec_names_search = ['name', 'code']
 

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -21,6 +21,7 @@ except ImportError:
 class ResCurrency(models.CachedModel):
     _name = 'res.currency'
     _description = "Currency"
+    _explanation = "Represents a monetary unit. Odoo uses this to handle multi-currency transactions, exchange rates, and financial reporting."
     _rec_names_search = ['name', 'full_name']
     _order = 'active desc, name'
     # invalidate cache for get_all_currencies

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -175,6 +175,7 @@ class ResPartnerCategory(models.Model):
 class ResPartner(models.Model):
     _name = 'res.partner'
     _description = 'Contact'
+    _explanation = "Foundational model for all people and companies (customers, vendors, employees, etc.). Used for identifying individuals or organizations."
     _inherit = ['format.address.mixin', 'format.vat.label.mixin', 'avatar.mixin', 'properties.base.definition.mixin']
     _order = "complete_name ASC, id DESC"
     _rec_names_search = ['complete_name', 'email', 'ref', 'vat', 'company_registry']  # TODO vat must be sanitized the same way for storing/searching

--- a/odoo/addons/base/models/res_partner_bank.py
+++ b/odoo/addons/base/models/res_partner_bank.py
@@ -15,6 +15,7 @@ class ResPartnerBank(models.Model):
     _name = 'res.partner.bank'
     _rec_name = 'account_number'
     _description = 'Bank Account'
+    _explanation = "Represents a bank account owned by a partner (customer, vendor, or company). It stores the account number (IBAN), bank details, and owner information."
     _order = 'sequence, id'
 
     active = fields.Boolean(default=True)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -170,6 +170,7 @@ class ResUsers(models.Model):
     """
     _name = 'res.users'
     _description = 'User'
+    _explanation = "Represents a person who has access to the system. Users have login credentials, assigned groups for security permissions, and are linked to a partner record for contact information."
     _inherits = {'res.partner': 'partner_id'}
     _order = 'name, login'
     _allow_sudo_commands = False

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -3,16 +3,27 @@
 import json
 from datetime import date
 from unittest.mock import patch
-
 import requests
 from markupsafe import Markup
 
 from odoo import Command
 from odoo.exceptions import AccessError, ValidationError
-from odoo.tests import tagged
+from odoo.tests import TransactionCase, tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+
+
+class TestActionExplanation(TransactionCase):
+
+    def test_action_explanation(self):
+        """ Test that explanation is correctly stored and retrieved for actions. """
+        action = self.env['ir.actions.act_window'].create({
+            'name': 'Test Action',
+            'res_model': 'res.partner',
+            'explanation': 'This action is used for testing explanations.',
+        })
+        self.assertEqual(action.explanation, 'This action is used for testing explanations.')
 
 
 class TestServerActionsBase(TransactionCaseWithUserDemo):

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -372,7 +372,6 @@ class TestIrModelInherit(TransactionCase):
         self.assertEqual(imi.parent_id.model, "res.partner")
         self.assertEqual(imi.parent_field_id.name, "partner_id")
 
-
 class TestCommonCustomFields(TransactionCase):
     MODEL = 'res.partner'
     COMODEL = 'res.users'
@@ -718,3 +717,61 @@ class TestCustomFieldsPostInstall(TestCommonCustomFields):
             self.assertIn(
                 f'The field `{field.name}` is not defined in the `{field.model}` Python class', log_catcher.output[0]
             )
+
+
+@tagged('at_install', '-post_install')
+class TestIrModelExplanation(TransactionCase):
+    def test_explanation_mro_reflection(self):
+        """ Test that _explanation is correctly aggregated across the MRO. """
+
+        class MockBaseModel:
+            _name = 'mock.mro.model'
+            _description = 'Mock'
+            _order = 'id'
+            _custom = False
+            _abstract = False
+            _transient = False
+            _fold_name = 'fold'
+            __module__ = 'odoo.addons.base.models.mock'
+            _explanation = 'Base explanation'
+            __doc__ = 'Base doc'
+
+        class MockExtensionModel(MockBaseModel):
+            __module__ = 'odoo.addons.hr.models.mock'
+            _explanation = 'Extension explanation'
+
+        # Instantiate the extension model as if the ORM built it
+        mock_model = MockExtensionModel()
+        self.env.registry['mock.mro.model'] = MockExtensionModel
+
+        try:
+            params = self.env['ir.model']._reflect_model_params(mock_model)
+
+            expected = 'Base explanation\n\nExtension explanation'
+            self.assertEqual(params['explanation'], expected)
+        finally:
+            del self.env.registry['mock.mro.model']
+
+    def test_model_explanation_reflection(self):
+        """ Test that _explanation is correctly reflected in ir.model. """
+        class MockModel:
+            _name = 'mock.model'
+            _description = 'Mock'
+            _order = 'id'
+            _custom = False
+            _abstract = False
+            _transient = False
+            _fold_name = 'fold'
+            __module__ = 'odoo.addons.base.models.mock'
+            _explanation = 'This is a mock model explanation.'
+            __doc__ = 'Base doc'
+
+        mock_model = MockModel()
+        self.env.registry['mock.model'] = MockModel
+
+        try:
+            params = self.env['ir.model']._reflect_model_params(mock_model)
+            expected = 'This is a mock model explanation.'
+            self.assertEqual(params['explanation'], expected)
+        finally:
+            del self.env.registry['mock.model']

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -13,8 +13,11 @@
                         <field name="name"/>
                         <field name="type"/>
                     </group>
+                    <group string="Explanation">
+                        <field name="explanation" nolabel="1"/>
+                    </group>
                 </sheet>
-                </form>
+            </form>
             </field>
         </record>
         <record id="action_view_tree" model="ir.ui.view">
@@ -104,6 +107,11 @@
                                     <field name="attachment"/>
                                 </group>
                             </page>
+                            <page name="explanation" string="Explanation">
+                                <group>
+                                    <field name="explanation" nolabel="1"/>
+                                </group>
+                            </page>
                         </notebook>
                     </sheet>
                 </form>
@@ -170,6 +178,9 @@
                         </group>
                         <group name="help" string="Help">
                             <field name="help" nolabel="1" class="oe-bordered-editor"/>
+                        </group>
+                        <group name="explanation" string="Explanation">
+                            <field name="explanation" nolabel="1" class="oe-bordered-editor"/>
                         </group>
                     </sheet>
                 </form>
@@ -499,6 +510,9 @@
 env['res.partner'].create({'name': partner_name})
     </pre>
                                     </div>
+                                </page>
+                                <page string="Explanation" name="explanation">
+                                    <field name="explanation" nolabel="1" class="oe-bordered-editor"/>
                                 </page>
                                 <page string="Usage" name="usage" invisible="1"/>
                             </notebook>

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -7,9 +7,17 @@
                 <form string="Model Description" duplicate="0">
                   <header><!-- used for override --></header>
                   <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1>
+                            <field name="name" placeholder="e.g. Sales Order"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <field name="explanation" placeholder="Provide a verbose explanation of the model's purpose..."/>
+                    </group>
                     <group>
                         <group>
-                            <field name="name"/>
                             <field name="model" readonly="id"/>
                             <field name="order"/>
                             <field name="abstract" readonly="id" groups="base.group_no_one"/>
@@ -172,6 +180,7 @@
                             </field>
                         </page>
                         <page string="Notes" name="notes" groups="base.group_no_one">
+                            <separator string="Information"/>
                             <field name="info"/>
                         </page>
                         <page string="Views" name="views" groups="base.group_no_one">

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -414,6 +414,7 @@ class BaseModel(metaclass=MetaModel):
 
     _name: str = None                   #: the model name (in dot-notation, module namespace)
     _description: str | None = None     #: the model's informal name
+    _explanation: str | None = None     #: the model's verbose explanation (what purpuse does it serve)
     _module: str | None = None          #: the model's module (in the Odoo sense)
     _custom: bool = False               #: should be True for custom models only
 


### PR DESCRIPTION
This PR introduces a dedicated _explanation attribute to Odoo's core models and actions to provide verbose, LLM-targeted context. 

Previously the AI agent relies on the _description attribute, which in fact has little to do with action of describing. It just the human readable display name of the model. 

By adding a separate explanation field to `ir.model` and `ir.actions.actions`, we can now provide better explainability of the model for both ai and humans use.

This PR has introduced a selection of description. Future work should continue to add more in the future.

https://github.com/odoo/enterprise/pull/112466

task-6009099

Description wasn't describing, let's hope that explanation would explain.

### Showcasing
as explaination isn't only usefull for ai I've also put it here 
<img width="1814" height="657" alt="image" src="https://github.com/user-attachments/assets/18a044bc-f60f-45ac-b114-266508694c07" />


and here
<img width="1248" height="374" alt="image" src="https://github.com/user-attachments/assets/78c0c4e8-7b70-4248-9d57-3efe3f12f575" />

