### PR TITLE
[FIX] Improve validation error message for inherited views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -539,7 +539,7 @@ actual arch.
             if (view.group_ids and
                 view.inherit_id and
                 view.mode != 'primary'):
-                raise ValidationError(_("Inherited view cannot have 'Groups' define on the record. Use 'groups' attributes inside the view definition"))
+                raise ValidationError(_("Inherited view cannot have ")+ "'Groups'"+_(" define on the record. Use ")+"'groups'"+_(" attributes inside the view definition"))
 
     @api.constrains('inherit_id')
     def _check_000_inheritance(self):


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Current behavior before PR:
Validation Error message is being translated base on user message, including development keys
<img width="1092" height="276" alt="image" src="https://github.com/user-attachments/assets/4c58f201-8bc6-4b5e-9510-e52f36e0cf2c" />
Desired behavior after PR is merged:
development keys will not be translated
<img width="1084" height="307" alt="image" src="https://github.com/user-attachments/assets/0ccbf570-b5a0-46ff-aaef-bc1aaa237371" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
