### PR TITLE
[FIX] account: tax-included price recomputation on branches

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -209,9 +209,10 @@ class ProductProduct(models.Model):
                 return 0.0
         if product_taxes is None:
             if document_type == 'sale':
-                product_taxes = product.taxes_id.filtered(lambda x: x.company_id == company)
+                product_taxes = product.taxes_id
             elif document_type == 'purchase':
-                product_taxes = product.supplier_taxes_id.filtered(lambda x: x.company_id == company)
+                product_taxes = product.supplier_taxes_id
+            product_taxes = product_taxes._filter_taxes_by_company(company)
         # Apply unit of measure.
         if product_uom and product.uom_id != product_uom:
             product_price_unit = product.uom_id._compute_price(product_price_unit, product_uom)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4731,3 +4731,49 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             1050.0,
             msg="Price should be recomputed when tax inclusion rate changes (10% -> 5%)"
         )
+
+    def test_out_invoice_fiscal_position_branch_taxes(self):
+        """Price should be recomputed when tax inclusion changes via fiscal position"""
+        # Create price-included taxes
+        tax_10_incl = self.env['account.tax'].create({
+            'name': '10% incl',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': True,
+        })
+        self.product_a.taxes_id = [Command.set(tax_10_incl.ids)]
+
+        # Create fiscal position mapping 10% -> 5%
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'Test FP',
+            'tax_ids': [Command.create({
+                'tax_src_id': tax_10_incl.id,
+                'tax_dest_id': self.tax_sale_a.id,
+            })],
+        })
+
+        # create a new branch
+        self.env.company.write({
+            'child_ids': [
+                Command.create({'name': 'Branch A'}),
+            ],
+        })
+        self.cr.precommit.run()  # load the CoA
+
+        # create an invoice on the new branch
+        branch_a = self.env.company.child_ids
+
+        # Create invoice - product will auto-apply price_unit from product with tax
+        move_form = Form(self.env['account.move'].with_company(branch_a).with_context(default_move_type='out_invoice'))
+        move_form.partner_id = self.partner_a
+        move_form.invoice_date = fields.Date.from_string('2019-01-01')
+        move_form.fiscal_position_id = fiscal_position
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_a
+        invoice = move_form.save()
+        self.assertEqual(
+            invoice.invoice_line_ids[0].price_unit,
+            909.09,
+            msg="Price should be tax included"
+        )


### PR DESCRIPTION
When operating in a multi-company branch environment, the unit price of
a product with price-included taxes is not correctly recalculated when
applying a fiscal position.

Steps to reproduce:
- Create a tax that is included in the price (e.g., 10% incl).
- Assign this tax to a product (e.g., Product A).
- Create a fiscal position that maps this 10% tax to a different tax.
- Create a branch (child company) of your main company.
- Create an invoice in the new branch using the fiscal position and add
  an invoice line for Product A.

Issue: The unit price of the product on the invoice line remains the
full tax-included amount rather than being reduced to exclude the
original 10% tax.

opw-5931302