### PR TITLE
[BUG] core: keep empty --addons-paths, for AI

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -607,8 +607,6 @@ class configmanager(object):
             res = os.path.abspath(os.path.expanduser(path))
             if not os.path.isdir(res):
                 raise optparse.OptionValueError("option %s: no such directory: %r" % (opt, res))
-            if not self._is_addons_path(res):
-                raise optparse.OptionValueError("option %s: the path %r is not a valid addons directory" % (opt, path))
             ad_paths.append(res)
 
         setattr(parser.values, option.dest, ",".join(ad_paths))


### PR DESCRIPTION
Initialize a new empty git repository where you are going to vide-code some new Odoo modules. Because the repository is empty (no addon yet) the CLI fails with an "option --addons-path: the path <path> is not a valid addons directory".

This makes vide-coder sad, and bigrams want vide-coders to be happy, so drop the sanity-check and also accept empty addons.