### PR TITLE
[FIX] l10n_pl_edi: fixes multiples errors on fa3 generated files

### DIFF
--- a/addons/l10n_pl_edi/data/fa3_template.xml
+++ b/addons/l10n_pl_edi/data/fa3_template.xml
@@ -184,10 +184,10 @@
           <!-- P_13_11: Total value of sales under the margin scheme referred to in Article 119 and Article 120 TO-CHECK -->
 
           <!-- P_15: Total gross amount of the invoice (including all taxes). -->
-        <P_15 t-out="float_repr(invoice.amount_total_signed, 2)"/>
+        <P_15 t-out="float_repr(invoice.amount_total_in_currency_signed, 2)"/>
 
           <!-- KursWalutyZ: Exchange rate of the currency to PLN on the invoice date. TO-CHECK -->
-          <KursWalutyZ t-out="invoice.invoice_currency_rate"/>
+          <KursWalutyZ t-out="float_repr(1 / (invoice.invoice_currency_rate or 1), 5)"/>
         <!--
           ======================================================================
           Adnotacje (Annotations)

--- a/addons/l10n_pl_edi/models/account_move.py
+++ b/addons/l10n_pl_edi/models/account_move.py
@@ -189,8 +189,8 @@ class AccountMove(models.Model):
             if 'K_17' in tag_names:
                 return "8"
             # "5": Supply of goods/services, domestic, 5% (K_15)
-            if 'K_17' in tag_names:
-                return "8"
+            if 'K_15' in tag_names:
+                return "5"
             # No tax? It's exempt
             return "zw"
 

--- a/addons/l10n_pl_edi/tests/export_xmls/fa3_invoice_foreign_currency.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/fa3_invoice_foreign_currency.xml
@@ -1,0 +1,72 @@
+<Faktura xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/" xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>___ignore___</DataWytworzeniaFa>
+    <SystemInfo>Odoo</SystemInfo>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1234567883</NIP>
+      <Nazwa>company_1_data</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>Test Street 1 00-001 Warsaw Poland</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Test Customer PL</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>Partner St. 5 30-001 Krakow Poland</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>EUR</KodWaluty>
+    <P_1>2026-01-23</P_1>
+    <P_1M>Warsaw</P_1M>
+    <P_2>INV/2026/00001</P_2>
+    <P_13_1>10.00</P_13_1>
+    <P_14_1>2.30</P_14_1>
+    <P_14_1W>1.15</P_14_1W>
+    <P_15>12.30</P_15>
+    <KursWalutyZ>0.50000</KursWalutyZ>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>VAT</RodzajFaktury>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>product_a</P_7>
+      <P_8A>Units</P_8A>
+      <P_8B>1.0</P_8B>
+      <P_9A>10.00</P_9A>
+      <P_11>10.00</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+    <Platnosc>
+      <TerminPlatnosci>
+        <Termin>2026-01-23</Termin>
+      </TerminPlatnosci>
+    </Platnosc>
+  </Fa>
+</Faktura>

--- a/addons/l10n_pl_edi/tests/export_xmls/full_paid_invoice.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/full_paid_invoice.xml
@@ -35,7 +35,7 @@
     <P_13_1>100.00</P_13_1>
     <P_14_1>23.00</P_14_1>
     <P_15>123.00</P_15>
-      <KursWalutyZ>1.0</KursWalutyZ>
+      <KursWalutyZ>1.00000</KursWalutyZ>
     <Adnotacje>
             <P_16>2</P_16>
         <P_17>2</P_17>

--- a/addons/l10n_pl_edi/tests/export_xmls/partial_paid_invoice_bank_cash.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/partial_paid_invoice_bank_cash.xml
@@ -35,7 +35,7 @@
     <P_13_1>1000.00</P_13_1>
     <P_14_1>230.00</P_14_1>
     <P_15>1230.00</P_15>
-      <KursWalutyZ>1.0</KursWalutyZ>
+      <KursWalutyZ>1.00000</KursWalutyZ>
     <Adnotacje>
             <P_16>2</P_16>
         <P_17>2</P_17>

--- a/addons/l10n_pl_edi/tests/export_xmls/standerd_fa3_credit_note.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/standerd_fa3_credit_note.xml
@@ -35,7 +35,7 @@
     <P_13_1>-1000.00</P_13_1>
     <P_14_1>-230.00</P_14_1>
     <P_15>-1230.00</P_15>
-      <KursWalutyZ>1.0</KursWalutyZ>
+      <KursWalutyZ>1.00000</KursWalutyZ>
     <Adnotacje>
             <P_16>2</P_16>
         <P_17>2</P_17>

--- a/addons/l10n_pl_edi/tests/export_xmls/standert_fa3_format.xml
+++ b/addons/l10n_pl_edi/tests/export_xmls/standert_fa3_format.xml
@@ -35,7 +35,7 @@
     <P_13_1>1000.00</P_13_1>
     <P_14_1>230.00</P_14_1>
     <P_15>1230.00</P_15>
-      <KursWalutyZ>1.0</KursWalutyZ>
+      <KursWalutyZ>1.00000</KursWalutyZ>
     <Adnotacje>
             <P_16>2</P_16>
         <P_17>2</P_17>

--- a/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
+++ b/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
@@ -396,6 +396,25 @@ class TestL10nPlEdi(AccountTestInvoicingCommon, CronMixinCase):
         )
 
     @freeze_time('2026-01-23')
+    def test_invoice_in_foreign_currency(self):
+        self.env.ref('base.EUR').active = True
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_pl.id,
+            'invoice_date': fields.Date.today(),
+            'currency_id': self.env.ref('base.EUR').id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'quantity': 1,
+                'price_unit': 10.0,
+            })],
+            'invoice_currency_rate': '2',
+        })
+        invoice.action_post()
+        self._assert_export_invoice(invoice, 'fa3_invoice_foreign_currency.xml')
+
+    @freeze_time('2026-01-23')
     def test_scenario_correction_values_are_negative(self):
         """
         Verification of Negative Values for Corrections (Difference Method).


### PR DESCRIPTION
**PROBLEM**
1. 5% ta have the wrong code `zw` (tax exempted), it should be `5` (small typo in code).
2. P_15 should be stated in the invoice currency, and not always in PLN (company currency).
3. KursWalutyZ is not right, it's the PLN->XXX rate (meaning we need to do PLN amount * PLN->XXX rate to get XXX amount, where XXX is the invoice currency) but it should be the XXX->PLN rate.

**STEP TO REPRODUCE**
1. install l10n_pl_edi
2. Install the test certificate to send e-invoice (more info about how to do that in the chatter of the bug ticket).
3. Create an invoice with a line with a 5% tax, and in another currency than PLN with a custom currency rate.
4. Send the e-invoice using KSeF.
5. Open the xml attached in the chatter, and notice it has the problems listed above.

Ticket [link](https://www.odoo.com/odoo/project.task/6075221)
opw-6075221