### PR TITLE
[FIX] l10n_pl_edi: auto-refresh KSeF tokens via cron

### DIFF
--- a/addons/l10n_pl_edi/data/ir_cron_data.xml
+++ b/addons/l10n_pl_edi/data/ir_cron_data.xml
@@ -22,5 +22,17 @@
             <field name="interval_number">3</field>
             <field name="interval_type">hours</field>
         </record>
+
+        <record id="cron_l10n_pl_edi_refresh_tokens" model="ir.cron">
+            <field name="name">Polish eInvoice: Refresh KSeF tokens</field>
+            <field name="model_id" ref="base.model_res_company"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_l10n_pl_edi_refresh_tokens()</field>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">6</field>
+            <field name="interval_type">days</field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/l10n_pl_edi/models/res_company.py
+++ b/addons/l10n_pl_edi/models/res_company.py
@@ -1,4 +1,7 @@
+import logging
 from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ResCompany(models.Model):
@@ -16,3 +19,25 @@ class ResCompany(models.Model):
     def _compute_l10n_pl_edi_register(self):
         for company in self:
             company.l10n_pl_edi_register = bool(company.l10n_pl_edi_certificate)
+
+    @api.model
+    def _cron_l10n_pl_edi_refresh_tokens(self):
+        """
+        Automatically performs a full KSeF authentication to renew both
+        the access token and the refresh token for active companies.
+        """
+        companies = self.search([
+            ('l10n_pl_edi_certificate', '!=', False)
+        ])
+
+        for company in companies:
+            try:
+                config = self.env['res.config.settings'].new({
+                    'company_id': company.id,
+                    'l10n_pl_edi_certificate': company.l10n_pl_edi_certificate.id,
+                })
+
+                config._l10n_pl_edi_ksef_authenticate()
+                _logger.info("Successfully renewed KSeF tokens for company %s via cron.", company.name)
+            except Exception:
+                _logger.exception("Failed to renew KSeF token for company %s", company.name)


### PR DESCRIPTION
The KSeF refresh token issued by the Polish Ministry of Finance expires after a week. Once it expires, the automatic fetching of incoming bills and sending of invoices will fail until the user manually re-authenticates in the settings.

To ensure uninterrupted synchronization with the KSeF API, this commit adds a new scheduled action that runs every 6 days to automatically renew the tokens.

task-6041758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
