### PR TITLE
[FIX] account: recomputation is_company on country change

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -366,6 +366,14 @@ class ResPartner(models.Model):
                 for code in company.account_fiscal_country_group_codes
             })
 
+    @api.depends('country_id')
+    def _compute_is_company(self):
+        """
+        Adding dependency of `country_id` because localization can then further refine this definition according to legal
+        definition of what is a company and that will be based on country_code
+        """
+        super()._compute_is_company()
+
     @property
     def _order(self):
         res = super()._order


### PR DESCRIPTION
Since `_compute_is_company` is inherited by l10n modules and the condition are based on the `country_code` it makes sense the is_company field must be recomputed based on country_id as well

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
