### PR TITLE
[IMP] point_of_sale: add spacing between Source Invoice and Reference

### DIFF
--- a/addons/point_of_sale/views/report_invoice.xml
+++ b/addons/point_of_sale/views/report_invoice.xml
@@ -7,7 +7,7 @@
             </t>
         </xpath>
         <xpath expr="//div[@name='origin']" position="after">
-            <div class="col" t-if="o.pos_refunded_invoice_ids" name="source_invoice">
+            <div class="col me-3" t-if="o.pos_refunded_invoice_ids" name="source_invoice">
                 <strong>Source Invoice</strong>
                 <div t-field="o.pos_refunded_invoice_ids"/>
             </div>


### PR DESCRIPTION
Before this commit:
- When the Source Invoice name is too long, it connect with the Reference field due to missing spacing.

After this commit:
- Added margin (`me-3`) to the Source Invoice block to ensure proper spacing and avoid overlap with the Reference field.

task-6074560

| Before | After |
|--------|--------|
| <img width="801" height="474" alt="image" src="https://github.com/user-attachments/assets/cbef48f8-c37b-4263-8c6f-a6b0de3716b9" /> | <img width="780" height="462" alt="image" src="https://github.com/user-attachments/assets/fa01e0b5-d877-424f-a51f-8da0ce5a6bd5" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
