### PR TITLE
[FIX] l10n_in_withholding: inactive tds/tcs tax applicability

### DIFF
--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -59,7 +59,10 @@ class AccountMove(models.Model):
                 for tax in line.tax_ids:
                     if (
                         tax.l10n_in_section_id.tax_source_type == 'tcs'
-                        and tax.amount != max(tax.l10n_in_section_id.l10n_in_section_tax_ids, key=lambda t: abs(t.amount)).amount
+                        and tax.amount != max(
+                            tax.l10n_in_section_id.with_context(active_test=False).l10n_in_section_tax_ids,
+                            key=lambda t: abs(t.amount),
+                        ).amount
                     ):
                         lines |= line._origin
             return lines
@@ -91,8 +94,8 @@ class AccountMove(models.Model):
             for tax in line.tax_ids:
                 if tax.l10n_in_section_id.tax_source_type == 'tcs':
                     max_tax = max(
-                        tax.l10n_in_section_id.l10n_in_section_tax_ids,
-                        key=lambda t: t.amount
+                        tax.l10n_in_section_id.with_context(active_test=False).l10n_in_section_tax_ids,
+                        key=lambda t: abs(t.amount),
                     )
                     updated_tax_ids.append(max_tax.id)
                 else:


### PR DESCRIPTION
Before this **PR**, attempting to apply an inactive tax resulted in a traceback. This occurred because l10n_in_section_tax_ids was empty, resulting in an empty iterable being passed to max(), which caused the error.

To resolve this issue, l10n_in_section_tax_ids is now called with the context `active_test=False`.

task-6074534
