### PR TITLE
[FIX] sale: send email from action menu now marks quotation as sent

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1722,6 +1722,11 @@ class SaleOrder(models.Model):
             return
         return super()._track_finalize()
 
+    def _message_mail_after_hook(self, mails):
+        super()._message_mail_after_hook(mails)
+        if self.env.context.get('mark_so_as_sent'):
+            self.filtered(lambda o: o.state == 'draft').with_context(tracking_disable=True).write({'state': 'sent'})
+
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         if self.env.context.get('mark_so_as_sent'):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1723,6 +1723,11 @@ class SaleOrder(models.Model):
             return
         return super()._track_finalize()
 
+    def _message_mail_after_hook(self, mails):
+        super()._message_mail_after_hook(mails)
+        if self.env.context.get('mark_so_as_sent'):
+            self.filtered(lambda o: o.state == 'draft').with_context(tracking_disable=True).write({'state': 'sent'})
+
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         if self.env.context.get('mark_so_as_sent'):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -607,6 +607,32 @@ class TestSaleOrder(SaleCommon):
         scheduled_message.post_message()
         self.assertEqual(order.state, 'sent')
 
+    def test_send_from_action_marks_as_sent(self):
+        """Sending email via Actions menu should mark SOs as sent (single and multi)."""
+        quotation_template = self.env.ref('sale.email_template_edi_sale')
+
+        email_act = self.sale_order.with_context(hide_default_template=True).action_quotation_send()
+        email_ctx = email_act.get('context', {})
+        composer = self.env['mail.compose.message'].with_context(**email_ctx).create({
+            'template_id': quotation_template.id,
+        })
+        composer.action_send_mail()
+
+        self.assertEqual(self.sale_order.state, 'sent')
+
+        orders = self.empty_order | self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+        })
+        email_act = orders.with_context(hide_default_template=True).action_quotation_send()
+        email_ctx = email_act.get('context', {})
+        composer = self.env['mail.compose.message'].with_context(**email_ctx).create({
+            'template_id': quotation_template.id,
+        })
+        composer.action_send_mail()
+
+        self.assertEqual(orders[0].state, 'sent')
+        self.assertEqual(orders[1].state, 'sent')
+
     def test_so_discount_is_not_reset(self):
         """ Discounts should not be recomputed on order confirmation """
         with patch(

--- a/addons/sale/wizard/mail_compose_message.py
+++ b/addons/sale/wizard/mail_compose_message.py
@@ -6,6 +6,17 @@ from odoo import models
 class MailComposer(models.TransientModel):
     _inherit = 'mail.compose.message'
 
+    def _action_send_mail(self, auto_commit=False):
+        composers = self
+        if not self.env.context.get('mark_so_as_sent'):
+            quotation_tmpl = self.env.ref('sale.email_template_edi_sale', raise_if_not_found=False)
+            if quotation_tmpl and self and all(
+                wizard.model == 'sale.order' and wizard.template_id == quotation_tmpl
+                for wizard in self
+            ):
+                composers = self.with_context(mark_so_as_sent=True)
+        return super(MailComposer, composers)._action_send_mail(auto_commit=auto_commit)
+
     def action_schedule_message(self, scheduled_date=False):
         return super(
             MailComposer,

--- a/addons/sale/wizard/mail_compose_message.py
+++ b/addons/sale/wizard/mail_compose_message.py
@@ -6,6 +6,19 @@ from odoo import models
 class MailComposer(models.TransientModel):
     _inherit = 'mail.compose.message'
 
+    def _action_send_mail(self, auto_commit=False):
+        composers = self
+        if (
+            not self.env.context.get('mark_so_as_sent')
+            and any(
+                wizard.model == 'sale.order'
+                and wizard.template_id == self.env.ref('sale.email_template_edi_sale', raise_if_not_found=False)
+                for wizard in self
+            )
+        ):
+            composers = self.with_context(mark_so_as_sent=True)
+        return super(MailComposer, composers)._action_send_mail(auto_commit=auto_commit)
+
     def action_schedule_message(self, scheduled_date=False):
         return super(
             MailComposer,


### PR DESCRIPTION
Steps to reproduce
1. Create a quotation
2. From the list view, select it and click Actions > Send an email
3. Pick the quotation template and send
4. The order stays in 'draft'

Issue
The Actions menu calls `action_quotation_send` with
`hide_default_template=True`:
https://github.com/odoo/odoo/blob/38734e4bc7d841a30524a2bc17fc94c9a83b5aa0/addons/sale/views/sale_order_views.xml#L1128-L1131
which skips the branch that sets `mark_so_as_sent` in context:
https://github.com/odoo/odoo/blob/38734e4bc7d841a30524a2bc17fc94c9a83b5aa0/addons/sale/models/sale_order.py#L1068-L1071

Without that flag, neither `message_post` (single order) nor the
mass-mail path (multi order) transitions the order to 'sent'. The
flag cannot be set unconditionally in `action_quotation_send` because
the same method also opens the composer for non-quotation emails
(e.g. `website_sale` cart recovery), which must stay in 'draft'.

Detect the quotation template at send time in `_action_send_mail`
and add `_message_mail_after_hook` for the mass-mail path.

opw-5248931