### PR TITLE
[IMP] spreadsheet_dashboard: manage frozen dashboard links

### DIFF
--- a/addons/spreadsheet_dashboard/controllers/share.py
+++ b/addons/spreadsheet_dashboard/controllers/share.py
@@ -2,12 +2,17 @@ from odoo import http, _
 from odoo.http import request
 from odoo.exceptions import UserError
 
+
 class DashboardShareRoute(http.Controller):
+    def _get_active_dashboard_share_or_not_found(self, share_id):
+        share = request.env["spreadsheet.dashboard.share"].sudo().browse(share_id).exists()
+        if not share or not share.active:
+            raise request.not_found()
+        return share
+
     @http.route(['/dashboard/share/<int:share_id>/<token>'], type='http', auth='public')
     def share_portal(self, share_id=None, token=None):
-        share = request.env["spreadsheet.dashboard.share"].sudo().browse(share_id).exists()
-        if not share:
-            raise request.not_found()
+        share = self._get_active_dashboard_share_or_not_found(share_id)
         share._check_dashboard_access(token)
         download_url = ""
         if request.env.user.has_group('base.group_allow_export'):
@@ -30,7 +35,7 @@ class DashboardShareRoute(http.Controller):
     @http.route(["/dashboard/download/<int:share_id>/<token>"],
                 type='http', auth='user', readonly=True)
     def download(self, token=None, share_id=None):
-        share = request.env["spreadsheet.dashboard.share"].sudo().browse(share_id)
+        share = self._get_active_dashboard_share_or_not_found(share_id)
         share._check_dashboard_access(token)
         if not request.env.user.has_group('base.group_allow_export'):
             raise UserError(_("You don't have the rights to export data. Please contact an Administrator."))
@@ -47,15 +52,7 @@ class DashboardShareRoute(http.Controller):
         readonly=True,
     )
     def get_shared_dashboard_data(self, share_id, token):
-        share = (
-            request.env["spreadsheet.dashboard.share"]
-            .sudo()
-            .browse(share_id)
-            .exists()
-        )
-        if not share:
-            raise request.not_found()
-
+        share = self._get_active_dashboard_share_or_not_found(share_id)
         share._check_dashboard_access(token)
         stream = request.env["ir.binary"]._get_stream_from(
             share, "spreadsheet_binary_data"

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard_share.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard_share.py
@@ -9,17 +9,26 @@ class SpreadsheetDashboardShare(models.Model):
     _name = 'spreadsheet.dashboard.share'
     _inherit = ['spreadsheet.mixin']
     _description = 'Copy of a shared dashboard'
+    _order = 'create_date desc'
 
     dashboard_id = fields.Many2one('spreadsheet.dashboard', required=True, ondelete='cascade')
+    dashboard_group_id = fields.Many2one(related='dashboard_id.dashboard_group_id')
     excel_export = fields.Binary()
+    active = fields.Boolean(default=True)
     access_token = fields.Char(required=True, default=lambda _x: str(uuid.uuid4()))
     full_url = fields.Char(string="URL", compute='_compute_full_url')
-    name = fields.Char(related='dashboard_id.name')
+    name = fields.Char(compute='_compute_name', readonly=False, store=True, required=True, precompute=True)
 
     @api.depends('access_token')
     def _compute_full_url(self):
         for share in self:
             share.full_url = "%s/dashboard/share/%s/%s" % (share.get_base_url(), share.id, share.access_token)
+
+    @api.depends('dashboard_id')
+    def _compute_name(self):
+        for share in self:
+            if not share.name and share.dashboard_id:
+                share.name = share.env._("%s - Share Link", share.dashboard_id.name)
 
     @api.model
     def action_get_share_url(self, vals):

--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -41,4 +41,11 @@
         <field name="groups" eval="[(4, ref('base.group_user'))]" />
         <field name="domain_force">[('create_uid', '=', user.id)]</field>
     </record>
+
+    <record id="spreadsheet_dashboard_share_rule_manager" model="ir.rule">
+        <field name="name">Spreadsheet dashboard share: manager</field>
+        <field name="model_id" ref="model_spreadsheet_dashboard_share" />
+        <field name="groups" eval="[(4, ref('spreadsheet_dashboard.group_dashboard_manager'))]" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
 </odoo>

--- a/addons/spreadsheet_dashboard/tests/common.py
+++ b/addons/spreadsheet_dashboard/tests/common.py
@@ -3,12 +3,18 @@
 from odoo import Command
 from odoo.tests.common import TransactionCase, new_test_user
 
+
 class DashboardTestCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.group = cls.env["res.groups"].create({"name": "test group"})
         cls.user = new_test_user(cls.env, login="Raoul")
+        cls.dashboard_manager = new_test_user(
+            cls.env,
+            login="Mitchell",
+            groups="spreadsheet_dashboard.group_dashboard_manager",
+        )
         cls.user.group_ids |= cls.group + cls.env.ref('base.group_allow_export', raise_if_not_found=False)
 
     def create_dashboard(self, group=None):
@@ -24,11 +30,10 @@ class DashboardTestCommon(TransactionCase):
         )
         return dashboard
 
-    def share_dashboard(self, dashboard):
-        share = self.env["spreadsheet.dashboard.share"].create(
-            {
-                "dashboard_id": dashboard.id,
-                "spreadsheet_data": dashboard.spreadsheet_data,
-            }
-        )
+    def share_dashboard(self, dashboard, **values):
+        share = self.env["spreadsheet.dashboard.share"].create({
+            "dashboard_id": dashboard.id,
+            "spreadsheet_data": dashboard.spreadsheet_data,
+            **values,
+        })
         return share

--- a/addons/spreadsheet_dashboard/tests/test_dashboard_share.py
+++ b/addons/spreadsheet_dashboard/tests/test_dashboard_share.py
@@ -2,6 +2,7 @@
 
 from .common import DashboardTestCommon
 from odoo.tests import tagged
+from odoo.tests.common import new_test_user
 
 from odoo.exceptions import AccessError
 
@@ -28,6 +29,7 @@ class DashboardSharing(DashboardTestCommon):
         )
         self.assertEqual(url, share.full_url)
         self.assertEqual(share.dashboard_id, dashboard)
+        self.assertEqual(share.name, "a dashboard - Share Link")
         self.assertTrue(share.excel_export)
 
     def test_can_create_own(self):
@@ -43,3 +45,15 @@ class DashboardSharing(DashboardTestCommon):
         share = self.share_dashboard(dashboard)
         with self.assertRaises(AccessError):
             share.with_user(self.user).access_token
+
+    def test_dashboard_manager_sees_all_shares(self):
+        second_user = new_test_user(self.env, login='Jeanne')
+        second_user.group_ids |= self.group
+        dashboard = self.create_dashboard()
+        with self.with_user(self.user.login):
+            user_share = self.share_dashboard(dashboard)
+        with self.with_user(second_user.login):
+            second_user_share = self.share_dashboard(dashboard)
+
+        shares = self.env['spreadsheet.dashboard.share'].with_user(self.dashboard_manager).search([])
+        self.assertEqual(shares, user_share | second_user_share)

--- a/addons/spreadsheet_dashboard/tests/test_share_controllers.py
+++ b/addons/spreadsheet_dashboard/tests/test_share_controllers.py
@@ -28,6 +28,13 @@ class TestShareController(DashboardTestCommon, HttpCase):
             response = self.url_open(f"/dashboard/share/{share.id}/a-random-token")
         self.assertEqual(response.status_code, 403)
 
+    def test_dashboard_share_portal_inactive_share(self):
+        dashboard = self.create_dashboard()
+        share = self.share_dashboard(dashboard, active=False)
+        with mute_logger('odoo.http'):
+            response = self.url_open(f"/dashboard/share/{share.id}/{share.access_token}")
+        self.assertEqual(response.status_code, 404)
+
     def test_public_dashboard_data(self):
         dashboard = self.create_dashboard()
         share = self.share_dashboard(dashboard)
@@ -41,6 +48,13 @@ class TestShareController(DashboardTestCommon, HttpCase):
         with mute_logger('odoo.http'):  # mute 403 warning
             response = self.url_open(f"/dashboard/data/{share.id}/a-random-token")
         self.assertEqual(response.status_code, 403)
+
+    def test_public_dashboard_data_inactive_share(self):
+        dashboard = self.create_dashboard()
+        share = self.share_dashboard(dashboard, active=False)
+        with mute_logger('odoo.http'):  # mute 403 warning
+            response = self.url_open(f"/dashboard/data/{share.id}/{share.access_token}")
+        self.assertEqual(response.status_code, 404)
 
     def test_public_dashboard_revoked_access(self):
         dashboard = self.create_dashboard()
@@ -87,6 +101,15 @@ class TestShareController(DashboardTestCommon, HttpCase):
         with mute_logger('odoo.http'):  # mute 403 warning
             response = self.url_open(f"/dashboard/download/{share.id}/a-random-token")
         self.assertEqual(response.status_code, 403)
+
+    def test_download_dashboard_inactive_share(self):
+        dashboard = self.create_dashboard()
+        share = self.share_dashboard(dashboard, active=False)
+        share.excel_export = BinaryBytes(b"test")
+        self.authenticate('AlexPort', 'AlexPort')
+        with mute_logger('odoo.http'):
+            response = self.url_open(f"/dashboard/download/{share.id}/{share.access_token}")
+        self.assertEqual(response.status_code, 404)
 
     def test_download_dashboard_revoked_access(self):
         dashboard = self.create_dashboard()

--- a/addons/spreadsheet_dashboard/views/menu_views.xml
+++ b/addons/spreadsheet_dashboard/views/menu_views.xml
@@ -39,6 +39,12 @@
         <field name="view_mode">list</field>
     </record>
 
+    <record id="spreadsheet_dashboard_share_action_configuration_share_links" model="ir.actions.act_window">
+        <field name="name">Share links</field>
+        <field name="res_model">spreadsheet.dashboard.share</field>
+        <field name="view_mode">list</field>
+    </record>
+
     <menuitem
         id="spreadsheet_dashboard_menu_configuration_dashboards"
         name="Dashboards"
@@ -52,5 +58,12 @@
         parent="spreadsheet_dashboard_menu_configuration"
         action="spreadsheet_dashboard_group_action_configuration_sections"
         sequence="20"/>
+
+    <menuitem
+        id="spreadsheet_dashboard_share_menu_configuration_share_links"
+        name="Share links"
+        parent="spreadsheet_dashboard_menu_configuration"
+        action="spreadsheet_dashboard_share_action_configuration_share_links"
+        sequence="30"/>
 
 </odoo>

--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -79,4 +79,38 @@
         </field>
     </record>
 
+    <record id="spreadsheet_dashboard_share_view_list" model="ir.ui.view">
+        <field name="name">spreadsheet.dashboard.share.view.list</field>
+        <field name="model">spreadsheet.dashboard.share</field>
+        <field name="arch" type="xml">
+            <list create="false" editable="bottom">
+                <field name="name"/>
+                <field name="dashboard_id" readonly="1"/>
+                <field name="dashboard_group_id" options="{'no_open': True}"/>
+                <field name="create_uid"/>
+                <field name="create_date"/>
+                <field name="full_url" string="URL" widget="CopyClipboardURL"/>
+                <field name="active" widget="boolean_toggle"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="spreadsheet_dashboard_share_view_search" model="ir.ui.view">
+        <field name="name">spreadsheet.dashboard.share.search</field>
+        <field name="model">spreadsheet.dashboard.share</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="dashboard_id"/>
+                <field name="create_uid"/>
+                <filter string="Active" name="filter_active" domain="[('active', '=', True)]"/>
+                <filter string="Inactive" name="filter_inactive" domain="[('active', '=', False)]"/>
+                <group>
+                    <filter string="Dashboard" name="groupby_dashboard_id" context="{'group_by': 'dashboard_id'}"/>
+                    <filter string="Created by" name="groupby_create_uid" context="{'group_by': 'create_uid'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
## Description:

Frozen dashboard links could be generated, but they were not easy to manage afterwards. There was no dedicated backend view to review them, rename them or revoke them cleanly.

This commit adds management views for `spreadsheet.dashboard.share` under Dashboards > Configuration > Frozen links.

To support that flow, the share name is now a real stored editable field instead of a related field.

An `active` field is added to revoke links without deleting them, and inactive public links now return 404. Access rules are also updated so regular users only see their own frozen links, while dashboard managers can see all of them.

Task: [6048745](https://www.odoo.com/odoo/project/2328/tasks/6048745)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
