### PR TITLE
[FIX] mail: strengthen edit-mode context menu test

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -20,6 +20,7 @@ import {
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
+import { Message } from "@mail/core/common/message";
 import { LONG_PRESS_DELAY } from "@mail/utils/common/hooks";
 import { describe, expect, test } from "@odoo/hoot";
 import {
@@ -2419,13 +2420,25 @@ test("context menu should not open on right-click when editing a message", async
         model: "discuss.channel",
         res_id: channelId,
     });
+    patchWithCleanup(Message.prototype, {
+        onContextMenu() {
+            expect.step("Message.onContextMenu");
+            super.onContextMenu(...arguments);
+        },
+        showRightClickMessageActions() {
+            expect.step("Message.showRightClickMessageActions");
+            super.showRightClickMessageActions(...arguments);
+        },
+    });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
     await rightClick(".o-mail-Message");
+    await expect.waitForSteps(["Message.onContextMenu", "Message.showRightClickMessageActions"]);
     await click(".o-dropdown-item:contains('Edit')");
     await contains(".o-mail-Message.o-editing .o-mail-Composer-input", { value: "Batman" });
     await rightClick(".o-mail-Message");
+    await expect.waitForSteps(["Message.onContextMenu"]);
     await animationFrame();
-    await contains(".o-dropdown-item", { count: 0 });
+    expect.verifySteps([]);
 });


### PR DESCRIPTION
This PR is a follow up of https://github.com/odoo/odoo/pull/256063

Use `expect.waitForSteps()` in the right-click editing test to assert the message context-menu flow more explicitly instead of relying only on `animationFrame()`.

The test now verifies that:
- `onContextMenu()` is triggered
- `showRightClickMessageActions()` is not triggered while editing

This makes the test less timing-dependent.