### PR TITLE
[FIX] pos_self_order: add missing translation in self ordering

### DIFF
--- a/addons/pos_self_order/i18n/pos_self_order.pot
+++ b/addons/pos_self_order/i18n/pos_self_order.pot
@@ -488,6 +488,12 @@ msgid "Easily load a set of configuration options"
 msgstr ""
 
 #. module: pos_self_order
+#. odoo-javascript
+#: code:addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml:0
+msgid "Email"
+msgstr ""
+
+#. module: pos_self_order
 #: model:ir.model.fields,field_description:pos_self_order.field_pos_preset__mail_template_id
 msgid "Email Confirmation"
 msgstr ""
@@ -978,6 +984,12 @@ msgstr ""
 
 #. module: pos_self_order
 #. odoo-javascript
+#: code:addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml:0
+msgid "Phone"
+msgstr ""
+
+#. module: pos_self_order
+#. odoo-javascript
 #: code:addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml:0
 msgid "Pickup At Counter"
 msgstr ""
@@ -1360,6 +1372,12 @@ msgid "Status"
 msgstr ""
 
 #. module: pos_self_order
+#. odoo-javascript
+#: code:addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml:0
+msgid "Street and Number"
+msgstr ""
+
+#. module: pos_self_order
 #: model:ir.model.fields,field_description:pos_self_order.field_pos_self_order_custom_link__style
 msgid "Style"
 msgstr ""
@@ -1611,6 +1629,12 @@ msgstr ""
 #: model:mail.template,subject:pos_self_order.delivery_email_template
 #: model:mail.template,subject:pos_self_order.takeout_email_template
 msgid "Your {{ object.config_id.name }} receipt"
+msgstr ""
+
+#. module: pos_self_order
+#. odoo-javascript
+#: code:addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml:0
+msgid "Zip"
 msgstr ""
 
 #. module: pos_self_order


### PR DESCRIPTION
Steps to reproduce:
- Enable QR-code ordering on a POS and set French as default language for self ordering.
- Open the POS self-order mobile menu and choose Takeout as preset.
- Go to checkout until the customer info popup is shown.
- Observe that placeholders like "Phone", "Zip", and "Street and Number" stay in English while other fields are translated.

Problem:
- The terms (`Email`, `Phone`, `Street and Number`, `Zip`) were missing from `pos_self_order.pot`.

opw-5938249

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
