### PR TITLE
[FIX] account_peppol: correct self-billing in multi-company

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -185,7 +185,7 @@ class AccountEdiProxyClientUser(models.Model):
                         # 389/527: Self-billing invoice; 261: Self-billing credit note
                         journal = self.env['account.journal'].search(
                             [
-                                *self.env['account.journal']._check_company_domain(self.company_id),
+                                *self.env['account.journal']._check_company_domain(company),
                                 ('type', '=', 'sale'),
                             ],
                             limit=1,

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -635,3 +635,41 @@ class TestPeppolSelfBillingImport(TestPeppolMessageCommon):
                 'currency_id': self.env.ref('base.EUR').id,
             },
         ])
+
+    def test_receive_self_billed_invoice_from_peppol_multi_company(self):
+        """Test that when two companies exist in the database and both are registered on Peppol, receiving a
+        self-billed invoice from Peppol assigns the invoice to the correct company."""
+
+        other_company = self.company_data_2["company"]
+        other_company.write(
+            {
+                "country_id": self.env.ref("base.be").id,
+                "peppol_eas": "0208",
+                "peppol_endpoint": "0477472701",
+                "account_peppol_proxy_state": "active",
+            }
+        )
+        edi_identification = self.env["account_edi_proxy_client.user"]._get_proxy_identification(
+            other_company, "peppol"
+        )
+        self.env["account_edi_proxy_client.user"].create(
+            {
+                "company_id": other_company.id,
+                "id_client": "random-id",
+                "proxy_type": "peppol",
+                "edi_mode": "test",
+                "edi_identification": edi_identification,
+                "private_key": b64encode(file_open(f"{FILE_PATH}/private_key.pem", "rb").read()),
+                "refresh_token": FAKE_UUID[0],
+            }
+        )
+
+        # Receive the self-billed invoices (using existing mock data)
+        self.env["account_edi_proxy_client.user"]._cron_peppol_get_new_documents()
+
+        # Verify that 1 invoice was received in each company
+        moves = self.env["account.move"].search([("peppol_message_uuid", "=", FAKE_UUID[1])])
+        self.assertEqual(len(moves), 2)
+        self.assertEqual(len(moves.company_id), 2)
+        self.assertEqual(len(moves.line_ids), 4)
+        self.assertEqual(set(moves.mapped("move_type")), {"out_invoice"})


### PR DESCRIPTION
Currently, if a database has multiple companies registered on Peppol, receiving a self-billed invoice may assign it to the wrong company. The system was searching the journal using a domain that included all companies (in self), instead of filtering by the correct current company.

Steps to reproduce:
- Create a database with 2 companies, both on Peppol
- Receive a self-billed invoice from a random other company on Peppol
- The received invoice will potentially be assigned to the wrong company

opw-6045669