### PR TITLE
[FIX] html_editor: parse history revision create_date as UTC

### DIFF
--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.js
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.js
@@ -74,7 +74,8 @@ export class HistoryDialog extends Component {
                 revision_id: revisionId,
                 create_date: DateTime.fromFormat(
                     record[0]["create_date"],
-                    "yyyy-MM-dd HH:mm:ss"
+                    "yyyy-MM-dd HH:mm:ss",
+                    { zone: "utc" }
                 ).toISO(),
                 create_uid: record[0]["create_uid"][0],
                 create_user_name: record[0]["create_uid"][1],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The record's `create_date` from `orm.read` is a naive datetime string in UTC, but `DateTime.fromFormat` without a zone option interprets it in the browser's local timezone. This causes the initial revision's date to be shifted by the user's UTC offset in the history dialog.

Current behavior before PR:
1) Create a task
2) Change/Add description in it
3) Check the version history
4) the task is having wrong date/date & time in the 1st revision (in my case -5:30 hours)

<img width="749" height="515" alt="image" src="https://github.com/user-attachments/assets/e9480570-7458-4e0a-9bba-6514d6b1aacf" />


Desired behavior after PR is merged:

<img width="751" height="483" alt="image" src="https://github.com/user-attachments/assets/ff9d1c95-fc8e-40bb-8cf8-bab39c9cd59b" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
