### PR TITLE
[REF] hr_work_entry: move payroll menus to hr_payroll

### DIFF
--- a/addons/hr_work_entry/views/menuitems.xml
+++ b/addons/hr_work_entry/views/menuitems.xml
@@ -1,37 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <odoo>
-    <menuitem
-        id="menu_hr_payroll_root"
-        name="Payroll"
-        sequence="190"
-        web_icon="hr_payroll,static/description/icon.png"
-        groups="hr.group_hr_manager"/>
-
-    <menuitem
-        id="menu_hr_payroll_configuration"
-        name="Configuration"
-        parent="menu_hr_payroll_root"
-        sequence="100"
-        groups="hr.group_hr_manager"/>
-
-    <!-- Work entries Configuration -->
-    <menuitem
-        id="menu_hr_work_entry_configuration"
-        name="Work Entries"
-        parent="menu_hr_payroll_configuration"
-        sequence="50"
-    />
-    <menuitem
-        id="menu_hr_work_entry_type_view"
-        action="hr_work_entry.hr_work_entry_type_action"
-        parent="menu_hr_work_entry_configuration"
-    />
-    <menuitem
-        id="menu_resource_calendar_view"
-        action="resource.action_resource_calendar_form"
-        parent="menu_hr_work_entry_configuration"
-    />
-
     <!-- Work Entries Configuration in HR/Employees app -->
     <menuitem
         id="menu_hr_work_entry_type_view_employee"

--- a/addons/hr_work_entry/views/menuitems.xml
+++ b/addons/hr_work_entry/views/menuitems.xml
@@ -1,37 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <odoo>
-    <menuitem
-        id="menu_hr_payroll_root"
-        name="Payroll"
-        sequence="190"
-        web_icon="hr_payroll,static/description/icon.png"
-        groups="hr.group_hr_manager"/>
-
-    <menuitem
-        id="menu_hr_payroll_configuration"
-        name="Configuration"
-        parent="menu_hr_payroll_root"
-        sequence="100"
-        groups="hr.group_hr_manager"/>
-
-    <!-- Work entries Configuration -->
-    <menuitem
-        id="menu_hr_work_entry_configuration"
-        name="Time"
-        parent="menu_hr_payroll_configuration"
-        sequence="50"
-    />
-    <menuitem
-        id="menu_hr_work_entry_type_view"
-        action="hr_work_entry.hr_work_entry_type_action"
-        parent="menu_hr_work_entry_configuration"
-    />
-    <menuitem
-        id="menu_resource_calendar_view"
-        action="resource.action_resource_calendar_form"
-        parent="menu_hr_work_entry_configuration"
-    />
-
     <!-- Work Entries Configuration in HR/Employees app -->
     <menuitem
         id="menu_hr_work_entry_type_view_employee"


### PR DESCRIPTION
If you take time off as a one app free, it will install hr_work_entry which contains the root payroll menu item, giving people the impression that payroll was installed.
-> Moving those menu items to hr_payroll.

Task: 6072554
