### PR TITLE
[FIX] base: mimetype can contains optional parameters

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -274,7 +274,7 @@ class IrAttachment(models.Model):
         self.ensure_one()
         if self.type != 'binary':
             return False
-        if self.mimetype != 'application/pdf':
+        if not self.mimetype.startswith('application/pdf'):
             return False
         return self.raw
 


### PR DESCRIPTION
The structure of a MIME type commonly consists of just two parts: a type and a subtype, separated by a slash (`/`), but optionally it can also contains parameters to provide additional details
(`type/subtype;parameter=value`).

This commit restores this nuance in the PDF mimetype check that was made stricter in the commit odoo/odoo@b048078971f4f12307740a8b382b762a35983059.

Reference:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types

runbot-241165
