### PR TITLE
[FIX] stock: Don't create inventory adjustments with 0 quantity

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1012,6 +1012,8 @@ class StockQuant(models.Model):
             inventory_location = quant.product_id.with_company(quant.company_id).property_stock_inventory or\
                 default_loss_locations.get(quant.company_id.id)
             # Create and validate a move so that the quant matches its `inventory_quantity`.
+            if quant.product_uom_id.compare(quant.inventory_diff_quantity, 0) == 0:
+                continue
             if quant.product_uom_id.compare(quant.inventory_diff_quantity, 0) > 0:
                 move_vals.append(
                     quant._get_inventory_move_values(quant.inventory_diff_quantity,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Create an inventory adjustment with no difference, try to Apply the inventory adjustment.
This will end up to create a move with -0.00, which should be there, because the difference is 0.

Current behavior before PR:

Desired behavior after PR is merged:
Do not create move for 0 qantity difference.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
