### PR TITLE
[FIX] web,*: add truncate class to m2m

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -9,7 +9,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <span t-out="autoCompleteItemScope.label"/>
+                    <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -9,7 +9,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128?unique={{autoCompleteItemScope.record.data.write_date.ts}}"/>
-                    <span t-out="autoCompleteItemScope.label"/>
+                    <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -11,7 +11,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
                         <AvatarEmployee resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <span t-out="autoCompleteItemScope.label"/>
+                        <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>
             </Many2One>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -10,7 +10,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <span t-out="autoCompleteItemScope.label"/>
+                    <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -18,7 +18,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
                         <Avatar resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <span t-out="autoCompleteItemScope.label"/>
+                        <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>
             </Many2OneAvatarUser>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
@@ -27,7 +27,7 @@
                     <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
                         <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                     </t>
-                    <span t-out="autoCompleteItemScope.label"/>
+                    <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
@@ -28,7 +28,7 @@
                         <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
                             <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                         </t>
-                        <span t-out="autoCompleteItemScope.label"/>
+                        <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                     </span>
                 </t>
             </Many2One>

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -35,7 +35,7 @@
         <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
             <img t-if="autoCompleteItemScope.record.id" class="rounded me-1"
                 t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-            <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" t-out="autoCompleteItemScope.label"/>
+            <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" class="text-truncate" t-out="autoCompleteItemScope.label"/>
         </span>
     </t>
 

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
@@ -12,7 +12,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <span t-out="autoCompleteItemScope.label"/>
+                    <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -17,7 +17,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                         <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                        <span t-out="autoCompleteItemScope.label"/>
+                        <span class="text-truncate" t-out="autoCompleteItemScope.label"/>
                     </span>
                 </t>
             </Many2One>


### PR DESCRIPTION
Currently, the m2m tags avatar field does not have the truncate class for the spans. When the text is too long, it overflows and the rest is cut off. This commit adds the truncate class to the spans of the m2m tags so that the text is truncated with an ellipsis when it exceeds the available space.

task-4809319
Before:
<img width="322" height="189" alt="c5f23b6aee6f63982f530c2e6a641d21" src="https://github.com/user-attachments/assets/b50fc70d-4d21-4023-8838-460f060a98fb" />
After:
<img width="310" height="167" alt="5ccf4bb07603a3d8c50d3763bd112f6d" src="https://github.com/user-attachments/assets/fa7e4167-98d8-47d7-a1e2-6639da8e5d05" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
