### PR TITLE
[FIX] website_sale: ensure proper border rendering in cart quantity input

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2848,7 +2848,7 @@
 
     <template id="cart_lines_quantity" name="Shopping Cart Line quantity">
         <div
-            class="css_quantity input-group justify-content-end h-100 border"
+            class="css_quantity input-group justify-content-end h-100"
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
             <t
@@ -2858,7 +2858,7 @@
             <t t-if="should_show_quantity_selector and line._is_sellable()">
                 <a
                     href="#"
-                    class="js_add_cart_json btn btn-link d-inline-block border-end-0"
+                    class="js_add_cart_json btn btn-link d-inline-block border border-end-0"
                     aria-label="Remove one"
                     title="Remove one"
                 >
@@ -2866,7 +2866,7 @@
                 </a>
                 <input
                     type="text"
-                    class="js_quantity quantity form-control border-0"
+                    class="js_quantity quantity form-control border border-start-0 border-end-0"
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"
@@ -2884,7 +2884,7 @@
                 <a
                     t-else=""
                     href="#"
-                    class="js_add_cart_json d-inline-block btn btn-link border-start-0"
+                    class="js_add_cart_json d-inline-block btn btn-link border border-start-0"
                     aria-label="Add one"
                     title="Add one"
                 >
@@ -2894,7 +2894,7 @@
             <t t-else="">
                 <input
                     type="text"
-                    class="js_quantity form-control quantity text-start text-md-end text-md-end border-0 p-0 shadow-none mw-100"
+                    class="js_quantity form-control quantity text-start text-md-end p-0 shadow-none w-auto"
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"


### PR DESCRIPTION
Steps to produce:
---
- Install the `E-commerce` module.
- Configure a product with a very large price.
- Open the product on the website, add it to the cart, and navigate to the cart.

Issue:
---
- The quantity input group appears visually stretched, and the border rendering is inconsistent.

Root Cause:
---
- After upgrading from Bootstrap 5.1 to 5.3, border utility behavior changed. Classes like `border-end-0` no longer apply unless a base border class is also present.

Solution:
---
- Explicitly add the `border` class alongside `border-end-0` on the affected elements to restore the intended border styling.

Before:
---
<img width="822" height="185" alt="image" src="https://github.com/user-attachments/assets/6478083e-f5c1-4374-9c9a-979254eaee3d" />

After:
---
<img width="828" height="188" alt="image" src="https://github.com/user-attachments/assets/5a1cb138-c9a5-4508-ad34-64d988904407" />


opw-6075996
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
