### PR TITLE
[PERF] mrp_workcenter: speed up _prepare_graph_data

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -129,8 +129,8 @@ class MrpWorkcenter(models.Model):
 
     def _get_workcenter_load_per_week(self, week_range, date_start, date_stop):
         load_data = {rec: {} for rec in self}
-        # demo data
-        if not self.order_ids:
+        has_workorders = bool(self.env['mrp.workorder'].search_count([('workcenter_id', 'in', self.ids)], limit=1))
+        if not has_workorders:  # demo data
             for wc in self:
                 load_limit = 40     # default max load per week is 40 hours on a new workcenter
                 load_data[wc] = {week_start: randint(0, int(load_limit * 2)) for week_start in week_range}
@@ -147,9 +147,13 @@ class MrpWorkcenter(models.Model):
 
     def _prepare_graph_data(self, load_data, week_range):
         graph_data = {wid: [] for wid in self._ids}
+        has_workorders = bool(self.env['mrp.workorder'].search_count([('workcenter_id', 'in', self.ids)], limit=1))
+        attendances_duration_hours_by_resource_calendar = defaultdict(int)
+        for resource_calendar in self.resource_calendar_id:
+            attendances_duration_hours_by_resource_calendar[resource_calendar.id] = sum(resource_calendar.attendance_ids.mapped('duration_hours'))
         for workcenter in self:
-            load_limit = sum(workcenter.resource_calendar_id.attendance_ids.mapped('duration_hours'))
-            wc_data = {'is_sample_data': not self.order_ids, 'labels': list(week_range.values())}
+            load_limit = attendances_duration_hours_by_resource_calendar[workcenter.resource_calendar_id.id]
+            wc_data = {'is_sample_data': not has_workorders, 'labels': list(week_range.values())}
             load_bar = []
             excess_bar = []
             for week_start in week_range:


### PR DESCRIPTION

Before this commit, calling the method `_prepare_graph_data` with a recordset of workcenters,
would traverse the recordset and then check if all the workcenters has at least one workorder by
fetching the field `order_ids` for all the workcenters. This can be too slow in cases where the
workcenters have a lot of workorders and in addition to that there is no need to do this repeatedly for
every workcenter.

In this commit, I have modified the check by invoking a `search_count` on the workorders before iterating
over the recordset and in addition to that I have pre-computed the sum of the duration hours of the attendances
related to a `resource_calendar` as multiple workcenters might have the same `resource_calendar`

The benchmark done below, was on a database that contained 78 workcenters.

| Workorders | Before | After |
| :--- | :--- | :--- |
| 1380828 | 12s | 0.16s |
| 138082 | 1.21s | 0.14s |
| 13808 | 0.21s | 0.09s |

opw-6040077

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
