### PR TITLE
[FIX] website: correctly block Google Ads cookies

### DIFF
--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -2,7 +2,6 @@
 import re
 
 from collections import OrderedDict
-from urllib.parse import urlsplit
 
 from odoo import models
 from odoo.http import request
@@ -127,45 +126,8 @@ class IrQweb(models.AbstractModel):
         if not website:
             return atts
 
-        if (
-            website.cookies_bar
-            and website.block_third_party_domains
-            and not self.env.context.get('cookies_allowed')
-            and not request.env.user.has_group('website.group_website_restricted_editor')
-        ):
-            # If the cookie banner is activated, 3rd-party embedded iframes and
-            # scripts should be controlled. As such:
-            # - 'domains' is a watchlist on the iframe/script's src itself,
-            # - 'classes' is a watchlist on container elements in which iframes
-            # are/could be built on the fly client-side for some reason.
-            cookies_watchlist = {
-                'domains': website.blocked_third_party_domains.split('\n'),
-                'classes': website._get_blocked_iframe_containers_classes(),
-            }
-            remove_src = False
-            if tagName in ('iframe', 'script'):
-                src_host = urlsplit((atts.get('src') or '').lower()).hostname
-                if src_host:
-                    remove_src = any(
-                        # "www.example.com" and "example.com" should block both.
-                        src_host == domain.removeprefix('www.')
-                        # "domain.com" should block "subdomain.domain.com", but
-                        # not "(subdomain.)mydomain.com".
-                        or src_host.endswith('.' + domain.removeprefix('www.'))
-                        for domain in cookies_watchlist['domains']
-                    )
-            if (
-                remove_src
-                or cookies_watchlist['classes'].intersection((atts.get('class') or '').split(' '))
-            ):
-                atts['data-need-cookies-approval'] = 'true'
-                # Case class in watchlist: we stop here. The element could
-                # contain an iframe created on the fly client-side. It is marked
-                # now so that the iframe can be marked later when created.
-                # Case iframe/script's src in watchlist: we adapt the src.
-                if 'src' in atts:
-                    atts['data-nocookie-src'] = atts['src']
-                    atts['src'] = 'about:blank'
+        if website._should_remove_third_party_trackers():
+            website._remove_third_party_trackers(tagName, atts, ['domains', 'classes'])
 
         name = self.URL_ATTRS.get(tagName)
         if request:

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -15,7 +15,8 @@ import werkzeug.routing
 
 from collections import defaultdict
 from lxml import etree, html
-from urllib.parse import urlparse
+from markupsafe import Markup
+from urllib.parse import urlparse, urlsplit
 from werkzeug import urls
 
 from odoo import api, fields, models, tools, release
@@ -2366,3 +2367,64 @@ class Website(models.Model):
         """
         self.ensure_one()
         return not self.cookies_bar or self.env['ir.http']._is_allowed_cookie('optional')
+
+    def _control_third_party_trackers_in_html(self, html_content):
+        if not html_content or not self._should_remove_third_party_trackers():
+            return html_content
+        try:
+            root_node = html.fromstring(str(html_content))
+            els = root_node.xpath("//script | //iframe")
+        except (etree.ParserError, etree.XMLSyntaxError):
+            return html_content
+        for el in els:
+            self._remove_third_party_trackers(el.tag, el.attrib, ['domains'])
+        return Markup(html.tostring(root_node, encoding="unicode"))
+
+    def _should_remove_third_party_trackers(self):
+        return (self.cookies_bar
+            and self.block_third_party_domains
+            and not self.env['ir.http']._is_allowed_cookie('optional')
+            and not self.env.user.has_group('website.group_website_restricted_editor'))
+
+    def _remove_third_party_trackers(self, tagName, atts, cookies_watchlist):
+        # If the cookie banner is activated, 3rd-party embedded iframes and
+        # scripts should be controlled. As such:
+        # - 'domains' is a watchlist on the iframe/script's src itself,
+        # - 'classes' is a watchlist on container elements in which iframes
+        # are/could be built on the fly client-side for some reason.
+        watchlist_checker = {
+            'domains': self._is_tag_domains_watchlisted,
+            'classes': self._is_tag_classes_watchlisted,
+        }
+        remove_src = False
+        for watch in cookies_watchlist:
+            if (checker := watchlist_checker.get(watch)) and checker(tagName, atts):
+                remove_src = True
+                break
+        if remove_src:
+            atts['data-need-cookies-approval'] = 'true'
+            # Case class in watchlist: we stop here. The element could
+            # contain an iframe created on the fly client-side. It is marked
+            # now so that the iframe can be marked later when created.
+            # Case iframe/script's src in watchlist: we adapt the src.
+            if atts.get("src"):
+                atts['data-nocookie-src'] = atts['src']
+                atts['src'] = 'about:blank'
+
+    def _is_tag_domains_watchlisted(self, tagName, atts):
+        domains = self.blocked_third_party_domains.split('\n')
+        if tagName in ('iframe', 'script'):
+            src_host = urlsplit((atts.get('src') or '').lower()).hostname
+            if src_host:
+                return any(
+                    # "www.example.com" and "example.com" should block both.
+                    src_host == domain.removeprefix('www.')
+                    # "domain.com" should block "subdomain.domain.com", but
+                    # not "(subdomain.)mydomain.com".
+                    or src_host.endswith('.' + domain.removeprefix('www.'))
+                    for domain in domains
+                )
+        return False
+
+    def _is_tag_classes_watchlisted(self, tagName, atts):
+        return self._get_blocked_iframe_containers_classes().intersection((atts.get('class') or '').split(' '))

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -324,10 +324,10 @@
 
 <template id="custom_code_layout" name="Custom Code Layout" inherit_id="website.layout" priority="55">
     <xpath expr="//head" position="inside">
-        <t t-out="website.custom_code_head"/>
+        <t t-out="website._control_third_party_trackers_in_html(website.custom_code_head)"/>
     </xpath>
     <xpath expr="//body" position="inside">
-        <t t-out="website.custom_code_footer"/>
+        <t t-out="website._control_third_party_trackers_in_html(website.custom_code_footer)"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
# How to reproduce
- Go to Website app > Configuration > Websites > Select your website > Custom Code
- In the "Custom <head> code" section add the script given at the last section of this PR (with a proper TAG_ID)
- Go to a new Incognito Tab and go to the Website front page
- Refuse the optionnal cookies
- Open the browser's console and go to Application > Storage > Cookies

# The problem
The Google Ads cookies are present (prefixed by _ga)

# Why
This commit introduced the blocking of 3rd party cookies :

https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1

It works by doing 2 things, but none of them works in our case :

First, it edits the view rendering to replace the `src` value with "about:blank" for watched
tags, but this does not work for `website.custom_code_head` (our case) and `website.custom_code_footer` because it is t-out'ed which bypasses this code :

https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1#diff-a27798e1ecfe96676dd48766e0aa9d12fbc0784e328ac1a3ec82b1ce199fc58bR121-R166

Second, it adds a script in the head of the page that patches the setter for the `src`
property of the script tags. If the value that we try to set is a URL to a site that we
block and the cookies are not yet accepted, we replace the `src` value with "about:blank".

https://github.com/odoo/odoo/blob/e906eb23d698061f146ba67aae420eb7bb5e8a68/addons/website/static/src/js/content/cookie_watcher.js#L8

This sadly does not work for parser-inserted scripts that are directly parsed from the HTML.
Indeed, they do not use the setter of `HTMLScriptElement.prototype`.

It is possible to verify this by adding a `MutationObserver` that checks for new script
insertions and adding breakpoints in this observer and in the patched setter. For the
first scripts of the page, the breakpoint in `MutationObserver`is triggerred while the
 one in the setter is not.

# Proposed solution
We move this code into new helper functions :
https://github.com/odoo/odoo/blob/95dc247ecd773044ef9c9f1512c7d86d73df836c/addons/website/models/ir_qweb.py#L130-L135

And use these helper functions to create another helper function that allows us to check
an html field for trackers that would need to be removed

We then use this helper function on `website.custom_code_head` and `website.custom_code_footer`

# The script
```html
<!-- Google tag (gtag.js) -->
  <script async src="[https://www.googletagmanager.com/gtag/js?id=TAG_ID"></script](https://www.googletagmanager.com/gtag/js?id=TAG_ID%22%3E%3C/script)>
  <script>
    window.dataLayer = window.dataLayer || [];
    function gtag(){dataLayer.push(arguments);}
    gtag('js', new Date());

    gtag('config', 'TAG_ID');
  </script>
```
Source : https://developers.google.com/tag-platform/gtagjs

opw-6007810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
