### PR TITLE
[FIX] base: display func name in forbidden opcode error

### DIFF
--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -125,7 +125,7 @@ class TestSafeEval(BaseCase):
            ast.literal_eval('{"a": True.__class__}')
 
     @mute_logger('odoo.tools.safe_eval')
-    def test_05_safe_eval_forbiddon(self):
+    def test_05_safe_eval_forbidden(self):
         """ Try forbidden expressions in safe_eval to verify they are not allowed"""
         # no forbidden builtin expression
         with self.assertRaises(ValueError):
@@ -134,6 +134,10 @@ class TestSafeEval(BaseCase):
         # no forbidden opcodes
         with self.assertRaises(ValueError):
             safe_eval("import odoo", mode="exec")
+
+        # Error message shows the function's name
+        with self.assertRaisesRegex(ValueError, r"forbidden opcode\(s\) in 'foo':"):
+            safe_eval("def foo(x): x.bar = 2", mode="exec")
 
         # no dunder
         with self.assertRaises(NameError):

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -293,7 +293,7 @@ def assert_valid_codeobj(allowed_codes, code_obj, expr):
     :type allowed_codes: set(int)
     :param code_obj: code object to name-validate
     :type code_obj: CodeType
-    :param str expr: expression corresponding to the code object, for debugging
+    :param str expr: expression or name of to the code object, for debugging
                      purposes
     :raises ValueError: in case of forbidden bytecode in ``code_obj``
     :raises NameError: in case a forbidden name (containing two underscores)
@@ -309,7 +309,7 @@ def assert_valid_codeobj(allowed_codes, code_obj, expr):
 
     for const in code_obj.co_consts:
         if isinstance(const, CodeType):
-            assert_valid_codeobj(allowed_codes, const, 'lambda')
+            assert_valid_codeobj(allowed_codes, const, const.co_name)
 
 
 def compile_codeobj(expr: str, /, filename: str = '<unknown>', mode: typing.Literal['eval', 'exec'] = 'eval'):


### PR DESCRIPTION
### Before this commit:
When using a forbidden opcode in a function, it would tell you the opcode was used in the expression 'lambda', which is not useful.

### After this commit:
The function's name is used instead of the hardcoded 'lambda', to provide more useful debugging information.

```python
def foo(x):
    x.bar = 2
```
Now raises `ValueError: forbidden opcode(s) in 'foo': STORE_ATTR` instead of `ValueError: forbidden opcode(s) in 'lambda': STORE_ATTR`, which is not helpful in big server actions.