### PR TITLE
[FIX] mail: support for multiline text

### DIFF
--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -77,6 +77,19 @@ export class MailComposerPlugin extends Plugin {
         if (sanitizedFragment.childNodes.length === 0) {
             return false;
         }
+        const createMultilineTextFragment = (text) => {
+            const fragment = document.createDocumentFragment();
+            const lines = text.split(/\r\n|\r|\n/);
+            lines.forEach((line, index) => {
+                if (index > 0) {
+                    fragment.append(document.createElement("br"));
+                }
+                if (line) {
+                    fragment.append(document.createTextNode(line));
+                }
+            });
+            return fragment;
+        };
         const removeStyle = (node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
                 const tagName = node.nodeName.toUpperCase();
@@ -86,6 +99,9 @@ export class MailComposerPlugin extends Plugin {
                 if (!ALLOWED_TAGS.includes(tagName)) {
                     node.replaceWith(document.createTextNode(node.textContent));
                     return;
+                }
+                for (const child of childNodes(node)) {
+                    child.replaceWith(createMultilineTextFragment(child.innerText || child.textContent || ""));
                 }
                 node.removeAttribute("style");
                 if (node.hasAttribute("class")) {


### PR DESCRIPTION
Currently, when pasting content into the composer, if the content contains multi-line text separated by line breaks (e.g. multiple lines of codes from `<pre>` block separated by \n), all the line breaks are lost and the text is pasted as a single line.
This commit ensures that when pasting content, the line breaks are preserved by replacing the text nodes with a fragment containing the text split by line breaks.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
