### PR TITLE
[FIX] point of sale: correct change amount on UI

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -251,7 +251,7 @@ export class PosOrder extends Base {
         const taxTotals = this.taxTotals;
 
         const order_rounding = taxTotals.order_rounding;
-        const order_change = this.get_change();
+        const order_change = -this.get_change();
 
         return {
             orderlines: this.getSortedOrderlines().map((l) =>
@@ -1095,7 +1095,7 @@ export class PosOrder extends Base {
                 name: pl.payment_method_id.name,
                 amount: formatCurrency(pl.get_amount(), this.currency),
             })),
-            change: this.get_change() && formatCurrency(this.get_change(), this.currency),
+            change: this.get_change() && formatCurrency(-this.get_change(), this.currency),
             generalNote: this.general_note || "",
             qrPaymentData: toRaw(this.get_selected_paymentline()?.qrPaymentData),
         };

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
@@ -7,7 +7,7 @@ export class PaymentScreenStatus extends Component {
     };
 
     get changeText() {
-        return this.env.utils.formatCurrency(this.props.order.get_change());
+        return this.env.utils.formatCurrency(-this.props.order.get_change());
     }
     get remainingText() {
         const { order_has_zero_remaining, order_remaining, order_sign } =

--- a/addons/point_of_sale/static/tests/tours/acceptance_tour.js
+++ b/addons/point_of_sale/static/tests/tours/acceptance_tour.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add("pos_basic_order_01_multi_payment_and_ch
             PaymentScreen.clickPaymentMethod("Bank", true, { amount: "5.2" }),
             PaymentScreen.enterPaymentLineAmount("Bank", "6", true, {
                 amount: "6.0",
-                change: "0.80",
+                change: "-0.80",
             }),
             ProductScreen.finishOrder(),
         ].flat(),

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -74,7 +74,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
             ProductScreen.isShown(),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
-            PaymentScreen.enterPaymentLineAmount("Cash", "20", true, { change: "18.0" }),
+            PaymentScreen.enterPaymentLineAmount("Cash", "20", true, { change: "-18.0" }),
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
             ReceiptScreen.totalAmountContains("2.0"),

--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -39,11 +39,11 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
             PaymentScreen.validateButtonIsHighlighted(false),
             PaymentScreen.clickNumpad("5"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "105"),
-            PaymentScreen.changeIs("52.2"),
+            PaymentScreen.changeIs("-52.2"),
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickNumpad("+50"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "155"),
-            PaymentScreen.changeIs("102.2"),
+            PaymentScreen.changeIs("-102.2"),
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickPaymentlineDelButton("Cash", "155.0"),
 
@@ -167,7 +167,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUp", {
             PaymentScreen.clickNumpad("2"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "2"),
 
-            PaymentScreen.changeIs("1.0"),
+            PaymentScreen.changeIs("-1.0"),
         ].flat(),
 });
 
@@ -181,7 +181,7 @@ registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", 
             PaymentScreen.totalIs("1.98"),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.enterPaymentLineAmount("Cash", "5", true, {
-                change: "3.05",
+                change: "-3.05",
             }),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/pos_cash_rounding_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_cash_rounding_tour.js
@@ -642,7 +642,7 @@ registry.category("web_tour.tours").add("test_cash_rounding_with_change", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickNumpad("2 0"),
             PaymentScreen.fillPaymentLineAmountMobile("Bank", "20.00"),
-            PaymentScreen.changeIs("4.30"),
+            PaymentScreen.changeIs("-4.30"),
 
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
@@ -668,7 +668,7 @@ registry.category("web_tour.tours").add("test_cash_rounding_up_with_change", {
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickNumpad("2 0 0"),
 
-            PaymentScreen.changeIs("21"),
+            PaymentScreen.changeIs("-21"),
         ].flat(),
 });
 
@@ -687,7 +687,7 @@ registry.category("web_tour.tours").add("test_cash_rounding_only_cash_method_wit
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickNumpad("+20"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "20.00"),
-            PaymentScreen.changeIs("4.30"),
+            PaymentScreen.changeIs("-4.30"),
 
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.enterPaymentLineAmount("Cash", "70", true, { remaining: "2.0" }),
             PaymentScreen.clickNumpad("0"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "700"),
-            PaymentScreen.changeIs("628.0"),
+            PaymentScreen.changeIs("-628.0"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
             ReceiptScreen.totalAmountContains("72.0"),

--- a/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
@@ -19,7 +19,7 @@ import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_u
  * clickPaymentMethod("Cash");
  *
  * // Clicks on the "Bank" payment method and checks the remaining amount and change
- * clickPaymentMethod("Cash", true, { remaining: "50.20", change: "10.50" });
+ * clickPaymentMethod("Cash", true, { remaining: "50.20", change: "-10.50" });
  *
  * // Clicks on the "Cash" payment method and checks the amount to be paid
  * clickPaymentMethod("Cash", true, { amount: "10.20" });
@@ -108,7 +108,7 @@ export function clickValidate() {
  *  PaymentScreen.clickNumpad("0"), <- desktop: add a 0
  *  PaymentScreen.fillPaymentLineAmountMobile("Cash", "700"), <- mobile: rewrite the amount
  *  PaymentScreen.remainingIs("0.00"),
- *  PaymentScreen.changeIs("628.0"),
+ *  PaymentScreen.changeIs("-628.0"),
  *
  * @param {String} keys space-separated numpad keys
  */
@@ -160,7 +160,7 @@ export function clickTipButton() {
  *
  * @example
  * // Enter the amount "100" on the "Bank" payment line and check that the remaining amount is 50 and the change is 20
- * enterPaymentLineAmount("Bank", "100", true, { remaining: "50.0", change: "20.0" });
+ * enterPaymentLineAmount("Bank", "100", true, { remaining: "50.0", change: "-20.0" });
  */
 export function enterPaymentLineAmount(lineName, keys, isCheckNeeded = false, options = {}) {
     const { remaining = null, change = null, amount = null } = options;

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -24,7 +24,7 @@ registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.enterPaymentLineAmount("Cash", "2"),
             PaymentScreen.selectedPaymentlineHas("Cash", "2.0"),
-            PaymentScreen.changeIs("1.0"),
+            PaymentScreen.changeIs("-1.0"),
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
             // successfully confirming the dialog would imply that the error popup is actually shown

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -342,7 +342,7 @@ registry.category("web_tour.tours").add("OrderChange", {
             PaymentScreen.clickNumpad("+10"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
-            TicketScreen.receiptChangeIs("7.80"),
+            TicketScreen.receiptChangeIs("-7.80"),
         ].flat(),
 });
 


### PR DESCRIPTION
Steps to Reproduce
------------------------
- Install point of sale.
- Do a order and pay more than the amount.

Issue
------
- The change amount is displayed as a positive value on the UI.
- Typically, amounts going out of the shop (like change given to the customer) should be shown as negative.

Cause
-------
- The change amount was not correctly represented in the UI.
- Since the change flows in the opposite direction of the payment, it should be displayed as the negation of the original amount.

FIX
-----
- Updated the frontend to display the change amount with the correct (negative) sign.
- No backend changes were required, as the correct value was already being handled during order synchronization

Enterprise PR: https://github.com/odoo/enterprise/pull/112560
task: 6074620