### PR TITLE
[FIX] website: fix `website_auto_hide_menu` tour

### DIFF
--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -79,6 +79,10 @@ registerWebsitePreviewTour(
             trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Small']",
             run: "click",
         },
+        {
+            content: "Wait for the operation to finish",
+            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
+        },
         checkThatLayoutChanged,
         {
             content: "Make content width large",
@@ -100,6 +104,10 @@ registerWebsitePreviewTour(
             content: "Set the page layout to 'boxed'",
             trigger: ".o-hb-select-dropdown-item[data-action-value='boxed']",
             run: "click",
+        },
+        {
+            content: "Wait for the operation to finish",
+            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
         },
         checkThatLayoutChanged,
     ]


### PR DESCRIPTION
Since the delay between tour steps was removed [1], this tour fails sometimes. After changing the layout, the iframe reloads, but the tour attempts to check if the navbar layout changed directly without any delay.

[1]: https://github.com/odoo/odoo/commit/769b193

runbot-241849
