### PR TITLE
[FIX] mrp_subcontracting_purchase: add PO source link on mtso resupply pickings

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/stock_picking.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_picking.py
@@ -36,7 +36,7 @@ class StockPicking(models.Model):
         return action
 
     def _get_subcontracting_source_purchase(self):
-        moves_subcontracted = self.move_ids.move_dest_ids.raw_material_production_id.move_finished_ids.move_dest_ids.filtered(lambda m: m.is_subcontract)
+        moves_subcontracted = self.reference_ids.move_ids.filtered(lambda m: m.is_subcontract)
         return moves_subcontracted.purchase_line_id.order_id
 
     def _get_subcontract_mo_confirmation_ctx(self):

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -108,11 +108,14 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
             self.assertEqual(component['availability_state'], 'estimated')
 
     def test_count_smart_buttons(self):
+        """
+        Test the source PO smart button both when the Resupply subcontractor rule is MTO and MTSO
+        """
         resupply_sub_on_order_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
         (self.comp1 + self.comp2).write({'route_ids': [Command.link(resupply_sub_on_order_route.id)]})
 
-        # I create a draft Purchase Order for first in move for 10 kg at 50 euro
-        po = self.env['purchase.order'].create({
+        # Create 2 subcontracted PO's, one to be resupplied in MTO the other in MTSO
+        purchase_orders = self.env['purchase.order'].create([{
             'partner_id': self.subcontractor_partner1.id,
             'order_line': [Command.create({
                 'name': 'finished',
@@ -121,17 +124,19 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
                 'product_uom_id': self.finished.uom_id.id,
                 'price_unit': 50.0}
             )],
-        })
+        } for _ in range(2)])
 
-        po.button_confirm()
-
-        self.assertEqual(po.subcontracting_resupply_picking_count, 1)
-        action1 = po.action_view_subcontracting_resupply()
-        picking = self.env[action1['res_model']].browse(action1['res_id'])
-        self.assertEqual(picking.subcontracting_source_purchase_count, 1)
-        action2 = picking.action_view_subcontracting_source_purchase()
-        po_action2 = self.env[action2['res_model']].browse(action2['res_id'])
-        self.assertEqual(po_action2, po)
+        # Perform the flow in Flow once in mto and once in mtso
+        for po, procure_method in zip(purchase_orders, ('make_to_order', 'mts_else_mto')):
+            resupply_sub_on_order_route.rule_ids.procure_method = procure_method
+            po.button_confirm()
+            self.assertEqual(po.subcontracting_resupply_picking_count, 1)
+            action1 = po.action_view_subcontracting_resupply()
+            picking = self.env[action1['res_model']].browse(action1['res_id'])
+            self.assertEqual(picking.subcontracting_source_purchase_count, 1)
+            action2 = picking.action_view_subcontracting_source_purchase()
+            po_action2 = self.env[action2['res_model']].browse(action2['res_id'])
+            self.assertEqual(po_action2, po)
 
     def test_decrease_qty(self):
         """ Tests when a PO for a subcontracted product has its qty decreased after confirmation


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: Subcontracting, Multi-Step Routes
- Inventory > Configuration > Warehouse Management > Routes
- Edit the 'Resupply Subcontractor on Order' route, rules supply method to: Take from stock, if unavailable, trigger another rule (mtso)
- Create a subcontracted bom For a product P with a component COMP
- Create and confirm a PO for 1 unit of P with your subcontractor
- Use the Resupply smart button to access the resupply picking
#### > The resupply picking does not refer to the source PO

### Cause of the issue:

The link is currently computed based on `move_dest_ids` which are only set for mto moves. However, moves created from mtso rules are `make_to_stock`.

### Fix:

Since 19.0 2713876dbc70d3984e584a9037a2206dcda4e84a, we can rely on references to rebuild the link between the resupply picking and the source PO even in mtso. Note that this will also add the source PO link to each other picking of the reference.

opw-6079680

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
