### PR TITLE
[IMP] account, l10n_us_account: adding Equity Unaffected accounts in COA 

### DIFF
--- a/addons/account/data/template/account.account-generic_coa.csv
+++ b/addons/account/data/template/account.account-generic_coa.csv
@@ -43,3 +43,5 @@
 "expense_sales","Sales Expenses","9620","expense","account.account_tag_investing","False","False"
 "pos_receivable","Account Receivable (PoS)","1013","asset_receivable","","True","False"
 "credit_card","Credit Card","201100","liability_credit_card","","False","False"
+"profit_or_loss","Profit or Loss Appropriation","999999","equity_unaffected","","False","False"
+"retained_earnings","Accumulated Retained Earnings","999998","equity_unaffected","","False","False"

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -844,7 +844,7 @@ class ResCompany(models.Model):
                 'xml_id': f"account.{str(self.id)}_unaffected_earnings_account",
                 'values': {
                               'code': str(code),
-                              'name': _('Undistributed Profits/Losses'),
+                              'name': _('Profit or Loss Appropriation'),
                               'account_type': unaffected_earnings_type,
                               'company_ids': [Command.link(self.id)],
                           },

--- a/addons/l10n_fr_account/tests/test_fec_export.py
+++ b/addons/l10n_fr_account/tests/test_fec_export.py
@@ -25,7 +25,7 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             b''.join(result['file_content']).decode(),
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
-            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Undistributed Profits/Losses|||-|20200101|/|0,00| 000000000003000,00|||20200101||\r\n'
+            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Profit or Loss Appropriation|||-|20200101|/|0,00| 000000000003000,00|||20200101||\r\n'
             f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|/| 000000000003000,00|0,00|||20200101||\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000001000,00|||20200101|-000000000001000,00|USD\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000002000,00|||20200101|-000000000002000,00|USD\r\n'

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
@@ -142,7 +142,7 @@ class L10n_FrFecExportWizard(models.TransientModel):
                 unaffected_earnings_account = self.env['account.account'].search([
                     *self.env['account.account']._check_company_domain(company),
                     ('account_type', '=', 'equity_unaffected'),
-                ], limit=1)
+                ], order='code desc', limit=1)
                 unaffected_earnings_line = True  # used to make sure that we add the unaffected earning initial balance only once
                 if unaffected_earnings_account:
                     # compute the benefit/loss of last year to add in the initial balance of the current year earnings account
@@ -214,7 +214,7 @@ class L10n_FrFecExportWizard(models.TransientModel):
                     # search an unaffected earnings account
                     unaffected_earnings_account = self.env['account.account'].search([
                         ('account_type', '=', 'equity_unaffected')
-                    ], limit=1)
+                    ], order='code desc', limit=1)
                     if unaffected_earnings_account:
                         unaffected_earnings_results[4] = unaffected_earnings_account.code
                         unaffected_earnings_results[5] = unaffected_earnings_account.name

--- a/addons/l10n_us_account/data/template/account.account-us.csv
+++ b/addons/l10n_us_account/data/template/account.account-us.csv
@@ -98,3 +98,5 @@
 "account_account_us_local_tax","Local/City Tax","803000","expense_other","Business or income taxes owed to local or municipal governments","False","False",""
 "account_account_us_property_tax","Property Tax","804000","expense_other","Local taxes that have to be paid due to the ownership of property","False","False",""
 "account_account_us_sales_tax","Sales Tax","805000","expense_other","Sales and use tax paid on purchases where not otherwise recoverable","False","False",""
+"account_account_us_profit_or_loss_appropriation","Profit or Loss Appropriation","999999","equity_unaffected","Appropriation of the profit or loss","False","False",""
+"account_account_us_retained_earnings","Accumulated Retained Earnings","999998","equity_unaffected","Cumulative undistributed profits and losses","False","False",""


### PR DESCRIPTION
Simplifying the structure of the Balance Sheet in order to distinguish clearly **Earnings** and **Equity**, in the generic and US balance sheet.

Improving the generic and us charts of accounts to better highlight the account pair for the allocation of earnings.

task-6053852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
