### PR TITLE
[FIX] resource: specify hours_per_week for flexible calendar in demo data

### DIFF
--- a/addons/resource/data/resource_demo.xml
+++ b/addons/resource/data/resource_demo.xml
@@ -55,6 +55,7 @@
             <field name="name">Flexible 40 hours/week</field>
             <field name="company_id" ref="base.main_company"/>
             <field name="hours_per_day">8</field>
+            <field name="hours_per_week">40</field>
             <field name="flexible_hours" eval="True"/>
         </record>
 


### PR DESCRIPTION
Currently the demo 'Flexible 40 hours/week' calendar has no `hours_per_week` specified. This field is not computed for flexible calendars since https://github.com/odoo/odoo/pull/219608.

This results in any number of days taken off being set to 0, and thus unable to be approved. This is computed in the method `_attendance_intervals_batch()` https://github.com/odoo/odoo/blob/2008c391691e8cbeaaee07dadbe66cc9cb63092f/addons/resource/models/resource_calendar.py#L424


**Steps to reproduce:**
- Go to any employee and change the Working Hours to Flexible 40 h/week in Payroll>Schedule
- Go to Time Off>Managment>Time off and create a new record
- Set the employee for which you changed the schedule and set the interval to at least two days.
- You will see that the total will be shown to be 0 days, and if you try to approve you will get an error.

opw-6034782