### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: encode XML before storing in attachment raw

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -432,7 +432,7 @@ class AccountMove(models.Model):
 
         attachment_vals = {
             'name': 'attachment.xml',
-            'raw': response,
+            'raw': response.encode('utf-8'),
             'type': 'binary',
             'mimetype': 'application/xml',
         }

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
@@ -98,7 +98,7 @@ def mock_requests_request(method, url, *args, **kwargs):
     elif method == 'GET' and '/einvoice/Purchase' in url:
         if '/xml' in url:
             with file_open('l10n_tr_nilvera_einvoice/tests/test_files/fetching/invoice.xml', 'rb') as xml:
-                response = xml.read()
+                response = xml.read().decode()
         elif '/pdf' in url:
             with file_open('l10n_tr_nilvera_einvoice/tests/test_files/fetching/invoice.pdf', 'rb') as pdf:
                 response = pdf.read()


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

In master, ir.attachment._check_contents() now enforces normalization of the raw field by passing it through fields.Binary.convert_to_cache(). This change exposes an issue where the Nilvera client returns XML content as a decoded Unicode string (str), which is directly assigned to raw.

Since convert_to_cache() expects binary-compatible input, passing a Unicode string containing non-ASCII characters (e.g., Turkish characters) results in a failure during base64 decoding.

# Current behavior before PR:

The XML response from Nilvera is returned as a Unicode string and passed directly to the raw field of ir.attachment. In master, this leads to a crash when convert_to_cache() attempts to process the string, raising a ValueError due to non-ASCII characters.

# Desired behavior after PR is merged:

The XML content is encoded to UTF-8 bytes before being assigned to the raw field. This ensures compatibility with fields.Binary.convert_to_cache() and allows attachments to be created successfully without errors, even when the XML contains non-ASCII characters.

-------------------

taskId - 6084442

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)