### PR TITLE
[18.0][FIX] hw_drivers: fixed iot image version

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -232,7 +232,7 @@ def check_image():
         if line:
             value, name = line.split('  ')
             checkFile.update({value: name})
-            if name == 'iotbox-latest.zip':
+            if name == 'iotboxv24_11.zip':
                 valueLastest = value
             elif name == get_img_name():
                 valueActual = value


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

As soon as new Odoo versions are released, deploy iotbox-latest.zip could be unreliable and lead to crash the IoT integration. And right now, the upgrade wasn't even working as the new image name convention doesn't match the 'iotboxv' string.

**Current behavior before PR:**

- When we upgrade the Odoo server to which the IoTs are connected, they automatically get the new code for that server, so drivers are aligned to that version but the image is still the former one.
- If we hit update in the IoT to have a proper image up to date with the current server version:

<img width="584" height="172" alt="image" src="https://github.com/user-attachments/assets/0881a8cc-e69c-4fc1-be31-71de42abcae9" />


```
2026-03-31 06:55:33,007 892 ERROR ? odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/home/pi/odoo/odoo/http.py", line 2592, in __call__
    response = request._serve_nodb()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/odoo/odoo/http.py", line 2064, in _serve_nodb
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/odoo/odoo/http.py", line 2297, in dispatch
    return endpoint(**self.request.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/odoo/addons/hw_posbox_homepage/controllers/homepage.py", line 208, in get_version_info
    'imageIsUpToDate': not bool(helpers.check_image()),
                                ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/odoo/addons/hw_drivers/tools/helpers.py", line 242, in check_image
    return {'major': version[0], 'minor': version[1]}
                                          ~~~~~~~^^^
IndexError: list index out of range
```

This code here can't simply match with the new naming convention, but we don't to break the compatibility anyway:

https://github.com/odoo/odoo/blob/38734e4bc7d841a30524a2bc17fc94c9a83b5aa0/addons/hw_drivers/tools/helpers.py#L225-L242


<img width="546" height="150" alt="image" src="https://github.com/user-attachments/assets/cb2c59f9-46ce-48c7-ad5a-cf5f1cbee062" />



**Desired behavior after PR is merged:**

We can update at least to last supported version for the connected server

(I've been conservative about the image version as the IoT code is so binded to the connected server code... Maybe a higher one is safe?)

cc @moduon MT-11428

opw-6084090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
