### PR TITLE
[FIX] stock_delivery: propagate carrier tracking in multi-step delivery

### DIFF
--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -40,12 +40,18 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
+        if not any(rule.propagate_carrier for rule in self.rule_id):
+            return vals
         carrier_id = self.reference_ids.sale_ids.carrier_id.id
+        carrier_tracking_ref = self.move_orig_ids.picking_id.filtered('carrier_tracking_ref')[:1].carrier_tracking_ref
         # check if the previous picking have a carrier_id, then take carrier from that
         # earlier we were taking carrier from sale but since carrier can be changed or updated in next steps so now we take carrier from prev picking
         if len(self.move_orig_ids.picking_id.carrier_id) == 1:
             carrier_id = self.move_orig_ids.picking_id.carrier_id.id
-        vals['carrier_id'] = any(rule.propagate_carrier for rule in self.rule_id) and carrier_id
+        if carrier_id:
+            vals['carrier_id'] = carrier_id
+        if carrier_tracking_ref:
+            vals['carrier_tracking_ref'] = carrier_tracking_ref
         return vals
 
     def _key_assign_picking(self):

--- a/addons/stock_delivery/tests/test_carrier_propagation.py
+++ b/addons/stock_delivery/tests/test_carrier_propagation.py
@@ -296,3 +296,29 @@ class TestCarrierPropagation(TransactionCase):
         # both pickings should be validated but and activity should have been created for the invalid picking
         self.assertEqual(pickings.mapped('state'), ['done', 'done'])
         self.assertTrue(self.env['mail.activity'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', pickings[1].id), ('user_id', '=', alien.id)], limit=1))
+
+    def test_carrier_tracking_ref_propagation(self):
+        """Ensure that the carrier tracking reference is propagated across pickings
+        (OUT → PACK → SHIP) when "propagate_carrier" is enabled on the rule.
+        """
+        so = self.SaleOrder.create({
+            'partner_id': self.partner_propagation.id,
+            'partner_invoice_id': self.partner_propagation.id,
+            'order_line': [
+                Command.create({
+                    'name': self.super_product.name,
+                    'product_id': self.super_product.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 1,
+                }),
+            ]
+        })
+        so.action_confirm()
+        pick = so.picking_ids
+        pick.carrier_tracking_ref = "123"
+        pick.button_validate()
+        pack = pick.move_ids.move_dest_ids.picking_id
+        self.assertEqual(pack.carrier_tracking_ref, "123")
+        pack.button_validate()
+        ship = pack.move_ids.move_dest_ids.picking_id
+        self.assertEqual(ship.carrier_tracking_ref, "123")


### PR DESCRIPTION
Steps to reproduce:
- Enable multi-step routes in Inventory settings
- Go to Warehouse Management → Operation Types
    - Set Delivery to 3 steps
- Open the 3-step delivery routes and enable “Propagate carrier” on any rule
- Create a storable product P1
- Create a sales order with 1 unit of P1
- Confirm the sales order
- Open the generated picking
    - Go to the Additional Info tab
    - Set Tracking Reference = 123
    - Confirm the picking
- Open the next picking (Pack operation)

Problem:
The tracking reference is not propagated to the next picking, even though the rule has “Propagate carrier” enabled.

Expected behavior:
The tracking reference should be propagated to the subsequent picking when carrier propagation is enabled on the rule. Even if no carrier set.

opw-6052930
