### PR TITLE
[FIX] mrp: trigger consumption issue only for compatible variants

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1777,7 +1777,10 @@ class MrpProduction(models.Model):
                 for bom, data in order.bom_id.explode(order.bom_id.product_id, order.product_qty)[0]:
                     if bom.type == 'phantom' or bom == order.bom_id:
                         bom_factors[bom.id] = bom_factor * data['qty'] / data['original_qty']
-                        all_lines |= bom.bom_line_ids.filtered(lambda line: line.child_bom_id.type != 'phantom')
+                        all_lines |= bom.bom_line_ids.filtered(lambda line:
+                            line.child_bom_id.type != 'phantom'
+                            and not line._skip_bom_line(order.product_id)
+                        )
                 missing_lines = all_lines - order.move_raw_ids.bom_line_id
             for move in order.move_raw_ids:
                 # If there's no BoM, we simply rely on the quantity specified by the user.

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1755,7 +1755,10 @@ class MrpProduction(models.Model):
                 for bom, data in order.bom_id.explode(order.bom_id.product_id, order.product_qty)[0]:
                     if bom.type == 'phantom' or bom == order.bom_id:
                         bom_factors[bom.id] = bom_factor * data['qty'] / data['original_qty']
-                        all_lines |= bom.bom_line_ids.filtered(lambda line: line.child_bom_id.type != 'phantom')
+                        all_lines |= bom.bom_line_ids.filtered(lambda line:
+                            line.child_bom_id.type != 'phantom'
+                            and not line._skip_bom_line(order.product_id)
+                        )
                 missing_lines = all_lines - order.move_raw_ids.bom_line_id
             for move in order.move_raw_ids:
                 # If there's no BoM, we simply rely on the quantity specified by the user.

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2911,6 +2911,32 @@ class TestBoM(TestMrpCommon):
         self.env['mrp.routing.workcenter'].search([]).unlink()
         self.assertFalse(self.bom_1.show_copy_operations_button, "The copy operations button should be visible even if the current BoM is empty.")
 
+    def test_consumption_issue_only_for_compatible_variant(self):
+        """A consumption issue should not be triggered for components that are not compatible with the produced variant."""
+        # Case 1: Product variant = red
+        self.product_4.product_template_attribute_value_ids = self.color_attribute.template_value_ids[0]
+        # First BoM line applies only to Blue variant
+        self.bom_1.bom_line_ids[0].bom_product_template_attribute_value_ids = self.color_attribute.template_value_ids[1]
+        mo = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        # The BoM contains 2 lines but only 1 raw move should be created
+        self.assertEqual(len(self.bom_1.bom_line_ids), 2)
+        self.assertEqual(len(mo.move_raw_ids), 1)
+        mo.action_confirm()
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done', "The MO should be completed without any consumption issue since the missing component is not compatible with the variant to produce.")
+        # Case 2: Blue variant
+        self.product_4.product_template_attribute_value_ids = self.color_attribute.template_value_ids[1]
+        mo_2 = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        self.assertEqual(len(mo_2.move_raw_ids), 2)
+        mo_2.move_raw_ids[0].unlink()  # Remove one component to simulate missing consumption
+        mo_2.action_confirm()
+        action = mo_2.button_mark_done()
+        self.assertEqual(action['res_model'], 'mrp.consumption.warning', "A consumption issue must be triggered when a component is missing.")
+
 
 @tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5505,6 +5505,32 @@ class TestMrpOrder(TestMrpCommon):
             mo_form.bom_id = self.env['mrp.bom']
             self.assertEqual(len(mo_form.workorder_ids), 0)
 
+    def test_consumption_issue_only_for_compatible_variant(self):
+        """A consumption issue should not be triggered for components that are not compatible with the produced variant."""
+        # Case 1: Product variant = red
+        self.product_4.product_template_attribute_value_ids = self.color_attribute.template_value_ids[0]
+        # First BoM line applies only to Blue variant
+        self.bom_1.bom_line_ids[0].bom_product_template_attribute_value_ids = self.color_attribute.template_value_ids[1]
+        mo = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        # The BoM contains 2 lines but only 1 raw move should be created
+        self.assertEqual(len(self.bom_1.bom_line_ids), 2)
+        self.assertEqual(len(mo.move_raw_ids), 1)
+        mo.action_confirm()
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done', "The MO should be completed without any consumption issue since the missing component is not compatible with the variant to produce.")
+        # Case 2: Blue variant
+        self.product_4.product_template_attribute_value_ids = self.color_attribute.template_value_ids[1]
+        mo_2 = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        self.assertEqual(len(mo_2.move_raw_ids), 2)
+        mo_2.move_raw_ids[0].unlink()  # Remove one component to simulate missing consumption
+        mo_2.action_confirm()
+        action = mo_2.button_mark_done()
+        self.assertEqual(action['res_model'], 'mrp.consumption.warning', "A consumption issue must be triggered when a component is missing.")
+
 
 @tagged('-at_install', 'post_install')
 class TestMrpOrderPostInstall(TestMrpCommon):


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - Variant: Color -> Red & Blue
    - BoM: -Components: - C1: apply on variant Blue - C2: apply on all variant

- Create a manufacturing order to produce one P1 red
- only the move raw C2 is created -> expected behavior
- Confirm the MO
- Try to validate the production

Problem:
A consumption issues is triggered to indicate that C1 is missing

Explication:

When confirming a manufacturing order, we checks if some BoM components are missing and may trigger a consumption issue.

However, the check was done on all BoM lines of the exploded BoM, without verifying whether the component was compatible with the variant being produced.

As a result, a consumption issue could be raised even when the missing component was not supposed to be consumed for the selected variant.

opw-6062762