### PR TITLE
[FIX] mail: prevent infinite loop in Store with lambda function value

### DIFF
--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -378,6 +378,20 @@ class TestDiscussTools(MailCase):
         data2 = store.get_result()
         self.assertEqual(data2["res.partner"][0]["im_status"], "online")
 
+    def test_391_add_no_loop_callable_identity_obj(self):
+        def _store_partner_test_fields(res):
+            res.attr("test", lambda p: p.id, predicate=lambda p: p.id)
+            res.one("main_user_id", _store_user_test_fields)
+
+        def _store_user_test_fields(res):
+            res.attr("test", lambda u: u.id, predicate=lambda u: u.id)
+            res.one("partner_id", _store_partner_test_fields)
+
+        user = new_test_user(self.env, "test_user_391@example.com")
+        data = Store().add(user, _store_user_test_fields).get_result()
+        self.assertEqual(data["res.partner"][0]["test"], user.partner_id.id)
+        self.assertEqual(data["res.users"][0]["test"], user.id)
+
     def test_393_delayed_add(self):
         """Test that delayed store.add() postpones reading fields until get_result()."""
         user_a = new_test_user(self.env, "test_user_390@example.com")

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -569,7 +569,7 @@ class Store:
             return tuple(Store._deep_freeze(i) for i in obj)
         if isinstance(obj, set):
             return frozenset(Store._deep_freeze(i) for i in obj)
-        return obj
+        return obj.__code__ if hasattr(obj, "__code__") else obj
 
     class Stores(dict[object | tuple, "Store"]):
         """Lazy mapping to manage a list of Store indexed by bus target.


### PR DESCRIPTION
This commit prevents possible infinite loops in the Store by
comparing the `__code__` attribute of identity objects when
available.
This is necessary for cases like lambda functions which would
otherwise be compared by reference.