### PR TITLE
[FIX] account_peppol: prevent Peppol journal type change

### DIFF
--- a/addons/account_peppol/models/account_journal.py
+++ b/addons/account_peppol/models/account_journal.py
@@ -1,4 +1,5 @@
-from odoo import _, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AccountJournal(models.Model):
@@ -6,6 +7,14 @@ class AccountJournal(models.Model):
 
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state')
     is_peppol_journal = fields.Boolean(string="Is journal used for Peppol invoices reception", default=False)
+
+    @api.constrains('type')
+    def _check_type_for_peppol_journal(self):
+        for journal in self:
+            if journal.is_peppol_journal and journal.type != 'purchase':
+                raise ValidationError(_("You can't change the type of a journal used for Peppol invoice reception to"
+                                  "a type different than 'Purchase'.\nPlease change the journal used for Peppol"
+                                  " reception before changing the type of this journal."))
 
     def peppol_get_new_documents(self):
         edi_users = self.env['account_edi_proxy_client.user'].search([

--- a/addons/account_peppol/tests/__init__.py
+++ b/addons/account_peppol/tests/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_account_journal
 from . import test_peppol_messages
 from . import test_peppol_participant

--- a/addons/account_peppol/tests/test_account_journal.py
+++ b/addons/account_peppol/tests/test_account_journal.py
@@ -1,0 +1,23 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestPeppolAccountJournal(AccountTestInvoicingCommon):
+
+    def test_peppol_journal_type_change(self):
+        self.env.company.write({"account_peppol_proxy_state": "active"})
+        journal = self.env.company.peppol_purchase_journal_id
+        self.assertTrue(journal)
+        with self.assertRaises(ValidationError):
+            journal.write({"type": "sale"})
+
+        other_journal = self.env['account.journal'].create({
+            'name': "Other purchase journal",
+            'code': "OPJ",
+            'type': 'purchase',
+        })
+        other_journal.write({"type": "sale"})
+        self.assertEqual(other_journal.type, 'sale')


### PR DESCRIPTION
Prevent changing a Peppol journal to a non-purchase type, to avoid import errors when receiving Peppol invoices.

Step to reproduce:
- Setup a company with Peppol
- Change the Peppol reception journal type to non-purchase
- Try to run Peppol cron to import invoice, it fails with "Cannot create a purchase document in a non purchase journal"

opw-6071992
opw-6064502