### PR TITLE
[IMP] hr_timesheet: redesign my/all timesheet kanban

### DIFF
--- a/addons/hr_timesheet/models/account_analytic_line.py
+++ b/addons/hr_timesheet/models/account_analytic_line.py
@@ -77,6 +77,8 @@ class AccountAnalyticLine(models.Model):
     milestone_id = fields.Many2one('project.milestone', related='task_id.milestone_id')
     message_partner_ids = fields.Many2many('res.partner', compute='_compute_message_partner_ids', search='_search_message_partner_ids')
     calendar_display_name = fields.Char(compute="_compute_calendar_display_name", export_string_translation=False)
+    color = fields.Integer(related="project_id.color")
+    sequence = fields.Integer(string='Sequence', export_string_translation=False, default=10)
 
     def _search_message_partner_ids(self, operator, value):
         followed_ids_by_model = dict(self.env['mail.followers']._read_group([

--- a/addons/hr_timesheet/static/src/components/timesheet_duration_uom/timesheet_duration_uom.scss
+++ b/addons/hr_timesheet/static/src/components/timesheet_duration_uom/timesheet_duration_uom.scss
@@ -1,0 +1,3 @@
+div.o_field_timesheet_duration_uom > button.o_field_float_toggle {
+    width: fit-content !important;
+}

--- a/addons/hr_timesheet/static/src/scss/timesheet_kanban.scss
+++ b/addons/hr_timesheet/static/src/scss/timesheet_kanban.scss
@@ -1,0 +1,3 @@
+.o_ts_kanban_card_amount {
+    min-width: fit-content;
+}

--- a/addons/hr_timesheet/static/src/services/timesheet_uom_service.js
+++ b/addons/hr_timesheet/static/src/services/timesheet_uom_service.js
@@ -30,7 +30,9 @@ export const timesheetUOMService = {
             },
             _getFactorCompanyDependentProps(props) {
                 const factor = user.activeCompany.timesheet_uom_factor || props.factor;
-                return { ...props, factor };
+                const digits = [0, 2];
+                const trailingZeros = false;
+                return { ...props, factor, digits, trailingZeros };
             },
             get formatter() {
                 if (this.timesheetWidget === "float_time") {

--- a/addons/hr_timesheet/static/tests/timesheet_uom.test.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom.test.js
@@ -72,7 +72,7 @@ test("hr.timesheet (form): FloatFactorField is used when the current_company uom
     expect('div[name="unit_amount"] input[inputmode="decimal"]').toBeVisible({
         message: "unit_amount is displayed as float",
     });
-    expect('div[name="unit_amount"] input').toHaveValue("1.00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1.0", {
         message: "unit_amount is not displayed as float and not as time",
     });
     expect('div[name="unit_amount"].o_field_float_toggle').not.toHaveCount(null, {
@@ -88,7 +88,7 @@ test("hr.timesheet (form): FloatFactorField is dependent on timesheet_uom_factor
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("2.00", {
+    expect('div[name="unit_amount"] input').toHaveValue("2.0", {
         message: "timesheet_uom_factor is taken into account",
     });
 });

--- a/addons/hr_timesheet/static/tests/timesheet_uom_no_toggle.test.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom_no_toggle.test.js
@@ -50,7 +50,7 @@ test("hr.timesheet (form): FloatToggleField is not used when current company uom
     expect('div[name="unit_amount"] input[inputmode="decimal"]').toBeVisible({
         message: "unit_amount should be displayed as float",
     });
-    expect('div[name="unit_amount"] input').toHaveValue("1.00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1.0", {
         message: "unit_amount shouldn't be displayed as float and not as time",
     });
 });
@@ -65,7 +65,7 @@ test("FloatFactorField is used when the current_company uom is not part of the s
     expect('div[name="unit_amount"] input[inputmode="decimal"]').toBeVisible({
         message: "unit_amount should be displayed as float",
     });
-    expect('div[name="unit_amount"] input').toHaveValue("1.00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1.0", {
         message: "unit_amount shouldn't be displayed as float and not as time",
     });
     expect('div[name="unit_amount"].o_field_float_toggle').not.toHaveCount(null, {
@@ -81,7 +81,7 @@ test("FloatFactorField is dependent of timesheet_uom_factor of the current compa
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("2.00", {
+    expect('div[name="unit_amount"] input').toHaveValue("2.0", {
         message: "timesheet_uom_factor should be taken into account",
     });
 });

--- a/addons/hr_timesheet/views/account_analytic_line_views.xml
+++ b/addons/hr_timesheet/views/account_analytic_line_views.xml
@@ -290,15 +290,18 @@
             <field name="name">account.analytic.line.kanban</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile" sample="1">
+                <kanban class="o_kanban_mobile" highlight_color="color" on_create="quick_create" quick_create_view="hr_timesheet.quick_create_account_analytic_line_form" default_order="date desc, sequence, id desc">
+                    <progressbar field="id" colors="{}" sum_field="unit_amount" widget="timesheet_uom"/>
                     <field name="company_id" invisible="1"/>
                     <templates>
                         <t t-name="card">
-                            <div class="d-flex gap-1">
-                                <span t-att-title="record.employee_id.value">
-                                    <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover me-2 float-start"/>
-                                </span>
-                                <div class="d-flex flex-column min-w-0 lh-sm">
+                            <div class="d-flex gap-1 flex-row">
+                                <div class="align-self-center me-2" invisible="context.get('default_date')">
+                                    <field name="date" invisible="1"/>
+                                    <div t-out="luxon.DateTime.fromISO(record.date.raw_value).toFormat('MMM d')"/>
+                                    <div t-out="luxon.DateTime.fromISO(record.date.raw_value).toFormat('yyyy')"/>
+                                </div>
+                                <div class="text-truncate d-flex flex-column min-w-1 max-w-10 lh-sm">
                                     <span class="text-truncate" invisible="context.get('default_project_id')" t-att-title="record.project_id.value">
                                         <field name="project_id" class="p-0 fw-bold fs-5"/>
                                     </span>
@@ -306,21 +309,34 @@
                                         <field name="task_id" invisible="context.get('default_project_id')"/>
                                         <field name="task_id" invisible="not context.get('default_project_id')" class="p-0 fw-bold fs-5"/>
                                     </span>
-                                    <span>
-                                        <i class="fa fa-calendar me-1" role="img" aria-label="Date" title="Date"></i>
-                                        <field name="date"/><span invisible="context.get('is_my_timesheets')"> - <field name="employee_id"/></span>
-                                    </span>
-                                    <span class="text-truncate" t-att-title="record.name.value"><field name="name" class="fst-italic"/></span>
+                                    <span class="text-truncate" t-att-title="record.name.value" invisible="name == '/'"><field name="name" class="fst-italic"/></span>
+                                </div>
+                                <div class="o_ts_kanban_card_amount d-flex ms-auto align-self-end" name="ts_footer">
+                                    <field name="employee_id" widget="many2one_avatar_employee" class="align-self-end"/>
+                                    <strong class="align-self-end"><field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0" decoration-muted="unit_amount == 0" class="min-w-fit"/></strong>
                                 </div>
                             </div>
-                            <footer class="mt-0 pt-0">
-                                <div class="d-flex ms-auto">
-                                    <strong><field name="unit_amount" widget="timesheet_duration_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0" class="ms-1"/></strong>
-                                </div>
-                            </footer>
                         </t>
                     </templates>
                 </kanban>
+            </field>
+        </record>
+
+        <record id="quick_create_account_analytic_line_form" model="ir.ui.view">
+            <field name="name">account.analytic.line.kanban.quick_create</field>
+            <field name="model">account.analytic.line</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group class="mb-3">
+                        <field name="project_id" required="1"/>
+                        <field name="task_id"/>
+                        <field name="name" string="Description" placeholder="Describe your activity... "/>
+                        <field name="employee_id" widget="many2one_avatar_employee" required="1" readonly="readonly_timesheet" context="{'active_test': True}"/>
+                        <field name="user_id" invisible="1"/>
+                        <field name="date"/>
+                        <field name="unit_amount" string="Time Spent" widget="timesheet_duration_uom" class="o_field_timesheet_duration_uom ms-1 "/>
+                    </group>
+                </form>
             </field>
         </record>
 

--- a/addons/web/static/src/views/fields/float_toggle/float_toggle_field.js
+++ b/addons/web/static/src/views/fields/float_toggle/float_toggle_field.js
@@ -13,11 +13,13 @@ export class FloatToggleField extends Component {
         range: { type: Array, optional: true },
         factor: { type: Number, optional: true },
         disableReadOnly: { type: Boolean, optional: true },
+        trailingZeros: { type: Boolean, optional: true },
     };
     static defaultProps = {
         range: [0.0, 0.5, 1.0],
         factor: 1,
         disableReadOnly: false,
+        trailingZeros: true,
     };
 
     // TODO perf issue (because of update round trip)
@@ -45,6 +47,7 @@ export class FloatToggleField extends Component {
             digits: this.props.digits,
             factor: this.factor,
             field: this.props.record.fields[this.props.name],
+            trailingZeros: this.props.trailingZeros,
         });
     }
 }
@@ -77,6 +80,12 @@ export const floatToggleField = {
             name: "force_button",
             type: "boolean",
         },
+        {
+            label: _t("Hide trailing zeros"),
+            name: "hide_trailing_zeros",
+            type: "boolean",
+            help: _t("Hide zeros to the right of the last non-zero digit, e.g. 1.20 becomes 1.2"),
+        },
     ],
     supportedTypes: ["float"],
     isEmpty: () => false,
@@ -92,6 +101,7 @@ export const floatToggleField = {
 
         return {
             digits,
+            trailingZeros: !options.hide_trailing_zeros,
             range: options.range,
             factor: options.factor,
             disableReadOnly: options.force_button || false,

--- a/addons/web/static/tests/views/fields/float_toggle_field.test.js
+++ b/addons/web/static/tests/views/fields/float_toggle_field.test.js
@@ -13,7 +13,10 @@ import {
 class Partner extends models.Model {
     float_field = fields.Float({ string: "Float field" });
 
-    _records = [{ id: 1, float_field: 0.44444 }];
+    _records = [
+        { id: 1, float_field: 0.44444 },
+        { id: 2, float_field: 1 },
+    ];
 }
 
 class User extends models.Model {
@@ -93,5 +96,20 @@ test("kanban view (readonly) with option force_button", async () => {
     await contains("button.o_field_float_toggle").click();
     expect("button.o_field_float_toggle").not.toHaveText(value, {
         message: "float_field field value should be changed",
+    });
+});
+
+test("with 'hide_trailing_zeros' option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="float_field" widget="float_toggle" options="{'range': [0, 1, 0.75, 0.5, 0.25], 'hide_trailing_zeros': true}"/>
+            </form>`,
+    });
+    expect(".o_field_widget").toHaveText("1", {
+        message: "The field would show 1.00 without the option",
     });
 });


### PR DESCRIPTION
Redesign the timesheet kanban views to display more relevant information and make the *My Timesheet* view feel more calendar‑like.

## Additional
- To ensure `is_billable` behaves correctly with the kanban progress bar, a non-stored `is_billable_select` field was added to `analytic.account.line`. This field can be queried through its `sql_search` method, allowing efficient access without introducing redundant stored fields in the database. Using a selection field is required for proper progress bar functionality.

task-[5180328](https://www.odoo.com/odoo/project/4105/tasks/5180328)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr