### PR TITLE
[IMP] account_peppol: log error traceback

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -218,6 +218,7 @@ class AccountEdiProxyClientUser(models.Model):
                         'res_id': move.id,
                     })
                     self.env['ir.attachment'].create(attachment_vals)
+                    _logger.exception('Error while processing the Peppol document with uuid %s', uuid)
                 if 'is_in_extractable_state' in move._fields:
                     move.is_in_extractable_state = False
 


### PR DESCRIPTION
This change improves error logging when receiving invoices by including the full traceback in the logs. This provides better visibility into the root cause and simplifies debugging by giving more context around the error.

opw-6059877