### PR TITLE
[FIX] pos_hr: prevent validation error when clicking on Manage users

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -24,9 +24,9 @@ class PosConfig(models.Model):
         group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
             lambda u: self.company_id in u.company_ids
         )
-        allowed_employees = group_users.sudo().mapped('employee_id')
+        allowed_employees = group_users.sudo().mapped('employee_ids')
         if not allowed_employees and group_users:
-            target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_id)[0]
+            target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_ids)[0]
             target_user.action_create_employee()
             allowed_employees = target_user.employee_id
 

--- a/addons/pos_hr/tests/test_res_config_settings.py
+++ b/addons/pos_hr/tests/test_res_config_settings.py
@@ -4,6 +4,7 @@ import odoo
 
 from odoo.addons.pos_hr.tests.test_frontend import TestPosHrHttpCommon
 from odoo.addons.point_of_sale.tests.test_res_config_settings import TestConfigureShops
+from odoo.tests import Form
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -42,3 +43,14 @@ class TestConfigureShopsPoSHR(TestPosHrHttpCommon, TestConfigureShops):
         self.assertEqual(len(self.main_pos_config.advanced_employee_ids), 1)
         self.assertEqual(self.main_pos_config.advanced_employee_ids.company_id, self.main_pos_config.company_id)
         self.assertEqual(self.main_pos_config.advanced_employee_ids, advanced_employee)
+
+    def test_write_pos_config_without_employee_id(self):
+        """
+        Checks that when we write on a config with a user that has a corresponding employee in employee_ids but no
+        corresponding employee in employee_id, we don't try to create an employee. If we do, a psycopg2 error
+        is raised as we try to create an employee that already exists.
+        """
+        self.manager_user.write({'group_ids': False })
+        self.pos_admin.write({'group_ids': False })
+        self.user.employee_id = False
+        self.main_pos_config.write({'status': 'active'})


### PR DESCRIPTION
## Short functional explanation of the error
When in settings, we click on Manage users, we sometimes get a validation error.

## Reproduction Steps
1. Go to settings.
2. Click on Manage Users.

### Expected behavior
The list of users is displayed.

### Unexpected behavior
Sometimes (around 20% of the time), we get the error:
```
Validation Error

The operation cannot be completed: A user cannot be linked to
multiple employees in the same company.
```

## Origin of the issue
This validation error is triggered due to a psycopg2 constraint error. Indeed, it occurs because the code tries to create an employee for the current user, when an employee for this user already exists:
https://github.com/odoo/odoo/blob/35da8c4d8e86a752cc76d275463a752039465984/addons/pos_hr/models/pos_config.py#L27-L30 In our case, the `group_users` only contains the admin user. This user has an existing corresponding employee in the field `employee_ids`, but not in `employee_id`.

__
opw-6066533






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
