### PR TITLE
[IMP] mail, *: support managing attachments while editing messages

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5073,16 +5073,18 @@ class MailThread(models.AbstractModel):
                     msg_values["body"] = escape(body) + Markup("<span class='o-mail-Message-edited' data-o-datetime='%s'/>") % fields.Datetime.to_string(fields.Datetime.now())
             else:
                 msg_values["body"] = ""
-        if attachment_ids:
-            msg_values.update(
-                self._process_attachments_for_post([], attachment_ids, {
-                    'body': body,
-                    'model': self._name,
-                    'res_id': self.id,
-                })
-            )
-        elif attachment_ids is not None:  # None means "no update"
-            message.attachment_ids._delete_and_notify()
+        if attachment_ids is not None:  # None means "no update"
+            target_attachments = message.env["ir.attachment"].browse(attachment_ids).exists()
+            if attachments_to_remove := message.attachment_ids - target_attachments:
+                attachments_to_remove._delete_and_notify(message)
+            if attachments_to_add := target_attachments - message.attachment_ids:
+                msg_values.update(
+                    self._process_attachments_for_post([], attachments_to_add.ids, {
+                        'body': body,
+                        'model': self._name,
+                        'res_id': self.id,
+                    })
+                )
         if partner_ids is not None:
             msg_values.update({"partner_ids": [int(pid) for pid in partner_ids] or False})
         if "subject" in kwargs:

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -482,6 +482,15 @@ export class Composer extends Component {
         );
     }
 
+    async unlinkAttachment(attachment) {
+        if (this.message && attachment.in(this.message.attachment_ids)) {
+            this.props.composer.savedAttachmentsToRemove.add(attachment);
+            this.props.composer.attachments.delete(attachment);
+            return;
+        }
+        await this.attachmentUploader.unlink(attachment);
+    }
+
     get hasSuggestions() {
         return Boolean(this.suggestion?.state.items);
     }
@@ -830,6 +839,18 @@ export class Composer extends Component {
         );
     }
 
+    getUnsavedAttachments() {
+        return this.props.composer.attachments.filter(
+            (attachment) => !attachment.message || attachment.message.notEq(this.message)
+        );
+    }
+
+    async removeEditedMessageAttachments() {
+        for (const attachment of this.props.composer.savedAttachmentsToRemove) {
+            await attachment.remove();
+        }
+    }
+
     async sendMessage() {
         const composer = toRaw(this.props.composer);
         this.composerActions.activePicker?.close?.();
@@ -937,23 +958,24 @@ export class Composer extends Component {
 
     async editMessage() {
         const composer = toRaw(this.props.composer);
-        if (!this.askDeleteFromEdit) {
-            await this.processMessage(async (value) =>
-                composer.message.edit(value, composer.attachments, {
+        if (this.askDeleteFromEdit) {
+            composer.message.showDeleteConfirm(this);
+        } else {
+            await this.processMessage(async (value) => {
+                await this.removeEditedMessageAttachments();
+                await composer.message.edit(value, this.getUnsavedAttachments(), {
                     mentionedChannels: composer.mentionedChannels,
                     mentionedPartners: composer.mentionedPartners,
                     mentionedRoles: composer.mentionedRoles,
-                })
-            );
-        } else {
-            composer.message.showDeleteConfirm(this);
+                });
+            });
         }
         this.suggestion?.clearRawMentions();
     }
 
     get askDeleteFromEdit() {
         const composer = toRaw(this.props.composer);
-        return !composer.composerText && composer.message.attachment_ids.length === 0;
+        return !composer.composerText && composer.attachments.length === 0;
     }
 
     onClickInsertCannedResponse(ev) {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -104,7 +104,7 @@
                 <AttachmentList
                     t-if="this.props.composer.attachments.length > 0"
                     attachments="this.props.composer.attachments"
-                    unlinkAttachment.bind="(...args) => this.attachmentUploader.unlink(...args)"/>
+                    unlinkAttachment.bind="this.unlinkAttachment"/>
                 <div t-if="!this.extended and !this.props.composer.message" class="o-mail-Composer-pickerContainer" t-att-class="{ 'o-active': this.composerActions.activePicker and this.ui.isSmall }" t-custom-ref="picker-container">
                     <div t-if="partitionedActions.pickers.length > 1 and this.composerActions.activePicker and this.ui.isSmall" class="o-mail-Composer-pickerSelection btn-group w-100">
                         <button t-foreach="partitionedActions.pickers" t-as="pickerAction" t-key="'PICKER_' + pickerAction.id" class="btn btn-secondary" t-out="pickerAction.pickerName" t-on-click="(ev) => pickerAction.onSelected(ev)" t-att-class="{

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -12,6 +12,7 @@ export class Composer extends Record {
 
     clear() {
         this.attachments.length = 0;
+        this.savedAttachmentsToRemove.length = 0;
         this.replyToMessage = undefined;
         this.restoredFromFullComposer = false;
         this.composerHtml = markup("<div class='o-paragraph'><br></div>");
@@ -41,6 +42,7 @@ export class Composer extends Record {
     }
 
     attachments = fields.Many("ir.attachment");
+    savedAttachmentsToRemove = fields.Many("ir.attachment");
     /** @type {boolean} */
     emailAddSignature = true;
     message = fields.One("mail.message");

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -137,7 +137,7 @@
                                 </div>
                                 <div class="position-relative">
                                     <AttachmentList
-                                        t-if="this.message.extra_body_attachment_ids.length > 0"
+                                        t-if="this.message.extra_body_attachment_ids.length > 0 and !this.isEditing"
                                         attachments="this.message.extra_body_attachment_ids"
                                         unlinkAttachment.bind="this.onClickAttachmentUnlink"
                                         messageSearch="this.props.messageSearch"/>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -656,7 +656,13 @@ export class Message extends Record {
         const updatedBodyEl = createElementWithContent("div", body);
         messageBodyEl.querySelector("span.o-mail-Message-edited")?.remove();
         updatedBodyEl.querySelector("span.o-mail-Message-edited")?.remove();
-        if (updatedBodyEl.innerHTML === messageBodyEl.innerHTML && attachments.length === 0) {
+        if (
+            updatedBodyEl.innerHTML === messageBodyEl.innerHTML &&
+            attachments.length === this.attachment_ids.length &&
+            attachments.every(
+                (attachment, index) => attachment.id === this.attachment_ids[index].id
+            )
+        ) {
             return;
         }
         const validMentions = this.store.getMentionsFromText(body, {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -665,13 +665,10 @@ export class Message extends Record {
             thread: this.thread,
         });
         const hadLink = this.hasLink; // to remove old previews if message no longer contains any link
+        const allAttachments = [...attachments, ...this.attachment_ids];
         const updateData = {
-            attachment_ids: attachments
-                .concat(this.attachment_ids)
-                .map((attachment) => attachment.id),
-            attachment_tokens: attachments
-                .concat(this.attachment_ids)
-                .map((attachment) => attachment.ownership_token),
+            attachment_ids: allAttachments.map((attachment) => attachment.id),
+            attachment_tokens: allAttachments.map((attachment) => attachment.ownership_token),
             body: await generateEmojisOnHtml(body),
             partner_ids: validMentions?.partners?.map((partner) => partner.id),
             role_ids: validMentions?.roles?.map((role) => role.id),
@@ -707,10 +704,12 @@ export class Message extends Record {
             thread.messageInEdition.composer = undefined;
         }
         this.composer = {
+            attachments: [...this.attachment_ids],
             composerHtml: getNonEditableMentions(this.body),
             mentionedChannels: validChannels,
             mentionedPartners: this.partner_ids,
             mentionedRoles: validRoles,
+            savedAttachmentsToRemove: [],
             selection: {
                 start: text.length,
                 end: text.length,

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1578,7 +1578,7 @@ test("Can remove saved attachments while editing a message", async () => {
         model: "discuss.channel",
         res_id: channelId,
     });
-    onRpcBefore("/mail/attachment/delete", ({ attachment_id }) => expect.step(`${attachment_id}`));
+    onRpcBefore("/mail/message/update_content", () => expect.step("update_content"));
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
@@ -1600,7 +1600,7 @@ test("Can remove saved attachments while editing a message", async () => {
         ".o-mail-Message .o-mail-Composer .o-mail-AttachmentContainer:has(:text('morty.txt'))"
     );
     await click(".o-mail-Message button:text('save')");
-    await expect.waitForSteps([`${rickId}`]);
+    await expect.waitForSteps(["update_content"]);
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
     await contains(".o-mail-Message .o-mail-AttachmentContainer", { count: 1 });
     await contains(".o-mail-Message .o-mail-AttachmentContainer:has(:text('morty.txt'))");

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1398,6 +1398,52 @@ test("Clear message body should not open message delete dialog if it has attachm
     );
 });
 
+test("Can remove saved attachments while editing a message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    const [rickId, mortyId] = pyEnv["ir.attachment"].create([
+        {
+            name: "rick.txt",
+            mimetype: "text/plain",
+        },
+        {
+            name: "morty.txt",
+            mimetype: "text/plain",
+        },
+    ]);
+    pyEnv["mail.message"].create({
+        attachment_ids: [rickId, mortyId],
+        body: "<p>Hello</p>",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    onRpcBefore("/mail/attachment/delete", ({ attachment_id }) =>
+        expect.step(`${attachment_id}`)
+    );
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('rick.txt'))");
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('morty.txt'))");
+    await click(".o-mail-Message.o-editing .o-mail-Attachment-unlink", {
+        parent: [".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('rick.txt'))"],
+    });
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('rick.txt'))", {
+        count: 0,
+    });
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('morty.txt'))");
+    await click(".o-mail-Message button:text('save')");
+    await expect.waitForSteps([`${rickId}`]);
+    await contains(".o-mail-Message .o-mail-AttachmentContainer:has(:text('morty.txt'))");
+    await contains(".o-mail-Message .o-mail-AttachmentContainer:has(:text('rick.txt'))", {
+        count: 0,
+    });
+});
+
 test("highlight the message mentioning the current user inside the channel", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ display_name: "Test Partner" });
@@ -2073,6 +2119,38 @@ test("Can edit a message only containing an attachment", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message.o-editing .o-mail-Composer-input");
+});
+
+test("Existing attachments are shown in composer when editing", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    const attachmentIds = pyEnv["ir.attachment"].create([
+        {
+            name: "oggy.txt",
+            mimetype: "text/plain",
+        },
+        {
+            name: "jack.txt",
+            mimetype: "text/plain",
+        },
+    ]);
+    pyEnv["mail.message"].create({
+        attachment_ids: attachmentIds,
+        author_id: serverState.partnerId,
+        body: "",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer", { count: 2 });
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('oggy.txt'))");
+    await contains(".o-mail-Message.o-editing .o-mail-AttachmentContainer:has(:text('jack.txt'))");
 });
 
 test("Click on view reactions shows the reactions on the message", async () => {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -663,10 +663,18 @@ async function mail_message_update_content(request) {
             }
         }
     }
-    if (update_data.attachment_ids.length === 0) {
-        IrAttachment.unlink(message.attachment_ids);
-    } else {
-        const attachments = IrAttachment.browse(update_data.attachment_ids).filter(
+    const target_attachments = update_data.attachment_ids;
+    const attachments_to_remove = message.attachment_ids.filter(
+        (id) => !target_attachments.includes(id)
+    );
+    const attachments_to_add = target_attachments.filter(
+        (id) => !message.attachment_ids.includes(id)
+    );
+    if (attachments_to_remove.length) {
+        IrAttachment.unlink(attachments_to_remove);
+    }
+    if (attachments_to_add.length) {
+        const attachments = IrAttachment.browse(attachments_to_add).filter(
             (attachment) =>
                 attachment.res_model === "mail.compose.message" &&
                 attachment.create_uid === this.env.user?.id
@@ -678,8 +686,8 @@ async function mail_message_update_content(request) {
                 res_id: message.res_id,
             }
         );
-        msg_values.attachment_ids = update_data.attachment_ids;
     }
+    msg_values.attachment_ids = target_attachments;
     if (update_data.body === "") {
         MailMessageLinkPreview.unlink(message.message_link_preview_ids);
     }

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -137,8 +137,8 @@ class TestMessageController(HttpCase, MailCommon):
                         "message_id": data1["message_id"],
                         "update_data": {
                             "body": "test",
-                            "attachment_ids": [self.attachments[1].id],
-                            "attachment_tokens": ["wrong token"],
+                            "attachment_ids": [self.attachments[0].id, self.attachments[1].id],
+                            "attachment_tokens": [self.attachments[0]._get_ownership_token(), "wrong token"],
                         },
                     },
                 },
@@ -160,8 +160,11 @@ class TestMessageController(HttpCase, MailCommon):
                         "message_id": data1["message_id"],
                         "update_data": {
                             "body": "test",
-                            "attachment_ids": [self.attachments[1].id],
-                            "attachment_tokens": [self.attachments[1]._get_ownership_token()],
+                            "attachment_ids": [self.attachments[0].id, self.attachments[1].id],
+                            "attachment_tokens": [
+                                self.attachments[0]._get_ownership_token(),
+                                self.attachments[1]._get_ownership_token(),
+                            ],
                         },
                     },
                 },

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1037,14 +1037,14 @@ class TestAPI(ThreadRecipients):
             ticket_record._message_update_content(
                 message,
                 body=Markup("<div>New Body</div>"),
-                attachment_ids=new_attachments.ids,
+                attachment_ids=(attachments + new_attachments).ids,
             )
         self.assertEqual(message.attachment_ids, attachments + new_attachments)
         self.assertEqual(set(message.mapped('attachment_ids.res_id')), set(ticket_record.ids))
         self.assertEqual(set(message.mapped('attachment_ids.res_model')), set([ticket_record._name]))
         self.assertEqual(message.body, Markup('<div>New Body <span class="o-mail-Message-edited" data-o-datetime="2025-04-08 11:00:00"></span></div>'))
 
-        # void attachments
+        # void attachments when attachment_ids is an empty list
         with freeze_time('2025-04-08 12:00:00'):
             ticket_record._message_update_content(
                 message,
@@ -1054,6 +1054,24 @@ class TestAPI(ThreadRecipients):
         self.assertFalse(message.attachment_ids)
         self.assertFalse((attachments + new_attachments).exists())
         self.assertEqual(message.body, Markup('<p>Another Body, void attachments <span class="o-mail-Message-edited" data-o-datetime="2025-04-08 12:00:00"></span></p>'))
+
+        # void attachments when attachment_ids is False (should behave like an empty list)
+        new_attachments_3 = self.env['ir.attachment'].create(
+            self._generate_attachments_data(1, 'mail.compose.message', 0)
+        )
+        with freeze_time('2025-04-08 12:30:00'):
+            ticket_record._message_update_content(
+                message,
+                body=Markup("<p>Another Body, void attachments (False)</p>"),
+                attachment_ids=new_attachments_3.ids,
+            )
+            ticket_record._message_update_content(
+                message,
+                body=Markup("<p>Another Body, void attachments (False)</p>"),
+                attachment_ids=False,
+            )
+        self.assertFalse(message.attachment_ids)
+        self.assertFalse(new_attachments_3.exists())
 
         with freeze_time('2025-04-08 13:00:00'):
             ticket_record._message_update_content(


### PR DESCRIPTION
*= test_mail

**Purpose of this PR:**

#### 1. show attachments in composer while editing

Before this commit, editing a message only allowed modifying its text content. Existing attachments remained outside the composer and could not be managed during edition.

This commit displays existing attachments in the composer, allowing users to review and manage the full message content from a single editing interface.

#### 2. synchronize attachments on message update

Before this commit, `_message_update_content()` only linked attachments provided in `attachment_ids` and preserved any attachments already linked to the message.

With attachment management now handled in the composer, this behavior became inconsistent: attachments removed from the composer remained attached to the message after saving.

This commit treats `attachment_ids` as the complete set of attachments to keep. Attachments linked to the message but missing from `attachment_ids` are removed, ensuring the message remains synchronized with the composer state.

task-[5947683](https://www.odoo.com/odoo/project/1519/tasks/5947683)