### PR TITLE
[FIX] payment: activate payment_method_unknown before provider creation

### DIFF
--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -64,22 +64,25 @@ class PaymentCommon(BaseCommon):
             'arch': arch,
         })
 
+        # Activate payment method unknown before creating the provider to ensure it's included
+        # in the Many2many relationship when the provider is created
+        pm_unknown = cls.env.ref('payment.payment_method_unknown')
+        pm_unknown.write({
+            'active': True,
+            'support_tokenization': True,
+        })
+
         cls.dummy_provider = cls.env['payment.provider'].create({
             'name': "Dummy Provider",
             'code': 'none',
             'state': 'test',
             'is_published': True,
-            'payment_method_ids': [Command.set([cls.env.ref('payment.payment_method_unknown').id])],
+            'payment_method_ids': [Command.set([pm_unknown.id])],
             'allow_tokenization': True,
             'redirect_form_view_id': redirect_form.id,
             'available_currency_ids': [Command.set(
                 (cls.currency_euro + cls.currency_usd + cls.env.company.currency_id).ids
             )],
-        })
-        # Activate pm
-        cls.env.ref('payment.payment_method_unknown').write({
-            'active': True,
-            'support_tokenization': True,
         })
 
         cls.provider = cls.dummy_provider


### PR DESCRIPTION
Before this commit:
- The payment_method_unknown was activated AFTER creating the dummy provider in test setup
- The provider creation read payment_method_ids as an empty recordset because the method was inactive and filtered out by active_test=True (default)
- This caused test failures with IndexError when trying to access payment forms that weren't rendered due to missing payment methods

After this commit:
- The payment_method_unknown is activated BEFORE creating the provider
- The Many2many relationship properly includes the payment method when the provider is created
- Payment forms render correctly and tests pass

The issue occurred because the ORM's active_test context filter (True by default) excludes inactive records from Many2many relationships. When Command.set() was executed with the inactive payment_method_unknown, the database relation was created but immediately filtered out when reading payment_method_ids.

This commit fixes all payment flow tests that were failing with:
  IndexError: list index out of range
  at payment/tests/http_common.py line 94


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
