### PR TITLE
[IMP] (test_)mail(_full): add documents-related attachment field to store

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -213,7 +213,7 @@ class ThreadController(http.Controller):
         message = thread.sudo().message_post(
             **self._prepare_message_data(post_data, thread=thread, from_create=True, **kwargs),
         )
-        store.add(message, "_store_message_fields")
+        store.add(message, "_store_message_fields", fields_params={"chatter_fields": True})
         return {"store_data": store, "message_id": message.id}
 
     @mail_route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -36,7 +36,7 @@ class WebclientController(ThreadController):
     def _process_request_loop(self, store: Store, fetch_params):
         # aggregate of messages to return, to batch them in a single query when all the fetch params
         # have been processed
-        request.update_context(messages=request.env["mail.message"], add_inbox_fields=False)
+        request.update_context(messages=request.env["mail.message"], add_inbox_fields=False, add_chatter_fields=False)
         for fetch_param in fetch_params:
             name, params, data_id = (
                 (fetch_param, None, None)
@@ -50,10 +50,14 @@ class WebclientController(ThreadController):
             if request.env.user._is_internal():
                 self._process_request_for_internal_user(store, name, params)
         if messages := request.env.context["messages"]:
+            fields_params = {
+                **({"inbox_fields": True} if request.env.context["add_inbox_fields"] else {}),
+                **({"chatter_fields": True} if request.env.context["add_chatter_fields"] else {}),
+            }
             if request.env.context["add_inbox_fields"]:
                 # sudo: bus.bus: reading non-sensitive last id
                 bus_last_id = request.env["bus.bus"].sudo()._bus_last_id()
-                store.add(messages, "_store_message_fields", fields_params={"inbox_fields": True})
+                store.add(messages, "_store_message_fields", fields_params=fields_params)
                 for records in messages._records_by_model_name().values():
                     if not isinstance(records, request.env.registry["mail.thread"]):
                         continue
@@ -67,7 +71,7 @@ class WebclientController(ThreadController):
                         as_thread=True,
                     )
             else:
-                store.add(messages, "_store_message_fields")
+                store.add(messages, "_store_message_fields", fields_params=fields_params)
         store.data_id = None
 
     @classmethod
@@ -93,7 +97,7 @@ class WebclientController(ThreadController):
                 store.add(
                     thread,
                     "_store_thread_fields",
-                    fields_params={"request_list": params["request_list"]},
+                    fields_params={"request_list": params["request_list"], "chatter_fields": True},
                     as_thread=True,
                 )
         if name == "res.partner":
@@ -140,6 +144,7 @@ class WebclientController(ThreadController):
                 lost.sudo().unlink()  # no unlink right except admin, ok to remove as lost anyway
             store.add(valid.mail_message_id, "_store_notification_fields")
         if name == "/mail/thread/messages":
+            request.update_context(add_chatter_fields=True)
             if thread := self._get_thread_with_access(
                 params["thread_model"],
                 params["thread_id"],

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -18,8 +18,8 @@ class IrAttachment(models.Model):
             return guest._bus_channels()
         return super()._bus_channels()
 
-    def _store_attachment_fields(self, res: Store.FieldList):
-        super()._store_attachment_fields(res)
+    def _store_attachment_fields(self, res: Store.FieldList, **kwargs):
+        super()._store_attachment_fields(res, **kwargs)
         # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible
         # attachments is fine
         res.many("voice_ids", [], sudo=True)

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -89,7 +89,7 @@ class IrAttachment(models.Model):
     def _store_ownership_fields(self, res: Store.FieldList):
         res.attr("ownership_token", lambda a: a._get_ownership_token())
 
-    def _store_attachment_fields(self, res: Store.FieldList):
+    def _store_attachment_fields(self, res: Store.FieldList, **kwargs):
         res.extend(["checksum", "create_date", "file_size", "has_thumbnail", "mimetype", "name"])
         res.attr("raw_access_token", lambda a: a._get_raw_access_token())
         res.attr("res_name")

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1064,6 +1064,7 @@ class MailMessage(models.Model):
         *,
         format_reply=True,
         msg_vals=False,
+        chatter_fields=False,
         inbox_fields=False,
         followers: Store.LazyValue[MailFollowers] = None,
     ):
@@ -1080,6 +1081,8 @@ class MailMessage(models.Model):
             each thread of each message as well as module icon and priority fields.
             Only applicable if ``res.target`` is a specific user.
 
+        :param chatter_fields: forwarded to _store_attachment_fields
+
         :param followers: if given, use this pre-computed list of followers instead of fetching
             them. It lessen query count in some optimized use cases.
             Only applicable if ``inbox_fields`` is True.
@@ -1091,6 +1094,7 @@ class MailMessage(models.Model):
             sort="id",
             dynamic_fields="_store_attachment_dynamic_fields",
             sudo=True,
+            fields_params={"chatter_fields": chatter_fields},
         )
         # sudo: mail.message: access to author_guest_id is allowed
         res.one("author_guest_id", "_store_avatar_fields", sudo=True)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5121,7 +5121,7 @@ class MailThread(models.AbstractModel):
     # STORE
     # ------------------------------------------------------
 
-    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list, **kwargs):
         if res.is_for_current_user():
             res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
             res.attr("hasWriteAccess", lambda t: t.sudo(False).has_access("write"))
@@ -5147,6 +5147,7 @@ class MailThread(models.AbstractModel):
                 "attachments",
                 "_store_attachment_fields",
                 value=lambda t: t._get_mail_thread_data_attachments(),
+                fields_params={"chatter_fields": kwargs.get("chatter_fields", False)},
             )
             res.append({"areAttachmentsLoaded": True, "isLoadingAttachments": False})
         if "contact_fields" in request_list:

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -49,7 +49,7 @@ class MailThreadMainAttachment(models.AbstractModel):
                     key=lambda r: (r.mimetype.endswith('pdf'), r.mimetype.startswith('image'))
                 ).id
 
-    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
-        super()._store_thread_fields(res, request_list=request_list)
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list, **kwargs):
+        super()._store_thread_fields(res, request_list=request_list, **kwargs)
         if "attachments" in request_list:
             res.attr("message_main_attachment_id")

--- a/addons/mail/models/mail_thread_subject_suggested.py
+++ b/addons/mail/models/mail_thread_subject_suggested.py
@@ -6,8 +6,8 @@ class MailThreadSubjectSuggest(models.AbstractModel):
     _name = 'mail.thread.subject.suggested'
     _description = 'Thread with suggested subject'
 
-    def _store_thread_fields(self, res, *, request_list):
-        super()._store_thread_fields(res, request_list=request_list)
+    def _store_thread_fields(self, res, *, request_list, **kwargs):
+        super()._store_thread_fields(res, request_list=request_list, **kwargs)
         if 'showSubjectInSmallComposer' in request_list:
             res.attr('showSubjectInSmallComposer', lambda _: True)
         if 'suggestedSubject' in request_list:

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2063,6 +2063,8 @@ class MailCommon(MailCase):
                 data.pop("original_id", None)
                 data.pop("public", None)
                 data.pop("res_id", None)
+            if "documents.document" not in self.env:
+                data.pop("linked_document_ids", None)
         return list(attachments_data)
 
     @classmethod

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -123,6 +123,7 @@ class TestMessageController(HttpCaseWithUserDemo, MailCommon):
                     "original_id": False,
                     "public": False,
                     "res_id": self.attachments[0].res_id,
+                    "linked_document_id": self.attachments[0].linked_document_id.id,
                 },
             ),
             "guest should be allowed to add attachment with token when posting message",

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1177,8 +1177,8 @@ class ProjectProject(models.Model):
         for partner, tasks in dict_tasks_per_partner.items():
             tasks.message_subscribe(dict_partner_ids_to_subscribe_per_partner[partner])
 
-    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
-        super()._store_thread_fields(res, request_list=request_list)
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list, **kwargs):
+        super()._store_thread_fields(res, request_list=request_list, **kwargs)
         if "followers" in request_list:
             res.many("collaborator_ids", [], value=lambda p: p.collaborator_ids.partner_id)
 


### PR DESCRIPTION
Add `chatter_fields` param for `_store_attachment_fields` to add fields 
only when viewing from a chatter (mainly for performance).

Adapt tests for usage thereof in `documents`.

Task-5882406