### PR TITLE
[FIX] iot_drivers: bluetooth caliper driver

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/bluetooth_caliper_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/bluetooth_caliper_driver_L.py
@@ -62,6 +62,7 @@ class GattSylvacBtDriver(Device):
         if total > 256 ** 4 / 2:
             total = total - 256 ** 4
         self.btdriver.data['value'] = total / 1000000.0
+        self.btdriver.data['status'] = 'success'
         event_manager.device_changed(self.btdriver)
 
     def characteristic_enable_notification_succeeded(self):


### PR DESCRIPTION
When a measurement was successfully read via Bluetooth, the driver broadcasted the `value` without the `status` flag. The frontend JavaScript received the `value` but rejected the payload because the `status` was not explicitly marked as successful, leading to a fake disconnection warning.

opw-5473691

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
