### PR TITLE
[FIX] payment_stripe, website_sale: handle avatax in express checkout

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -179,12 +179,13 @@ paymentExpressCheckoutForm.include({
                         },
                     },
                 );
-                this.paymentContext['minorAmount'] = await this.rpc(
+                const recomputedAmount = await this.rpc(
                     this.paymentContext['shippingAddressUpdateRoute'] + '/compute_taxes',
                 );
-                if (availableCarriers.length === 0) {
+                if (availableCarriers.length === 0 || recomputedAmount.external_tax_error) {
                     ev.updateWith({status: 'invalid_shipping_address'});
                 } else {
+                    this.paymentContext['minorAmount'] = recomputedAmount;
                     ev.updateWith({
                         status: 'success',
                         shippingOptions: availableCarriers.map(carrier => ({

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1786,7 +1786,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
     )
     def express_checkout_shipping_address_compute_taxes(self):
         order_sudo = request.website.sale_get_order()
-        order_sudo._recompute_taxes()
+        try:
+            order_sudo.with_context(is_express_checkout_flow=True)._recompute_taxes()
+        except UserError:
+            return {'external_tax_error': True}
+
         amount_without_delivery = order_sudo._compute_amount_total_without_delivery()
 
         return payment_utils.to_minor_currency_units(


### PR DESCRIPTION
Issue:
---
The extra external_tax call introduced in odoo/enterprise#101579 is causing multiple issues:
1- It doesn't catch errors while
`_get_and_set_external_taxes_on_eligible_records` easily raises errors, causing uncatch errors in `website_sale`.
2- Extra unnecessary external api call in non-express checkout methods which is not desirable.

Steps to reproduce:
---
1- Install l10n_br_avatax_sale, website_sale
2- Using a public user, add a product to cart and got to checkout.
3- In the address form, use CPF identification type.

Outcome:
The confirm button is unresponsive.

Cause:
---
This is due to uncatch error raised by external tax call, while it was not necessary at this step of this flow to call external tax api.

opw-6005767