### PR TITLE
[FIX] microsoft_calendar: fix synchronization of cancelled events

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -279,8 +279,8 @@ class MicrosoftCalendarSync(models.AbstractModel):
         :return: synchronized odoo
         """
         existing = microsoft_events.match_with_odoo_events(self.env)
-        cancelled = microsoft_events.cancelled()
-        new = microsoft_events - existing - cancelled
+        cancelled = existing.cancelled()
+        new = microsoft_events - existing - microsoft_events.cancelled()
         new_recurrence = new.filter(lambda e: e.is_recurrent())
 
         # create new events and reccurrences


### PR DESCRIPTION
Before this commit, when syncing events from Microsoft, if there was a cancelled event that was not yet synchronized with Odoo, calling browse on event.odoo_id would raise an error as it would be None.

opw-5917677

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
