### PR TITLE
[FIX] l10n_it: set deferred accounts explicitly on chart template

### DIFF
--- a/addons/l10n_it/models/template_it.py
+++ b/addons/l10n_it/models/template_it.py
@@ -28,6 +28,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_gain_account_id': '3111',
                 'account_sale_tax_id': '22v',
                 'account_purchase_tax_id': '22am',
+                'deferred_expense_account_id': '1902',
+                'deferred_revenue_account_id': '2702',
                 'expense_account_id': '4101',
                 'income_account_id': '3101',
                 'account_stock_journal_id': 'inventory_valuation',


### PR DESCRIPTION
Italy's chart template did not explicitly define deferred expense and revenue accounts, so deferred accounts fell back to the first `asset_current` and `liability_current` accounts in the chart. That could assign incorrect defaults such as `140100` and `220100`. This patch sets the intended Italian deferred accounts to `190200` and `270200` directly in the template to ensure correct configuration during chart loading.

task-6076711