### PR TITLE
[IMP] mail: show draft indicator in sidebar

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -28,7 +28,14 @@ class ChatBubblePreview extends Component {
         return this.props.chatWindow.channel;
     }
 
+    get draftLabel() {
+        return _t("[Draft]");
+    }
+
     get previewText() {
+        if (this.channel.hasDraft) {
+            return this.channel.draftPreview;
+        }
         const lastMessage = this.channel.newestPersistentOfAllMessage;
         return lastMessage?.previewText || _t("This is the start of your conversation");
     }

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -3,12 +3,13 @@ import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
 import { Component } from "@odoo/owl";
-
 import { useChildRef, useService } from "@web/core/utils/hooks";
 import { useHover } from "@mail/utils/common/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { isMobileOS } from "@web/core/browser/feature_detection";
+import { browser } from "@web/core/browser/browser";
+import { _t } from "@web/core/l10n/translation";
 
 class ChatBubblePreview extends Component {
     static components = { MessageSeenIndicator };
@@ -20,7 +21,38 @@ class ChatBubblePreview extends Component {
         return this.props.chatWindow.channel;
     }
 
+    get draftLabel() {
+        return _t("[Draft]");
+    }
+
+    get draftContent() {
+        if (!this.channel.hasDraft) {
+            return "";
+        }
+        const localId = this.channel.thread?.composer?.localId;
+        if (!localId) {
+            return "";
+        }
+        let config;
+        try {
+            config = JSON.parse(browser.localStorage.getItem(localId));
+        } catch {
+            return "";
+        }
+        let composerHtml = config?.composerHtml;
+        if (Array.isArray(composerHtml)) {
+            composerHtml = composerHtml[1];
+        }
+        if (!composerHtml) {
+            return "";
+        }
+        return new DOMParser().parseFromString(String(composerHtml), "text/html").body.textContent || "";
+    }
+
     get previewText() {
+        if (this.channel.hasDraft) {
+            return this.draftContent;
+        }
         const lastMessage = this.channel.newestPersistentOfAllMessage;
         if (!lastMessage) {
             return false;

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -17,8 +17,9 @@
             <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-out="this.props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="this.channel.newestPersistentOfAllMessage" />
             <div class="text-truncate small mx-2 px-1 text-muted">
+                <span t-if="this.channel.hasDraft" class="text-danger me-1" t-out="this.draftLabel"/>
                 <MessageSeenIndicator t-if="message?.showSeenIndicator(this.channel.thread)" message="message"/>
-                <t t-out="this.previewText" />
+                <span class="text-truncate" t-out="this.previewText" />
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -16,9 +16,10 @@
         <div t-if="this.props.chatWindow?.channel" class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
             <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-out="this.props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="this.channel.newestPersistentOfAllMessage" />
-            <div t-if="this.previewText" class="text-truncate small mx-2 px-1 text-muted">
-                <MessageSeenIndicator t-if="message.showSeenIndicator(this.channel.thread)" message="message"/>
-                <t t-out="message.previewText" />
+            <div t-if="this.channel.hasDraft or this.previewText" class="small mx-2 px-1 d-flex align-items-baseline gap-1 o-min-width-0 text-muted">
+                <span t-if="this.channel.hasDraft" class="text-danger" t-out="this.draftLabel"/>
+                <MessageSeenIndicator t-if="!this.channel.hasDraft and message and message.showSeenIndicator(this.channel.thread)" message="message"/>
+                <span class="text-truncate" t-out="this.previewText"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -7,7 +7,11 @@ import { NavigableList } from "@mail/core/common/navigable_list";
 import { MAIL_PLUGINS, MAIL_SMALL_UI_PLUGINS } from "@mail/core/common/plugin/plugin_sets";
 import { mapSuggestionsToOptions, useSuggestion } from "@mail/core/common/suggestion_hook";
 import { propComputed, useSelection, useVisible } from "@mail/utils/common/hooks";
-import { generatePartnerMentionElement, trimEmptyBlocksAround } from "@mail/utils/common/format";
+import {
+    generatePartnerMentionElement,
+    htmlToTextContentInline,
+    trimEmptyBlocksAround,
+} from "@mail/utils/common/format";
 import { getInnerHtml } from "@mail/utils/common/html";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { Wysiwyg } from "@html_editor/wysiwyg";
@@ -67,6 +71,8 @@ const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
     SAVE: "save",
 };
+/** Amount of characters of the draft kept to preview it in the sidebar and in the chat bubbles. */
+const DRAFT_PREVIEW_LENGTH = 200;
 export const MENTION_AMOUNT_WARNING = 50;
 export const COMPOSER_TYPES = {
     NOTE: "note",
@@ -859,6 +865,11 @@ export class Composer extends Component {
 
     async sendMessage() {
         this.composerActions.activeAction?.actionPanelClose?.();
+        const channel = this.composer().thread?.channel;
+        if (channel) {
+            channel.draftPreview = "";
+            channel.hasDraft = false;
+        }
         if (this.props.composer.message) {
             this.editMessage();
             return;
@@ -1065,8 +1076,13 @@ export class Composer extends Component {
             replyToMessageId,
             fromFullComposer = this.props.composer.restoredFromFullComposer,
         }) => {
+            const channel = this.composer().thread?.channel;
             if (isHtmlEmpty(composerHtml)) {
                 await this.deleteSavedContent();
+                if (channel) {
+                    channel.draftPreview = "";
+                    channel.hasDraft = false;
+                }
             } else {
                 const db = new IndexedDB("mail");
                 await db.write("composer", this.props.composer.localId, {
@@ -1075,6 +1091,13 @@ export class Composer extends Component {
                     composerHtml: isMarkup(composerHtml) ? ["markup", composerHtml] : composerHtml,
                     fromFullComposer,
                 });
+                if (channel) {
+                    channel.draftPreview = htmlToTextContentInline(composerHtml).slice(
+                        0,
+                        DRAFT_PREVIEW_LENGTH
+                    );
+                    channel.hasDraft = true;
+                }
             }
         };
         if (this.state.isFullComposerOpen) {

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -833,6 +833,9 @@ export class Composer extends Component {
     async sendMessage() {
         const composer = toRaw(this.props.composer);
         this.composerActions.activePicker?.close?.();
+        if (composer.thread?.channel) {
+            composer.thread.channel.hasDraft = false;
+        }
         if (composer.message) {
             this.editMessage();
             return;
@@ -1042,6 +1045,9 @@ export class Composer extends Component {
         }) => {
             if (isHtmlEmpty(composerHtml)) {
                 browser.localStorage.removeItem(composer.localId);
+                if (composer.thread?.channel) {
+                    composer.thread.channel.hasDraft = false;
+                }
             } else {
                 browser.localStorage.setItem(
                     composer.localId,
@@ -1054,6 +1060,9 @@ export class Composer extends Component {
                         fromFullComposer,
                     })
                 );
+                if (composer.thread?.channel) {
+                    composer.thread.channel.hasDraft = true;
+                }
             }
         };
         if (this.state.isFullComposerOpen) {

--- a/addons/mail/static/src/discuss/core/common/thread_compare_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_compare_patch.js
@@ -2,6 +2,21 @@ import { threadCompareRegistry } from "@mail/core/common/thread_compare";
 import { compareDatetime } from "@mail/utils/common/misc";
 
 threadCompareRegistry.add(
+    "mail.draft",
+    (t1, t2) => {
+        const c1Draft = Boolean(t1.channel?.hasDraft);
+        const c2Draft = Boolean(t2.channel?.hasDraft);
+        if (c2Draft && !c1Draft) {
+            return 1;
+        }
+        if (c1Draft && !c2Draft) {
+            return -1;
+        }
+    },
+    { sequence: 5 }
+);
+
+threadCompareRegistry.add(
     "mail.favorite",
     (t1, t2) => {
         const c1Fav = Boolean(t1.channel?.self_member_id?.is_favorite);

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
@@ -7,6 +7,9 @@ export class DiscussAppCategory extends Record {
      * @param {import("models").DiscussChannel} c2
      */
     sortChannels(c1, c2) {
+        if (Boolean(c1.hasDraft) !== Boolean(c2.hasDraft)) {
+            return c1.hasDraft ? -1 : 1;
+        }
         if (["channels", "favorites"].includes(this.id) || this.discussCategoryAsAppCategory) {
             return (
                 (c1.displayName &&

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -37,6 +37,7 @@
                 <div t-if="!this.store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName o-mail-DiscussSidebar-itemName overflow-hidden ms-2 text-start flex-grow-1 z-1" t-att-class="this.itemNameAttClass">
                     <div class="d-flex align-items-baseline o-min-width-0 gap-2">
                         <span class="text-truncate" t-out="this.channel.displayName" t-custom-ref="displayName"/>
+                        <div t-if="this.channel.hasDraft" class="small text-danger" t-out="this.channel.draftLabel"/>
                         <div class="d-flex gap-2 ms-auto" t-custom-ref="displayNameAdditionalContent"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -3,6 +3,7 @@ import { fields } from "@mail/model/misc";
 
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
 
 /** @type {import("models").DiscussChannel} */
 const discussChannelPatch = {
@@ -45,6 +46,7 @@ const discussChannelPatch = {
                 this.onPinStateUpdated();
             },
         });
+        this.hasDraft = fields.Attr(false, { localStorage: true });
         this.lastSubChannelLoaded = fields.One("discuss.channel");
         this.loadSubChannelsDone = false;
         this.subChannelsInSidebar = fields.Many("discuss.channel", {
@@ -81,6 +83,9 @@ const discussChannelPatch = {
     },
     get autoOpenChatWindowOnNewMessage() {
         return false;
+    },
+    get draftLabel() {
+        return _t("[Draft]");
     },
     /** @param {string} description */
     async notifyDescriptionToServer(description) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -3,6 +3,7 @@ import { fields } from "@mail/model/misc";
 
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
 
 /** @type {import("models").DiscussChannel} */
 const discussChannelPatch = {
@@ -13,6 +14,8 @@ const discussChannelPatch = {
                 this.onPinStateUpdated();
             },
         });
+        this.draftPreview = fields.Attr("", { localStorage: true });
+        this.hasDraft = fields.Attr(false, { localStorage: true });
         this.lastSubChannelLoaded = fields.One("discuss.channel");
         this.loadSubChannelsDone = false;
         this.messagingMenuTabs = fields.Many("MessagingMenuTab", {
@@ -66,6 +69,9 @@ const discussChannelPatch = {
     },
     get autoOpenChatWindowOnNewMessage() {
         return false;
+    },
+    get draftLabel() {
+        return _t("[Draft]");
     },
     /** @param {string} description */
     async notifyDescriptionToServer(description) {

--- a/addons/mail/static/src/discuss/core/public_web/messaging_menu_item_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/messaging_menu_item_patch.js
@@ -63,6 +63,9 @@ const messagingMenuItemPatch = {
     get itemName() {
         return this.channel?.thread?.displayName ?? super.itemName;
     },
+    get itemPreviewText() {
+        return this.channel?.hasDraft ? this.channel.draftPreview : super.itemPreviewText;
+    },
     get itemPreviewThread() {
         return super.itemPreviewThread || this.channel?.thread;
     },

--- a/addons/mail/static/src/discuss/core/public_web/messaging_menu_item_patch.xml
+++ b/addons/mail/static/src/discuss/core/public_web/messaging_menu_item_patch.xml
@@ -13,6 +13,9 @@
         </div>
         <t t-else="">$0</t>
     </xpath>
+    <xpath expr="//t[@t-set-slot='body']/span" position="before">
+        <span t-if="this.channel?.hasDraft" class="text-danger me-1" t-out="this.channel.draftLabel"/>
+    </xpath>
     <xpath expr="//t[@t-set-slot='icon']" position="inside">
         <CountryFlag t-if="this.channel?.showCorrespondentCountry" country="this.channel.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border shadow-sm'"/>
     </xpath>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -201,6 +201,25 @@ test("Hover on chat bubble shows chat name + last message preview", async () => 
     await contains(".o-mail-ChatBubble-preview:text('Demo You: Hi')");
 });
 
+test("Hover on chat bubble shows draft indicator along with draft content", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Marc" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "chat",
+    });
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await insertText(".o-mail-Composer-input", "Not sent yet");
+    await click(".o-mail-ChatWindow-header [title='Fold']");
+    await hover(".o-mail-ChatBubble[name='Marc']");
+    await contains(".o-mail-ChatBubble-preview .text-danger:text('[Draft]')");
+    await contains(".o-mail-ChatBubble-preview:text('Marc [Draft]Not sent yet')");
+});
+
 test("Hover on chat bubble shows message preview along with message seen indicator", async () => {
     const pyEnv = await startServer();
     const partnerId_1 = pyEnv["res.partner"].create({ name: "Marc" });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1,7 +1,9 @@
+import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
 import {
     click,
     contains,
     defineMailModels,
+    focus,
     insertText,
     isDiscussSidebarCategoryFolded,
     listenStoreFetch,
@@ -150,6 +152,47 @@ test("sub threads are sorted with last_interest_dt", async () => {
     await contains(".o-mail-DiscussSidebarChannel-subChannel:text('Sub Channel_1')", {
         before: [".o-mail-DiscussSidebarChannel-subChannel:text('Sub Channel_2')"],
     });
+});
+
+test.tags("html composer");
+test("sidebar shows draft indicator and drafts are sorted first", async () => {
+    const pyEnv = await startServer();
+    const [zuluId] = pyEnv["discuss.channel"].create([
+        { name: "Zulu", channel_type: "channel" },
+        { name: "Alpha", channel_type: "channel" },
+    ]);
+    await start();
+    await openDiscuss(zuluId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello");
+    await contains(
+        ".o-mail-DiscussSidebarChannel-itemName:has(:text('Zulu')) .text-danger:text('[Draft]')",
+        {
+            count: 0,
+        }
+    );
+    await click(".o-mail-DiscussSidebarChannel-itemName:has(:text('Alpha'))");
+    await contains(
+        ".o-mail-DiscussSidebarChannel-itemName:has(:text('Zulu')) .text-danger:text('[Draft]')"
+    );
+    await contains(".o-mail-DiscussSidebarChannel-itemName:has(:text('Zulu'))", {
+        before: [".o-mail-DiscussSidebarChannel-itemName:has(:text('Alpha'))"],
+    });
+    await click(".o-mail-DiscussSidebarChannel-itemName:has(:text('Zulu'))");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello')");
+    await press("Enter");
+    await contains(
+        ".o-mail-DiscussSidebarChannel-itemName:has(:text('Zulu')) .text-danger:text('[Draft]')",
+        {
+            count: 0,
+        }
+    );
 });
 
 test("channel - command: should have view command when category is unfolded", async () => {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1,7 +1,9 @@
+import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
 import {
     click,
     contains,
     defineMailModels,
+    focus,
     insertText,
     listenStoreFetch,
     openDiscuss,
@@ -26,6 +28,37 @@ import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
+
+test.tags("html composer");
+test("sidebar shows draft indicator and drafts are sorted first", async () => {
+    const pyEnv = await startServer();
+    const [zuluId] = pyEnv["discuss.channel"].create([
+        { name: "Zulu", channel_type: "channel" },
+        { name: "Alpha", channel_type: "channel" },
+    ]);
+    await start();
+    await openDiscuss(zuluId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello");
+    await contains(".o-mail-MessagingMenuItem-name", { textContent: "Zulu" });
+    await click(".o-mail-NotificationItem:has(:text('Alpha'))");
+    await contains(".o-mail-MessagingMenuItem-name", { textContent: "Zulu" });
+    await contains(".o-mail-NotificationItem:has(:text('Zulu')) .text-danger:text('[Draft]')");
+    await contains(".o-mail-MessagingMenuItem-body", { textContent: "Hello" });
+    await contains(".o-mail-NotificationItem:has(:text('Zulu'))", {
+        before: [".o-mail-NotificationItem:has(:text('Alpha'))"],
+    });
+    await click(".o-mail-NotificationItem:has(:text('Zulu'))");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello')");
+    await press("Enter");
+    await contains(".o-mail-MessagingMenuItem-name", { textContent: "Zulu" });
+});
 
 test("default thread rendering", async () => {
     const pyEnv = await startServer();


### PR DESCRIPTION
Navigating through multiple channels can cause users to lose track of unsent messages. This commit introduces an indicator for channels containing a draft in the composer, allowing users to easily identify and return to pending conversations. Those channels are also sorted at the top of the list for better visibility.

task-6085836

<img width="298" height="490" alt="70d03e9605f00081d8e5eec8323fd65e" src="https://github.com/user-attachments/assets/23506e09-7f49-45d4-ac32-f7fff44d44cb" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
