### PR TITLE
[FIX] web_tour: prevent crashes on tour resumption and missing steps

### DIFF
--- a/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
+++ b/addons/web_tour/static/src/js/tour_interactive/tour_interactive.js
@@ -84,13 +84,13 @@ export class TourInteractive {
 
     play() {
         this.removeListeners();
-        if (this.currentActionIndex === this.actions.length) {
+        this.currentAction = this.actions.at(this.currentActionIndex);
+
+        if (!this.currentAction) {
             TourInteractive.observer.disconnect();
             this.onTourEnd();
             return;
         }
-
-        this.currentAction = this.actions.at(this.currentActionIndex);
 
         if (!this.currentAction.step.active || this.currentAction.event === "warn") {
             if (this.currentAction.event === "warn") {

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -259,7 +259,9 @@ export class TourService {
                 browser.console.log("tour succeeded");
                 let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
                 if (message) {
-                    message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
+                    if (window.DOMPurify) {
+                        message = window.DOMPurify.sanitize(message);
+                    }
                     this.effect.add({
                         type: "rainbow_man",
                         message: markup(message),

--- a/addons/web_tour/static/src/js/tour_state.js
+++ b/addons/web_tour/static/src/js/tour_state.js
@@ -17,15 +17,16 @@ export const tourState = {
         browser.localStorage.setItem(CURRENT_TOUR_LOCAL_STORAGE, tourName);
     },
     getCurrentIndex() {
-        const index = browser.localStorage.getItem(CURRENT_TOUR_INDEX_LOCAL_STORAGE, "0");
-        return parseInt(index, 10);
+        const index = browser.localStorage.getItem(CURRENT_TOUR_INDEX_LOCAL_STORAGE);
+        const parsed = parseInt(index, 10);
+        return isNaN(parsed) ? 0 : parsed;
     },
     setCurrentIndex(index) {
         browser.localStorage.setItem(CURRENT_TOUR_INDEX_LOCAL_STORAGE, index.toString());
     },
     getCurrentConfig() {
-        const config = browser.localStorage.getItem(CURRENT_TOUR_CONFIG_LOCAL_STORAGE, "{}");
-        return JSON.parse(config);
+        const config = browser.localStorage.getItem(CURRENT_TOUR_CONFIG_LOCAL_STORAGE);
+        return config ? JSON.parse(config) : {};
     },
     setCurrentConfig(config) {
         config = JSON.stringify(config);


### PR DESCRIPTION
This commit fixes several TypeErrors occurring when the tour state in localStorage is inconsistent, particularly in the Point of Sale.

1. tour_state.js:
   - Handle cases where `localStorage.getItem` returns `null` for missing keys.
   - Ensure `getCurrentIndex` returns 0 instead of `NaN` and `getCurrentConfig` returns an empty object instead of `null`.
2. tour_interactive.js:
   - Simplified `play()` to stop gracefully if no valid action is found at the current index. This covers both the normal end of a tour and cases with corrupted or out-of-bounds indices.
3. tour_service.js:
   - Added a safety check for `window.DOMPurify` to avoid crashes in environments where it's not loaded (like POS).

task-id: 6084982

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
