### PR TITLE
[FIX] l10n_it_pos: prevent printer deadlock

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -362,11 +362,7 @@ export class PaymentScreen extends Component {
         let nextScreen = this.nextScreen;
         let switchScreen = true;
 
-        if (
-            nextScreen === "ReceiptScreen" &&
-            this.currentOrder.nb_print === 0 &&
-            this.pos.config.iface_print_auto
-        ) {
+        if (nextScreen === "ReceiptScreen" && this.currentOrder.nb_print === 0 && this.autoPrint) {
             const invoiced_finalized = this.currentOrder.is_to_invoice()
                 ? this.currentOrder.finalized
                 : true;
@@ -392,6 +388,9 @@ export class PaymentScreen extends Component {
         if (!this.pos.config.module_pos_restaurant) {
             this.pos.checkPreparationStateAndSentOrderInPreparation(this.currentOrder);
         }
+    }
+    get autoPrint() {
+        return this.pos.config.iface_print_auto;
     }
     selectNextOrder() {
         if (this.currentOrder.originalSplittedOrder) {


### PR DESCRIPTION
Module: l10n_it_pos

Steps to reproduce:
- In the POS settings, enable "Automatic Receipt Printing";
- Enable "ePos Printer" to make the "Skip Preview Screen" option appear;
- Disable "Skip Preview Screen";
- Disable "ePos Printer";
- Set up an Italian Fiscal Printer;
- Open a POS session and process a first order. Issue: After the first receipt, no other messages (price display, receipt, open register) are sent to the fiscal printer. A page reload is required.

Issue: After the first receipt, no other messages (price display, receipt, open register) are sent to the fiscal printer. A page reload is required.

Cause:
When "Automatic Receipt Printing" is true but "Skip Preview Screen" is false, a race condition occurs. `afterOrderValidation` triggers a print job while simultaneously transitioning to the `ReceiptScreen`. When the `ReceiptScreen` mounts, it triggers a second fiscal print job before the first has resolved. This creates a deadlock in `toHtml` of  `renderService`, permanently blocking the printer queue.

Solution:
Since the italian localisation sending the receipt to the fiscal printer is mandatory, the printing route is now tied to the "Skip Preview Screen" option.

Enterprise PR: https://github.com/odoo/enterprise/pull/112654

[opw-5979212](https://www.odoo.com/odoo/project/49/tasks/5979212)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
