### PR TITLE
[FIX] hr: correctly compute user's employee

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -254,15 +254,18 @@ class ResUsers(models.Model):
     @api.depends('employee_ids')
     @api.depends_context('company', 'uid')
     def _compute_company_employee(self):
-        Employee = self.env['hr.employee']
-        if self == self.env.user:
-            Employee = Employee.sudo()
-        employee_per_user = {
-            employee.user_id: employee
-            for employee in Employee.search([('user_id', 'in', self.ids), ('company_id', '=', self.env.company.id)])
-        }
+        employee_per_user = dict(self.env['hr.employee'].sudo()._read_group(
+            domain=[('user_id', 'in', self.ids), ('company_id', '=', self.env.company.id)],
+            groupby=['user_id'],
+            aggregates=['id:recordset'],
+        ))
+
         for user in self:
-            user.employee_id = employee_per_user.get(user)
+            employee = employee_per_user.get(user, self.env['hr.employee'])
+            if user != self.env.user and not self.env.su:
+                # since the search is done in sudo to avoid cache issues, apply access rules
+                employee = employee.filtered(lambda e: e.has_access('read'))
+            user.employee_id = employee
 
     def _search_company_employee(self, operator, value):
         # Equivalent to `[('employee_ids', operator, value)]`,

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -88,6 +88,19 @@ class TestHrEmployee(TestHrCommon):
         employee = employee_form.save()
         self.assertEqual(employee.tz, _tz)
 
+    def test_compute_user_company_employee(self):
+        test_user = new_test_user(self.env, login='test_user', groups='base.group_user', name='testuser', email='test@user.com')
+        test_user.action_create_employee()
+        employee = test_user.employee_id
+        multiple_users = self.user_without_image + test_user
+
+        multiple_users.invalidate_recordset(['employee_id'])
+
+        multiple_users.with_user(test_user).employee_id  # trigger the compute in batch and in non-sudo
+
+        self.assertEqual(test_user.with_user(test_user).employee_id, employee)
+        self.assertEqual(test_user.with_user(test_user).sudo().employee_id, employee)
+
     def test_employee_timezone(self):
         self.res_users_hr_officer.tz = "Africa/Cairo"
         Employee = self.env['hr.employee'].with_user(self.res_users_hr_officer)


### PR DESCRIPTION
**Steps to reproduce**
- Install `pos_hr` with demo data
- Open Settings > Manage Users
- Validation Error: A user cannot be linked to multiple employees in the same company

**Cause**
`employee_id` for the current user was computed as False here: https://github.com/odoo/odoo/blob/361aa8505506f9686b1cdb244ba1723ee3f06f7b/addons/pos_hr/models/pos_config.py#L27 Despite an employee already existing, which led to the error here: https://github.com/odoo/odoo/blob/361aa8505506f9686b1cdb244ba1723ee3f06f7b/addons/pos_hr/models/pos_config.py#L30

This exposes an issue with `_compute_company_employee`:
- the compute is called a first time on multiple users, including the current user, in a non-sudo environment
- the `employee_id` field for the current user is accessed in a sudo environment

The problem comes from the search in non-sudo, which uses an `ir.rule` that evaluates `user.employee_id` in sudo while we are computing `user.employee_id`.

**Fix**
We avoid the cache issue by always performing the search in sudo.

opw-6046297