### PR TITLE
Task-6076119: Adding "to pay" filter to th invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -666,15 +666,6 @@ class AccountMove(models.Model):
         compute='_compute_is_being_sent'
     )
 
-    move_sent_values = fields.Selection(
-        selection=[
-            ('sent', 'Sent'),
-            ('not_sent', 'Not Sent'),
-        ],
-        string='Sent',
-        compute='compute_move_sent_values',
-        search='_search_move_sent_values',
-    )
     invoice_user_id = fields.Many2one(
         string='Salesperson',
         comodel_name='res.users',
@@ -818,16 +809,6 @@ class AccountMove(models.Model):
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.sending_data)
-
-    @api.depends('is_move_sent')
-    def compute_move_sent_values(self):
-        for move in self:
-            move.move_sent_values = 'sent' if move.is_move_sent else 'not_sent'
-
-    def _search_move_sent_values(self, operator, value):
-        if operator != 'in' or value - {'sent', 'not_sent'}:
-            return NotImplemented
-        return [('is_move_sent', 'in', [elem == 'sent' for elem in value])]
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (
@@ -1340,13 +1321,6 @@ class AccountMove(models.Model):
                 f"WHEN {alias}.state = 'draft' THEN 'draft' "
                 f"WHEN {alias}.state = 'cancel' THEN 'cancel' "
                 f"ELSE {alias}.payment_state "
-                "END"
-            )
-        elif fname == 'move_sent_values':
-            return SQL(
-                "CASE "
-                f"WHEN {alias}.is_move_sent THEN 'sent' "
-                f"ELSE 'not_sent' "
                 "END"
             )
         return super()._field_to_sql(alias, fname, query=query)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4900,23 +4900,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         )
         self.assertEqual(discounted_amount, 52.95)
 
-    def test_search_move_sent_values(self):
-        # Create a partner to only get invoices from this test
-        partner = self.env['res.partner'].create({
-            'name': 'Test Partner',
-        })
-
-        invoice_sent = self.init_invoice('out_invoice', products=self.product_a, partner=partner, post=True)
-        invoice_sent._generate_and_send()
-
-        invoice_not_sent = self.init_invoice('out_invoice', products=self.product_a, partner=partner, post=True)
-
-        res = self.env['account.move'].search([('partner_id', '=', partner.id), ('move_sent_values', '=', 'sent')])
-        self.assertEqual(invoice_sent, res)
-
-        res = self.env['account.move'].search([('partner_id', '=', partner.id), ('move_sent_values', '=', 'not_sent')])
-        self.assertEqual(invoice_not_sent, res)
-
     def test_invoice_currency_rate_round_globally(self):
         """Ensure that when the tax rounding method is set to 'global', changing the currency rate directly
          on the invoice results in journal entries that are rounded globally, not per line. """

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -532,7 +532,7 @@
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" readonly="state != 'draft'" string="Invoice Date" decoration-warning="abnormal_date_warning"/>
                     <field name="date" optional="hide" string="Accounting Date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="invoice_date_due" widget="remaining_days" optional="show" invisible="payment_state in ('paid', 'in_payment', 'reversed') or state == 'cancel'"/>
+                    <field name="invoice_date_due" widget="remaining_days" optional="show" invisible="payment_state in ('paid', 'in_payment', 'reversed')"/>
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" column_invisible="context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')"/>
                     <field name="ref" optional="hide"/>
@@ -555,14 +555,6 @@
                            decoration-success="status_in_payment in ('in_payment', 'paid', 'reversed')"
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
-                    />
-                    <field name="move_sent_values"
-                           string="Sent"
-                           widget="badge"
-                           decoration-success="move_sent_values == 'sent'"
-                           decoration-danger="move_sent_values == 'not_sent'"
-                           column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')"
-                           optional="hide"
                     />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
@@ -1412,12 +1404,12 @@
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
-                                               decoration-muted="debit == 0"/>
+                                        />
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
-                                               decoration-muted="credit == 0"/>
+                                        />
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"
                                                string="Discount Date"
@@ -1709,8 +1701,6 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
-                    <!-- not_paid & partial -->
-                    <filter name="open" string="To pay" domain="[('state', '!=', 'cancel'), ('payment_state', 'in', ('not_paid', 'partial')), ('move_type', '!=', 'entry')]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1701,6 +1701,9 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
+                     <!-- to_be_paid -->
+                    <filter name="to_pay" string="To Pay" domain="[('state', '!=', 'cancelled'), '|', 
+                                                                    ('payment_state', '=', 'not_paid'), ('payment_state', '=', 'partial')]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->

--- a/addons/l10n_in_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_ewaybill/views/account_move_views.xml
@@ -39,7 +39,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_invoice_tree"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='move_sent_values']" position="after">
+            <xpath expr="//field[@name='move_type']" position="after">
                 <field name="l10n_in_ewaybill_name" optional="hide"/>
             </xpath>
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently there is no filter to see the invoices that need to be paid (fully or if they have paid some part of it and need to pay the rest).

Current behavior before PR:
There is no filter to easily access the invoices that need to be paid.

Desired behavior after PR is merged:
The filter to access them does exist now, you just need to click on the "To Pay" filter and you'll have them.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
