### PR TITLE
[FIX] point_of_sale: fix duplicate order after validation

### DIFF
--- a/addons/l10n_ar_pos/static/src/app/services/pos_store.js
+++ b/addons/l10n_ar_pos/static/src/app/services/pos_store.js
@@ -16,13 +16,10 @@ patch(PosStore.prototype, {
     isArgentineanCompany() {
         return this.company.country_id?.code == "AR";
     },
-    createNewOrder() {
-        const order = super.createNewOrder(...arguments);
-
-        if (this.isArgentineanCompany() && !order.partner_id) {
-            order.partner_id = this.config._consumidor_final_anonimo_id;
+    getDefaultPartnerId() {
+        if (this.isArgentineanCompany()) {
+            return this.config._consumidor_final_anonimo_id;
         }
-
-        return order;
+        return super.getDefaultPartnerId();
     },
 });

--- a/addons/l10n_pe_pos/static/src/app/services/pos_store.js
+++ b/addons/l10n_pe_pos/static/src/app/services/pos_store.js
@@ -14,13 +14,10 @@ patch(PosStore.prototype, {
     isPeruvianCompany() {
         return this.company.country_id?.code == "PE";
     },
-    createNewOrder() {
-        const order = super.createNewOrder(...arguments);
-
-        if (this.isPeruvianCompany() && !order.partner_id) {
-            order.partner_id = this.config._consumidor_final_anonimo_id;
+    getDefaultPartnerId() {
+        if (this.isPeruvianCompany()) {
+            return this.config._consumidor_final_anonimo_id;
         }
-
-        return order;
+        return super.getDefaultPartnerId();
     },
 });

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1300,6 +1300,10 @@ export class PosStore extends WithLazyGetterTrap {
         this.setNextOrderRefs(order);
         order.setPricelist(this.config.pricelist_id);
 
+        if (!order.partner_id) {
+            order.partner_id = this.getDefaultPartnerId();
+        }
+
         if (this.config.use_presets && !data["preset_id"]) {
             this.selectPreset(this.config.default_preset_id, order);
         }
@@ -1341,13 +1345,17 @@ export class PosStore extends WithLazyGetterTrap {
     get openOrder() {
         return this.models["pos.order"].find((o) => o.state === "draft") || this.addNewOrder();
     }
+    getDefaultPartnerId() {
+        return null;
+    }
     getEmptyOrder() {
+        const defaultPartnerId = this.getDefaultPartnerId();
         const emptyOrders = this.models["pos.order"].filter(
             (order) =>
                 order.isEmpty() &&
                 !order.finalized &&
                 order.payment_ids.length === 0 &&
-                !order.partner_id &&
+                (!order.partner_id || order.partner_id.id === defaultPartnerId) &&
                 order.pricelist_id?.id === this.config.pricelist_id?.id &&
                 order.fiscal_position_id?.id === this.config.default_fiscal_position_id?.id
         );


### PR DESCRIPTION
When a default partner is assigned to new orders, `getEmptyOrder()` failed to find the existing empty order because it filtered on `!order.partner_id`, causing a duplicate order to be created after each validation.

Add a `getDefaultPartnerId()` hook returning `null` by default. `createNewOrder()` uses it to assign the default partner centrally, and `getEmptyOrder()` uses it to correctly identify orders still considered empty despite having a default partner set.

Also update l10n_ar_pos and l10n_pe_pos to override `getDefaultPartnerId()` instead of `createNewOrder()`.

opw-6077656

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
