### PR TITLE
[FIX] sale: block combo product selection on mobile sale order line form

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -418,7 +418,7 @@
                                                 invisible="state not in ['draft', 'sent'] or not is_product_archived"
                                             />
                                             <field name="product_id"
-                                                domain="[('sale_ok', '=', True)]"
+                                                domain="[('sale_ok', '=', True), ('type', '!=', 'combo')]"
                                                 context="{
                                                     'partner_id': parent.partner_id,
                                                     'quantity': product_uom_qty,


### PR DESCRIPTION
Combo products bypasses the configurator in mobile view, resulting in a
0-price line with no child lines. Exclude them via domain on the field.

opw-5999935