### PR TITLE
[IMP] mail: enable full composer while editing chatter messages

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5118,8 +5118,9 @@ class MailThread(models.AbstractModel):
                 if len(children) > 0:  # body is a valid html
                     # If the last element is a div or p, add the edited span inside it to avoid the edit markup
                     # to be on its own line. Otherwise, append it to the end of the last element.
+                    target_index = -2 if not message.email_add_signature and len(children) >= 2 else -1
                     last_div_element = (
-                        children[-1] if children[-1].tag in ["div", "p"] else tree
+                        children[target_index] if children[target_index].tag in ["div", "p"] else tree
                     )
                     last_div_element.text = (last_div_element.text or '') + (' ' if last_div_element.text else '')
                     etree.SubElement(last_div_element, "span", attrib={"class": "o-mail-Message-edited", "data-o-datetime": fields.Datetime.to_string(fields.Datetime.now())})

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5047,8 +5047,9 @@ class MailThread(models.AbstractModel):
                 if len(children) > 0:  # body is a valid html
                     # If the last element is a div or p, add the edited span inside it to avoid the edit markup
                     # to be on its own line. Otherwise, append it to the end of the last element.
+                    target_index = -2 if not message.email_add_signature and len(children) >= 2 else -1
                     last_div_element = (
-                        children[-1] if children[-1].tag in ["div", "p"] else tree
+                        children[target_index] if children[target_index].tag in ["div", "p"] else tree
                     )
                     last_div_element.text = (last_div_element.text or '') + (' ' if last_div_element.text else '')
                     etree.SubElement(last_div_element, "span", attrib={"class": "o-mail-Message-edited", "data-o-datetime": fields.Datetime.to_string(fields.Datetime.now())})

--- a/addons/mail/static/src/chatter/web/composer_patch.js
+++ b/addons/mail/static/src/chatter/web/composer_patch.js
@@ -50,8 +50,8 @@ patch(Composer.prototype, {
         return super.setup();
     },
 
-    async onClickFullComposerGetAction() {
-        const res = await super.onClickFullComposerGetAction();
+    async onClickFullComposerGetAction(message) {
+        const res = await super.onClickFullComposerGetAction(message);
         if (this.props.withMessageFields && this.props.thread.showSubjectInSmallComposer) {
             res.action.context.default_subject = this.subject;
         }

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -3,9 +3,11 @@ import { EventBus, t } from "@odoo/owl";
 
 import { x2ManyCommands } from "@web/core/orm_plugin";
 import { useService } from "@web/core/utils/hooks";
-import { createDocumentFragmentFromContent } from "@web/core/utils/html";
+import { createDocumentFragmentFromContent, isHtmlEmpty } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { FormController, formControllerProps } from "@web/views/form/form_controller";
+
+import { discussComponentRegistry } from "@mail/core/common/discuss_component_registry";
 
 Object.assign(formControllerProps, {
     fullComposerBus: t.instanceOf(EventBus).optional(),
@@ -34,6 +36,26 @@ patch(FormController.prototype, {
 
     async onWillSaveRecord(record, changes) {
         if (record.resModel === "mail.compose.message") {
+            const messageId = record.context.default_message_id;
+            if (messageId && changes.attachment_ids?.length === 0 && isHtmlEmpty(changes.body)) {
+                const message = this.mailStore?.["mail.message"].get(messageId);
+                if (message) {
+                    this.env.services.dialog.add(
+                        discussComponentRegistry.get("MessageDeleteDialog"),
+                        {
+                            message,
+                            onConfirm: () => {
+                                message.onShowDeleteConfirm(this);
+                                void this.env.services.action.doAction({
+                                    type: "ir.actions.act_window_close",
+                                });
+                            },
+                        },
+                        { rootRef: this.rootRef }
+                    );
+                    return false;
+                }
+            }
             const doc = createDocumentFragmentFromContent(changes.body);
             const partnerElements = doc.querySelectorAll('[data-oe-model="res.partner"]');
             const partnerIds = Array.from(partnerElements).map((element) =>

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -1,11 +1,13 @@
 import { useSubEnv } from "@web/owl2/utils";
-import { EventBus } from "@odoo/owl";
+import { EventBus, toRaw } from "@odoo/owl";
 
 import { x2ManyCommands } from "@web/core/orm_service";
 import { useService } from "@web/core/utils/hooks";
-import { createDocumentFragmentFromContent } from "@web/core/utils/html";
+import { createDocumentFragmentFromContent, isHtmlEmpty } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
+
+import { discussComponentRegistry } from "@mail/core/common/discuss_component_registry";
 
 FormController.props = {
     ...FormController.props,
@@ -41,6 +43,26 @@ patch(FormController.prototype, {
 
     async onWillSaveRecord(record, changes) {
         if (record.resModel === "mail.compose.message") {
+            const messageId = record.context.default_message_id;
+            if (isHtmlEmpty(changes.body) && record.context.is_editing_message && messageId) {
+                const message = this.mailStore?.["mail.message"].get(messageId);
+                if (message) {
+                    this.env.services.dialog.add(
+                        discussComponentRegistry.get("MessageDeleteDialog"),
+                        {
+                            message,
+                            onConfirm: () => {
+                                toRaw(message).onShowDeleteConfirm(this);
+                                void this.env.services.action.doAction({
+                                    type: "ir.actions.act_window_close",
+                                });
+                            },
+                        },
+                        { context: this }
+                    );
+                    return false;
+                }
+            }
             const doc = createDocumentFragmentFromContent(changes.body);
             const partnerElements = doc.querySelectorAll('[data-oe-model="res.partner"]');
             const partnerIds = Array.from(partnerElements).map((element) =>

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -2,8 +2,10 @@ import { useSubEnv } from "@web/owl2/utils";
 import { formView } from "@web/views/form/form_view";
 import { registry } from "@web/core/registry";
 import { EventBus, t, useOnChange, useProps } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { formControllerProps } from "@web/views/form/form_controller";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
@@ -18,6 +20,35 @@ export class MailComposerFormController extends formView.Controller {
         this.env.dialogData.model = this.props.resModel;
         useSubEnv({
             fullComposerBus: this.props.fullComposerBus,
+        });
+        if (this.props.context.default_message_id) {
+            this.dialogService = useService("dialog");
+            this.stopEditingConfirmation();
+        }
+    }
+
+    stopEditingConfirmation() {
+        const dialogData = this.env.dialogData;
+        const close = dialogData.close;
+        dialogData.close = async (params) => {
+            if (params?.dismiss && !(await this.askStopEditingConfirmation())) {
+                return;
+            }
+            return close(params);
+        };
+    }
+
+    /** @returns {Promise<boolean>} whether the message edition should be stopped */
+    askStopEditingConfirmation() {
+        return new Promise((resolve) => {
+            this.dialogService.add(ConfirmationDialog, {
+                body: _t("Leaving will stop editing this message."),
+                cancel: () => resolve(false),
+                cancelLabel: _t("Keep editing"),
+                confirm: () => resolve(true),
+                confirmLabel: _t("Stop editing"),
+                title: _t("Stop editing"),
+            });
         });
     }
 }

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -354,7 +354,9 @@ export class Composer extends Component {
             () => [
                 this.state.isFullComposerOpen,
                 this.props.composer.restoredFromFullComposer,
-                untrack(this.rootRef)?.querySelector("button[name='open-full-composer']"),
+                this.props.composer.message
+                    ? untrack(() => this.moreAction()?.actionRef())
+                    : untrack(this.rootRef)?.querySelector("button[name='open-full-composer']"),
             ]
         );
         onMounted(() => {
@@ -707,9 +709,13 @@ export class Composer extends Component {
     }
 
     async onClickFullComposerGetAction() {
+        const message = this.props.composer.message;
         this.props.composer.restoredFromFullComposer = false;
-        const allRecipients = [...this.thread.suggestedRecipients];
-        if (this.props.type !== "note") {
+        const isEditing = Boolean(message);
+        const allRecipients = isEditing
+            ? message.partner_ids
+            : [...this.thread.suggestedRecipients];
+        if (!isEditing && this.props.type !== "note") {
             allRecipients.push(...this.thread.additionalRecipients);
             // auto-create partners:
             const newPartners = allRecipients.filter((recipient) => !recipient.partner_id);
@@ -732,46 +738,62 @@ export class Composer extends Component {
                 }
             }
         }
-        const attachmentIds = this.props.composer.attachments.map((attachment) => attachment.id);
+        const attachmentIds = isEditing
+            ? message.attachment_ids.map((a) => a.id)
+            : this.props.composer.attachments.map((attachment) => attachment.id);
         let default_body = this.props.composer.composerHtml;
-        if (isHtmlEmpty(default_body)) {
-            // Reset signature when recovering an empty body.
-            this.props.composer.emailAddSignature = true;
+        if (!isEditing) {
+            if (isHtmlEmpty(default_body)) {
+                // Reset signature when recovering an empty body.
+                this.props.composer.emailAddSignature = true;
+            }
+            const signature = this.thread.effectiveSelf.main_user_id?.getSignatureBlock();
+            default_body = this.formatDefaultBodyForFullComposer(
+                default_body,
+                this.props.composer.emailAddSignature ? signature : ""
+            );
         }
-        const signature = this.thread.effectiveSelf.main_user_id?.getSignatureBlock();
-        default_body = this.formatDefaultBodyForFullComposer(
-            default_body,
-            this.props.composer.emailAddSignature ? signature : ""
-        );
         const context = {
             default_attachment_ids: attachmentIds,
             default_body,
             default_email_add_signature: false,
-            default_model: this.thread.model,
-            default_partner_ids:
-                this.props.type === "note"
-                    ? []
-                    : allRecipients
-                          .filter((r) => r.recipient_type !== "cc" && r.partner_id)
-                          .map((r) => r.partner_id),
-            default_partner_cc_ids:
-                this.props.type === "note"
-                    ? []
-                    : allRecipients
-                          .filter((r) => r.recipient_type === "cc" && r.partner_id)
-                          .map((r) => r.partner_id),
-            default_res_ids: [this.thread.id],
-            default_subtype_xmlid: this.props.type === "note" ? "mail.mt_note" : "mail.mt_comment",
-            clicked_on_full_composer: true,
+            default_model: isEditing ? message.thread.model : this.thread.model,
+            default_partner_ids: isEditing
+                ? message.partner_ids.map((p) => p.id)
+                : this.props.type === "note"
+                ? []
+                : allRecipients
+                      .filter((r) => r.recipient_type !== "cc" && r.partner_id)
+                      .map((r) => r.partner_id),
+            default_partner_cc_ids: isEditing
+                ? message.partner_cc_ids?.map((p) => p.id) || []
+                : this.props.type === "note"
+                ? []
+                : allRecipients
+                      .filter((r) => r.recipient_type === "cc" && r.partner_id)
+                      .map((r) => r.partner_id),
+            default_res_ids: isEditing ? [message.thread.id] : [this.thread.id],
+            default_subtype_xmlid:
+                this.props.type === "note" || (isEditing && message.isNote)
+                    ? "mail.mt_note"
+                    : "mail.mt_comment",
             body_contains_signature_only:
                 !this.props.composer.composerText ||
                 this.props.composer.composerText.trim().length === 0,
+            default_message_id: isEditing ? message.id : undefined,
             // Changed in 18.2+: finally get rid of autofollow, following should be done manually
             sync_attachments_to_thread_composer: true,
+            is_full_composer: true,
             ...this.fullComposerAdditionalContext,
         };
         const action = {
-            name: this.props.type === "note" ? _t("Log note") : _t("Compose Email"),
+            name: isEditing
+                ? message.isNote
+                    ? _t("Editing note")
+                    : _t("Editing message")
+                : this.props.type === "note"
+                ? _t("Log note")
+                : _t("Compose Email"),
             type: "ir.actions.act_window",
             res_model: "mail.compose.message",
             view_mode: "form",
@@ -785,7 +807,7 @@ export class Composer extends Component {
                 // args === { special: true } : click on 'discard'
                 const accidentalDiscard = args?.dismiss;
                 const isDiscard = accidentalDiscard || args?.special;
-                if (accidentalDiscard) {
+                if (accidentalDiscard && !isEditing) {
                     this.fullComposerBus.trigger("ACCIDENTAL_DISCARD", {
                         onAccidentalDiscard: async (isEmpty) => {
                             if (!isEmpty) {
@@ -798,6 +820,9 @@ export class Composer extends Component {
                     });
                 } else {
                     this.clear();
+                    if (isEditing) {
+                        message.exitEditMode();
+                    }
                 }
                 this.props.composer.replyToMessage = undefined;
                 this.onCloseFullComposerCallback(isDiscard);

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -668,10 +668,13 @@ export class Composer extends Component {
         return {};
     }
 
-    async onClickFullComposerGetAction() {
+    async onClickFullComposerGetAction(message) {
         this.props.composer.restoredFromFullComposer = false;
-        const allRecipients = [...this.thread.suggestedRecipients];
-        if (this.props.type !== "note") {
+        const isEditing = !!message;
+        const allRecipients = isEditing
+            ? message.partner_ids
+            : [...this.thread.suggestedRecipients];
+        if (!isEditing && this.props.type !== "note") {
             allRecipients.push(...this.thread.additionalRecipients);
             // auto-create partners:
             const newPartners = allRecipients.filter((recipient) => !recipient.partner_id);
@@ -694,35 +697,52 @@ export class Composer extends Component {
                 }
             }
         }
-        const attachmentIds = this.props.composer.attachments.map((attachment) => attachment.id);
+        const attachmentIds = isEditing
+            ? message.attachment_ids.map((a) => a.id)
+            : this.props.composer.attachments.map((attachment) => attachment.id);
         let default_body = this.props.composer.composerHtml;
-        if (isHtmlEmpty(default_body)) {
-            const composer = toRaw(this.props.composer);
-            // Reset signature when recovering an empty body.
-            composer.emailAddSignature = true;
+        if (!isEditing) {
+            if (isHtmlEmpty(default_body)) {
+                const composer = toRaw(this.props.composer);
+                // Reset signature when recovering an empty body.
+                composer.emailAddSignature = true;
+            }
+            const signature = this.thread.effectiveSelf.main_user_id?.getSignatureBlock();
+            default_body = this.formatDefaultBodyForFullComposer(
+                default_body,
+                this.props.composer.emailAddSignature ? signature : ""
+            );
+        } else {
+            const doc = new DOMParser().parseFromString(message.body, "text/html");
+            doc.querySelector("span.o-mail-Message-edited")?.remove();
+            default_body = markup(doc.body.innerHTML);
         }
-        const signature = this.thread.effectiveSelf.main_user_id?.getSignatureBlock();
-        default_body = this.formatDefaultBodyForFullComposer(
-            default_body,
-            this.props.composer.emailAddSignature ? signature : ""
-        );
         const context = {
             default_attachment_ids: attachmentIds,
             default_body,
             default_email_add_signature: false,
-            default_model: this.thread.model,
-            default_partner_ids:
-                this.props.type === "note"
-                    ? []
-                    : allRecipients.map((recipient) => recipient.partner_id),
-            default_res_ids: [this.thread.id],
-            default_subtype_xmlid: this.props.type === "note" ? "mail.mt_note" : "mail.mt_comment",
+            default_model: isEditing ? message.thread.model : this.thread.model,
+            default_partner_ids: isEditing
+                ? message.partner_ids.map((p) => p.id)
+                : this.props.type === "note"
+                ? []
+                : allRecipients.map((recipient) => recipient.partner_id),
+            default_res_ids: isEditing ? [message.thread.id] : [this.thread.id],
+            default_subtype_xmlid:
+                this.props.type === "note" || (isEditing && message.isNote)
+                    ? "mail.mt_note"
+                    : "mail.mt_comment",
             clicked_on_full_composer: true,
+            is_editing_message: isEditing,
+            default_message_id: isEditing ? message.id : undefined,
             // Changed in 18.2+: finally get rid of autofollow, following should be done manually
             ...this.fullComposerAdditionalContext,
         };
         const action = {
-            name: this.props.type === "note" ? _t("Log note") : _t("Compose Email"),
+            name:
+                this.props.type === "note" || (isEditing && message.isNote)
+                    ? _t("Log note")
+                    : _t("Compose Email"),
             type: "ir.actions.act_window",
             res_model: "mail.compose.message",
             view_mode: "form",
@@ -737,7 +757,7 @@ export class Composer extends Component {
                 const accidentalDiscard = args?.dismiss;
                 const isDiscard = accidentalDiscard || args?.special;
                 // otherwise message is posted (args === [undefined])
-                if (!isDiscard && this.props.composer.thread.model === "mail.box") {
+                if (!isDiscard && this.props.composer.thread?.model === "mail.box") {
                     this.notifySendFromMailbox();
                 }
                 if (accidentalDiscard) {
@@ -753,6 +773,9 @@ export class Composer extends Component {
                     });
                 } else {
                     this.clear();
+                    if (!isDiscard && isEditing && message) {
+                        message.exitEditMode(message.thread);
+                    }
                 }
                 this.props.composer.replyToMessage = undefined;
                 this.onCloseFullComposerCallback(isDiscard);
@@ -768,8 +791,9 @@ export class Composer extends Component {
         return { action, options };
     }
 
-    async onClickFullComposer(ev) {
-        const { action, options } = await this.onClickFullComposerGetAction();
+    async onClickFullComposer(params = {}) {
+        const { message } = params;
+        const { action, options } = await this.onClickFullComposerGetAction(message);
         await this.env.services.action.doAction(action, options);
         this.state.isFullComposerOpen = true;
     }

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -101,6 +101,10 @@
 
 .o-mail-Composer-bg {
     background-color: var(--mail-Composer-bg, $o-view-background-color);
+
+    &:disabled {
+        background-color: var(--mail-Composer-bg, $o-view-background-color);
+    }
 }
 
 .o-mail-Composer-inputStyle, .o-mail-Composer-html {

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -106,7 +106,6 @@ registerComposerAction("upload-files", {
 });
 registerComposerAction("open-full-composer", {
     condition: ({ composer, owner }) =>
-        !composer.message &&
         owner.props.showFullComposer &&
         composer.targetThread &&
         composer.targetThread.model !== "discuss.channel" &&
@@ -117,7 +116,8 @@ registerComposerAction("open-full-composer", {
     icon: "expand_content",
     isActive: ({ composer, owner }) =>
         (composer.restoredFromFullComposer && !owner.state.isFullComposerOpen) || undefined,
-    name: _t("Open Full Composer"),
+    name: ({ composer }) =>
+        composer.message ? _t("Edit in Full Composer") : _t("Open Full Composer"),
     onSelected: ({ owner }) => owner.onClickFullComposer(),
     sequence: 30,
     tags: ({ composer, owner }) =>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -132,7 +132,6 @@ registerComposerAction("upload-files", {
 });
 registerComposerAction("open-full-composer", {
     condition: ({ composer, owner }) =>
-        !composer.message &&
         owner.props.showFullComposer &&
         composer.targetThread &&
         composer.targetThread.model !== "discuss.channel" &&
@@ -144,7 +143,11 @@ registerComposerAction("open-full-composer", {
     isActive: ({ composer, owner }) =>
         (composer.restoredFromFullComposer && !owner.state.isFullComposerOpen) || undefined,
     name: _t("Open Full Composer"),
-    onSelected: ({ owner }) => owner.onClickFullComposer(),
+    onSelected: ({ composer, owner }) => {
+        owner.onClickFullComposer({
+            message: composer.message,
+        });
+    },
     sequence: 30,
     tags: ({ composer, owner }) =>
         composer.restoredFromFullComposer && !owner.state.isFullComposerOpen

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -19,7 +19,11 @@ import { deserializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { createElementWithContent, htmlTrim } from "@web/core/utils/html";
+import {
+    createDocumentFragmentFromContent,
+    createElementWithContent,
+    htmlTrim,
+} from "@web/core/utils/html";
 import { renderToElement } from "@web/core/utils/render";
 import { url } from "@web/core/utils/urls";
 
@@ -688,6 +692,14 @@ export class Message extends Record {
         return data;
     }
 
+    get fromFullComposer() {
+        return Boolean(
+            createDocumentFragmentFromContent(this.body).querySelector(
+                "[data-o-mail-full-composer]"
+            )
+        );
+    }
+
     enterEditMode() {
         const validRoles = Array.from(
             this.bodyEl?.querySelectorAll(".o-discuss-mention[data-oe-model='res.role']") ?? []
@@ -702,6 +714,7 @@ export class Message extends Record {
             isEditComposerVisible: true,
             mentionedPartners: this.partner_ids,
             mentionedRoles: validRoles,
+            restoredFromFullComposer: this.fromFullComposer,
             selection: {
                 start: text.length,
                 end: text.length,

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -321,6 +321,88 @@ test("Can edit message comment in chatter (MacOS)", async () => {
     await canEditMessageCommentInChatter({ isMacOS: true });
 });
 
+test("Can edit message using full composer", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "original message",
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    mockService("action", {
+        doAction(action) {
+            if (action.res_model === "mail.compose.message") {
+                expect(action.context.default_res_ids).toEqual([partnerId]);
+                action.context.default_res_ids = JSON.stringify(action.context.default_res_ids);
+            }
+            return super.doAction(...arguments);
+        },
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-dropdown-item:text('Edit')");
+    await contains(".o-mail-Composer");
+    await click(".o-mail-Composer button[title='More Actions']");
+    await click(".dropdown-item:contains('Edit in Full Composer')");
+
+    const paragraph = await waitFor(".modal .odoo-editor-editable .o-paragraph");
+    setSelection({
+        anchorNode: paragraph.firstChild,
+        anchorOffset: paragraph.textContent.length,
+    });
+    await contains(".modal .o_form_view");
+    const editor = { document, editable: document.querySelector(".modal .odoo-editor-editable") };
+    await htmlInsertText(editor, " updated");
+    await click(".modal button:contains('Save')");
+    await contains(".o-mail-Message-content:text('original message updated')");
+});
+
+test("Full composer opens with the message's live edited content", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "original message",
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-dropdown-item:text('Edit')");
+    await contains(".o-mail-Composer");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "new text", { replace: true });
+    await click(".o-mail-Composer button[title='More Actions']");
+    await click(".dropdown-item:contains('Edit in Full Composer')");
+    await contains(".modal .odoo-editor-editable .o-paragraph:text('new text')");
+    await contains(".modal .odoo-editor-editable:not(:text('original message'))");
+});
+
+test("Editing a message written with the full composer offers to reopen it", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: '<span data-o-mail-full-composer="1"></span><p>rich <strong>content</strong></p>',
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-dropdown-item:text('Edit')");
+    await contains(".o-mail-Message .o-mail-Composer-input:disabled");
+    await contains(".o_popover:has(:text('Continue with Full Composer?'))");
+    await click(".o_popover button:contains('No')");
+    await contains(".o_popover", { count: 0 });
+    await contains(".o-mail-Message .o-mail-Composer-input:not(:disabled)");
+});
+
 test("Basic list of edit message actions in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
@@ -337,8 +419,9 @@ test("Basic list of edit message actions in chatter", async () => {
     await click(".o-dropdown-item:text('Edit')");
     await contains(".o-mail-Message .o-mail-Composer.o-focused");
     await click(".o-mail-Message .o-mail-Composer button[title='More Actions']");
-    await contains(".dropdown-menu .dropdown-item", { count: 1 });
+    await contains(".dropdown-menu .dropdown-item", { count: 2 });
     await contains(".dropdown-menu .dropdown-item:has(:text('Attach Files'))");
+    await contains(".dropdown-menu .dropdown-item:has(:text('Edit in Full Composer'))");
 });
 
 test("Cursor is at end of composer input on edit", async () => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -12,6 +12,7 @@ import {
     hover,
     insertText,
     listenStoreFetch,
+    mailModels,
     onRpcBefore,
     openDiscuss,
     openFormView,
@@ -53,6 +54,7 @@ const { DateTime } = luxon;
 
 describe.current.tags("desktop");
 defineMailModels();
+mailModels.MailComposeMessage._views = {};
 
 test("Start edition on click edit", async () => {
     const pyEnv = await startServer();
@@ -340,6 +342,52 @@ test("Can edit message comment in chatter (MacOS)", async () => {
     await canEditMessageCommentInChatter({ isMacOS: true });
 });
 
+test("edit message via full composer should update message", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "original message",
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    mockService("action", {
+        doAction(action) {
+            if (action.res_model === "mail.compose.message") {
+                expect(action.context.default_res_ids).toEqual([partnerId]);
+                action.context.default_res_ids = JSON.stringify(action.context.default_res_ids);
+            }
+            return super.doAction(...arguments);
+        },
+    });
+    mailModels.MailComposeMessage._views = {
+        "form,false": `
+            <form>
+                <field name="body" widget="html_composer_message"/>
+            </form>
+        `,
+    };
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Composer");
+    await click(".o-mail-Composer button[title='More Actions']");
+    await click(".dropdown-item:contains('Open Full Composer')");
+
+    const paragraph = await waitFor(".modal .odoo-editor-editable .o-paragraph");
+    setSelection({
+        anchorNode: paragraph.firstChild,
+        anchorOffset: paragraph.textContent.length,
+    });
+    await contains(".modal .o_form_view");
+    const editable = document.querySelector(".modal .odoo-editor-editable");
+    const editor = { document, editable };
+    await htmlInsertText(editor, " updated");
+    await click(".modal .o_form_button_save");
+    await contains(".o-mail-Message-content:text('original message updated')");
+});
+
 test("Basic list of edit message actions in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
@@ -355,8 +403,9 @@ test("Basic list of edit message actions in chatter", async () => {
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer.o-focused");
     await click(".o-mail-Message .o-mail-Composer button[title='More Actions']");
-    await contains(".dropdown-menu .dropdown-item", { count: 1 });
+    await contains(".dropdown-menu .dropdown-item", { count: 2 });
     await contains(".dropdown-menu .dropdown-item:has(:text('Attach Files'))");
+    await contains(".dropdown-menu .dropdown-item:has(:text('Open Full Composer'))");
 });
 
 test("Cursor is at end of composer input on edit", async () => {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_composer_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_composer_message.js
@@ -1,3 +1,5 @@
+import { Store } from "@mail/../tests/mock_server/store";
+
 import { models } from "@web/../tests/web_test_helpers";
 
 export class MailComposeMessage extends models.ServerModel {
@@ -7,7 +9,10 @@ export class MailComposeMessage extends models.ServerModel {
                 <form>
                     <field name="body" widget="html_composer_message"/>
                     <footer>
-                        <button name="action_send_mail" type="object" string="Send"/>
+                        <button name="action_send_mail" type="object" string="Send"
+                            invisible="context.get('default_message_id')"/>
+                        <button name="action_update_message" type="object" string="Save"
+                            invisible="not context.get('default_message_id')"/>
                         <button special="cancel" string="Discard"/>
                     </footer>
                 </form>
@@ -22,5 +27,18 @@ export class MailComposeMessage extends models.ServerModel {
                 record_name: "Mitchell Admin",
             },
         };
+    }
+
+    action_update_message(ids, kwargs = {}) {
+        const MailMessage = this.env["mail.message"];
+        const messageId = kwargs.context?.default_message_id;
+        const [composer] = this.browse(ids);
+        MailMessage.write([messageId], { body: composer.body || "" });
+        this.env["bus.bus"]._sendone(
+            MailMessage._bus_notification_target(messageId),
+            "mail.record/insert",
+            new Store().add(MailMessage.browse(messageId), "_store_message_fields").as_dict()
+        );
+        return { type: "ir.actions.act_window_close" };
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_composer_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_composer_message.js
@@ -1,5 +1,36 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+
 import { models } from "@web/../tests/web_test_helpers";
 
 export class MailComposeMessage extends models.ServerModel {
     _name = "mail.compose.message";
+
+    web_save(ids, values, kwargs = {}) {
+        const context = kwargs.context || {};
+        if (!context.is_editing_message || !context.default_message_id) {
+            return super.web_save(ids, values, kwargs);
+        }
+        const messageId = context.default_message_id;
+        const MailMessage = this.env["mail.message"];
+        const [message] = MailMessage.browse(messageId);
+        if (!message) {
+            return [];
+        }
+        const msg_values = {};
+        if (values.body !== null) {
+            msg_values.body = values.body || "";
+        }
+        MailMessage.write([messageId], msg_values);
+        this.env["bus.bus"]._sendone(
+            MailMessage._bus_notification_target(message.id),
+            "mail.record/insert",
+            new mailDataHelpers.Store(MailMessage.browse(message.id)).get_result()
+        );
+        return [
+            {
+                id: messageId,
+                body: values.body || "",
+            },
+        ];
+    }
 }

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -4,6 +4,8 @@ import ast
 import datetime
 import json
 
+from markupsafe import Markup
+
 from odoo import _, api, fields, models, Command, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
@@ -829,6 +831,18 @@ class MailComposeMessage(models.TransientModel):
             create_values.append(wizard._prepare_schedule_message_post_values(post_values))
         return self.env['mail.scheduled.message'].create(create_values)
 
+    def action_update_message(self):
+        self.ensure_one()
+        message = self.env['mail.message'].browse(self.env.context['default_message_id'])
+        record = self.env[message.model].browse(message.res_id)
+        record._message_update_content(
+            message,
+            body=self._get_body_with_full_composer_marker() or None,
+            attachment_ids=self.attachment_ids.ids,
+            partner_ids=self.partner_ids.ids,
+        )
+        return {'type': 'ir.actions.act_window_close'}
+
     def action_send_mail(self):
         """ Used for action button that do not accept arguments. """
         self._action_send_mail(auto_commit=False)
@@ -877,10 +891,18 @@ class MailComposeMessage(models.TransientModel):
 
         return result_mails_su, result_messages
 
+    def _get_body_with_full_composer_marker(self):
+        self.ensure_one()
+        if is_html_empty(self.body) or 'data-o-mail-full-composer' in self.body:
+            return self.body
+        return Markup('<span data-o-mail-full-composer="1"></span>') + self.body
+
     def _action_send_mail_comment(self, res_ids):
         """ Send in comment mode. It calls message_post on model, or the generic
         implementation of it if not available (as message_notify). """
         self.ensure_one()
+        if self.env.context.get('is_full_composer'):
+            self.body = self._get_body_with_full_composer_marker()
         post_values_all = self._manage_mail_values(self._prepare_mail_values(res_ids))
         ActiveModel = self.env[self.model] if self.model and hasattr(self.env[self.model], 'message_post') else self.env['mail.thread']
         if self.composition_batch:

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -795,6 +795,17 @@ class MailComposeMessage(models.TransientModel):
         """ Send in comment mode. It calls message_post on model, or the generic
         implementation of it if not available (as message_notify). """
         self.ensure_one()
+        # Handle editing an existing message via the full composer
+        if self.env.context.get('is_editing_message') and self.env.context.get('default_message_id'):
+            message = self.env['mail.message'].browse(self.env.context['default_message_id'])
+            record = self.env[message.model].browse(message.res_id)
+            record._message_update_content(
+                message,
+                body=self.body or None,
+                attachment_ids=self.attachment_ids.ids,
+                partner_ids=self.partner_ids.ids,
+            )
+            return message
         post_values_all = self._manage_mail_values(self._prepare_mail_values(res_ids))
         ActiveModel = self.env[self.model] if self.model and hasattr(self.env[self.model], 'message_post') else self.env['mail.thread']
         if self.composition_batch:

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -45,12 +45,13 @@
                         <label for="partner_ids" string="To" groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log"/>
                         <div class="d-flex gap-3" groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log">
                             <field name="partner_ids" widget="many2many_tags_email" placeholder="Followers only" class="w-auto flex-grow-1"
-                                invisible="composition_comment_option == 'forward' or (composition_comment_option != 'reply_all' and not context.get('clicked_on_full_composer', False))"
+                                invisible="composition_comment_option == 'forward' or (composition_comment_option != 'reply_all' and not context.get('is_full_composer', False))"
+                                readonly="context.get('default_message_id')"
                                 context="{'form_view_ref': 'base.view_partner_simple_form', 'show_email': True}"
                                 options="{'on_tag_click': 'open_form'}"/>
                             <field name="partner_ids" widget="many2many_tags_email" placeholder="Add recipients..." class="w-auto flex-grow-1"
-                                required="composition_comment_option == 'forward' or (composition_comment_option != 'reply_all' and not context.get('clicked_on_full_composer', False) and composition_mode == 'comment' and not notified_bcc_contains_share)"
-                                invisible="composition_comment_option != 'forward' and (context.get('clicked_on_full_composer', False) or composition_comment_option == 'reply_all' )"
+                                required="composition_comment_option == 'forward' or (composition_comment_option != 'reply_all' and not context.get('is_full_composer', False) and composition_mode == 'comment' and not notified_bcc_contains_share)"
+                                invisible="composition_comment_option != 'forward' and (context.get('is_full_composer', False) or composition_comment_option == 'reply_all' )"
                                 options="{'on_tag_click': 'open_form'}"
                                 context="{'force_email': True, 'show_email': True, 'form_view_ref': 'base.view_partner_simple_form', 'forward_mode': True}"/>
                             <div class="d-flex gap-2">
@@ -63,10 +64,11 @@
                         <div class="d-flex gap-3"
                             groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log or not partner_cc_allowed">
                             <field name="partner_cc_ids" widget="many2many_tags_email" placeholder="Add Cc recipients..."
-                                class="w-auto flex-grow-1"/>
+                                class="w-auto flex-grow-1" readonly="context.get('default_message_id')"/>
                         </div>
                         <field name="subject_placeholder" invisible="1"/><!--used as dynamic placeholder-->
-                        <field name="subject" options="{'placeholder_field': 'subject_placeholder'}" required="composition_mode == 'mass_mail'"/>
+                        <field name="subject" options="{'placeholder_field': 'subject_placeholder'}" required="composition_mode == 'mass_mail'"
+                            readonly="context.get('default_message_id')"/>
                         <field name="reply_to" placeholder="e.g. info@company.com"
                             invisible="reply_to_mode == 'update'"
                             required="reply_to_mode != 'update'"/>
@@ -99,25 +101,28 @@
                         <div invisible="not attachment_links_info" class="alert alert-info py-1 my-0 align-right w-100" role="alert">
                             <field name="attachment_links_info" nolabel="1"/>
                         </div>
+                        <button string="Save" name="action_update_message"
+                                type="object" class="btn-primary" data-hotkey="q"
+                                invisible="not context.get('default_message_id')"/>
                         <button string="Send" name="action_send_mail"
                                 type="object" class="btn-primary o_mail_send" data-hotkey="q"
-                                invisible="(subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or not partner_ids_all_have_email"/>
+                                invisible="(subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or not partner_ids_all_have_email or context.get('default_message_id')"/>
                         <button string="Log" name="action_send_mail"
                                 type="object" class="btn-primary" data-hotkey="q"
-                                invisible="(not subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or not partner_ids_all_have_email"/>
+                                invisible="(not subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or not partner_ids_all_have_email or context.get('default_message_id')"/>
                         <button string="Schedule" name="action_schedule_message" type="object" class="btn-primary" data-hotkey="q"
                                 invisible="(composition_mode != 'comment' or composition_batch or not scheduled_date) or not partner_ids_all_have_email"/>
                         <button string="Send" name="action_send_mail" disabled="1"
                                 type="object" class="btn-primary o_mail_send" data-hotkey="q"
-                                invisible="(subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or partner_ids_all_have_email"/>
+                                invisible="(subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or partner_ids_all_have_email or context.get('default_message_id')"/>
                         <button string="Log" name="action_send_mail" disabled="1"
                                 type="object" class="btn-primary" data-hotkey="q"
-                                invisible="(not subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or partner_ids_all_have_email"/>
+                                invisible="(not subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or partner_ids_all_have_email or context.get('default_message_id')"/>
                         <button string="Schedule" name="action_schedule_message" type="object" class="btn-primary" data-hotkey="q" disabled="1"
                                 invisible="(composition_mode != 'comment' or composition_batch or not scheduled_date) or partner_ids_all_have_email"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_selector" invisible="not can_edit_body"/>
-                        <field name="scheduled_date" widget="text_scheduled_date" invisible="composition_batch or composition_mode != 'comment'"/>
+                        <field name="scheduled_date" widget="text_scheduled_date" invisible="composition_batch or composition_mode != 'comment' or context.get('default_message_id')"/>
                         <field name="template_id" widget="mail_composer_template_selector"/>
                     </footer>
                 </form>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -68,6 +68,7 @@ else:
 safe_attrs = defs.safe_attrs | frozenset(
     ['style',
      'data-o-mail-quote', 'data-o-mail-quote-node',  # quote detection
+     'data-o-mail-full-composer',  # body composed with the full composer
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-source-sha', 'data-oe-nodeid',
      'data-last-history-commits', 'data-oe-protected', 'data-embedded', 'data-embedded-editable', 'data-embedded-props', 'data-oe-version',
      'data-oe-transient-content', 'data-behavior-props', 'data-prop-name', 'data-width', 'data-height', 'data-scale-x', 'data-scale-y', 'data-x', 'data-y',  # legacy editor


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
When editing messages or log notes from the Chatter, users are limited to
the inline composer and cannot switch to the full composer. This restricts
their ability to perform advanced editing (rich formatting, attachments,
mentions handling, etc.) once edit mode is initiated.


**Current behavior before PR:**
----------------------------------------------
- No option is available to open the full composer while editing
- Users must either continue with limited inline editing or discard changes
- Full composer can only be used when creating new messages, not editing existing ones


**Desired behavior after PR is merged:**
----------------------------------------------
- "Open Full Composer" action is available while editing messages/notes
- Full composer opens with existing message content pre-filled
- Attachments, mentions, and formatting are preserved during transition
- Saving from full composer updates the original message instead of creating a new one
- Existing behavior for new messages remains unchanged

Related Enterprise PR: https://github.com/odoo/enterprise/pull/126622

Task-6015654

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr