### PR TITLE
Master mail too heavy att field pydu

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import re
 import requests
 
 from datetime import datetime, timezone, timedelta
@@ -216,6 +217,10 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
     def test_cloud_storage_attachments(self):
         """Cloud attachments should be converted to links in outgoing emails."""
 
+        def count_attachment_link_in(body, attachment):
+            return len(re.findall(
+                rf"<a.*/web/content/{attachment.id}\?download=1.*access_token={attachment.access_token}", body))
+
         thread_model = self.env["res.partner"].create({"name": "Cloud Test Partner", "email": "cloud@test.com"})
         cloud_attachment = self.env["ir.attachment"].create({
                 "name": "cloud_attachment.txt",
@@ -246,10 +251,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         self.assertEqual(len(self._mails), 2, "Two emails should be sent.")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": attachment}))
-            self.assertEqual(body.count(large_attachment_link), 1,
-                    "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
-            )
+            self.assertEqual(count_attachment_link_in(body, attachment), 1,
+                             "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.")
 
         # A cloud attachment and small txt attachment sent -> 1st should become a link, 2nd should be sent with the message
         small_attachment = self.env["ir.attachment"].create({
@@ -283,10 +286,9 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
                 "Only text attachment should be sent in the message")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": cloud_attachment}))
-            self.assertEqual(body.count(large_attachment_link), 1,
-                    "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
-            )
+            self.assertEqual(
+                count_attachment_link_in(body, cloud_attachment), 1,
+                "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.")
 
         # A large txt attachment and 2 cloud attachments sent -> All 3 shall became links
         cloud_attachment2 = self.env["ir.attachment"].create({
@@ -324,8 +326,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
             cloud_attachment_present = body.count(cloud_attachment.access_token) == body.count(cloud_attachment.name) == 1
             cloud_attachment2_present = body.count(cloud_attachment2.access_token) == body.count(cloud_attachment2.name) == 1
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": large_attachment}))
-            self.assertTrue(body.count(large_attachment_link) == 1 and cloud_attachment_present and cloud_attachment2_present,
+            large_attachment_link_present = count_attachment_link_in(body, large_attachment) == 1
+            self.assertTrue(large_attachment_link_present and cloud_attachment_present and cloud_attachment2_present,
                 "Two cloud and one large attachments should be converted and sent as links in the outgoing email.",
             )
 

--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -41,14 +41,18 @@
         </template>
 
         <template id="mail_attachment_links" name="Attachment links">
-<div style="max-width: 900px; width: 100%;">
-    <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 10px 0px;"/>
-    <div t-foreach="attachments" t-as="attachment">
-        <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
-           style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
-            &amp;#128229; <t t-out="attachment.name"/>
-        </a>
-    </div>
+<div class="o-attachments-container" style="margin: 10px 0 10px; max-width: 900px; width: 100%;">
+    <span t-foreach="attachments" t-as="attachment">
+        <div style="margin:3px; padding: 10px; min-width:400px; display:inline-block; vertical-align:middle; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;" t-att-data-attachment-id="attachment.id">
+            <div t-if="is_preview" style="text-decoration:none; font-weight:500; font-size: 15px; width:fit-content; color:#008f8c;" width="fit-content">
+                &amp;#11015; <t t-out="attachment.name"/>
+            </div>
+            <a t-else="" t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
+                style="text-decoration:none; font-weight:500; font-size: 15px; width:fit-content; color:#008f8c;" width="fit-content" target="_blank">
+                 &amp;#11015; <t t-out="attachment.name"/>
+            </a>
+        </div>
+    </span>
 </div>
         </template>
     </data>

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -15,6 +15,7 @@ from dateutil.parser import parse
 
 from odoo import _, api, fields, models, modules, SUPERUSER_ID, tools
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
+from odoo.addons.mail.tools.attachment import extract_attachment_ids_from_html
 from odoo.exceptions import UserError, ValidationError
 from odoo.modules.registry import Registry
 
@@ -476,9 +477,7 @@ class MailMail(models.Model):
         # Prepare attachments:
         # Remove attachments if user send the link with the access_token.
         if body and attachments:
-            link_ids = {int(link) for link in re.findall(r'/web/(?:content|image)/([0-9]+)', body)}
-            if link_ids:
-                attachments = attachments - self.env['ir.attachment'].browse(list(link_ids))
+            attachments = attachments - self.env['ir.attachment'].browse(extract_attachment_ids_from_html(body))
 
         # Convert URL-only attachments (e.g. cloud or plain external links) into email links
         url_attachments = attachments.sudo().filtered(
@@ -502,7 +501,7 @@ class MailMail(models.Model):
                 record_owned_attachments.sudo().generate_access_token()
                 attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links',
                                                                 {'attachments': record_owned_attachments})
-                body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+                body = tools.mail.prepend_html_content(str(body), str(attachments_links))
                 attachments -= record_owned_attachments
         # attachments sorted by increasing ID to match front-end and upload ordering
         attachments.sudo().fetch(['name', 'raw', 'mimetype'])

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -496,8 +496,7 @@ class MailMail(models.Model):
                 lambda a: a.res_model and a.res_id and a.res_model != 'mail.message'):
             estimated_email_size_bytes = self._estimate_email_size(
                 headers, body, [a.file_size for a in attachments.sudo()])
-            max_email_size_bytes = (mail_server or self.env['ir.mail_server']
-                                    ).sudo()._get_max_email_size() * 1024 * 1024
+            max_email_size_bytes = self.env['ir.mail_server'].sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
                 # Remove attachments and prepare downloadable links to be added in the body
                 record_owned_attachments.sudo().generate_access_token()

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -7,7 +7,7 @@ import { MailFullComposerSuggestionPlugin } from "./mail_full_composer_suggestio
 import { ContentExpandablePlugin } from "./content_expandable_plugin";
 import { DisableBannerCommandsPlugin } from "./disable_banner_commands_plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
-import { markup } from "@odoo/owl";
+import { markup, onWillUnmount } from "@odoo/owl";
 
 export class HtmlComposerMessageField extends HtmlMailField {
     setup() {
@@ -36,6 +36,13 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 this.editor.shared.history.addStep();
             });
         }
+        this.lastAttachmentSet = new Set();
+        this.attachmentObserver = null;
+        onWillUnmount(() => {
+            if (this.attachmentObserver) {
+                this.attachmentObserver.disconnect();
+            }
+        });
     }
 
     getConfig() {
@@ -53,7 +60,7 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 (plugin) => !DYNAMIC_FIELD_PLUGINS.includes(plugin)
             );
         }
-        config.onAttachmentChange = (attachment) => {
+        config.onAttachmentChange = async (attachment) => {
             // This only needs to happen for the composer for now
             if (
                 !(
@@ -63,12 +70,24 @@ export class HtmlComposerMessageField extends HtmlMailField {
             ) {
                 return;
             }
+            await this.commitChanges();
             this.props.record.data.attachment_ids.linkTo(attachment.id, attachment);
         };
         config.thread = this.env.services["mail.store"]?.["mail.thread"].get({
             model: this.props.record.data.model,
             id: JSON.parse(this.props.record.data.res_ids || "[]")[0],
         });
+        config.onEditorReady = () => {
+            this.attachmentObserver = new MutationObserver(
+                this._commitChangesIfInlineAttachmentsHasChanged.bind(this)
+            );
+            this.attachmentObserver.observe(this.editor.editable, {
+                attributes: true,
+                attributeFilter: ["data-attachment-id"],
+                childList: true, // to be notified when attachment links are removed
+                subtree: true,
+            });
+        };
         return config;
     }
 
@@ -78,6 +97,17 @@ export class HtmlComposerMessageField extends HtmlMailField {
             el.remove();
         }
         return elContent;
+    }
+
+    _commitChangesIfInlineAttachmentsHasChanged() {
+        const nodes = this.editor.editable.querySelectorAll("[data-attachment-id]");
+        const newAttachmentSet = new Set(
+            [...nodes].map((node) => node.getAttribute("data-attachment-id"))
+        );
+        if (newAttachmentSet.symmetricDifference(this.lastAttachmentSet).size) {
+            this.lastAttachmentSet = newAttachmentSet;
+            this.commitChanges();
+        }
     }
 }
 

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -26,6 +26,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 import {
     click,
+    contains as waitForContains,
     defineMailModels,
     mailModels,
     openFormView,
@@ -116,9 +117,10 @@ test("media dialog: upload", async function () {
     await animationFrame();
     await insertText(htmlEditor, "/image");
     await press("Enter");
-    await animationFrame();
 
     // upload test
+    await waitForContains(".modal-title", { text: "Select a media" });
+    await waitForContains("[name='attachment_ids'] .o_attachment[title='test.jpg']", { count: 0 });
     const fileInputs = queryAll(".o_select_media_dialog input.d-none.o_file_input");
     const fileB64 =
         "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==";
@@ -136,11 +138,9 @@ test("media dialog: upload", async function () {
     fileInputs.forEach((input) => {
         manuallyDispatchProgrammaticEvent(input, "change");
     });
-    expect("[name='attachment_ids'] .o_attachment[title='test.jpg']").toHaveCount(0);
 
     await isUploaded;
-    await animationFrame();
-    expect("[name='attachment_ids'] .o_attachment[title='test.jpg']").toHaveCount(1);
+    await waitForContains("[name='attachment_ids'] .o_attachment[title='test.jpg']", { count: 1 });
 
     await contains(".o_form_button_save").click();
     await expect.waitForSteps(["web_save"]);

--- a/addons/mail/tools/__init__.py
+++ b/addons/mail/tools/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import alias_error
+from . import attachment
 from . import discuss
 from . import link_preview
 from . import parser

--- a/addons/mail/tools/attachment.py
+++ b/addons/mail/tools/attachment.py
@@ -1,0 +1,7 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
+
+def extract_attachment_ids_from_html(html):
+    """ Return the set of attachments ids present as link in the html. """
+    return {int(link) for link in re.findall(r'/web/(?:content|image)/([0-9]+)', html)}

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -7,8 +7,10 @@ import json
 from odoo import _, api, fields, models, Command, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
+from odoo.tools import human_size
 from odoo.tools.mail import is_html_empty, email_normalize, email_split_and_format, html_remove_xpath
 from odoo.tools.misc import clean_context
+from odoo.addons.mail.tools.attachment import extract_attachment_ids_from_html
 from odoo.addons.mail.tools.parser import parse_res_ids
 
 
@@ -92,6 +94,8 @@ class MailComposeMessage(models.TransientModel):
         'ir.attachment', 'mail_compose_message_ir_attachments_rel',
         'wizard_id', 'attachment_id', string='Attachments',
         compute='_compute_attachment_ids', readonly=False, store=True, bypass_search_access=True)
+    attachment_links = fields.Html("Attachment links", compute="_compute_attachment_links")
+    attachment_links_info = fields.Char(compute="_compute_attachment_links")
     email_layout_xmlid = fields.Char(
         'Email Notification Layout',
         compute='_compute_email_layout_xmlid', readonly=False, store=True,
@@ -291,6 +295,30 @@ class MailComposeMessage(models.TransientModel):
                     composer.attachment_ids = attachment_ids
             elif not composer.template_id:
                 composer.attachment_ids = False
+
+    @api.depends('attachment_ids', 'body')
+    def _compute_attachment_links(self):
+        if len(self) != 1:
+            self.attachment_links_info = False
+            self.attachment_links = False
+            return
+        # Headers are not yet defined at this stage, so we add a default size for them for the email size estimation.
+        default_estimated_header_size = 5000
+        max_email_size_bytes = self.env['ir.mail_server']._get_max_email_size() * 1024 * 1024
+        # We consider only attachments not already in the body (added through the html editor)
+        attachments = self.env['ir.attachment'].browse(
+            list(set(self.attachment_ids.ids) - extract_attachment_ids_from_html(self.body or '')))
+        estimate_size = self.env['mail.mail']._estimate_email_size(
+            {}, self.body, attachments.mapped('file_size')) + default_estimated_header_size
+        if not attachments or estimate_size <= max_email_size_bytes:
+            self.attachment_links_info = False
+            self.attachment_links = False
+            return
+        self.attachment_links = self.env['ir.qweb']._render(
+            'mail.mail_attachment_links', {'attachments': attachments, 'is_preview': True})
+        self.attachment_links_info = _(
+            "Your attachments exceed %(max_email_size)s and will be sent as secure links to ensure they reach your recipients",
+            max_email_size=human_size(max_email_size_bytes))
 
     @api.depends('template_id')
     def _compute_email_add_signature(self):

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -56,6 +56,7 @@
                         <field name="reply_to" placeholder="e.g. info@company.com"
                             invisible="reply_to_mode == 'update'"
                             required="reply_to_mode != 'update'"/>
+                        <field name="attachment_links" nolabel="1" colspan="2" invisible="not attachment_links"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>
                     <div invisible="composition_mode == 'mass_mail'">
@@ -81,6 +82,9 @@
                         </page>
                     </notebook>
                     <footer>
+                        <div invisible="not attachment_links_info" class="alert alert-info py-1 my-0 align-right w-100" role="alert">
+                            <field name="attachment_links_info" nolabel="1"/>
+                        </div>
                         <button string="Send" name="action_send_mail"
                                 type="object" class="btn-primary o_mail_send" data-hotkey="q"
                                 invisible="(subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or not partner_ids_all_have_email"/>

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -273,6 +273,31 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
         self.assertFalse(composer_form.subtype_is_log)
 
+    def test_mail_composer_form_attachments_in_body(self):
+        # Only 1 attachment won't trigger the warning but 2 attachments will
+        # because one of them is in the body, we should not show the warning
+        self.env['ir.config_parameter'].set_float('base.default_max_email_size', 19)
+        attachments = self.env['ir.attachment'].create([{
+            "name": "test",
+            "raw": b"a" * 10 * 1024 * 1024,
+        } for _ in range(2)])
+        self.assertEqual(attachments.mapped("file_size"), [10 * 1024 * 1024, 10 * 1024 * 1024])
+
+        composer_form = Form(
+            self.env['mail.compose.message'].with_context({
+                'default_composition_mode': 'comment',
+                'default_model': self.test_record._name,
+                'default_res_ids': self.test_record.ids,
+            })
+        )
+        composer_form.body = f'<a href="/web/content/{attachments[0].id}"/>'
+        composer_form.attachment_ids = attachments
+        self.assertFalse(composer_form.attachment_links_info)
+
+        # Now no attachment are in the body, the limit is reached
+        composer_form.body = 'No attachment in body'
+        self.assertIn("Your attachments exceed", composer_form.attachment_links_info or "")
+
     @users('employee')
     def test_mail_composer_comment_wtpl(self):
         composer_form = Form(self.env['mail.compose.message'].with_context(

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -1023,7 +1023,7 @@ class TestMailMailServer(MailCommon):
         email content.
 
         The feature is tested in the following conditions:
-        - using a specified server or the default one (to test command ICP parameter)
+        - using a specified server or the default one
         - in batch mode
         - with mail that exceed (with one or more attachments) or not the limit
         - with attachment owned by a business record or not: attachments not owned by a
@@ -1041,37 +1041,25 @@ class TestMailMailServer(MailCommon):
 
         mock_attachment_file_size.return_value = 1024 * 128
         # Define some constant to ease the understanding of the test
-        test_mail_server = self.mail_server_domain_2
         max_size_always_exceed = 0.1
         max_size_never_exceed = 10
 
-        for n_attachment, mail_server, business_attachment, expected_is_links in (
+        for n_attachment, business_attachment, expected_is_links in (
                 # 1 attachment which doesn't exceed max size
-                (1, self.env['ir.mail_server'], True, False),
+                (1, True, False),
                 # 3 attachment: exceed max size
-                (3, self.env['ir.mail_server'], True, True),
+                (3, True, True),
                 # 1 attachment: exceed max size
-                (1, self.env['ir.mail_server'], True, True),
-                # Same as above with a specific server. Note that the default and server max_email size are reversed.
-                (1, test_mail_server, True, False),
-                (3, test_mail_server, True, True),
-                (1, test_mail_server, True, True),
+                (1, True, True),
                 # Attachments not linked to a business record are never turned to link
-                (3, self.env['ir.mail_server'], False, False),
-                (1, test_mail_server, False, False),
+                (3, False, False),
         ):
             # Setup max email size to check that the right maximum is used (default or mail server one)
             if expected_is_links:
                 max_size_test_succeed = max_size_always_exceed * n_attachment
-                max_size_test_fail = max_size_never_exceed
             else:
                 max_size_test_succeed = max_size_never_exceed
-                max_size_test_fail = max_size_always_exceed * n_attachment
-            if mail_server:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_fail)
-                mail_server.max_email_size = max_size_test_succeed
-            else:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
+            self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
 
             attachments = self.env['ir.attachment'].sudo().create([{
                 'name': f'attachment{idx_attachment}',
@@ -1087,14 +1075,14 @@ class TestMailMailServer(MailCommon):
                     'email_from': 'test@test_2.com',
                     'email_to': f'mail_{mail_idx}@test.com',
                 } for mail_idx in range(2)])
-                mails._send(mail_server=mail_server)
+                mails._send()
 
             self.assertEqual(len(self.emails), 2)
             for outgoing_email in self.emails:
                 message_raw = outgoing_email['message']
                 message_parsed = message_from_string(message_raw)
                 message_cleaned = re.sub(r'[\s=]', '', message_raw)
-                with self.subTest(n_attachment=n_attachment, mail_server=mail_server,
+                with self.subTest(n_attachment=n_attachment,
                                   business_attachment=business_attachment, expected_is_links=expected_is_links):
                     if expected_is_links:
                         self.assertEqual(count_attachments(message_parsed), 0,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -464,7 +464,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=18, employee=18):  # tm 17/17
+        with self.assertQueryCount(admin=26, employee=26):  # tm 25/25
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/odoo/addons/base/data/ir_config_parameter_data.xml
+++ b/odoo/addons/base/data/ir_config_parameter_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="default_max_email_size" model="ir.config_parameter">
             <field name="key">base.default_max_email_size</field>
-            <field name="value">10</field>
+            <field name="value">20</field>
         </record>
     </data>
 </odoo>

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -30,7 +30,6 @@ from odoo.tools import (
     email_normalize,
     encapsulate_email,
     formataddr,
-    human_size,
     parse_version,
 )
 
@@ -272,10 +271,9 @@ class IrMail_Server(models.Model):
         """
         return dict()
 
+    @api.model
     def _get_max_email_size(self):
-        if self.max_email_size:
-            return self.max_email_size
-        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size') or 10
+        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size', 20)
 
     def _get_test_email_from(self):
         self.ensure_one()
@@ -297,16 +295,13 @@ class IrMail_Server(models.Model):
     def _get_test_email_to(self):
         return "noreply@odoo.com"
 
-    def test_smtp_connection(self, autodetect_max_email_size=False):
-        """Test the connection and if autodetect_max_email_size, set auto-detected max email size.
+    def test_smtp_connection(self):
+        """Test the connection.
 
-        :param bool autodetect_max_email_size: whether to autodetect the max email size
-        :return: client action to notify the user of the result of the operation (connection test or
-            auto-detection successful depending on the ``autodetect_max_email_size`` parameter)
+        :return: client action to notify the user of the result of the operation
         :rtype: dict
 
-        :raises UserError: if the connection fails and if ``autodetect_max_email_size`` and
-            the server doesn't support the auto-detection of email max size
+        :raises UserError: if the connection fails
         """
         for server in self:
             smtp = False
@@ -329,12 +324,6 @@ class IrMail_Server(models.Model):
                 (code, repl) = smtp.getreply()
                 if code != 354:
                     raise UserError(_('The server refused the test connection with error %(repl)s', repl=repl))  # noqa: TRY301
-                if autodetect_max_email_size:
-                    max_size = smtp.esmtp_features.get('size')
-                    if not max_size:
-                        raise UserError(_('The server "%(server_name)s" doesn\'t return the maximum email size.',
-                                          server_name=server.name))
-                    server.max_email_size = float(max_size) / (1024 ** 2)
             except (UnicodeError, idna.core.InvalidCodepoint) as e:
                 raise UserError(_("Invalid server name!\n %s", e)) from e
             except (gaierror, timeout) as e:
@@ -363,27 +352,16 @@ class IrMail_Server(models.Model):
                 except Exception:
                     # ignored, just a consequence of the previous exception
                     pass
-
-        if autodetect_max_email_size:
-            message = _(
-                'Email maximum size updated (%(details)s).',
-                details=', '.join(f'{server.name}: {human_size(server.max_email_size * 1024 ** 2)}' for server in self))
-        else:
-            message = _('Connection Test Successful!')
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'message': message,
+                'message': _('Connection Test Successful!'),
                 'type': 'success',
                 'sticky': False,
                 'next': {'type': 'ir.actions.act_window_close'},  # force a form reload
             },
         }
-
-    def action_retrieve_max_email_size(self):
-        self.ensure_one()
-        return self.test_smtp_connection(autodetect_max_email_size=True)
 
     @classmethod
     def _disable_send(cls):

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -19,17 +19,6 @@
                             </group>
                             <group>
                                 <field name="sequence"/>
-                                <div colspan="2" class="d-flex justify-content-between">
-                                    <div>
-                                        <label for="max_email_size"
-                                               string="Convert attachments to links for emails over"/>
-                                        <field name="max_email_size" class="oe_inline mx-1"/>
-                                        <span class="o_form_label">MB</span>
-                                    </div>
-                                    <button class="btn btn-link pt-0" type="object" name="action_retrieve_max_email_size">
-                                        <i class="fa fa-gear"/> Detect Max Limit
-                                    </button>
-                                </div>
                             </group>
                         </group>
                         <group>


### PR DESCRIPTION
[IMP] {test_}mail,cloud_storage_azure: make attachment links impossible to miss

When an email is too big the server turns attachments into links but often recipients don't see the links as they are appended at the end of the email. To avoid that, we turn the attachments into links directly in the composer when the attachments are added so the sender is aware that the attachments are converted into links.

We keep the server mechanism that turns attachments into links as a fallback as we only support the convertion into link in the composer for now but we improve the rendering of the attachments with the same layout as in the composer and instead of appending the attachment links at the bottom, we append them at the top.

Technical notes:
- We use a `MutationObserver` to force the body to be saved when an attachment link is removed within the HTML editor. As the attachment remains when the attachment link is removed, saving the body forces the compute to reevaluate whether to convert it as link or not.
- We increase the query count in test_mail_composer_form_attachments because of the _compute_attachment_links that is triggered each time the attachment_ids are modified to compute whether attachments should be converted into links or not.

[IMP] base, {test_}mail: remove the "per server" maximum email size setting

We remove the "per server" max email size setting in favor of the existing max email size global setting. We also change that global setting from 10MB to 20MB.

Task-5912830