### PR TITLE
[FIX] account_peppol: Hide participation role setting for branches

### DIFF
--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -36,7 +36,7 @@
                                     required="account_peppol_proxy_state in ('sender', 'smp_registration', 'receiver')"/>
                         </div>
                         <div class="o_setting_right_pane" id="peppol_participation_role_config" company_dependent="1"
-                            invisible="not peppol_participation_role">
+                            invisible="not peppol_participation_role or peppol_use_parent_company">
                             <div class="mb-2">
                                 <span class="o_form_label">
                                     <label string="Peppol Participation Role" for="peppol_participation_role"/>


### PR DESCRIPTION
In v19.0 -> master, if a branch company used the VAT of the parent company to register for peppol, the peppol participation role would be shown in the configuration settings, with a default value being "Sending and receiving", And since branches in this case should be able to ONLY send, the setting shouldnt be visibile to the user.
task-none
