### PR TITLE
[FIX] sale_management: move SO section with order line in edition

### DIFF
--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -174,6 +174,9 @@ patch(SaleOrderLineListRenderer.prototype, {
      */
     async sortDrop(dataRowId, dataGroupId, { element, previous }) {
         const record = this.props.list.records.find(r => r.id === dataRowId);
+        // Prevent the record from being abandoned when leaveEditMode or sortDrop is called
+        record.dirty = true;
+        await this.props.list.leaveEditMode();
         const recordMap = this._getRecordsToRecompute(record, previous ? previous.dataset.id : null);
 
         await super.sortDrop(dataRowId, dataGroupId, { element, previous });

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
@@ -112,6 +112,9 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
      */
     async sortDrop(dataRowId, dataGroupId, { element, previous }) {
         const record = this.props.list.records.find(r => r.id === dataRowId);
+        // Prevent the record from being abandoned when leaveEditMode or sortDrop is called
+        record.dirty = true;
+        await this.props.list.leaveEditMode();
         const recordMap = this._getRecordsToRecompute(record, previous ? previous.dataset.id : null);
 
         await super.sortDrop(dataRowId, dataGroupId, { element, previous });


### PR DESCRIPTION
Moving a section around in sale order lines when there is a line that can be abandoned throws an error

Steps to reproduce:
1. Install Sales app
2. Go to Sales and create a new quotation
3. Add any product, then add a section: enter any name for the section and then immediately press Enter (it should create an empty product line)
4. Without leaving edit mode, drag and drop the section at the top of the sale order lines (the empty product line should still be there)
5. An error is thrown

The same issue can be reproduced by moving a section down:
3b. Add any product, then add a section: move it to the top of the order lines then enter any name for the section and immediately press Enter (it should create an empty product line)
4b. Without leaving edit mode, drag and drop the section just between the product line and the empty product line

Issue:
`sortDrop` calls `leaveEditMode` at
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/web/static/src/views/list/list_renderer.js#L2242 which removes order lines that can be abandoned
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/web/static/src/model/relational_model/static_list.js#L379-L381 This can remove records from the recordMap generated before calling `super.sortDrop` in
https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js#L175-L182 so we end up calling `_handleQuantityAdjustment` with a recordMap that contains record ids that have been deleted, throwing an error when we try to access the deleted record

Solution:
Call `leaveEditMode` before computing recordMap in order to remove the records that can be abandoned. This prevents `this.props.list.records` from being different when we generate recordMap and when we call
`_handleQuantityAdjustment`.
We also need to set the record being moved as dirty. This prevents the record from being abandoned when `leaveEditMode` is called.

opw-6022538