### PR TITLE
[FIX] google_gmail: change logger error to logger warning

### DIFF
--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -113,7 +113,7 @@ class GoogleGmailMixin(models.AbstractModel):
                     timeout=GMAIL_TOKEN_REQUEST_TIMEOUT)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
-                _logger.error('Can not contact IAP: %s.', e)
+                _logger.warning('Can not contact IAP: %s.', e)
                 raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
             response = response.json()
@@ -221,7 +221,7 @@ class GoogleGmailMixin(models.AbstractModel):
         )
 
         if not response.ok:
-            _logger.error('Can not contact IAP: %s.', response.text)
+            _logger.warning('Can not contact IAP: %s.', response.text)
             raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
         response = response.json()


### PR DESCRIPTION
Currently, the logger prints an error message to the terminal when a response 
s not ok or a request exception is generated, and after this, a user error is raised to inform the users.

Since this is non-blocking and the error warning shows to the users (by` UserError`),
it’s better to log a warning here rather than an error.

Sentry-6992264566

