### PR TITLE
[FIX] web: prevent virtual keyboard on touch devices in dialogs

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -4,6 +4,7 @@ import { useForwardRefToParent } from "@web/core/utils/hooks";
 import { Component, onWillDestroy, useChildSubEnv, useExternalListener, useState } from "@odoo/owl";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { makeDraggableHook } from "../utils/draggable_hook_builder_owl";
+import { hasTouch } from "@web/core/browser/feature_detection";
 
 const useDialogDraggable = makeDraggableHook({
     name: "useDialogDraggable",
@@ -114,6 +115,7 @@ export class Dialog extends Component {
                 this.data.scrollToOrigin();
             }
         });
+        this.bodyTabIndex = hasTouch() ? "0" : undefined;
     }
 
     get isFullscreen() {

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -18,7 +18,7 @@
                                 </t>
                             </t>
                         </header>
-                        <main class="modal-body" t-attf-class="{{ props.bodyClass }} {{ !props.withBodyPadding ? 'p-0': '' }}">
+                        <main class="modal-body" t-attf-class="{{ props.bodyClass }} {{ !props.withBodyPadding ? 'p-0': '' }}" t-att-tabindex="this.bodyTabIndex">
                             <t t-slot="default" close="() => this.data.close()" />
                         </main>
                         <footer t-if="props.footer" class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -187,6 +187,8 @@ test("concurrency with custom debounce delay", async () => {
     expect(".o_command").toHaveCount(0);
     expect(".o_command_palette .o_namespace").toHaveCount(0);
 
+    // On mobile we need to focus the input
+    await click(".o_command_palette_search input");
     await fill("@");
     await animationFrame();
     expect(".o_command_palette .o_namespace").toHaveText("@");
@@ -530,6 +532,7 @@ test("open the command palette with a searchValue already in the searchbar", asy
     expect(queryAllTexts(".o_command")).toEqual(["Command1"]);
 });
 
+test.tags("desktop");
 test("command palette keeps the same top position when its content changes", async () => {
     await mountWithCleanup(MainComponentsContainer);
     const action = () => {};

--- a/addons/web/static/tests/core/dialog.test.js
+++ b/addons/web/static/tests/core/dialog.test.js
@@ -1,4 +1,4 @@
-import { destroy, expect, test } from "@odoo/hoot";
+import { destroy, expect, mockTouch, test } from "@odoo/hoot";
 import { keyDown, keyUp, press, queryAllTexts, queryOne, resize } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Component, onMounted, useState, xml } from "@odoo/owl";
@@ -34,6 +34,37 @@ test("simple rendering", async () => {
     expect("main").toHaveText("Hello!");
     expect(".o_dialog footer").toHaveCount(1, { message: "the footer is rendered by default" });
     expect(".o_dialog footer:visible").toHaveCount(0, { message: "the footer is hidden if empty" });
+});
+
+test("simple rendering - touch display with trap focus", async () => {
+    mockTouch(true);
+    class Parent extends Component {
+        static components = { Dialog };
+        static template = xml`
+          <Dialog>
+            <input type="text" placeholder="withFocus"/>
+          </Dialog>
+      `;
+        static props = ["*"];
+    }
+    await makeDialogMockEnv();
+    await mountWithCleanup(Parent);
+
+    expect(".o_dialog").toHaveCount(1);
+    expect("input[placeholder=withFocus]").not.toBeFocused();
+    await press("Tab", { shiftKey: false });
+    await animationFrame();
+    expect("input[placeholder=withFocus]").toBeFocused();
+
+    await press("Tab", { shiftKey: true });
+    await animationFrame();
+    expect("input[placeholder=withFocus]").not.toBeFocused();
+    // The main became focusable, this affects devices with touch and keyboard.
+    expect(".o_dialog main").toBeFocused();
+
+    await press("Tab", { shiftKey: true });
+    await animationFrame();
+    expect("input[placeholder=withFocus]").toBeFocused();
 });
 
 test("hotkeys work on dialogs", async () => {

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -97,6 +97,7 @@ test("multiple dialogs can become the UI active element", async () => {
     );
 });
 
+test.tags("desktop");
 test("a popover with an autofocus child can become the UI active element", async () => {
     class TestPopover extends Component {
         static template = xml`<input type="text" t-ref="autofocus" />`;


### PR DESCRIPTION
Commit 1 addressed an issue where the virtual keyboard would pop up unexpectedly when navigating on touch devices.

However, due to commit 2, opening a dialog traps the focus in the dialog and automatically focuses on the first element. On touch screens, this behavior triggers the virtual keyboard.

This commit changes the behavior so that, on touch devices, the focus is on the main part of the dialog instead of the first input field. This prevents the virtual keyboard from opening while ensuring the focus trap remains active.

opw-5970020

1: https://github.com/odoo/odoo/commit/9d8f9d90743490c37a89fa71be087d38924164e7
2: https://github.com/odoo/odoo/commit/cd624c891f356c0527f5bb75cdfe1e05b7b79a21
