### PR TITLE
[FIX] html_builder, *: add missing conversions for em, px, % units

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -56,6 +56,19 @@ export class BuilderNumberInput extends Component {
     }
 
     /**
+     * Returns element style for `em`, otherwise document root style.
+     *
+     * @param {boolean} isUnitEM - True if either source or target unit is "em".
+     * @returns {CSSStyleDeclaration}
+     **/
+    getStyle(isUnitEM) {
+        const editingElement = this.env.getEditingElement();
+        return isUnitEM
+            ? getComputedStyle(editingElement)
+            : getHtmlStyle(editingElement.ownerDocument);
+    }
+
+    /**
      * @param {string | number} values - Values separated by spaces or a number
      * @param {(string) => string} convertSingleValueFn - Convert a single value
      */
@@ -76,15 +89,19 @@ export class BuilderNumberInput extends Component {
         return this.convertSpaceSplitValues(rawValue, (value) => {
             const unit = this.props.unit;
             const { savedValue, savedUnit } = value.match(
-                /(?<savedValue>[\d.e+-]+)(?<savedUnit>\w*)/
+                // [+-]? - optional sign
+                // \d*\.?\d+ - number (int or decimal)
+                // (?:e[+-]?\d+)? - optional scientific notation
+                /(?<savedValue>[+-]?\d*\.?\d+(?:e[+-]?\d+)?)(?<savedUnit>\w*)/
             ).groups;
-            if (savedUnit || this.props.saveUnit) {
+            const saveUnit = savedUnit || this.props.saveUnit;
+            if (saveUnit) {
                 // Convert value from saveUnit to unit
                 value = convertNumericToUnit(
                     parseFloat(savedValue),
-                    savedUnit || this.props.saveUnit,
+                    saveUnit,
                     unit,
-                    getHtmlStyle(this.env.getEditingElement().ownerDocument)
+                    this.getStyle(unit === "em" || saveUnit === "em")
                 );
             }
             // Put *at most* 3 decimal digits
@@ -144,7 +161,7 @@ export class BuilderNumberInput extends Component {
                     value,
                     unit,
                     saveUnit,
-                    getHtmlStyle(this.env.getEditingElement().ownerDocument)
+                    this.getStyle(unit === "em" || saveUnit === "em")
                 );
             }
             if (unit && applyWithUnit) {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -781,6 +781,51 @@ describe("unit & saveUnit", () => {
         expect.verifySteps(["customAction 57000ms"]);
         expect(":iframe .test-options-target").toHaveInnerHTML("57000ms");
     });
+    test("should correctly convert values between em <-> %, em <-> px units", async () => {
+        addBuilderAction({
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
+                    expect.step(`customAction ${value}`);
+                    editingElement.innerHTML = value;
+                }
+            },
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".test-px-em-conversion";
+                static template = xml`<BuilderNumberInput action="'customAction'" unit="'px'" saveUnit="'em'"/>`;
+            }
+        );
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".test-em-percent-conversion";
+                static template = xml`<BuilderNumberInput action="'customAction'" unit="'em'" saveUnit="'%'"/>`;
+            }
+        );
+        await setupHTMLBuilder(`
+                    <div style="font-size: 10px">
+                        <div class="test-px-em-conversion">1em</div>
+                        <div class="test-em-percent-conversion">10%</div>
+                    </div>
+                `);
+        await contains(":iframe .test-px-em-conversion").click();
+        expect(".options-container input").toHaveValue("10");
+        await click(".options-container input");
+        await fill("0");
+        await click(document.body);
+        expect.verifySteps(["customAction 10em", "customAction 10em"]);
+        expect(":iframe .test-px-em-conversion").toHaveInnerHTML("10em");
+        await contains(":iframe .test-em-percent-conversion").click();
+        expect(".options-container input").toHaveValue("0.1");
+        await click(".options-container input");
+        await fill("0");
+        expect.verifySteps(["customAction 10%"]);
+        expect(":iframe .test-em-percent-conversion").toHaveInnerHTML("10%");
+    });
 });
 describe("sanitized values", () => {
     test("don't allow multi values by default", async () => {

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -180,6 +180,10 @@ const CSS_UNITS_CONVERSION = {
     "ms-s": () => 0.001,
     "rem-px": (htmlStyle) => parseFloat(htmlStyle["font-size"]),
     "px-rem": (htmlStyle) => 1 / parseFloat(htmlStyle["font-size"]),
+    "em-px": (htmlStyle) => parseFloat(htmlStyle["font-size"]),
+    "px-em": (htmlStyle) => 1 / parseFloat(htmlStyle["font-size"]),
+    "em-%": () => 100, // 1em = 100%
+    "%-em": () => 1 / 100, // 1% = 0.01em
     "%-px": () => -1, // Not implemented but should simply be ignored for now
     "px-%": () => -1, // Not implemented but should simply be ignored for now
 };


### PR DESCRIPTION
[*] = html_editor

### Issue 1: Traceback "cannot convert m to em"

Steps to reproduce:

1. Create an option with "BuilderNumberInput" and set the unit to "em".
2. Open the builder and try changing the option value.

Reason for traceback:
The regex used to separate the value and unit incorrectly allows "e" in the numeric part. As a result, a value like "12em" is parsed as "value = 12e" and "unit = m". The "e" in regex was meant to allow scientific notation (e.g. "1e3"), but it also matches the "e" in unit.

---

### Issue 2: Traceback "Error: Cannot convert 'px' units into 'em' units !"

Steps to reproduce:

1. Create an option with a "BuilderNumberInput" with unit "px" and saveUnit set to "em".
2. Open the builder and try changing the option value.

Reason for traceback:
No conversion was defined for "px <-> em" in the "CSS_UNITS_CONVERSION" object, which is responsible for converting values when unit and saveUnit differ. The same issue exists for "% <-> em".

---

task-6048918