### PR TITLE
[IMP] orm: initialize a field using a custom function

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -17,7 +17,6 @@ from lxml import etree, html
 from textwrap import shorten
 
 from odoo import api, fields, models, _, SUPERUSER_ID, modules
-from odoo.tools.sql import column_exists, create_column
 from odoo.addons.account.tools import format_structured_reference_iso
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
 from odoo.fields import Command, Domain
@@ -818,11 +817,6 @@ class AccountMove(models.Model):
     # used in <account.journal>._query_has_sequence_holes
     _made_gaps = models.Index('(journal_id, state, payment_state, move_type, date) WHERE (made_sequence_gap IS TRUE)')
     _duplicate_bills_idx = models.Index("(ref) WHERE (move_type IN ('in_invoice', 'in_refund'))")
-
-    def _auto_init(self):
-        super()._auto_init()
-        if not column_exists(self.env.cr, "account_move", "preferred_payment_method_line_id"):
-            create_column(self.env.cr, "account_move", "preferred_payment_method_line_id", "int4")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -513,6 +513,7 @@ class AccountMove(models.Model):
         compute='_compute_preferred_payment_method_line_id',
         store=True,
         readonly=False,
+        default_init=lambda model: None,  # skip initialization
     )
 
     # === Currency fields === #
@@ -789,11 +790,6 @@ class AccountMove(models.Model):
     # used in <account.journal>._query_has_sequence_holes
     _made_gaps = models.Index('(journal_id, state, payment_state, move_type, date) WHERE (made_sequence_gap IS TRUE)')
     _duplicate_bills_idx = models.Index("(ref) WHERE (move_type IN ('in_invoice', 'in_refund'))")
-
-    def _auto_init(self):
-        super()._auto_init()
-        if not column_exists(self.env.cr, "account_move", "preferred_payment_method_line_id"):
-            create_column(self.env.cr, "account_move", "preferred_payment_method_line_id", "int4")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 from odoo.tools.misc import formatLang, format_date
-from odoo.tools.sql import column_exists, create_column
 
 INV_LINES_PER_STUB = 9
 
@@ -24,6 +22,7 @@ class AccountPayment(models.Model):
         copy=False,
         compute='_compute_check_number',
         inverse='_inverse_check_number',
+        init_storage=lambda model: None,  # skip initialization OOM on large databases
         help="The selected journal is configured to print check numbers. If your pre-printed check paper already has numbers "
              "or if the current numbering is wrong, you can change it in the journal configuration page.",
     )
@@ -49,16 +48,6 @@ class AccountPayment(models.Model):
         for payment_check in self.filtered('check_number'):
             if not payment_check.check_number.isdecimal():
                 raise ValidationError(_('Check numbers can only consist of digits'))
-
-    def _auto_init(self):
-        """
-        Create compute stored field check_number
-        here to avoid MemoryError on large databases.
-        """
-        if not column_exists(self.env.cr, 'account_payment', 'check_number'):
-            create_column(self.env.cr, 'account_payment', 'check_number', 'varchar')
-
-        return super()._auto_init()
 
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number_unique(self):

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 from odoo.tools.misc import formatLang, format_date
-from odoo.tools.sql import column_exists, create_column
 
 INV_LINES_PER_STUB = 9
 
@@ -24,6 +22,7 @@ class AccountPayment(models.Model):
         copy=False,
         compute='_compute_check_number',
         inverse='_inverse_check_number',
+        default_init=lambda model: None,  # skip initialization OOM on large databases
         help="The selected journal is configured to print check numbers. If your pre-printed check paper already has numbers "
              "or if the current numbering is wrong, you can change it in the journal configuration page.",
     )
@@ -49,16 +48,6 @@ class AccountPayment(models.Model):
         for payment_check in self.filtered('check_number'):
             if not payment_check.check_number.isdecimal():
                 raise ValidationError(_('Check numbers can only consist of digits'))
-
-    def _auto_init(self):
-        """
-        Create compute stored field check_number
-        here to avoid MemoryError on large databases.
-        """
-        if not column_exists(self.env.cr, 'account_payment', 'check_number'):
-            create_column(self.env.cr, 'account_payment', 'check_number', 'varchar')
-
-        return super()._auto_init()
 
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number_unique(self):

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -11,9 +11,6 @@ from odoo.tools.urls import urljoin as url_join
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    def _default_company_token(self):
-        return str(uuid.uuid4())
-
     # TODO: Remove in master
     overtime_company_threshold = fields.Integer(string="Tolerance Time In Favor Of Company", default=0)
     # TODO: Remove in master

--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.tools.sql import column_exists, create_column
 
 
 class ProductTemplate(models.Model):
@@ -10,25 +8,14 @@ class ProductTemplate(models.Model):
 
     @api.model
     def default_get(self, fields):
-        result = super(ProductTemplate, self).default_get(fields)
+        result = super().default_get(fields)
         if self.env.context.get('default_can_be_expensed'):
             result['supplier_taxes_id'] = False
         return result
 
     can_be_expensed = fields.Boolean(string="Expenses", compute='_compute_can_be_expensed',
+        init_storage=lambda model: None,  # skip initialization (False)
         store=True, readonly=False, help="Specify whether the product can be selected in an expense.")
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "product_template", "can_be_expensed"):
-            create_column(self.env.cr, "product_template", "can_be_expensed", "boolean")
-            self.env.cr.execute(
-                """
-                UPDATE product_template
-                SET can_be_expensed = false
-                WHERE type NOT IN ('consu', 'service')
-                """
-            )
-        return super()._auto_init()
 
     @api.depends('type', 'purchase_ok')
     def _compute_can_be_expensed(self):

--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -7,7 +7,6 @@ from . import report
 from odoo import fields
 
 from odoo.addons.project import _check_exists_collaborators_for_project_sharing
-from odoo.tools.sql import SQL
 
 
 def create_internal_project(env):
@@ -50,23 +49,3 @@ def _uninstall_hook(env):
 
     if rule := env.ref('project.account_analytic_line_rule_manager', raise_if_not_found=False):
         rule.active = True
-
-
-def _pre_init_hook(env):
-    """
-    Create manually new compute+stored columns to allow installing the module on large databases without trigger an Out-of-memory error.
-    """
-    env.cr.execute(SQL("""
-       ALTER TABLE account_analytic_line
-       -- The task_id is set to False when there is no project_id on the line, but at installation,
-       -- no line is associated with a project -> task_id = False
-       ADD COLUMN IF NOT EXISTS task_id        INT4,
-       -- At fresh installation, `task_id` is False -> parent_task_id, which is related to it, will also be False
-       ADD COLUMN IF NOT EXISTS parent_task_id INT4,
-       -- The project_id is defined as being the same as the one from the task, but task_id = False -> project_id = False
-       ADD COLUMN IF NOT EXISTS project_id     INT4,
-       -- The department_id is the one from the `employee_id`, but `employee_id` by default is False -> department_id = False
-       ADD COLUMN IF NOT EXISTS department_id  INT4,
-       -- The manager_id is the manager of the employee_id, but there is no `employee_id` by default -> manager_id = False
-       ADD COLUMN IF NOT EXISTS manager_id     INT4
-    """))

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -43,7 +43,6 @@ up a management by affair.
     'demo': [
         'data/hr_timesheet_demo.xml',
     ],
-    'pre_init_hook': '_pre_init_hook',
     'post_init_hook': 'create_internal_project',
     'uninstall_hook': '_uninstall_hook',
     'assets': {

--- a/addons/hr_timesheet/models/account_analytic_line.py
+++ b/addons/hr_timesheet/models/account_analytic_line.py
@@ -59,17 +59,20 @@ class AccountAnalyticLine(models.Model):
     task_id = fields.Many2one(
         'project.task', 'Task', index='btree_not_null',
         compute='_compute_task_id', store=True, readonly=False,
+        # The task_id is set to False when there is no project_id on the line,
+        # but at installation, no line is associated with a project
+        init_storage=lambda model: None,
         domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False)]")
-    parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True, index='btree_not_null')
+    parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True, index='btree_not_null', init_storage=lambda model: None)
     project_id = fields.Many2one(
         'project.project', 'Project', domain=_domain_project_id, index=True,
-        compute='_compute_project_id', store=True, readonly=False)
+        compute='_compute_project_id', store=True, readonly=False, init_storage=lambda model: None)
     user_id = fields.Many2one(compute='_compute_user_id', store=True, readonly=False)
     employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id, context={'active_test': False},
         index=True, help="Define an 'hourly cost' on the employee to track the cost of their time.")
     job_title = fields.Char(related='employee_id.job_title', export_string_translation=False)
-    department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True)
-    manager_id = fields.Many2one('hr.employee', "Manager", related='employee_id.parent_id', store=True)
+    department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True, init_storage=lambda model: None)
+    manager_id = fields.Many2one('hr.employee', "Manager", related='employee_id.parent_id', store=True, init_storage=lambda model: None)
     encoding_uom_id = fields.Many2one('uom.uom', compute='_compute_encoding_uom_id', export_string_translation=False)
     partner_id = fields.Many2one(compute='_compute_partner_id', store=True, readonly=False)
     readonly_timesheet = fields.Boolean(compute="_compute_readonly_timesheet", compute_sudo=True, export_string_translation=False)

--- a/addons/l10n_dk/__init__.py
+++ b/addons/l10n_dk/__init__.py
@@ -1,36 +1,6 @@
-from odoo.tools.sql import column_exists, create_column
-
 from . import models
 from . import tools
 from . import wizard
-
-
-def _pre_init_nemhandel(env):
-    """
-        Force the creation of the columns to avoid having the ORM compute on potentially millions of records.
-        Mimic the compute method of nemhandel_identifier_type and nemhandel_identifier_value to fill these columns.
-    """
-    if not column_exists(env.cr, "account_move", "nemhandel_move_state"):
-        create_column(env.cr, "account_move", "nemhandel_move_state", "varchar")
-        create_column(env.cr, "res_partner", "nemhandel_identifier_type", "varchar")
-        create_column(env.cr, "res_partner", "nemhandel_identifier_value", "varchar")
-
-    query = """
-        WITH _dk AS (
-            SELECT p.id
-              FROM res_partner p
-         LEFT JOIN res_country c
-                ON c.id = p.country_id
-             WHERE p.vat ILIKE 'DK%'
-                OR c.code = 'DK'
-        )
-        UPDATE res_partner p
-           SET nemhandel_identifier_type = '0184',
-               nemhandel_identifier_value = (p.additional_identifiers->>'DK_CVR')::text
-          FROM _dk
-         WHERE _dk.id = p.id
-    """
-    env.cr.execute(query)
 
 
 def uninstall_hook(env):

--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -48,6 +48,5 @@ Also provides Nemhandel registration and invoice sending throught the Odoo Acces
         ],
     },
     'license': 'LGPL-3',
-    'pre_init_hook': '_pre_init_nemhandel',
     'uninstall_hook': 'uninstall_hook',
 }

--- a/addons/l10n_dk/models/account_move.py
+++ b/addons/l10n_dk/models/account_move.py
@@ -17,6 +17,7 @@ class AccountMove(models.Model):
             ('error', 'Error'),
         ],
         compute='_compute_nemhandel_move_state',
+        init_storage=lambda model: None,
         store=True,
         string='Nemhandel status',
         copy=False,

--- a/addons/l10n_dk/models/res_partner.py
+++ b/addons/l10n_dk/models/res_partner.py
@@ -6,6 +6,7 @@ from urllib import parse
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools.business_data import split_vat
+from odoo.tools.sql import SQL, table_columns
 
 from odoo.addons.l10n_dk.tools.demo_utils import handle_demo
 
@@ -35,6 +36,7 @@ class ResPartner(models.Model):
         string='Nemhandel Endpoint Type',
         help='Unique identifier used by OIOUBL and Nemhandel',
         compute="_compute_nemhandel_identifier_type", store=True, readonly=False,
+        init_storage='_init_column_nemhandel_identifier',
         tracking=True,
         selection=[
             ('0088', "EAN/GLN"),
@@ -47,12 +49,26 @@ class ResPartner(models.Model):
         string='Nemhandel Endpoint',
         help='Code used to identify the Endpoint on Nemhandel',
         compute="_compute_nemhandel_identifier_value", store=True, readonly=False,
+        init_storage='_init_column_nemhandel_identifier',
         tracking=True,
     )
     nemhandel_supported_documents = fields.Json('Supported Nemhandel Documents')
     nemhandel_response_support = fields.Boolean('Nemhandel Response Service', compute='_compute_nemhandel_response_support')
 
     is_using_nemhandel = fields.Boolean(compute='_compute_is_using_nemhandel')
+
+    def _init_column_nemhandel_identifier(self):
+        columns = table_columns(self.env.cr, 'res_partner')
+        if 'nemhandel_identifier_type' not in columns or 'nemhandel_identifier_value' not in columns:
+            return
+        country_dk = self.env.ref('base.dk').id
+        self.env.execute_query(SQL("""
+            UPDATE res_partner p
+            SET nemhandel_identifier_type = '0184',
+                nemhandel_identifier_value = (p.additional_identifiers->>'DK_CVR')::text
+            WHERE (p.vat ILIKE 'DK%%' OR p.country_id = %s)
+                AND p.nemhandel_identifier_value IS NULL
+        """, country_dk))
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -5,7 +5,6 @@ import json
 from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import float_is_zero
-from odoo.tools.sql import column_exists, create_column
 from datetime import datetime
 
 _logger = logging.getLogger(__name__)
@@ -16,8 +15,8 @@ class AccountMove(models.Model):
 
     l10n_eg_long_id = fields.Char(string='ETA Long ID', compute='_compute_eta_long_id')
     l10n_eg_qr_code = fields.Char(string='ETA QR Code', compute='_compute_eta_qr_code_str')
-    l10n_eg_submission_number = fields.Char(string='Submission ID', compute='_compute_eta_response_data', store=True, copy=False)
-    l10n_eg_uuid = fields.Char(string='Document UUID', compute='_compute_eta_response_data', store=True, copy=False)
+    l10n_eg_submission_number = fields.Char(string='Submission ID', compute='_compute_eta_response_data', store=True, copy=False, init_storage=lambda model: None)
+    l10n_eg_uuid = fields.Char(string='Document UUID', compute='_compute_eta_response_data', store=True, copy=False, init_storage=lambda model: None)
     l10n_eg_eta_json_doc_file = fields.Binary(
         string='ETA JSON Document',
         attachment=True,
@@ -25,13 +24,6 @@ class AccountMove(models.Model):
     )
     l10n_eg_signing_time = fields.Datetime('Signing Time', copy=False)
     l10n_eg_is_signed = fields.Boolean(copy=False)
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "account_move", "l10n_eg_uuid"):
-            create_column(self.env.cr, "account_move", "l10n_eg_uuid", "VARCHAR")
-            # Since l10n_eg_uuid columns does not exist we can assume l10n_eg_submission_number doesn't exist either
-            create_column(self.env.cr, "account_move", "l10n_eg_submission_number", "VARCHAR")
-        return super()._auto_init()
 
     @api.depends('l10n_eg_eta_json_doc_file')
     def _compute_eta_long_id(self):

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -10,7 +10,6 @@ from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_round, float_repr, float_compare, date_utils, SQL
 from odoo.tools.xml_utils import cleanup_xml_node, find_xml_value
-from odoo.tools.sql import column_exists, create_column
 from odoo.addons.l10n_es_edi_facturae.xml_utils import (
     NS_MAP,
     _canonicalize_node,
@@ -120,6 +119,7 @@ class AccountMove(models.Model):
         compute='_compute_l10n_es_edi_facturae_reason_code',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_es_invoicing_period_start_date = fields.Date(string="Invoice Period Start Date")
     l10n_es_invoicing_period_end_date = fields.Date(string="Invoice Period End Date")
@@ -149,18 +149,10 @@ class AccountMove(models.Model):
         compute='_compute_l10n_es_payment_means',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
 
     l10n_es_original_invoice_credited = fields.Char(string='Original Invoice Credited', store=True)
-
-    def _auto_init(self):
-        # Create compute stored field l10n_es_edi_facturae_reason_code and
-        # l10n_es_payment_means here to avoid timeout error on large databases.
-        if not column_exists(self.env.cr, 'account_move', 'l10n_es_edi_facturae_reason_code'):
-            create_column(self.env.cr, 'account_move', 'l10n_es_edi_facturae_reason_code', 'varchar')
-        if not column_exists(self.env.cr, 'account_move', 'l10n_es_payment_means'):
-            create_column(self.env.cr, 'account_move', 'l10n_es_payment_means', 'varchar')
-        return super()._auto_init()
 
     @api.depends('country_code')
     def _compute_l10n_es_edi_facturae_reason_code(self):

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import cleanup_xml_node
-from odoo.tools.sql import column_exists, create_column
 
 from odoo.addons.l10n_gr_edi.models.l10n_gr_edi_document import _make_mydata_request
 from odoo.addons.l10n_gr_edi.models.preferred_classification import (
@@ -34,11 +33,13 @@ class AccountMove(models.Model):
         string='Mark',
         compute='_compute_from_l10n_gr_edi_document_ids',
         store=True,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_cls_mark = fields.Char(
         string='Classification Mark',
         compute='_compute_from_l10n_gr_edi_document_ids',
         store=True,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_document_ids = fields.One2many(
         comodel_name='l10n_gr_edi.document',
@@ -56,6 +57,7 @@ class AccountMove(models.Model):
         compute='_compute_from_l10n_gr_edi_document_ids',
         store=True,
         tracking=True,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_available_inv_type = fields.Char(compute='_compute_l10n_gr_edi_available_inv_type')
     l10n_gr_edi_correlation_id = fields.Many2one(
@@ -68,12 +70,14 @@ class AccountMove(models.Model):
         compute='_compute_l10n_gr_edi_inv_type',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_payment_method = fields.Selection(
         selection=PAYMENT_METHOD_SELECTION,
         string='Payment Method',
         compute='_compute_l10n_gr_edi_payment_method',
         store=True,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_alerts = fields.Json(compute='_compute_l10n_gr_edi_alerts')
     l10n_gr_edi_need_correlated = fields.Boolean(compute='_compute_l10n_gr_edi_need_fields')
@@ -85,6 +89,7 @@ class AccountMove(models.Model):
         comodel_name='ir.attachment',
         compute='_compute_from_l10n_gr_edi_document_ids',
         store=True,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_budget_type = fields.Selection([
         ('1', '1 - Ordinary Budget'),
@@ -100,28 +105,9 @@ class AccountMove(models.Model):
         string='Contract ADAM',
         help='Internet contract posting number(ADAM) of the Central Electronic Register of Public Procurement (KIMDIS)',
         default='0',
+        init_storage=lambda model: None,
         required=True,
     )
-
-    def _auto_init(self):
-        """
-        Create all compute-stored fields here to avoid MemoryError when initializing on large databases.
-        """
-        for column_name, column_type in (
-            ('l10n_gr_edi_mark', 'varchar'),
-            ('l10n_gr_edi_cls_mark', 'varchar'),
-            ('l10n_gr_edi_state', 'varchar'),
-            ('l10n_gr_edi_inv_type', 'varchar'),
-            ('l10n_gr_edi_payment_method', 'varchar'),
-            ('l10n_gr_edi_attachment_id', 'int4'),
-            ('l10n_gr_edi_budget_type', 'varchar'),
-            ('l10n_gr_edi_project_reference', 'varchar'),
-            ('l10n_gr_edi_contract_reference', 'varchar'),
-        ):
-            if not column_exists(self.env.cr, 'account_move', column_name):
-                create_column(self.env.cr, 'account_move', column_name, column_type)
-
-        return super()._auto_init()
 
     ################################################################################
     # Standard Field Computes

--- a/addons/l10n_gr_edi/models/account_move_line.py
+++ b/addons/l10n_gr_edi/models/account_move_line.py
@@ -8,7 +8,6 @@ from odoo.addons.l10n_gr_edi.models.preferred_classification import (
     TAX_EXEMPTION_CATEGORY_SELECTION,
     TYPES_WITH_SEND_EXPENSE,
 )
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
@@ -25,6 +24,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_gr_edi_detail_type',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_cls_category = fields.Selection(
         selection=CLASSIFICATION_CATEGORY_SELECTION,
@@ -32,6 +32,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_gr_edi_cls_category',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_cls_type = fields.Selection(
         selection=CLASSIFICATION_TYPE_SELECTION,
@@ -39,6 +40,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_gr_edi_cls_type',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_cls_vat = fields.Selection(
         selection=CLASSIFICATION_VAT_SELECTION,
@@ -46,6 +48,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_gr_edi_cls_vat',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_tax_exemption_category = fields.Selection(
         selection=TAX_EXEMPTION_CATEGORY_SELECTION,
@@ -53,6 +56,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_gr_edi_tax_exemption_category',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_cpv_code = fields.Char(
         string='Item CPV Code',
@@ -60,24 +64,8 @@ class AccountMoveLine(models.Model):
         store=True,
         compute='_compute_l10n_gr_edi_cpv_code',
         readonly=False,
+        init_storage=lambda model: None,
     )
-
-    def _auto_init(self):
-        """
-        Create all compute-stored fields here to avoid MemoryError when initializing on large databases.
-        """
-        for column_name, column_type in (
-            ('l10n_gr_edi_detail_type', 'varchar'),
-            ('l10n_gr_edi_cls_category', 'varchar'),
-            ('l10n_gr_edi_cls_type', 'varchar'),
-            ('l10n_gr_edi_cls_vat', 'varchar'),
-            ('l10n_gr_edi_tax_exemption_category', 'varchar'),
-            ('l10n_gr_edi_cpv_code', 'varchar'),
-        ):
-            if not column_exists(self.env.cr, 'account_move_line', column_name):
-                create_column(self.env.cr, 'account_move_line', column_name, column_type)
-
-        return super()._auto_init()
 
     @api.depends('product_id.l10n_gr_edi_cpv_code')
     def _compute_l10n_gr_edi_cpv_code(self):

--- a/addons/l10n_gr_edi/models/res_partner.py
+++ b/addons/l10n_gr_edi/models/res_partner.py
@@ -2,7 +2,6 @@ import re
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools.sql import column_exists, create_column
 
 _CONTRACTING_AUTHORITY_REGEX = re.compile(r'^\d+\.\d+\.\d+$')
 
@@ -16,6 +15,7 @@ class ResPartner(models.Model):
         compute='_compute_l10n_gr_edi_branch_number',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
     l10n_gr_edi_contracting_authority_name = fields.Char(
         string="Contracting authority",
@@ -26,16 +26,6 @@ class ResPartner(models.Model):
         help="Code of the contracting authority (e.g. 2048.8010430600.00061)"
     )
     invoice_edi_format = fields.Selection(selection_add=[('ubl_gr', "Greece (Greek CIUS BIS 3.0)")])
-
-    def _auto_init(self):
-        for column_name, column_type in (
-            ('l10n_gr_edi_branch_number', 'int4'),
-            ('l10n_gr_edi_contracting_authority_name', 'varchar'),
-            ('l10n_gr_edi_contracting_authority_code', 'varchar'),
-        ):
-            if not column_exists(self.env.cr, 'res_partner', column_name):
-                create_column(self.env.cr, 'res_partner', column_name, column_type)
-        return super()._auto_init()
 
     @api.depends('country_code')
     def _compute_l10n_gr_edi_branch_number(self):

--- a/addons/l10n_hr_edi/models/account_move.py
+++ b/addons/l10n_hr_edi/models/account_move.py
@@ -5,7 +5,6 @@ import re
 from odoo import api, models, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import SQL
-from odoo.tools.sql import column_exists, create_column
 
 from odoo.addons.l10n_hr_edi.tools.api import (
     _mer_api_mark_paid,
@@ -45,6 +44,7 @@ class AccountMove(models.Model):
         store=True,
         readonly=False,
         copy=False,
+        init_storage=lambda model: None,
     )
     l10n_hr_customer_defined_process_name = fields.Char(
         string="Custom Process Name",
@@ -79,11 +79,6 @@ class AccountMove(models.Model):
     # MojEracun integration fields
     l10n_hr_mer_document_eid = fields.Char(related='l10n_hr_edi_addendum_id.mer_document_eid')
     l10n_hr_mer_document_status = fields.Selection(related='l10n_hr_edi_addendum_id.mer_document_status')
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, 'account_move', 'l10n_hr_process_type'):
-            create_column(self.env.cr, 'account_move', 'l10n_hr_process_type', 'varchar')
-        return super()._auto_init()
 
     @api.depends('l10n_hr_edi_addendum_id.payment_reported_amount', 'amount_residual', 'amount_total')
     def _compute_l10n_hr_payment_unreported(self):

--- a/addons/l10n_hr_edi/models/account_move_line.py
+++ b/addons/l10n_hr_edi/models/account_move_line.py
@@ -1,5 +1,4 @@
 from odoo import api, models, fields
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
@@ -11,6 +10,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_l10n_hr_product_id_kpd',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
     )
 
     @api.depends('product_id')
@@ -19,8 +19,3 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.product_id:
                 line.l10n_hr_kpd_category_id = line.product_id.l10n_hr_kpd_category_id
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, 'account_move_line', 'l10n_hr_kpd_category_id'):
-            create_column(self.env.cr, 'account_move_line', 'l10n_hr_kpd_category_id', 'integer')
-        return super()._auto_init()

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -10,7 +10,6 @@ from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
 from odoo.exceptions import LockError, UserError
 from odoo.fields import Domain
 from odoo.tools import BinaryBytes, cleanup_xml_node, float_compare, float_is_zero, float_repr, float_round, html2plaintext
-from odoo.tools.sql import column_exists, create_column
 
 from stdnum.it import codicefiscale, iva
 
@@ -115,6 +114,7 @@ class AccountMove(models.Model):
         compute='_compute_l10n_it_payment_method',
         store=True,
         readonly=False,
+        init_storage=lambda model: None,  # avoid timeout on large databases
     )
 
     l10n_it_document_type = fields.Many2one(
@@ -123,6 +123,7 @@ class AccountMove(models.Model):
         store=True,
         readonly=False,
         copy=False,
+        init_storage=lambda model: None,  # avoid timeout on large databases
     )
 
     l10n_it_convention_code = fields.Char(
@@ -130,16 +131,6 @@ class AccountMove(models.Model):
         size=100,
         help=" Used to connect an individual invoice to a broader framework agreement, a specific project, or a long-term convention."
     )
-
-    def _auto_init(self):
-        # Create compute stored field l10n_it_document_type and l10n_it_payment_method
-        # here to avoid timeout error on large databases.
-        if not column_exists(self.env.cr, 'account_move', 'l10n_it_payment_method'):
-            create_column(self.env.cr, 'account_move', 'l10n_it_payment_method', 'varchar')
-        if not column_exists(self.env.cr, 'account_move', 'l10n_it_document_type'):
-            create_column(self.env.cr, 'account_move', 'l10n_it_document_type', 'integer')
-        return super()._auto_init()
-
 
     # -------------------------------------------------------------------------
     # Computes

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -5,13 +5,12 @@ from werkzeug.urls import url_encode
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools import BinaryBytes
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_jo_edi_uuid = fields.Char(string="Invoice UUID", copy=False, compute="_compute_l10n_jo_edi_uuid", store=True)
+    l10n_jo_edi_uuid = fields.Char(string="Invoice UUID", copy=False, compute="_compute_l10n_jo_edi_uuid", store=True, init_storage=lambda model: None)
     l10n_jo_edi_qr = fields.Char(string="QR", copy=False)
 
     l10n_jo_edi_is_needed = fields.Boolean(
@@ -66,11 +65,6 @@ class AccountMove(models.Model):
         tracking=True,
         help="Invoice Types as per the Income and Sales Tax Department for JoFotara",
     )
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, 'account_move', 'l10n_jo_edi_uuid'):
-            create_column(self.env.cr, 'account_move', 'l10n_jo_edi_uuid', 'char')
-        return super()._auto_init()
 
     @api.depends("country_code", "move_type")
     def _compute_l10n_jo_edi_is_needed(self):

--- a/addons/l10n_jo_edi_pos/models/pos_order.py
+++ b/addons/l10n_jo_edi_pos/models/pos_order.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools import BinaryBytes
-from odoo.tools.sql import create_column, column_exists
 
 
 class PosOrder(models.Model):
@@ -13,7 +12,7 @@ class PosOrder(models.Model):
 
     l10n_jo_edi_pos_return_reason = fields.Char(string="Return Reason", help="Return Reason reported to JoFotara")
     l10n_jo_edi_pos_enabled = fields.Boolean(related='company_id.l10n_jo_edi_pos_enabled')
-    l10n_jo_edi_pos_uuid = fields.Char(string="Order UUID", copy=False, compute='_compute_l10n_jo_edi_pos_uuid', store=True)
+    l10n_jo_edi_pos_uuid = fields.Char(string="Order UUID", copy=False, compute='_compute_l10n_jo_edi_pos_uuid', store=True, init_storage=lambda model: None)
     l10n_jo_edi_pos_qr = fields.Char(string="QR", copy=False)
     l10n_jo_edi_pos_state = fields.Selection(
         selection=[('to_send', 'To Send'), ('sent', 'Sent'), ('demo', 'Sent (Demo)')],
@@ -36,11 +35,6 @@ class PosOrder(models.Model):
         string="Jordan E-Invoice XML",
         help="Jordan: e-invoice XML.",
     )
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, 'pos_order', 'l10n_jo_edi_pos_uuid'):
-            create_column(self.env.cr, 'pos_order', 'l10n_jo_edi_pos_uuid', 'char')
-        return super()._auto_init()
 
     @api.depends('country_code')
     def _compute_l10n_jo_edi_pos_uuid(self):

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMove(models.Model):
@@ -23,7 +22,10 @@ class AccountMove(models.Model):
         "Another entry with the same name already exists.",
     )
 
-    def _auto_init(self):
+    l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')
+    l10n_latam_document_type_id = fields.Many2one(
+        'l10n_latam.document.type', string='Document Type', readonly=False, bypass_search_access=True, index='btree_not_null',
+        init_storage=lambda model: None,
         # Skip the computation of the field `l10n_latam_document_type_id` at the module installation
         # Without this, at the module installation,
         # it would call `_compute_l10n_latam_document_type` on all existing records
@@ -51,13 +53,7 @@ class AccountMove(models.Model):
         # Though I don't think this is needed.
         # In practical, it's very rare to already have invoices (draft, in addition)
         # for a Chilian or Argentian company (`res.company`) before installing `l10n_cl` or `l10n_ar`.
-        if not column_exists(self.env.cr, "account_move", "l10n_latam_document_type_id"):
-            create_column(self.env.cr, "account_move", "l10n_latam_document_type_id", "int4")
-        return super()._auto_init()
-
-    l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')
-    l10n_latam_document_type_id = fields.Many2one(
-        'l10n_latam.document.type', string='Document Type', readonly=False, bypass_search_access=True, index='btree_not_null', compute='_compute_l10n_latam_document_type', store=True)
+        compute='_compute_l10n_latam_document_type', store=True)
     l10n_latam_document_number = fields.Char(
         compute='_compute_l10n_latam_document_number', inverse='_inverse_l10n_latam_document_number',
         string='Document Number', readonly=False)

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -1,19 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    def _auto_init(self):
+    l10n_latam_document_type_id = fields.Many2one(
         # Skip the computation of the field `l10n_latam_document_type_id` at the module installation
         # See `_auto_init` in `l10n_latam_invoice_document/models/account_move.py` for more information
-        if not column_exists(self.env.cr, "account_move_line", "l10n_latam_document_type_id"):
-            create_column(self.env.cr, "account_move_line", "l10n_latam_document_type_id", "int4")
-        return super()._auto_init()
-
-    l10n_latam_document_type_id = fields.Many2one(
-        related='move_id.l10n_latam_document_type_id', bypass_search_access=True, store=True, index='btree_not_null')
+        related='move_id.l10n_latam_document_type_id', bypass_search_access=True, store=True, index='btree_not_null', init_storage=lambda model: None)
     l10n_latam_use_documents = fields.Boolean(related='move_id.l10n_latam_use_documents')

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -1,17 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
 from . import wizard
 from . import report
 
-
-def _pre_init_mrp(env):
-    """ Allow installing MRP in databases with large stock.move table (>1M records)
-        - Creating the computed stored fields `stock_move` and `unit_factor`
-        is terribly slow with the ORM and leads to "Out of Memory" crashes.
-    """
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision NOT NULL DEFAULT 1;""")
 
 def _create_warehouse_data(env):
     """ This hook is used to add a default manufacture_pull_id, manufacture

--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -51,7 +51,6 @@
         'data/mrp_demo.xml',
     ],
     'application': True,
-    'pre_init_hook': '_pre_init_mrp',
     'post_init_hook': '_create_warehouse_data',
     'uninstall_hook': 'uninstall_hook',
     'assets': {

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -50,7 +50,8 @@ class StockMove(models.Model):
     byproduct_id = fields.Many2one(
         'mrp.bom.byproduct', 'By-products', check_company=True,
         help="By-product line that generated the move in a manufacturing order")
-    unit_factor = fields.Float('Unit Factor', compute='_compute_unit_factor', store=True)
+    unit_factor = fields.Float('Unit Factor', compute='_compute_unit_factor', store=True,
+        init_storage=lambda self: self.env.cr.execute("UPDATE stock_move SET unit_factor = 1 WHERE unit_factor IS NULL"))
     should_consume_qty = fields.Float('Quantity To Consume', compute='_compute_should_consume_qty', digits='Product Unit')
     cost_share = fields.Float(
         "Cost Share (%)", digits=0,

--- a/addons/pos_bancontact_pay/models/pos_payment_method.py
+++ b/addons/pos_bancontact_pay/models/pos_payment_method.py
@@ -4,7 +4,6 @@ import requests
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools.sql import column_exists, create_column
 
 from odoo.addons.pos_bancontact_pay import const
 from odoo.addons.pos_bancontact_pay.errors.http import HTTP_ERRORS
@@ -16,11 +15,6 @@ class PosPaymentMethod(models.Model):
     # ----- Fields ----- #
     def _get_external_qr_provider_selection(self):
         return super()._get_external_qr_provider_selection() + [("bancontact_pay", "Bancontact Pay")]
-
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "pos_payment_method", "bancontact_usage"):
-            create_column(self.env.cr, "pos_payment_method", "bancontact_usage", "varchar")
-        return super()._auto_init()
 
     bancontact_api_key = fields.Char("Bancontact API Key")
     bancontact_ppid = fields.Char("Bancontact PPID")

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
 
 from odoo import api, fields, models
-from odoo.tools.sql import column_exists, create_column
 
 
 class StockMoveLine(models.Model):
@@ -13,23 +11,11 @@ class StockMoveLine(models.Model):
     expiration_date = fields.Datetime(
         string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
-        ' become dangerous and must not be consumed.')
-    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', readonly=False, store=True)
+        ' become dangerous and must not be consumed.', init_storage=lambda model: None)
+    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', readonly=False, store=True, init_storage=lambda model: None)
     is_expired = fields.Boolean(related='lot_id.product_expiry_alert')
     use_expiration_date = fields.Boolean(
         string='Use Expiration Date', related='product_id.use_expiration_date')
-
-    def _auto_init(self):
-        """ Create column for 'expiration_date' here to avoid MemoryError when letting
-        the ORM compute it after module installation. Since both 'lot_id.expiration_date'
-        and 'product_id.use_expiration_date' are new fields introduced in this module,
-        there is no need for an UPDATE statement here.
-        """
-        if not column_exists(self.env.cr, "stock_move_line", "expiration_date"):
-            create_column(self.env.cr, "stock_move_line", "expiration_date", "timestamp")
-        if not column_exists(self.env.cr, "stock_move_line", "removal_date"):
-            create_column(self.env.cr, "stock_move_line", "removal_date", "timestamp")
-        return super()._auto_init()
 
     @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date', 'quant_id')
     def _compute_expiration_date(self):

--- a/addons/sale/__init__.py
+++ b/addons/sale/__init__.py
@@ -6,21 +6,6 @@ from odoo.tools.sql import SQL
 from . import const, controllers, models, report, wizard
 
 
-def _pre_init_sale(env):
-    """Allow installing sale in databases with large account.analytic.line tables.
-
-    The different fields are all NULL (falsy) for existing AAL,
-    the computation is way more efficient in SQL than in Python.
-    """
-    env.cr.execute(
-        SQL("""
-       ALTER TABLE account_analytic_line
-       ADD COLUMN IF NOT EXISTS order_id INT4,
-       ADD COLUMN IF NOT EXISTS so_line  INT4
-    """)
-    )
-
-
 def _post_init_hook(env):
     _synchronize_crons(env)
     _setup_downpayment_account(env)

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -96,7 +96,6 @@ This module contains all the common features of Sales Management and eCommerce.
         ],
         "web.report_assets_common": ["sale/static/src/scss/sale_report.scss"],
     },
-    "pre_init_hook": "_pre_init_sale",
     "post_init_hook": "_post_init_hook",
     "author": "Odoo S.A.",
     "license": "LGPL-3",

--- a/addons/sale/models/account_analytic_line.py
+++ b/addons/sale/models/account_analytic_line.py
@@ -22,6 +22,7 @@ class AccountAnalyticLine(models.Model):
         compute="_compute_so_line",
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
         index="btree_not_null",
         domain=lambda self: str(self._domain_so_line()),
     )
@@ -31,6 +32,7 @@ class AccountAnalyticLine(models.Model):
         compute="_compute_order_id",
         store=True,
         readonly=False,
+        init_storage=lambda model: None,
         index=True,
     )
 

--- a/addons/sale_management/__init__.py
+++ b/addons/sale_management/__init__.py
@@ -1,14 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tools.sql import column_exists, create_column
-
 from . import controllers, models
-
-
-def pre_init_hook(env):
-    """Do not compute the sale_order_template_id field on existing SOs."""
-    if not column_exists(env.cr, "sale_order", "sale_order_template_id"):
-        create_column(env.cr, "sale_order", "sale_order_template_id", "int4")
 
 
 def uninstall_hook(env):

--- a/addons/sale_management/__manifest__.py
+++ b/addons/sale_management/__manifest__.py
@@ -62,7 +62,6 @@ The Dashboard for the Sales Manager will include
         ],
     },
     "application": True,
-    "pre_init_hook": "pre_init_hook",
     "post_init_hook": "post_init_hook",
     "uninstall_hook": "uninstall_hook",
     "author": "Odoo S.A.",

--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -2,7 +2,6 @@
 
 from odoo import api, fields, models
 from odoo.tools import format_amount
-from odoo.tools.sql import column_exists, create_column
 
 
 class SaleOrderLine(models.Model):
@@ -11,7 +10,7 @@ class SaleOrderLine(models.Model):
     _name_search_services_index = models.Index("(order_id DESC, sequence, id) WHERE is_service IS TRUE")
 
     # used to know if generate a task and/or a project, depending on the product settings
-    is_service = fields.Boolean("Is a Service", compute='_compute_is_service', store=True, compute_sudo=True, export_string_translation=False)
+    is_service = fields.Boolean("Is a Service", compute='_compute_is_service', store=True, compute_sudo=True, export_string_translation=False, init_storage='_init_column_is_service')
 
     def _domain_sale_line_service(self, **kwargs):
         """
@@ -52,20 +51,14 @@ class SaleOrderLine(models.Model):
                     sol |= line
         super(SaleOrderLine, self - sol)._compute_display_name()
 
-    def _auto_init(self):
-        """
-        Create column to stop ORM from computing it himself (too slow)
-        """
-        if not column_exists(self.env.cr, 'sale_order_line', 'is_service'):
-            create_column(self.env.cr, 'sale_order_line', 'is_service', 'bool')
-            self.env.cr.execute("""
-                UPDATE sale_order_line line
-                SET is_service = (pt.type = 'service')
-                FROM product_product pp
-                LEFT JOIN product_template pt ON pt.id = pp.product_tmpl_id
-                WHERE pp.id = line.product_id
-            """)
-        return super()._auto_init()
+    def _init_column_is_service(self):
+        self.env.cr.execute("""
+            UPDATE sale_order_line line
+            SET is_service = (pt.type = 'service')
+            FROM product_product pp
+            LEFT JOIN product_template pt ON pt.id = pp.product_tmpl_id
+            WHERE pp.id = line.product_id AND is_service IS NULL
+        """)
 
     def _additional_name_per_id(self):
         name_per_id = super()._additional_name_per_id() if not self.env.context.get('hide_partner_ref') else {}

--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -2,7 +2,6 @@
 
 from odoo import api, fields, models
 from odoo.tools import format_amount
-from odoo.tools.sql import column_exists, create_column
 
 
 class SaleOrderLine(models.Model):
@@ -11,7 +10,7 @@ class SaleOrderLine(models.Model):
     _name_search_services_index = models.Index("(order_id DESC, sequence, id) WHERE is_service IS TRUE")
 
     # used to know if generate a task and/or a project, depending on the product settings
-    is_service = fields.Boolean("Is a Service", compute='_compute_is_service', store=True, compute_sudo=True, export_string_translation=False)
+    is_service = fields.Boolean("Is a Service", compute='_compute_is_service', store=True, compute_sudo=True, export_string_translation=False, default_init='_auto_init_is_service')
 
     def _domain_sale_line_service(self, **kwargs):
         """
@@ -49,20 +48,17 @@ class SaleOrderLine(models.Model):
                     sol |= line
         super(SaleOrderLine, self - sol)._compute_display_name()
 
-    def _auto_init(self):
+    def _auto_init_is_service(self):
         """
         Create column to stop ORM from computing it himself (too slow)
         """
-        if not column_exists(self.env.cr, 'sale_order_line', 'is_service'):
-            create_column(self.env.cr, 'sale_order_line', 'is_service', 'bool')
-            self.env.cr.execute("""
-                UPDATE sale_order_line line
-                SET is_service = (pt.type = 'service')
-                FROM product_product pp
-                LEFT JOIN product_template pt ON pt.id = pp.product_tmpl_id
-                WHERE pp.id = line.product_id
-            """)
-        return super()._auto_init()
+        self.env.cr.execute("""
+            UPDATE sale_order_line line
+            SET is_service = (pt.type = 'service')
+            FROM product_product pp
+            LEFT JOIN product_template pt ON pt.id = pp.product_tmpl_id
+            WHERE pp.id = line.product_id
+        """)
 
     def _additional_name_per_id(self):
         name_per_id = super()._additional_name_per_id() if not self.env.context.get('hide_partner_ref') else {}

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
 
 from odoo import api, fields, models, Command
-from odoo.tools.sql import column_exists, create_column
 
 
 class StockRoute(models.Model):
@@ -199,7 +197,8 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     allow_spontaneous_returns = fields.Boolean(related="company_id.allow_spontaneous_returns")
-    sale_id = fields.Many2one('sale.order', compute="_compute_sale_id", inverse="_set_sale_id", string="Sales Order", store=True, index='btree_not_null')
+    sale_id = fields.Many2one('sale.order', compute="_compute_sale_id", inverse="_set_sale_id", string="Sales Order", store=True, index='btree_not_null', init_storage=lambda model: None)
+    # init_storage: Since group_id.sale_id is created in this module, no need for an UPDATE statement.
     return_reason_id = fields.Many2one("return.reason")
 
     @api.depends('reference_ids.sale_ids', 'move_ids.sale_line_id.order_id')
@@ -237,18 +236,6 @@ class StockPicking(models.Model):
                 })
                 self._add_reference(reference)
         self.move_ids._reassign_sale_lines(self.sale_id)
-
-    def _auto_init(self):
-        """
-        Create related field here, too slow
-        when computing it afterwards through _compute_related.
-
-        Since group_id.sale_id is created in this module,
-        no need for an UPDATE statement.
-        """
-        if not column_exists(self.env.cr, 'stock_picking', 'sale_id'):
-            create_column(self.env.cr, 'stock_picking', 'sale_id', 'int4')
-        return super()._auto_init()
 
     def _action_done(self):
         res = super()._action_done()

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools.sql import column_exists, create_column
 
 
 class StockRoute(models.Model):
@@ -14,22 +13,18 @@ class StockRoute(models.Model):
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "stock_move", "weight"):
-            # In case of a big database with a lot of stock moves, the RAM gets exhausted
-            # To prevent a process from being killed We create the column 'weight' manually
-            # Then we do the computation in a query by multiplying product weight with qty
-            create_column(self.env.cr, "stock_move", "weight", "numeric")
-            self.env.cr.execute("""
+    weight = fields.Float(compute='_cal_move_weight', digits='Stock Weight', store=True, compute_sudo=True,
+        # In case of a big database with a lot of stock moves, the RAM gets exhausted
+        # To prevent a process from being killed We create the column 'weight' manually
+        # Then we do the computation in a query by multiplying product weight with qty
+        init_storage=lambda model: model.env.cr.execute("""
                 UPDATE stock_move move
                 SET weight = move.product_qty * product.weight
                 FROM product_product product
                 WHERE move.product_id = product.id
                 AND move.state != 'cancel'
-                """)
-        return super()._auto_init()
-
-    weight = fields.Float(compute='_cal_move_weight', digits='Stock Weight', store=True, compute_sudo=True)
+                """),
+    )
 
     @api.depends('product_id', 'product_uom_qty', 'uom_id')
     def _cal_move_weight(self):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -11,7 +11,7 @@ from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.db import FunctionStatus
 from odoo.tools import float_round, is_html_empty, lazy
-from odoo.tools.sql import SQL, column_exists, create_column
+from odoo.tools.sql import SQL
 from odoo.tools.translate import adapt_translated_field_value, html_translate
 
 from odoo.addons.website.tools import text_from_html
@@ -166,6 +166,7 @@ class ProductTemplate(models.Model):
     variants_default_code = fields.Char(
         compute="_compute_variants_default_code",
         store=True,
+        init_storage='_init_column_variants_default_code',
         index="trigram",
         help="Technical field to enhance performance when looking up default code of product"
         "variants (LIKE/ILIKE)",
@@ -198,30 +199,28 @@ class ProductTemplate(models.Model):
         )
     )
 
-    def _auto_init(self):
-        """Override _auto_init to prevent MemoryError on ecommerce installation in dbs with lots of
+    def _init_column_variants_default_code(self):
+        """Prevent MemoryError on ecommerce installation in dbs with lots of
         products."""
-        if not column_exists(self.env.cr, "product_template", "variants_default_code"):
-            create_column(self.env.cr, "product_template", "variants_default_code", "varchar")
-            self.env.cr.execute(
-                SQL(
-                    """
-                    UPDATE product_template
-                    SET variants_default_code = variants.default_codes
-                    FROM (
-                        SELECT pt.id AS template_id,
-                               STRING_AGG(pv.default_code, %s) AS default_codes
-                        FROM product_template pt
-                        JOIN product_product pv ON pv.product_tmpl_id = pt.id
-                        WHERE pv.default_code IS NOT NULL
-                        GROUP BY pt.id
-                    ) AS variants
-                    WHERE product_template.id = variants.template_id
-                """,
-                    RARE_DELIMITER,
-                )
+        self.env.execute_query(
+            SQL(
+                """
+                UPDATE product_template
+                SET variants_default_code = variants.default_codes
+                FROM (
+                    SELECT pt.id AS template_id,
+                            STRING_AGG(pv.default_code, %s) AS default_codes
+                    FROM product_template pt
+                    JOIN product_product pv ON pv.product_tmpl_id = pt.id
+                    WHERE pv.default_code IS NOT NULL
+                    GROUP BY pt.id
+                ) AS variants
+                WHERE product_template.id = variants.template_id
+                AND variants_default_code IS NULL
+            """,
+                RARE_DELIMITER,
             )
-        return super()._auto_init()
+        )
 
     # === COMPUTE METHODS ===#
 
@@ -1136,7 +1135,7 @@ class ProductTemplate(models.Model):
             self._table,
             'website_sequence',
         )
-        self.env.cr.execute("SELECT id FROM %s WHERE website_sequence IS NULL" % self._table)
+        self.env.cr.execute(SQL("SELECT id FROM %s WHERE website_sequence IS NULL", SQL.identifier(self._table)))
         prod_tmpl_ids = self.env.cr.dictfetchall()
         max_seq = self._default_website_sequence()
         query = f"""

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -12,7 +12,7 @@ from odoo import api, fields, models, tools, _
 from odoo.addons.website.tools import text_from_html
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
-from odoo.tools import is_html_empty
+from odoo.tools import SQL, is_html_empty
 from odoo.tools.misc import format_duration
 
 _logger = logging.getLogger(__name__)
@@ -475,12 +475,11 @@ class SlideChannel(models.Model):
 
     def _init_access_token(self):
         """ Generate different access tokens for all records. """
-        query = """
+        self.env.execute_query(SQL("""
             UPDATE %(table_name)s
             SET access_token = md5(md5(random()::varchar || id::varchar) || clock_timestamp()::varchar)::uuid::varchar
             WHERE access_token IS NULL
-        """ % {'table_name': self._table}
-        self.env.cr.execute(query)
+        """, table_name=SQL.identifier(self._table)))
 
     def _populate_description_short(self, vals):
         """ Populate the empty ``vals['description_short']`` with the non-empty ``vals['description']`` for the ``self``

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -122,6 +122,13 @@ class Field[T]:
         ``default=None`` to discard default values for the field
     :type default: value or callable
 
+    :param str default_init: the function that can initialize the column in the database;
+
+        The function can initialize the column in the database. It should
+        register a callback in `model.pool.post_init`.
+        The function returns a list of ids to recompute (can be nothing).
+        The ORM cannot be used in this function!
+
     :param str groups: comma-separated list of group xml ids (string); this
         restricts the field access to the users of the given groups only
 
@@ -296,6 +303,7 @@ class Field[T]:
     related: str | None = None          # sequence of field names, for related fields
     company_dependent: bool = False     # whether ``self`` is company-dependent (property field)
     default: Callable[[BaseModel], T] | T | None = None  # default(recs) returns the default value
+    default_init: str | Callable[[BaseModel], list[IdType] | bool | None] | None = None  # initializes the newly created column
 
     string: str | None = None           # field label
     export_string_translation: bool = True  # whether the field label translations are exported
@@ -684,6 +692,16 @@ class Field[T]:
             # being on the abstract model) are assigned an XML id
             delegate_field = model._fields[self.related.split('.')[0]]
             self._modules = tuple({*self._modules, *delegate_field._modules, *field._modules})
+
+        if (
+            self.related.count('.') == 1
+            and self.related_field.store
+            and not self.related_field.compute
+            and self.related_field.column_type
+            and not self.default_init
+        ):
+            # optimization for computing simple related fields like 'foo_id.bar'
+            self.default_init = self._init_field_related
 
     def _compute_related(self, records: BaseModel) -> None:
         """ Compute the related field ``self`` on ``records``. """
@@ -1140,12 +1158,12 @@ class Field[T]:
         """ Prescribed column order in table. """
         return 0 if self.column_type is None else sql.SQL_ORDER_BY_TYPE[self.column_type[0]]
 
-    def update_db(self, model: BaseModel, columns: dict[str, dict[str, typing.Any]]) -> bool:
+    def update_db(self, model: BaseModel, columns: dict[str, dict[str, typing.Any]]) -> list[IdType] | bool:
         """ Update the database schema to implement this field.
 
             :param model: an instance of the field's model
             :param columns: a dict mapping column names to their configuration in database
-            :return: ``True`` if the field must be recomputed on existing rows
+            :return: ``True`` if the field must be recomputed on all rows, ids otherwise
         """
         if not self.column_type:
             return False
@@ -1157,24 +1175,13 @@ class Field[T]:
         self.update_db_column(model, column)
         self.update_db_notnull(model, column)
 
-        # optimization for computing simple related fields like 'foo_id.bar'
-        if (
-            not column
-            and self.related and self.related.count('.') == 1
-            and self.related_field.store and not self.related_field.compute
-            and not (self.related_field.type == 'binary' and self.related_field.attachment)
-            and self.related_field.type not in ('one2many', 'many2many')
-        ):
-            join_field = model._fields[self.related.split('.')[0]]
-            if (
-                join_field.type == 'many2one'
-                and join_field.store and not join_field.compute
-            ):
-                model.pool.post_init(self.update_db_related, model)
-                # discard the "classical" computation
-                return False
+        if column:  # column already exists
+            return False
 
-        return not column
+        if self.default_init:
+            return determine(self.default_init, model)
+
+        return bool(self.compute)  # recompute all
 
     def update_db_column(self, model: BaseModel, column: dict[str, typing.Any]):
         """ Create/update the column corresponding to ``self``.
@@ -1233,7 +1240,18 @@ class Field[T]:
         elif not self.required and has_notnull:
             sql.drop_not_null(model.env.cr, model._table, self.name)
 
-    def update_db_related(self, model: BaseModel) -> None:
+    def _init_field_related(self, model: BaseModel) -> bool:
+        join_field = model._fields[self.related.split('.')[0]]
+        if (
+            join_field.type == 'many2one'
+            and join_field.store and not join_field.compute
+        ):
+            model.pool.post_init(self._update_db_related, model)
+            # discard the "classical" computation
+            return False
+        return True
+
+    def _update_db_related(self, model: BaseModel) -> None:
         """ Compute a stored related field directly in SQL. """
         comodel = model.env[self.related_field.model_name]
         join_field, comodel_field = self.related.split('.')

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2489,20 +2489,25 @@ class BaseModel(metaclass=MetaModel):
                     continue
                 if field.manual and not update_custom_fields:
                     continue            # don't update custom fields
-                new = field.update_db(self, columns)
-                if new and field.compute:
-                    fields_to_compute.append(field)
+                to_recompute = field.update_db(self, columns)
+                if to_recompute and field.compute:
+                    fields_to_compute.append((field, to_recompute))
 
-            if fields_to_compute:
-                # mark existing records for computation now, so that computed
-                # required fields are flushed before the NOT NULL constraint is
-                # added to the database
+            # mark existing records for computation now, so that computed
+            # required fields are flushed before the NOT NULL constraint is
+            # added to the database
+            if any(records is True for _field, records in fields_to_compute):
                 cr.execute(SQL('SELECT id FROM %s', SQL.identifier(self._table)))
-                records = self.browse(row[0] for row in cr.fetchall())
-                if records:
-                    for field in fields_to_compute:
-                        _logger.info("Prepare computation of %s", field)
-                        self.env.add_to_compute(field, records)
+                all_records = self.browse(row[0] for row in cr.fetchall())
+            for field, record_ids in fields_to_compute:
+                if record_ids is True:
+                    records = all_records
+                else:
+                    records = self.browse(record_ids)
+                if not records:
+                    continue
+                _logger.info("Prepare computation of %s", field)
+                self.env.add_to_compute(field, records)
 
         if self._auto:
             self._add_sql_constraints()


### PR DESCRIPTION
Sometimes, we need to have a custom initialization logic for field. The
most common case are computed-stored fields where we don't want to call
the compute function for the whole table that might be too big to fit in
memory. In such cases, we allow to create a custom initialization
function for the field.

```py
x = field.Char(..., init_storage='_init_field_x')
x = field.Char(..., init_storage=lambda model: None)

def _init_field_x(self):
  self.env.cr("UPDATE ...")
```

https://github.com/odoo/enterprise/pull/118398

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
