### PR TITLE
[FIX] mail: hide IM status icon when not received

### DIFF
--- a/addons/mail/static/src/core/common/discuss_avatar.js
+++ b/addons/mail/static/src/core/common/discuss_avatar.js
@@ -56,10 +56,7 @@ export class DiscussAvatar extends Component {
         if (this.channel) {
             return this.channel.showThreadIcon({ ignoreTyping: !this.props.typing });
         }
-        if (this.props.member || this.persona) {
-            return true;
-        }
-        return false;
+        return this.props.member?.imStatusUI || this.persona?.imStatusUI;
     }
 
     get user() {

--- a/addons/mail/static/src/discuss/core/common/channel_member.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member.js
@@ -33,7 +33,10 @@ export class ChannelMember extends Component {
     }
 
     get attClass() {
-        return { "cursor-pointer": this.isClickable, "o-offline": !this.member.isOnline };
+        return {
+            "cursor-pointer": this.isClickable,
+            "o-offline": this.member.imStatusUI === "offline",
+        };
     }
 
     get canOpenChat() {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -41,6 +41,12 @@ export class ChannelMemberList extends Component {
         });
     }
 
+    get unknownStatusSectionText() {
+        return _t("Others - %(unknown_status_count)s", {
+            unknown_status_count: this.props.channel.unknownStatusMembers.length,
+        });
+    }
+
     onClickInviteButton() {
         if (this.env.inMeetingView) {
             this.props.openChannelInvitePanel?.({ keepPrevious: true });

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -20,6 +20,14 @@
                     <ChannelMember t-foreach="this.props.channel.offlineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
+            <t name="unknownStatusMembers" t-if="this.props.channel.unknownStatusMembers.length > 0">
+                <t t-call="discuss.ChannelMemberList.section">
+                    <t t-set="sectionName" t-value="this.unknownStatusSectionText"/>
+                </t>
+                <div class="d-flex flex-column bg-inherit gap-1">
+                    <ChannelMember t-foreach="this.props.channel.unknownStatusMembers" t-as="member" t-key="member.id" member="member"/>
+                </div>
+            </t>
             <span t-if="this.props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
             <span t-if="this.props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-out="this.props.channel.unknownMembersCount"/> other members.</span>
             <div t-if="!this.props.channel.areAllMembersLoaded" class="mx-2 my-1">

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -182,10 +182,6 @@ export class ChannelMember extends Record {
         return this.partner_id?.imStatusUI || this.guest_id?.imStatusUI;
     }
 
-    get isOnline() {
-        return this.store.onlineMemberStatuses.includes(this.imStatusUI);
-    }
-
     /**
      * @returns {string}
      */

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -286,7 +286,7 @@ export class DiscussChannel extends Record {
         /** @this {import("models").DiscussChannel} */
         compute() {
             return this.channel_member_ids
-                .filter((member) => member.isOnline)
+                .filter((member) => this.store.onlineMemberStatuses.includes(member.imStatusUI))
                 .sort((m1, m2) => this.store.sortMembers(m1, m2)); // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
         },
     });
@@ -451,9 +451,9 @@ export class DiscussChannel extends Record {
     offlineMembers = fields.Many("discuss.channel.member", {
         /** @this {import("models").DiscussChannel} */
         compute() {
-            return this._computeOfflineMembers().sort(
-                (m1, m2) => this.store.sortMembers(m1, m2) // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
-            );
+            return this.channel_member_ids
+                .filter((member) => member.imStatusUI === "offline")
+                .sort((m1, m2) => this.store.sortMembers(m1, m2)); // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
         },
     });
     /** @type {true|undefined} */
@@ -529,6 +529,14 @@ export class DiscussChannel extends Record {
     get unknownMembersCount() {
         return (this.member_count ?? 0) - (this.channel_member_ids.length ?? 0);
     }
+    unknownStatusMembers = fields.Many("discuss.channel.member", {
+        /** @this {import("models").DiscussChannel} */
+        compute() {
+            return this._computeUnknownStatusMembers().sort(
+                (m1, m2) => this.store.sortMembers(m1, m2) // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
+            );
+        },
+    });
 
     _onDeleteChatWindow() {}
 
@@ -804,8 +812,10 @@ export class DiscussChannel extends Record {
     }
 
     /** @returns {import("models").ChannelMember[]} */
-    _computeOfflineMembers() {
-        return this.channel_member_ids.filter((member) => !member.isOnline);
+    _computeUnknownStatusMembers() {
+        return this.channel_member_ids.filter((member) =>
+            [undefined, "im_partner"].includes(member.imStatusUI)
+        );
     }
     get composerHidden() {
         return !this.canSelfInteractWithChannel;

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -77,11 +77,12 @@ test("should have correct members in member list", async () => {
     await contains(".o-discuss-ChannelMember:text('Demo')");
 });
 
-test("members should be correctly categorised into online/offline", async () => {
+test("members should be correctly categorised into online/offline/others", async () => {
     const pyEnv = await startServer();
-    const [onlinePartnerId, idlePartnerId] = pyEnv["res.partner"].create([
+    const [onlinePartnerId, idlePartnerId, offlinePartnerId] = pyEnv["res.partner"].create([
         { name: "Online Partner", im_status: "online" },
         { name: "Idle Partner", im_status: "away" },
+        { name: "Offline Partner", im_status: "offline" },
     ]);
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "im_partner" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -90,6 +91,7 @@ test("members should be correctly categorised into online/offline", async () => 
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ partner_id: onlinePartnerId }),
             Command.create({ partner_id: idlePartnerId }),
+            Command.create({ partner_id: offlinePartnerId }),
         ],
         channel_type: "channel",
     });
@@ -97,6 +99,7 @@ test("members should be correctly categorised into online/offline", async () => 
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMemberList h6:text('Online - 2')");
     await contains(".o-discuss-ChannelMemberList h6:text('Offline - 1')");
+    await contains(".o-discuss-ChannelMemberList h6:text('Others - 1')");
 });
 
 test("chat with member should be opened after clicking on channel member", async () => {


### PR DESCRIPTION
Since [1], non-internal users don't receive the IM status of other users.
This leads to the "No IM status available" icon to be shown to non-internal users.
This commit fixes the issue by only showing the icon when the value is available.
This commit also uncategorizes the channel member list in the public page since the IM status of the members is not always available there.

[1] https://github.com/odoo/odoo/pull/251938

| Before  | After |
| ------------- | ------------- |
| <img width="245" height="346" alt="image" src="https://github.com/user-attachments/assets/ca078424-f97c-4b25-a465-9bdc9a6bf084" />  | <img width="244" height="298" alt="image" src="https://github.com/user-attachments/assets/102944c9-b7a8-4085-9397-b0053cf8aa5a" />  |