### PR TITLE
[FIX] test_orm: force prefetch in test_basic

### DIFF
--- a/odoo/addons/test_orm/tests/test_sort.py
+++ b/odoo/addons/test_orm/tests/test_sort.py
@@ -27,8 +27,9 @@ class TestSort(TransactionCase):
 
     def test_basic(self):
         db_result = self.env['test_orm.country'].search([])
+        # 1 query to fetch the fields, in practice it is already prefetched
+        self.countries.invalidate_model()
         with self.assertQueryCount(1):
-            # 1 query to fetch the fields, in practice it is already prefetched
             self.assertEqual(db_result.ids, self.countries.sorted().ids)
         with self.assertQueryCount(0):
             self.assertEqual(db_result[::-1].ids, self.countries.sorted(reverse=True).ids)


### PR DESCRIPTION
If modules are installed, the countries may be prefetched. Invalidate the transaction cache for repeatable results.

runbot-242220


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
