### PR TITLE
[FIX] account,product: remove original product name from translation

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -48,9 +48,9 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
     }
 
     parseLabel(value) {
-        return (this.productName && value && this.productName.concat("\n", value))
-            || (this.productName && !value && this.productName)
-            || (value || "");
+       return this.currentProductName && value && this.currentProductName.concat("\n", value) ||
+            this.currentProductName && !value && this.currentProductName ||
+            value || "";
     }
 
     shouldShowWarning() {

--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -54,6 +54,7 @@ export class ProductNameAndDescriptionField extends Component {
         useProductAndLabelAutoresize(this.labelNode, { targetParentName: this.props.name });
         this.productNode = useRef("productNodeRef");
         useProductAndLabelAutoresize(this.productNode, { targetParentName: this.props.name });
+        this.currentProductName = "";
 
         this.descriptionColumn = this.constructor.descriptionColumn;
         useInputField({
@@ -106,9 +107,15 @@ export class ProductNameAndDescriptionField extends Component {
 
     get label() {
         let label = this.props.record.data[this.descriptionColumn];
-        if (label.includes(this.productName)) {
-            label = label.replace(this.productName, "");
+        this.currentProductName = this.productName ? label.split("\n")[0] : "";
+
+        if(this.productName && label.startsWith(this.productName)){
+            label = label.slice(this.productName.length + 1);
         }
+        else if(this.currentProductName && label.startsWith(this.currentProductName)){
+            label = label.slice(this.currentProductName.length + 1);
+        }
+
         return label.trim();
     }
 


### PR DESCRIPTION
Steps to reproduce:
1- Install invoicing app
2- Add French language in the settings
3- Create a customer with language set as French
4- Create a product and define french translations of the name and the description in Sales tab
5- Create an invoice for that customer and choose the product you created
6- You will find the translated product name and description under the product name
7- Edit the description, save and preview the invoice
8- The invoice line will contain [Product Name EN] [Product Name FR] [Product Description FR]

Description of the issue:
When creating an invoice for a customer whose language differs from the user's account language, manually editing the product description on an invoice line causes the original product name to be prepended to the description. The same issue happens in a RFQ in Purchase.

Expected behaviour:
User can edit the product description in the invoice line and the output in the invoice should only be the translated name and description, without the original product name.

Why this happens?
1- When the product is selected in the invoice line, the label is loaded from _compute_name method in account_move_line, which holds the translated name and description.
2- After editing the description and escaping the field (clicking outside it), the parseLabel method is called, which prepends the original name to the label, making the invoice output as [original name] [translated name] [translated desc.]

Fix:
Use the product name returned in the label for trimming and concatenation to handle both original/translated text scenarios.

References:
original PR: #248401
partial revert: #254158

opw-5480494