### PR TITLE
[FIX] sale_margin: wrong projected margins list view

### DIFF
--- a/addons/sale_margin/report/sale_report_views.xml
+++ b/addons/sale_margin/report/sale_report_views.xml
@@ -42,6 +42,7 @@
         <field name="res_model">sale.report</field>
         <field name="path">project-projected-margins</field>
         <field name="view_mode">list,kanban</field>
+        <field name="view_id" ref="sale_report_projected_margins_list" />
         <field name="search_view_id" ref="sale.view_order_product_search" />
         <field name="context">{'search_default_Customer': 1, 'search_default_filter_order_date': 1}</field>
         <field name="help" type="html">


### PR DESCRIPTION
Specify the custom list view for the projected margin action window instead of showing the default `sale.report` list view in saas-19.2

---

task-6084014