### PR TITLE
[FIX] html_builder, website: support custom snippets as block and inner

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -230,8 +230,8 @@ export class SnippetModel extends Reactive {
                 : snippet.name;
             if (this.isCustomInnerContent(customSnippetName)) {
                 customInnerContent.unshift(snippet);
-                customSnippets.splice(i, 1);
-            } else if (!this.isCustomStructure(customSnippetName)) {
+            }
+            if (!this.isCustomStructure(customSnippetName)) {
                 // If no structure snippet could be found, it means that the
                 // module is not installed (i.e. the original snippet has no
                 // `data-snippet` attribute).
@@ -249,14 +249,15 @@ export class SnippetModel extends Reactive {
                 {
                     body: message,
                     confirm: async () => {
-                        const isInnerContent =
-                            this.snippetsByCategory.snippet_custom_content.includes(snippet);
-                        const snippetCustom = isInnerContent
-                            ? this.snippetsByCategory.snippet_custom_content
-                            : this.snippetsByCategory.snippet_custom;
-                        const index = snippetCustom.findIndex((s) => s.id === snippet.id);
-                        if (index > -1) {
-                            snippetCustom.splice(index, 1);
+                        for (const categoryKey of ["snippet_custom", "snippet_custom_content"]) {
+                            const snippetList = this.snippetsByCategory[categoryKey] || [];
+                            const snippetIndex = snippetList.findIndex(
+                                (item) => item.id === snippet.id
+                            );
+
+                            if (snippetIndex > -1) {
+                                snippetList.splice(snippetIndex, 1);
+                            }
                         }
                         await this.orm.call("ir.ui.view", "delete_snippet", [], {
                             view_id: snippet.viewId,

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -15,7 +15,7 @@ import {
     getSnippetView,
 } from "@html_builder/../tests/helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { animationFrame, Deferred, queryText, tick } from "@odoo/hoot-dom";
+import { animationFrame, Deferred, queryText, tick, click } from "@odoo/hoot-dom";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
@@ -343,4 +343,82 @@ test("applying option container button should wait for actions in progress", asy
 
     undo(editor);
     expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+});
+
+test("Custom snippet appears in block and inner content on save and is removed on delete", async () => {
+    const mapSnippetDesc = {
+        name: "Map",
+        groupName: "geo",
+        structureContent: `
+            <section data-snippet="s_map" data-name="Map">
+                <div class="o_map">Map</div>
+            </section>
+        `,
+        innerContent: `<div data-snippet="s_map" class="o_snippet_drop_in_only">Map</div>`,
+    };
+
+    const snippets = {
+        snippet_groups: [
+            "<div name='Custom' data-o-snippet-group='custom'><section data-snippet='s_snippet_group'></section></div>",
+            "<div name='Geo' data-o-snippet-group='geo'><section data-snippet='s_snippet_group'></section></div>",
+        ],
+        snippet_structure: [
+            getSnippetStructure({
+                name: mapSnippetDesc.name,
+                groupName: mapSnippetDesc.groupName,
+                content: mapSnippetDesc.structureContent,
+            }),
+        ],
+        snippet_content: [
+            getInnerContent({
+                name: mapSnippetDesc.name,
+                content: mapSnippetDesc.innerContent,
+            }),
+        ],
+        snippet_custom: [],
+    };
+
+    const snippetWithMap = `
+        <section data-snippet="s_map" data-name="Map">
+            <div class="o_map">Map content</div>
+        </section>
+    `;
+
+    await setupWebsiteBuilder(snippetWithMap, { snippets });
+
+    onRpc("ir.ui.view", "save_snippet", ({ kwargs }) => {
+        expect.step("save snippet");
+        const { name, arch } = kwargs;
+        const customSnippet = `<div name="${name}">${arch}</div>`;
+        snippets.snippet_custom.push(customSnippet);
+        return name;
+    });
+    onRpc("ir.ui.view", "delete_snippet", () => {
+        expect.step("delete snippet");
+        snippets.snippet_custom.length = 0;
+        return true;
+    });
+    onRpc("ir.ui.view", "render_public_asset", () => getSnippetView(snippets));
+
+    // Save the snippet and check that it appears in the sidebar.
+    await contains(":iframe section[data-snippet='s_map']").click();
+    await contains(".oe_snippet_save").click();
+    await contains(".o_dialog .btn:contains('Save')").click();
+    expect.verifySteps(["save snippet"]);
+    await contains(".o-snippets-tabs button:contains(Add)").click();
+    expect(
+        ".o-snippets-menu div:contains('Custom Inner Content') div[name='Custom Map']"
+    ).toHaveCount(1);
+    expect(".o-snippets-menu .o_snippet[data-snippet-group='custom']").toHaveCount(1);
+
+    // Delete the custom snippet and check that it is removed from the sidebar.
+    await click(".o-snippets-menu #snippet_groups .o_snippet_thumbnail .o_snippet_thumbnail_area");
+    await waitForSnippetDialog();
+    await contains(".o_add_snippet_iframe:iframe button.fa-trash").click();
+    await contains(".o_dialog .btn:contains('Yes')").click();
+    expect.verifySteps(["delete snippet"]);
+    expect(
+        ".o-snippets-menu div:contains('Custom Inner Content') div[name='Custom Map']"
+    ).toHaveCount(0);
+    expect(".o-snippets-menu .o_snippet[data-snippet-group='custom']").toHaveCount(0);
 });


### PR DESCRIPTION
Steps to reproduce:
1. Go to Website > Edit mode.
2. Drag and drop a `Map` from `Inner Content` snippets.
3. Save it as a custom snippet.

Current behavior:
- The custom snippet is saved only as inner content and does not appear as a block in custom snippets.

Expected behavior:
- The snippet should be available both as a block and as inner content, consistent with behavior in `saas-18.3`.

Issue:
- Custom inner content snippets were systematically extracted from `snippet_custom`. As a result, snippets that can serve both purposes were only kept as inner content, preventing their usage as blocks.

Solution:
- Update the logic to:
  1. Keep dual-purpose snippets in `snippet_custom` (block usage).
  2. Also add them to `snippet_custom_content` (inner content usage).
  3. Remove only inner-only snippets from the block category to avoid display issues.

task-6064917