### PR TITLE
[FIX] html_editor: fix non-deterministic notebook test

### DIFF
--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2627,11 +2627,12 @@ describe("save image", () => {
         expect(b64img).toHaveClass("o_b64_image_to_save");
 
         // Switch tab, this should trigger the image save.
-        await contains(".o_notebook_headers .nav-link:not(.active)").click();
-        await delay(50);
-        // reswitch tab, and check the image was saved properly.
-        await contains(".o_notebook_headers .nav-link:not(.active)").click();
-        await waitFor(".odoo-editor-editable");
+        await contains(".o_notebook_headers .nav-link:not(.active)[name='empty']").click();
+        await waitFor(".o_notebook_headers .nav-link.active[name='empty']");
+        // Reswitch tab, and check the image was saved properly.
+        await contains(".o_notebook_headers .nav-link:not(.active)[name='html']").click();
+        await waitFor(".o_notebook_headers .nav-link.active[name='html']");
+        await waitFor(".odoo-editor-editable", { timeout: 1500 });
         const savedImg = htmlEditor.editable.querySelector("img");
         expect(savedImg.getAttribute("src")).toBe("/test_image_url.png?access_token=1234");
         expect(savedImg).not.toHaveClass("o_b64_image_to_save");


### PR DESCRIPTION
Since [1], switching between notebook pages is asynchronous. This test did not wait for the switch and dit not identify which button it used to click on either, relying on a simple toggle. When the runbot was slow, the test ended up clicking on the same tab twice, thus never returning to the one with the editor.

runbot-241941
runbot-241258

[1]: https://github.com/odoo/odoo/commit/968dd2cd5d11ce9b39fbacfb60c37bc1bfaa1d9e
