### PR TITLE
[FIX] stock_account: remove locations from context

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -307,6 +307,11 @@ class Product(models.Model):
                 location_ids = set(Warehouse.search(
                     [('company_id', 'in', self.env.companies.ids)]
                 ).mapped('view_location_id').ids)
+        if self.env.context.get('transit_loc'):
+            location_ids.update(self.env['stock.location'].search([
+                ('usage', '=', 'transit'),
+                ('company_id', 'in', self.env.companies.ids),
+            ]).ids)
 
         return self._get_domain_locations_new(location_ids)
 

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -202,7 +202,7 @@ will update the cost of every lot/serial number in stock."),
             "value_svl": value_svl,
             "quantity_svl": quantity_sum,
             "avg_cost": avg_cost,
-            "total_value": avg_cost * self.sudo(False)._with_valuation_context().qty_available if avg_cost else 0
+            "total_value": avg_cost * self.sudo(False).with_context(transit_loc=True).qty_available if avg_cost else 0
         }
 
     @api.depends('stock_valuation_layer_ids')
@@ -217,10 +217,6 @@ will update the cost of every lot/serial number in stock."),
             aggregates = group_mapping.get(product._origin, (0, 0))
             vals = product._prepare_valuation_layer_field_values(aggregates)
             product.update(vals)
-
-    def _with_valuation_context(self):
-        valued_locations = self.env['stock.location'].search([('company_id', 'in', self.env.companies.ids), ('usage', 'in', ['internal', 'transit'])])
-        return self.with_context(location=valued_locations.ids)
 
     # -------------------------------------------------------------------------
     # Actions


### PR DESCRIPTION
This commit change the context introduced in c71c21647d468bd1f2e3261b6b612a060c4b6461 The idea was to give all the valuated locations in the context of `qty_available` to compute the total value. This can overload the domain while the only advantages was to pass the transit location in the computation.

Instead we send a new context key to add the transit locations. The domain will still be populated from the warehouse locations and be completed by the transit locations that are valuated. We assume the number of transit location is significantly lower than the internal location one.

opw: 5924110

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
