### PR TITLE
[FIX] l10n_pl_edi: fix KSeF bill import with custom taxes and EDI dec…

### DIFF
--- a/addons/l10n_pl_edi/models/account_move.py
+++ b/addons/l10n_pl_edi/models/account_move.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import logging
 import re
 from xml.dom.minidom import parseString
@@ -505,6 +506,40 @@ class AccountMove(models.Model):
             "np I": "vz_impu",
         }
 
+        def get_tax_amount_from_p12(tax_name):
+            """ Derive the tax rate (as a percentage) from the KSeF P_12 code,
+                without relying on a specific tax record existing in the database.
+            """
+            if tax_name in ("0 KR", "0 WDT", "0 EX", "zw", "oo", "np I", "np II"):
+                return 0.0
+            with contextlib.suppress(ValueError):
+                return float(tax_name)
+
+        def get_tax_fallback(tax_name, fiscal_position):
+            tax_amount = get_tax_amount_from_p12(tax_name)
+            domain = [
+                ('type_tax_use', '=', 'purchase'),
+                ('amount_type', '=', 'percent'),
+                ('price_include', '=', False),
+                ('amount', '=', tax_amount),
+                *self.env['account.tax']._check_company_domain(self.env.company)
+            ]
+            matching_taxes = self.env['account.tax'].search(domain, order='sequence')
+            mapped_tax = None
+            if matching_taxes:
+                if fiscal_position:
+                    mapped_taxes = fiscal_position.map_tax(matching_taxes)
+                    mapped_tax = mapped_taxes[0] if mapped_taxes else matching_taxes[0]
+                else:
+                    mapped_tax = matching_taxes[0]
+            return mapped_tax
+
+        def get_tax(tax_name):
+            if xml_id := p12_to_tax_xml_id_map.get(tax_name):
+                if tax := self.env['account.chart.template'].ref(xml_id, raise_if_not_found=False):
+                    return tax
+                raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", tax_name))
+
         def parse_fa3_bill_xml(xml_content):
             root = etree.fromstring(xml_content)
 
@@ -533,13 +568,10 @@ class AccountMove(models.Model):
                 if P_9A := get_value(line_node, '{*}P_9A'):
                     price_unit = float(P_9A)
                 elif P_9B := get_value(line_node, '{*}P_9B'):
-                    if xml_id := p12_to_tax_xml_id_map.get(tax_name):
-                        if tax := self.env['account.chart.template'].ref(xml_id, raise_if_not_found=False):
-                            price_unit = float(P_9B) * (1 - tax.amount / (100 + tax.amount))
-                        else:
-                            raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", tax_name))
-                    else:
-                        raise UserError(self.env._("Tax corresponding to '%s' required to derive the net unit price from gross price during KSeF import was not found in the mapping.", tax_name))
+                    tax_amount = get_tax_amount_from_p12(tax_name)
+                    if tax_amount is None:
+                        raise UserError(self.env._("Tax corresponding to '%s' required to derive the net unit price from gross price during KSeF import could not be interpreted.", tax_name))
+                    price_unit = float(P_9B) * (1 - tax_amount / (100 + tax_amount))
                 else:
                     price_unit = 0.0
 
@@ -589,7 +621,15 @@ class AccountMove(models.Model):
                     },
                 )
 
-            currency = self.env['res.currency'].with_context(active_test=False).search([('name', '=', data['currency_code'])], limit=1)
+            currency = self.env['res.currency'].with_context(active_test=False).search(
+                [('name', '=', data['currency_code'])], limit=1,
+            )
+            if not currency:
+                raise UserError(self.env._("Currency '%s' from the KSeF bill was not found.", data['currency_code']))
+            if not currency.active:
+                currency.sudo().active = True
+
+            fiscal_position = self.env['account.fiscal.position']._get_fiscal_position(partner)
 
             move_vals = {
                 'move_type': 'in_invoice',
@@ -603,12 +643,10 @@ class AccountMove(models.Model):
 
             for line in data['lines']:
 
-                tax_ids = []
-                if xml_id := p12_to_tax_xml_id_map.get(line['tax_name']):
-                    if tax := self.env['account.chart.template'].ref(xml_id, raise_if_not_found=False):
-                        tax_ids.append(Command.set(tax.ids))
-                    else:
-                        raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", line['tax_name']))
+                tax_name = line['tax_name']
+                mapped_tax = get_tax(tax_name) or get_tax_fallback(tax_name, fiscal_position)
+                if not mapped_tax:
+                    raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", line['tax_name']))
 
                 move_vals['invoice_line_ids'].append(
                     Command.create(
@@ -616,7 +654,7 @@ class AccountMove(models.Model):
                             'name': line['name'],
                             'quantity': line['quantity'],
                             'price_unit': line['price_unit'],
-                            'tax_ids': tax_ids,
+                            'tax_ids': [Command.set(mapped_tax.ids)],
                         }
                     )
                 )
@@ -755,3 +793,22 @@ class AccountMove(models.Model):
                         'res_id': bill.id,
                         'res_model': bill._name,
                     })
+
+    def _decode_fa3_ksef(self, invoice, file_data, new):
+        xml_content = file_data.get('content')
+        move_vals = self.l10n_pl_edi_get_ksef_bill_vals_from_xml(xml_content)
+
+        if move_vals:
+            invoice.write(move_vals)
+            return True
+
+        return False
+
+    def _get_edi_decoder(self, file_data, new=False):
+        if file_data.get('type') == 'xml' and file_data.get('xml_tree') is not None:
+            tree = file_data['xml_tree']
+            kod_node = tree.find('.//{*}KodFormularza')
+            if kod_node is not None and kod_node.get('kodSystemowy') == 'FA (3)':
+                return self._decode_fa3_ksef
+
+        return super()._get_edi_decoder(file_data, new=new)

--- a/addons/l10n_pl_edi/models/account_move.py
+++ b/addons/l10n_pl_edi/models/account_move.py
@@ -446,19 +446,6 @@ class AccountMove(models.Model):
     @api.model
     def l10n_pl_edi_get_ksef_bill_vals_from_xml(self, xml_content):
 
-        p12_to_tax_xml_id_map = {
-            "23": "vz_kraj_23",
-            "8": "vz_kraj_8",
-            "5": "vz_kraj_5",
-            "0 KR": "vz_kraj_0",
-            "zw": "vz_kraj_zw",
-            "oo": "vz_stal",
-            "0 WDT": "vz_unia",
-            "np II": "vz_nabu",
-            "0 EX": "vz_imp_tow",
-            "np I": "vz_impu",
-        }
-
         def parse_fa3_bill_xml(xml_content):
             root = etree.fromstring(xml_content)
 
@@ -523,6 +510,8 @@ class AccountMove(models.Model):
 
             currency = self.env['res.currency'].search([('name', '=', data['currency_code'])], limit=1)
 
+            fiscal_position = self.env['account.fiscal.position']._get_fiscal_position(partner)
+
             move_vals = {
                 'move_type': 'in_invoice',
                 'partner_id': partner.id,
@@ -534,11 +523,38 @@ class AccountMove(models.Model):
             }
 
             for line in data['lines']:
-
                 tax_ids = []
-                if xml_id := p12_to_tax_xml_id_map.get(line['tax_name']):
-                    if tax := self.env['account.chart.template'].ref(xml_id, raise_if_not_found=False):
-                        tax_ids.append(Command.set(tax.ids))
+                tax_name = line['tax_name']
+
+                if tax_name in ["0 KR", "0 WDT", "0 EX", "zw", "oo", "np I", "np II"]:
+                    tax_amount = 0.0
+                else:
+                    try:
+                        tax_amount = float(tax_name)
+                    except ValueError:
+                        tax_amount = None
+
+                if tax_amount is not None:
+                    domain = [
+                        ('type_tax_use', '=', 'purchase'),
+                        ('amount_type', '=', 'percent'),
+                        ('price_include', '=', False),
+                        ('amount', '=', tax_amount),
+                        *self.env['account.tax']._check_company_domain(self.env.company)
+                    ]
+
+                    matching_taxes = self.env['account.tax'].search(domain, order='sequence')
+
+                    mapped_tax = None
+                    if matching_taxes:
+                        if fiscal_position:
+                            mapped_taxes = fiscal_position.map_tax(matching_taxes)
+                            mapped_tax = mapped_taxes[0] if mapped_taxes else matching_taxes[0]
+                        else:
+                            mapped_tax = matching_taxes[0]
+
+                    if mapped_tax:
+                        tax_ids.append(Command.set(mapped_tax.ids))
                     else:
                         raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", line['tax_name']))
 
@@ -642,3 +658,22 @@ class AccountMove(models.Model):
         self.create(bills_vals_list)
 
         return blocking_error
+
+    def _decode_fa3_ksef(self, invoice, file_data, new):
+        xml_content = file_data.get('content')
+        move_vals = self.l10n_pl_edi_get_ksef_bill_vals_from_xml(xml_content)
+
+        if move_vals:
+            invoice.write(move_vals)
+            return True
+
+        return False
+
+    def _get_edi_decoder(self, file_data, new=False):
+        if file_data.get('type') == 'xml' and file_data.get('xml_tree') is not None:
+            tree = file_data['xml_tree']
+            kod_node = tree.find('.//{*}KodFormularza')
+            if kod_node is not None and kod_node.get('kodSystemowy') == 'FA (3)':
+                return self._decode_fa3_ksef
+
+        return super()._get_edi_decoder(file_data, new=new)

--- a/addons/l10n_pl_edi/tests/export_xmls/fa3_bill_intra_comunity.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/fa3_bill_intra_comunity.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/"
+         xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-10T10:50:29Z</DataWytworzeniaFa>
+        <SystemInfo>Odoo</SystemInfo>
+    </Naglowek>
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>IT12345670017</NIP>
+            <Nazwa>Italian seller</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>IT</KodKraju>
+            <AdresL1>12 via casia 21 rome</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>it@hadron.eu.com</Email>
+            <Telefon>112</Telefon>
+        </DaneKontaktowe>
+    </Podmiot1>
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>5795955811</NIP>
+            <Nazwa>PL Company</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1> 47-400 Racibórz Polska</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>info@company.plexample.com</Email>
+            <Telefon>+48 512 345 678</Telefon>
+        </DaneKontaktowe>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-10</P_1>
+        <P_1M>Kędzierzyn-Koźle</P_1M>
+        <P_2>FV/2026/00001-demo-test-005</P_2>
+        <P_13_1>3.19</P_13_1>
+        <P_14_1>0.73</P_14_1>
+        <P_15>38.42</P_15>
+        <KursWalutyZ>1.0</KursWalutyZ>
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+        <RodzajFaktury>VAT</RodzajFaktury>
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>[FURN_0006] Podstawka pod monitor</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1.0</P_8B>
+            <P_9A>3.19</P_9A>
+            <P_11>3.19</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>2</NrWierszaFa>
+            <P_7>[FOOD_0001] Chleb pszenny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2.5</P_8B>
+            <P_9A>5.00</P_9A>
+            <P_11>12.50</P_11>
+            <P_12>0 WDT</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>3</NrWierszaFa>
+            <P_7>[BOOK_0001] Podręcznik szkolny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>4.0</P_8B>
+            <P_9A>5.00</P_9A>
+            <P_11>20.00</P_11>
+            <P_12>5</P_12>
+        </FaWiersz>
+        <Platnosc>
+            <TerminPlatnosci>
+                <Termin>2026-02-10</Termin>
+            </TerminPlatnosci>
+        </Platnosc>
+    </Fa>
+</Faktura>

--- a/addons/l10n_pl_edi/tests/import_xmls/fa3_standard_bill.xml
+++ b/addons/l10n_pl_edi/tests/import_xmls/fa3_standard_bill.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/"
+         xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-10T10:50:29Z</DataWytworzeniaFa>
+        <SystemInfo>Odoo</SystemInfo>
+    </Naglowek>
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Italian seller</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>47-490 Racibórz Polska</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>pl@plclient.com</Email>
+            <Telefon>112</Telefon>
+        </DaneKontaktowe>
+    </Podmiot1>
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>5795955811</NIP>
+            <Nazwa>PL Company</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1> 47-400 Racibórz Polska</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>info@company.plexample.com</Email>
+            <Telefon>+48 512 345 678</Telefon>
+        </DaneKontaktowe>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-10</P_1>
+        <P_1M>Kędzierzyn-Koźle</P_1M>
+        <P_2>FV/2026/00001-demo-test-005</P_2>
+        <P_13_1>3.19</P_13_1>
+        <P_14_1>0.73</P_14_1>
+        <P_15>38.42</P_15>
+        <KursWalutyZ>1.0</KursWalutyZ>
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+        <RodzajFaktury>VAT</RodzajFaktury>
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>[FURN_0006] Podstawka pod monitor</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1.0</P_8B>
+            <P_9A>3.19</P_9A>
+            <P_11>3.19</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>2</NrWierszaFa>
+            <P_7>[FOOD_0001] Chleb pszenny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2.5</P_8B>
+            <P_9A>5.00</P_9A>
+            <P_11>12.50</P_11>
+            <P_12>0 WDT</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>3</NrWierszaFa>
+            <P_7>[BOOK_0001] Podręcznik szkolny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>4.0</P_8B>
+            <P_9B>5.25</P_9B>
+            <P_11>20.00</P_11>
+            <P_12>5</P_12>
+        </FaWiersz>
+        <Platnosc>
+            <TerminPlatnosci>
+                <Termin>2026-02-10</Termin>
+            </TerminPlatnosci>
+        </Platnosc>
+    </Fa>
+</Faktura>

--- a/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
+++ b/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
@@ -1002,3 +1002,23 @@ class TestL10nPlEdi(AccountTestInvoicingCommon, CronMixinCase):
         self.assertEqual(capt.call_count, 3)
         new_bill = self.env['account.move'].search([('l10n_pl_edi_number', '=', 'KSEF-NEW-BILL-001')])
         self.assertTrue(new_bill)
+
+    def test_ksef_bill_import_dynamic_taxes_and_fiscal_position(self):
+        """ Test that importing a KSeF bill maps taxes dynamically using amounts and fiscal positions. """
+
+        path = 'l10n_pl_edi/tests/import_xmls/fa3_standard_bill.xml'
+        with tools.file_open(path, mode='rb') as file:
+            xml_content = file.read()
+
+        parsed_vals = self.env['account.move'].with_company(self.company).l10n_pl_edi_get_ksef_bill_vals_from_xml(xml_content)
+        bill = self.env['account.move'].with_company(self.company).create(parsed_vals)
+
+        self.assertRecordValues(bill.invoice_line_ids, [
+            {'price_unit': 3.19},
+            {'price_unit': 5.00},
+            {'price_unit': 5.00},
+        ])
+        self.assertEqual(
+            bill.invoice_line_ids.mapped('tax_ids.amount'),
+            [23.0, 23.0, 5.0],
+        )

--- a/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
+++ b/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
@@ -619,3 +619,32 @@ class TestL10nPlEdi(AccountTestInvoicingCommon, CronMixinCase):
         self.assertEqual(len(capt.records), cron_runs_before + 1)
         self.assertGreaterEqual(capt.records[-1].call_at, start + timedelta(seconds=120))
         self.assertLessEqual(capt.records[-1].call_at, start + timedelta(seconds=240))
+
+    def test_ksef_bill_import_dynamic_taxes_and_fiscal_position(self):
+        """ Test that importing a KSeF bill maps taxes dynamically using amounts and fiscal positions. """
+
+        path = 'l10n_pl_edi/tests/export_xmls/fa3_bill_intra_comunity.xml'
+        with tools.file_open(path, mode='rb') as file:
+            xml_content = file.read()
+
+        parsed_vals = self.env['account.move'].with_company(self.company).l10n_pl_edi_get_ksef_bill_vals_from_xml(xml_content)
+
+        expected_tax_amounts = [23.0, 23.0, 23.0]
+
+        for index, expected_amount in enumerate(expected_tax_amounts):
+
+            line_vals = parsed_vals['invoice_line_ids'][index][2]
+            applied_tax_ids = line_vals['tax_ids'][0][2]
+            applied_taxes = self.env['account.tax'].browse(applied_tax_ids)
+            self.assertEqual(
+                len(applied_taxes),
+                1,
+                f"Expected exactly 1 tax on line {index + 1}, got {len(applied_taxes)}."
+            )
+
+            # 2. Assert that the applied tax amount is correct
+            self.assertEqual(
+                applied_taxes[0].amount,
+                expected_amount,
+                f"The applied tax amount for line {index + 1} ('{line_vals['name']}') is incorrect. Expected {expected_amount}%, got {applied_taxes[0].amount}%."
+            )


### PR DESCRIPTION
…oder signature

When importing a vendor bill from KSeF, the system strictly relied on official Odoo tax XML IDs (e.g., `vz_kraj_23`). If a user had custom taxes (e.g., from a third-party localization), the import would crash with a UserError indicating the tax was not found.

Allow manually uploading a FA(3) XML file to vendor bills, and it is detected automatically by the system

This commit fixes these issues by:
1. Implementing a smart fallback tax search. If the official XML ID is not found, it dynamically searches for a matching purchase tax based on the KSeF tax code (e.g., '23' -> 23% purchase tax, 'zw' -> 0%).
2. Adding an adapter method that matches the expected EDI decoder signature, processes the file data, and writes the parsed values to the draft invoice.

task-6067168

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
