### PR TITLE
[FIX] website_profile: allow portal user profile editing

### DIFF
--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -125,8 +125,11 @@ class WebsiteProfile(http.Controller):
 
     # Edit Profile
     # ---------------------------------------------------
-    def _profile_edition_preprocess_values(self, user, **kwargs):
-        values = {
+    @http.route('/profile/user/save', type='jsonrpc', auth='user', methods=['POST'], website=True)
+    def save_edited_profile(self, **kwargs):
+        user_id = int(kwargs.get('user_id', 0))
+        user = request.env['res.users'].browse(user_id or request.env.uid)
+        qcontext = {
             'name': kwargs.get('name'),
             'website': kwargs.get('website'),
             'email': kwargs.get('email'),
@@ -136,20 +139,20 @@ class WebsiteProfile(http.Controller):
         }
 
         if 'image_1920' in kwargs:
-            values['image_1920'] = kwargs.get('image_1920')
+            qcontext['image_1920'] = kwargs.get('image_1920')
 
         if request.env.uid == user.id:  # the controller allows to edit only its own privacy settings; use partner management for other cases
-            values['website_published'] = kwargs.get('website_published')
-        return values
+            qcontext['website_published'] = kwargs.get('website_published')
 
-    @http.route('/profile/user/save', type='jsonrpc', auth='user', methods=['POST'], website=True)
-    def save_edited_profile(self, **kwargs):
-        user_id = int(kwargs.get('user_id', 0))
-        user = request.env['res.users'].browse(user_id or request.env.uid)
-        values = self._profile_edition_preprocess_values(user, **kwargs)
-        if not user.partner_id._can_edit_country() and values.get('country_id') != user.partner_id.country_id.id:
+        if not user.partner_id._can_edit_country() and qcontext.get('country_id') != user.partner_id.country_id.id:
             raise UserError(_("Changing the country is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."))
-        user.write(values)
+        if not user.has_access('write'):
+            # no write access, grant it if we can edit the partner
+            if user.partner_id._can_be_edited_by_current_customer(**kwargs):
+                user = user.sudo()
+            else:
+                raise UserError(_("You are not allowed to edit this user"))
+        user.write(qcontext)
 
     # Ranks and Badges
     # ---------------------------------------------------


### PR DESCRIPTION
# How to reproduce
- Install the eLearning module
- Log in as a portal user
- Make sure this portal user has more than 0 karma (Use demo Joel Willis or go through a quick Course)
- Go to Courses > View your profile (on the right side) > Edit Profile
- Edit any value and confirm by clicking on the Update button

# The problem
The popup is not saved and a warning notification is displayed with : "You are not allowed to modifiy 'User' (res.users) records"

# Why
In 19.0, there was no access rights problem because the write operation was done in `sudo` due to this code that checked that every edited field was safe :

https://github.com/odoo/odoo/blob/4f77b4c8f7a3ee9f85f045eea02a5749affd4b6a/odoo/addons/base/models/res_users.py#L615

This was the case because we preventively filtered only the safe fields in the save controller :

https://github.com/odoo/odoo/blob/355643291e2f4bb05185b996adce6e1f403ecbd4/addons/website_profile/controllers/main.py#L153

In 19.1 though, this commit totally changed the way the acces rights for the fields of the user model were handled :

https://github.com/odoo/odoo/commit/a816d151ae16afc62d7980cedc492942bc181884

One of the purpose of this improvement was to make sure a `sudo` is not automatically introduced and rather should be done explicitely when it is needed.

# Proposed solution
We first check that the current user can modifiy the specified user. If that is the case, we write with `sudo`

opw-6032339

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
