### PR TITLE
[FIX] account_edi_ubl_cii: Changing tax exemption reason when no tax

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -213,7 +213,7 @@ class AccountEdiCommon(models.AbstractModel):
         if supplier.country_id == customer.country_id:
             if not tax or tax.amount == 0:
                 # in theory, you should indicate the precise law article
-                return create_dict(tax_category_code='E', tax_exemption_reason=_('Articles 226 items 11 to 15 Directive 2006/112/EN'))
+                return create_dict(tax_category_code='E', tax_exemption_reason=_('Exempt from tax'))
             elif self._is_reverse_charge_tax(tax):
                 # Special case: Purchase reverse-charge taxes for self-billed invoices.
                 # From the buyer's perspective, this is a standard tax with a non-zero percentage but
@@ -248,7 +248,7 @@ class AccountEdiCommon(models.AbstractModel):
         if tax.amount != 0:
             return create_dict(tax_category_code='S')
         else:
-            return create_dict(tax_category_code='E', tax_exemption_reason=_('Articles 226 items 11 to 15 Directive 2006/112/EN'))
+            return create_dict(tax_category_code='E', tax_exemption_reason=_('Exempt from tax'))
 
     def _get_tax_category_list(self, invoice, taxes):
         """ Full list: https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -298,7 +298,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                     'tax_scheme_vals': {
                         'id': "VAT",
                     },
-                    'tax_exemption_reason': "Exempt from tax",
+                    'tax_exemption_reason': _("Exempt from tax"),
                 },
             }
             tax_totals_vals['tax_subtotal_vals'].append(subtotal)
@@ -316,7 +316,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                     'tax_scheme_vals': {
                         'id': "VAT",
                     },
-                    'tax_exemption_reason': "Exempt from tax",
+                    'tax_exemption_reason': _("Exempt from tax"),
                 },
             })
         return [tax_totals_vals]

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -104,7 +104,7 @@
 			<cbc:TaxAmount currencyID="EUR">0.50</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
-				<cbc:TaxExemptionReason>Articles 226 items 11 to 15 Directive 2006/112/EN</cbc:TaxExemptionReason>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines.xml
@@ -98,12 +98,24 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">93.42</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">393.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">9.00</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">10.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">0.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
 				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
@@ -111,11 +123,12 @@
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">402.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">84.42</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">1.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
 			<cac:TaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
@@ -123,25 +136,19 @@
 		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">393.00</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">393.00</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">486.42</cbc:TaxInclusiveAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">11.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">11.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">13.10</cbc:TaxInclusiveAmount>
 		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="EUR">486.42</cbc:PayableAmount>
+		<cbc:PayableAmount currencyID="EUR">13.10</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">99.00</cbc:LineExtensionAmount>
+		<cbc:InvoicedQuantity unitCode="C62">2.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">10.00</cbc:LineExtensionAmount>
 		<cac:Item>
 			<cbc:Description>product_a</cbc:Description>
 			<cbc:Name>product_a</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>E</cbc:ID>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -151,40 +158,45 @@
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">99.0</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">5.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">4.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">294.00</cbc:LineExtensionAmount>
-		<cac:AllowanceCharge>
-			<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-			<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
-			<cbc:MultiplierFactorNumeric>25.0</cbc:MultiplierFactorNumeric>
-			<cbc:Amount currencyID="EUR">98.00</cbc:Amount>
-			<cbc:BaseAmount currencyID="EUR">392.00</cbc:BaseAmount>
-		</cac:AllowanceCharge>
+		<cbc:InvoicedQuantity unitCode="C62">-1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
 		<cac:Item>
 			<cbc:Description>product_a</cbc:Description>
 			<cbc:Name>product_a</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>E</cbc:ID>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:Percent>0.0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">98.0</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">0.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">1.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>Vidange</cbc:Description>
+			<cbc:Name>Vidange</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">1.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
@@ -105,7 +105,7 @@
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>
-				<cbc:TaxExemptionReason>Articles 226 items 11 to 15 Directive 2006/112/EN</cbc:TaxExemptionReason>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -284,6 +284,34 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines')
 
+    def test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines(self):
+        """ Ensure the emptying taxes (a.k.a 'vidange') works on line with negative quantity for when the clients return the 'vidange'."""
+        tax_emptying = self.fixed_tax(1.0, name="Vidange")
+        tax_21 = self.percent_tax(21.0)
+        tax_0 = self.percent_tax(0)
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=5.0,
+                    quantity=2.0,
+                    tax_ids=tax_emptying + tax_21,
+                ),
+                # line with price zero used for returning 'vidange'.
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=0.0,
+                    quantity=-1.0,
+                    tax_ids=tax_emptying + tax_0,
+                ),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines')
+
     def test_invoice_manual_tax_amount(self):
         tax_12 = self.percent_tax(12.0)
         tax_21 = self.percent_tax(21.0)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_gln.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_gln.xml
@@ -112,7 +112,7 @@
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>
-				<cbc:TaxExemptionReason>Articles 226 items 11 to 15 Directive 2006/112/EN</cbc:TaxExemptionReason>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
@@ -111,7 +111,7 @@
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>
-				<cbc:TaxExemptionReason>Articles 226 items 11 to 15 Directive 2006/112/EN</cbc:TaxExemptionReason>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>


### PR DESCRIPTION
**PROBLEM**
Early payment discount create a new line which is tax exempted. The tax exemption reason is 'Exempted from tax'.
0% tax also have a tax exemption reason that is different, which means the tax exemption subtotal are not merged.

**STEP TO REPRODUCE**
1. Create a early payment discount payment term.
2. Create an invoice, with a line with a 0% tax and the early payment term.
3. Send the invoice using peppol, use a validator to validate the xml and notice you get the following errors: [BR-E-01] [BR-E-08].

A similar issue was fix in 18.0 by https://github.com/odoo/odoo/pull/250413, and the fix works for this bug.

opw-6075910