### PR TITLE
[FIX] mrp: fix work center inline fields

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -172,15 +172,11 @@
                                 <group invisible="type == 'phantom'">
                                     <field name="picking_type_id" groups="stock.group_adv_location"/>
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
-                                    <div class="o_input_box">
-                                        <field name="produce_delay"/>
-                                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
-                                    </div>
+                                    <field name="produce_delay" class="oe_inline"/>days
                                     <label for="days_to_prepare_mo"/>
-                                    <div class="o_input_box">
-                                        <field name="days_to_prepare_mo"/>
-                                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
-                                        <button class="btn btn-link o_input_box_overlay_end" type="button">
+                                    <div>
+                                        <field name="days_to_prepare_mo" class="oe_inline"/>days
+                                        <button class="btn btn-link" type="button">
                                             <field name="json_popover" widget="mrp_bom_popover"/>
                                         </button>
                                     </div>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -319,29 +319,20 @@
                                 <group>
                                     <group string="Production Information" name="capacity">
                                         <label for="time_efficiency"/>
-                                        <div class="o_input_box">
-                                            <field name="time_efficiency"/>
-                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">%</span>
+                                        <div>
+                                            <field name="time_efficiency" class="oe_inline"/>%
                                         </div>
                                         <label for="oee_target"/>
-                                        <div class="o_input_box">
-                                            <field name="oee_target"/>
-                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">%</span>
+                                        <div>
+                                            <field name="oee_target" class="oe_inline"/>%
                                         </div>
-                                        <label for="time_start"/>
-                                        <div class="o_input_box">
-                                            <field name="time_start" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
-                                        </div>
-                                        <label for="time_stop"/>
-                                        <div class="o_input_box">
-                                            <field name="time_stop" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
-                                        </div>
+                                        <field name="time_start" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
+                                        <field name="time_stop" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                                     </group>
                                     <group string="Costing Information" name="costing">
                                         <label for="costs_hour"/>
-                                        <div class="o_input_box" id="costs_hour">
-                                            <field name="costs_hour" widget="monetary"/>
-                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">per workcenter</span>
+                                        <div id="costs_hour">
+                                            <field name="costs_hour" class="oe_inline" widget="monetary"/>per workcenter
                                         </div>
                                     </group>
                                 </group>


### PR DESCRIPTION
This commit removes o_input_box class and overlay elements from the view template, since inline fields are implemented with the oe_inline class instead. This restores the correct display of those fields in desktop.

task-6037387