### PR TITLE
[FIX] l10n_es_edi_facturae: Error when generating invoice without tax

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -468,6 +468,8 @@ class AccountMove(models.Model):
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, grouping_function_per_base_line_tax)
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
         for grouping_key, values in values_per_grouping_key.items():
+            if not grouping_key:
+                continue
             tax_record = values['base_line_x_taxes_data'][0][1][0]['tax']
             if not tax_record:
                 continue


### PR DESCRIPTION
Issue: Attempting to generate facturae document for an invoice without a tax set on one or more line resulted in an IndexError. Solution: adding a check that prevents the function from trying to build tax values when there is no tax on the line.
task-none

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
