### PR TITLE
[FIX] web: date field in list: do not reopen datepicker

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -2,6 +2,7 @@ import { onWillRender, useLayoutEffect, useRef, useState } from "@web/owl2/utils
 import { Component } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
 import { areDatesEqual, deserializeDate, deserializeDateTime, today } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
@@ -153,6 +154,7 @@ export class DateTimeField extends Component {
         this.state = useState(dateTimePicker.state);
         this.picker = useState({ activeInput: "" });
         this.openPicker = dateTimePicker.open;
+        this.isPickerOpen = dateTimePicker.isOpen;
 
         this.startDate = useRef("start-date");
         this.endDate = useRef("end-date");
@@ -162,7 +164,11 @@ export class DateTimeField extends Component {
                 [this.startDate, this.endDate].forEach((ref, index) => {
                     if (ref.el?.getAttribute("data-field") === this.picker.activeInput) {
                         ref.el.focus();
-                        this.openPicker(index);
+                        // openPickerOnNextPatch is set in the template on pointerdown on the button
+                        if (this.openPickerOnNextPatch) {
+                            this.openPicker(index);
+                            this.openPickerOnNextPatch = false;
+                        }
                     }
                 });
             },
@@ -207,6 +213,32 @@ export class DateTimeField extends Component {
             pickerProps.minPrecision = this.props.minPrecision;
         }
         return pickerProps;
+    }
+
+    /**
+     * Returns the placeholder for the input of the given fieldName. If a placeholder has been given
+     * in props, we want to always display that placeholder (on both inputs if any). If no
+     * placeholder has been given, we display a technical placeholder, which is the localized date
+     * or datetime format, on the focused input only. This prevent from displaying a bunch of
+     * technical placeholders.
+     *
+     * @param {string} [fieldName]
+     * @returns string
+     */
+    getPlaceholder(fieldName) {
+        if (this.props.placeholder) {
+            return this.props.placeholder;
+        }
+        if (this.picker.activeInput === fieldName) {
+            let placeholder = localization.dateFormat.toLowerCase();
+            // we purposely avoid using the dateTimeFormat because we don't want to see the `a`
+            // token (which stands for AM/PM)
+            if (this.field.type === "datetime") {
+                placeholder += " hh:mm";
+            }
+            return placeholder;
+        }
+        return "";
     }
 
     onToggleRange() {
@@ -357,6 +389,12 @@ export class DateTimeField extends Component {
 
     onInput() {
         this.triggerIsDirty(true);
+    }
+
+    onInputBlured() {
+        if (!this.isPickerOpen()) {
+            this.picker.activeInput = "";
+        }
     }
 }
 

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -15,6 +15,7 @@
                         t-att-data-tooltip="this.getFormattedValue(0, true)"
                         t-att-id="showSeparator ? this.props.endDateField and this.props.id : this.props.id"
                         t-on-focus="() => this.picker.activeInput = this.startDateField"
+                        t-on-pointerdown="() => this.openPickerOnNextPatch = true"
                         t-att-data-field="this.startDateField"
                         data-available-offline=""
                         t-att-class="'o_input o_daterange_start w-100 text-start ' + (this.props.warnFuture and this.isDateInTheFuture(0) ? 'text-danger' : '')">
@@ -29,10 +30,11 @@
                         t-att-class="'o_input cursor-pointer user-select-none' + (this.props.warnFuture and this.isDateInTheFuture(0) ? 'text-danger' : '')"
                         autocomplete="off"
                         inputmode="none"
-                        t-att-placeholder="this.props.placeholder"
+                        t-att-placeholder="this.getPlaceholder(this.startDateField)"
                         t-att-data-field="this.startDateField"
                         t-on-input="this.onInput"
                         t-on-focus="() => this.picker.activeInput = this.startDateField"
+                        t-on-blur="this.onInputBlured"
                         t-att-title="this.props.warnFuture and this.isDateInTheFuture(0) ? this.futureWarningMsg : ''"
                     />
                 </t>
@@ -54,6 +56,7 @@
                             t-custom-ref="end-date"
                             t-att-data-tooltip="this.getFormattedValue(1, true)"
                             t-on-focus="() => this.picker.activeInput = this.endDateField"
+                            t-on-pointerdown="() => this.openPickerOnNextPatch = true"
                             t-att-id="this.props.startDateField and this.props.id"
                             t-att-data-field="this.endDateField"
                             data-available-offline=""
@@ -69,10 +72,11 @@
                             t-att-class="'o_input cursor-pointer user-select-none' + (this.props.warnFuture and this.isDateInTheFuture(1) ? 'text-danger' : '')"
                             autocomplete="off"
                             inputmode="none"
-                            t-att-placeholder="this.props.placeholder"
+                            t-att-placeholder="this.getPlaceholder(this.endDateField)"
                             t-att-data-field="this.endDateField"
                             t-on-input="this.onInput"
                             t-on-focus="() => this.picker.activeInput = this.endDateField"
+                            t-on-blur="this.onInputBlured"
                             t-att-title="this.props.warnFuture and this.isDateInTheFuture(1) ? this.futureWarningMsg : ''"
                         />
                     </t>

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -308,10 +308,7 @@ export class ListRenderer extends Component {
                     const forward = this.cellToFocus.forward;
                     this.focusCell(column, forward);
                 } else {
-                    const column = this.lastEditedCell?.column || this.columns[0];
-                    if (column.widget !== "daterange" || !this.editedRecord.data[column.name]) {
-                        this.focusCell(column);
-                    }
+                    this.focusCell(this.lastEditedCell?.column || this.columns[0]);
                 }
             }
             this.cellToFocus = null;

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -29,8 +29,10 @@ import {
     models,
     mountView,
     onRpc,
+    patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
+import { localization } from "@web/core/l10n/localization";
 
 class Partner extends models.Model {
     _name = "res.partner";
@@ -637,4 +639,65 @@ test("DateField contains a calendar icon on touch devices", async () => {
     await mountView({ type: "form", resModel: "res.partner", resId: 1 });
     expect(".fa-calendar").toHaveCount(1);
     expect(".fa-calendar").toBeVisible();
+});
+
+test(`DateField in x2many list: open/close picker`, async () => {
+    Partner._fields.foo_o2m = fields.One2many({ relation: "res.partner" });
+
+    await mountView({
+        resModel: "res.partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="foo_o2m">
+                    <list editable="bottom">
+                        <field name="date" />
+                    </list>
+                </field>
+            </form>`,
+        resId: 1,
+    });
+
+    await contains(`.o_field_x2many_list_row_add button`).click();
+    await contains(`.o_data_row .o_field_widget[name=date] input`).click();
+    await waitFor(".o_datetime_picker");
+    expect(".o_datetime_picker").toBeDisplayed();
+    expect(".o_field_widget[name=date] input").toBeFocused();
+
+    await contains(getPickerCell("15")).click();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+
+    // Wait to check if the picker is still closed
+    await animationFrame();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+});
+
+test("DateField: placeholder", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        arch: `
+            <form>
+                <group>
+                    <field name="date" placeholder="I'm the placeholder"/>
+                    <field name="date"/>
+                </group>
+            </form>`,
+    });
+
+    patchWithCleanup(localization, {
+        dateFormat: "MM yyyy dd",
+    });
+
+    expect(".o_field_widget[name=date]:eq(0) input").toHaveAttribute(
+        "placeholder",
+        "I'm the placeholder"
+    );
+    expect(".o_field_widget[name=date]:eq(1) input").toHaveAttribute("placeholder", "");
+
+    // when focused, a default placeholder is displayed and it depends on the localization
+    await contains(".o_field_widget[name=date]:eq(1) input").focus();
+    expect(".o_field_widget[name=date]:eq(1) input").toHaveAttribute("placeholder", "mm yyyy dd");
 });

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -4,6 +4,7 @@ import {
     click,
     Deferred,
     edit,
+    pointerDown,
     press,
     queryAll,
     queryAllProperties,
@@ -12,6 +13,7 @@ import {
     queryFirst,
     queryValue,
     resize,
+    waitFor,
 } from "@odoo/hoot-dom";
 import { disableAnimations, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import { editTime } from "@web/../tests/core/datetime/datetime_test_helpers";
@@ -1173,6 +1175,52 @@ test("list daterange: start date input width matches its span counterpart", asyn
     expect(".o_field_daterange input").toHaveProperty("offsetWidth", initialWidth + 1);
 });
 
+test(`list daterange in x2many: open/close picker`, async () => {
+    Partner._fields.foo_o2m = fields.One2many({ relation: "partner" });
+    Partner._fields.date_end = fields.Date();
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <sheet>
+                    <field name="foo_o2m">
+                        <list editable="bottom">
+                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end', 'always_range': True}"/>
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    await contains(`.o_field_x2many_list_row_add button`).click();
+    await contains(`.o_data_row .o_field_widget[name=date] input`).click();
+    await waitFor(".o_datetime_picker");
+    expect(".o_datetime_picker").toBeDisplayed();
+    expect("input[data-field=date]").toBeFocused();
+
+    await contains(getPickerCell("15")).click();
+    await contains(getPickerCell("20")).click();
+
+    if (getMockEnv().isSmall) {
+        // Close the bottom sheet
+        await click(".o_bottom_sheet_backdrop");
+    } else {
+        // Close picker
+        await pointerDown(`.o_view_controller`);
+    }
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+
+    // Wait to check if the picker is still closed
+    await animationFrame();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+});
+
 test("always range: related end date, both start date and end date empty", async () => {
     Partner._records[0].datetime = false;
 
@@ -1199,8 +1247,9 @@ test("always range: related end date, both start date and end date empty", async
     expect(".o_field_daterange input:eq(1)").toHaveAttribute("data-field", "datetime_end");
     expect(".o_field_daterange input:eq(1)").toHaveValue("");
     expect(".o_toggle_range").toHaveCount(0);
-    await contains(".o_field_daterange input:eq(1)").edit("07/07/2023 13:00:00");
-    await animationFrame();
+    await contains(".o_field_daterange input:eq(1)").edit("07/07/2023 13:00:00", {
+        confirm: "blur",
+    });
 
     expect(".o_field_daterange button").toHaveCount(2);
     expect(".o_field_daterange button:eq(0)").toHaveAttribute("data-field", "datetime");
@@ -1210,7 +1259,6 @@ test("always range: related end date, both start date and end date empty", async
     expect(".o_toggle_range").toHaveCount(0);
     await contains(".o_field_daterange button:eq(0)").click();
     await contains(".o_field_daterange input").clear();
-    await animationFrame();
 
     expect(".o_field_daterange input").toHaveCount(1);
     expect(".o_field_daterange input").toHaveAttribute("data-field", "datetime");

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -24,7 +24,9 @@ import {
     mountView,
     onRpc,
     contains,
+    patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
+import { localization } from "@web/core/l10n/localization";
 import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
 
 class Partner extends models.Model {
@@ -719,4 +721,35 @@ test("DateTimeField contains a calendar icon on touch devices", async () => {
     });
     expect(".fa-calendar").toHaveCount(1);
     expect(".fa-calendar").toBeVisible();
+});
+
+test("DateTimeField: placeholder", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <group>
+                    <field name="datetime" placeholder="I'm the placeholder"/>
+                    <field name="datetime"/>
+                </group>
+            </form>`,
+    });
+
+    patchWithCleanup(localization, {
+        dateFormat: "MM yyyy dd",
+    });
+
+    expect(".o_field_widget[name=datetime]:eq(0) input").toHaveAttribute(
+        "placeholder",
+        "I'm the placeholder"
+    );
+    expect(".o_field_widget[name=datetime]:eq(1) input").toHaveAttribute("placeholder", "");
+
+    // when focused, a default placeholder is displayed and it depends on the localization
+    await contains(".o_field_widget[name=datetime]:eq(1) input").focus();
+    expect(".o_field_widget[name=datetime]:eq(1) input").toHaveAttribute(
+        "placeholder",
+        "mm yyyy dd hh:mm"
+    );
 });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -11564,53 +11564,6 @@ test(`list daterange with empty start date and end date`, async () => {
     ]);
 });
 
-test(`list daterange in form: open/close picker`, async () => {
-    Foo._fields.foo_o2m = fields.One2many({ relation: "foo" });
-    Foo._fields.date_end = fields.Date();
-
-    await mountView({
-        resModel: "foo",
-        type: "form",
-        arch: `
-            <form>
-                <sheet>
-                    <field name="foo_o2m">
-                        <list editable="bottom">
-                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end', 'always_range': True}"/>
-                        </list>
-                    </field>
-                </sheet>
-            </form>
-        `,
-        resId: 1,
-    });
-
-    await contains(`.o_field_x2many_list_row_add button`).click();
-    await contains(".o_field_daterange[name=date]").click();
-    await animationFrame();
-    await animationFrame();
-    expect(".o_datetime_picker").toBeDisplayed();
-    expect("input[data-field=date]").toBeFocused();
-
-    await contains(getPickerCell("15")).click();
-    await contains(getPickerCell("20")).click();
-
-    if (getMockEnv().isSmall) {
-        // Close the bottom sheet
-        await click(".o_bottom_sheet_backdrop");
-    } else {
-        // Close picker
-        await pointerDown(`.o_view_controller`);
-    }
-    await animationFrame();
-    expect(".o_datetime_picker").toHaveCount(0);
-
-    // Wait to check if the picker is still closed
-    await animationFrame();
-    await animationFrame();
-    expect(".o_datetime_picker").toHaveCount(0);
-});
-
 test.tags("desktop");
 test(`editable list view: contexts are correctly sent`, async () => {
     serverState.userContext = { someKey: "some value" };
@@ -20356,7 +20309,7 @@ test("multi_edit: must work for copy/paster or operation", async () => {
 
     await contains(`.o_list_record_selector`).click();
     await contains(`.o_data_cell[name=datetime]`).click();
-    await animationFrame();
+    await contains(`.o_data_cell[name=datetime] input`).click();
     await waitFor(`.o_datetime_picker`);
     await contains(`input[data-field=datetime]`).edit("+125d", { confirm: "tab" });
     expect(`tbody tr:eq(0) td[name=datetime]`).toHaveText("Jul 14, 11:30 AM");
@@ -20478,8 +20431,7 @@ test(`multi edition: edit date with operation`, async () => {
 
     async function checkOperation(operation) {
         await contains(`tr:eq(1) .o_data_cell[name=datetime]`).click();
-        await animationFrame();
-        await edit(operation.op, { confirm: "tab" });
+        await contains(`tr:eq(1) .o_data_cell[name=datetime] input`).edit(operation.op);
         await animationFrame();
         expect(`.modal .o_modal_changes [name=datetime]`).toHaveText(`Datetime ${operation.text}`);
         expect(`.modal .alert`).toHaveCount(1);
@@ -20492,8 +20444,7 @@ test(`multi edition: edit date with operation`, async () => {
     }
 
     await contains(`tr:eq(1) .o_data_cell[name=datetime]`).click();
-    await animationFrame();
-    await edit("-=4d", { confirm: "tab" });
+    await contains(`tr:eq(1) .o_data_cell[name=datetime] input`).edit("-=4d");
     await animationFrame();
     expect(`.modal .alert`)
         .toHaveText(`Use the operators "+=", "-=" to update the current date by days (d), weeks (w), months (m), years (y), hours (H), minutes (M) and seconds (S).
@@ -20510,8 +20461,7 @@ For example, if the date is Mar 11 and you enter "+=2d", it will be updated to M
         "Dec 28, 2020, 1:00 AM",
     ]);
     await contains(`tr:eq(1) .o_data_cell[name=datetime]`).click();
-    await animationFrame();
-    await edit("+=4y", { confirm: "tab" });
+    await contains(`tr:eq(1) .o_data_cell[name=datetime] input`).edit("+=4y");
     await animationFrame();
     await contains(`.modal-dialog button:contains(update)`).click();
     expect(queryAllTexts(`.o_data_cell`)).toEqual([


### PR DESCRIPTION
This commit aims at fixing an annoying behavior introduced by [1] which [2] partially fixed (it fixed it but only for the date_range widget). The issue is fully explained in the description of [2].

This commit provides a alternative solution, which is to avoid the issue by slightly modifying the behavior of the date(time) fields introduced in [1]. Before this commit, the datepicker was always opened, automatically, when the input was focused. With this commit, we only open it automatically when the user clicks on the input. If it navigates to the input (e.g. with "tab"), the pickers doesn't open. This makes the date(time) fields behave like many2one fields.

When a datetime field is empty, it's not always obvious that it is a datetime field, and that clicking on it would open the picker. To make it obvious, we force a default placeholder on those fields, which is the localized numeric format of a date(time), for instance "dd/mm/yyyy hh:mm").

Some tests had to be adapted due to the behavior change.

[1] https://github.com/odoo/odoo/pull/218387
[2] https://github.com/odoo/odoo/pull/231229

task~6045658

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
