### PR TITLE
[FIX] <hr_expense>: Required vendor field for SEPA payment method.

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -234,6 +234,9 @@ class HrExpense(models.Model):
         domain="[('id', 'in', selectable_payment_method_line_ids)]",
         help="The payment method used when the expense is paid by the company.",
     )
+    payment_method_code = fields.Char(
+        related='payment_method_line_id.code',
+    )
     account_move_id = fields.Many2one(
         string="Journal Entry",
         comodel_name='account.move',

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -264,7 +264,7 @@
                             <field name="manager_id" widget="many2one_avatar_user" readonly="state != 'draft'" placeholder="Auto-validation"/>
                             <field name="department_id" invisible="1" readonly="not is_editable"
                                    context="{'default_company_id': company_id}"/>
-                            <field name="vendor_id" invisible="payment_mode != 'company_account'"/>
+                            <field name="vendor_id" invisible="payment_mode != 'company_account'" required="payment_method_code == 'sepa_ct'"/>
                             <field name="account_id" options="{'no_create': True}"
                                    domain="[('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card')), ('company_ids', 'parent_of', company_id)]"
                                    groups="account.group_account_readonly" readonly="not is_editable"


### PR DESCRIPTION
**Context:**
For payment methods of type SEPA Credit Transfer, the vendor field is required in a vendor payment but not in the expense form. Since a vendor payment is created from the expense form, if the vendor information is not provided in the expense form for a SEPA payment method, the vendor payment and the expense will not be able to be resetted to draft. As it's being locked into a state of paid.

**Before this commit:**
The user can create an expense with a SEPA Credit Transfer payment method without filling the vendor field. When the user tries to reset to draft the expense or the vendor payment, the missing required fields message will block them from doing it. Since the state is in draft, the user cannot fill the vendor field and reset it to draft.

**After this commit:**
The vendor field is required in the expense form when the payment method is of type SEPA Credit Transfer. This directly prevents the issue from happening.

opw-6073594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
