### PR TITLE
[FIX] account_{edi_ubl_cii,peppol}: align zugferd with facturx

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -241,7 +241,7 @@ class ResPartner(models.Model):
     def _compute_hide_peppol_fields(self):
         """ Hides the people fields depending on the UBL format. Can be extended to add different hiding conditions. """
         for partner in self:
-            partner.hide_peppol_fields = not partner.ubl_cii_format or partner.ubl_cii_format == 'facturx'
+            partner.hide_peppol_fields = not partner.ubl_cii_format or partner.ubl_cii_format in ('zugferd', 'facturx')
 
     def _build_error_peppol_endpoint(self, eas, endpoint):
         """ This function contains all the rules regarding the peppol_endpoint."""

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -198,7 +198,7 @@ class ResPartner(models.Model):
     @api.depends('ubl_cii_format')
     def _compute_is_peppol_edi_format(self):
         for partner in self:
-            partner.is_peppol_edi_format = partner.ubl_cii_format not in (False, 'facturx', 'oioubl_201', 'ciusro', 'ubl_tr')
+            partner.is_peppol_edi_format = partner.ubl_cii_format not in (False, 'zugferd', 'facturx', 'oioubl_201', 'ciusro', 'ubl_tr')
 
     @api.depends('peppol_eas', 'peppol_endpoint', 'ubl_cii_format')
     def _compute_account_peppol_is_endpoint_valid(self):


### PR DESCRIPTION
The 'zugferd' key was missing from the `_get_customization_ids` mapping,
causing potential failures when attempting to identify the correct
CustomizationID for German hybrid-style invoices being processed
through the Peppol exchange.

This is because the 'zugferd' format was wrongly considered as peppol edi format,
whereas it should behave like the 'facturx' format and be excluded from
the peppol edi formats.

opw-6009214
