### PR TITLE
[PERF] mrp: limit the _bom_find() calls number

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -374,6 +374,7 @@ class MrpBom(models.Model):
         """
         product_ids = set()
         product_boms = {}
+        product_boms = self.env.context.get('product_boms', {}).get((picking_type or self.picking_type_id, self.company_id.id), {})
         def update_product_boms():
             products = self.env['product.product'].browse(product_ids)
             product_boms.update(self._bom_find(products, picking_type=picking_type or self.picking_type_id,
@@ -390,7 +391,8 @@ class MrpBom(models.Model):
             product_id = bom_line.product_id
             bom_lines.append((bom_line, product, quantity, False))
             product_ids.add(product_id.id)
-        update_product_boms()
+        if not product_boms:
+            update_product_boms()
         product_ids.clear()
         while bom_lines:
             current_line, current_product, current_qty, parent_line = bom_lines[0]

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -363,6 +363,19 @@ class ProductProduct(models.Model):
                 kit_products |= kit.product_id
             else:
                 kit_products |= kit.product_tmpl_id.product_variant_ids
+        product_boms_per_picking = {}
+        unique_combinations = {
+            (bom.picking_type_id, bom.company_id)
+            for bom in kit_boms
+        }
+        for picking_id, company_id in unique_combinations:
+            product_boms = {}
+            product_boms.update(kit_boms._bom_find(kit_products, picking_type=picking_id,
+                company_id=company_id.id, bom_type='phantom'))
+            for product in kit_products:
+                product_boms.setdefault(product, self.env['mrp.bom'])
+            product_boms_per_picking[picking_id, company_id] = product_boms
+        kit_products = kit_products.with_context(product_boms_per_picking=product_boms_per_picking)
         for product in kit_products:
             if OPERATORS[operator](product.qty_available, value):
                 product_ids.append(product.id)


### PR DESCRIPTION
When searching product based on the qty_available field, a lot of time is spent in explode() calls.

In the explode() method, we call _bom_find() for each bom involved. This method only depends on the picking_type_id and company_id of the bom.

Thus we could batch it and call the method once per tuple (picking_type_id, company_id).

Benchmark:

|No BoM | No product variants | Before | After |
|-------|---------------------|--------|-------|
|     1 |                  65 |   44ms |  27ms |
|   100 |               2000 |  300ms | <100ms|
|  1700 |               13000 |    80s |   40s |

opw-6017527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
