### PR TITLE
[FIX] im_livechat: display `script_external` as text

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -67,6 +67,7 @@ class Im_LivechatChannel(models.Model):
         "Agents Connected", compute="_compute_available_operator_ids"
     )
     script_external = fields.Html('Script (external)', compute='_compute_script_external', store=False, readonly=True, sanitize=False)
+    script_external_text = fields.Char('Script (external) Text', compute='_compute_script_external')
     nbr_channel = fields.Integer('Number of conversations in the past 30 days', compute='_compute_nbr_channel', store=False, readonly=True)
     rating_percentage_satisfaction = fields.Float("Rating Satisfaction", compute="_compute_rating_percentage_satisfaction")
     rating_count = fields.Integer(string='# Ratings', compute="_compute_rating_percentage_satisfaction")
@@ -232,7 +233,9 @@ class Im_LivechatChannel(models.Model):
         for record in self:
             values["channel_id"] = record.id
             values["url"] = record.get_base_url()
-            record.script_external = self.env['ir.qweb']._render('im_livechat.external_loader', values) if record.id else False
+            script_external = self.env['ir.qweb']._render('im_livechat.external_loader', values) if record.id else False
+            record.script_external = script_external
+            record.script_external_text = str(script_external) if script_external else False
 
     def _compute_web_page_link(self):
         for record in self:

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -228,12 +228,12 @@
                                     <p>
                                         Add the following code to the &lt;head&gt; section of your website:
                                     </p>
-                                    <field class="text-muted" name="script_external" readonly="1" widget="CopyClipboardChar"/>
+                                    <field class="w-100 text-muted border px-2 py-1 rounded-2" name="script_external_text" readonly="1" widget="CopyClipboardChar"/>
                                     <br/><br/>
                                     <p>
                                         Alternatively, share this URL with your customers or suppliers via email:
                                     </p>
-                                    <field class="text-muted" name="web_page" readonly="1" widget="CopyClipboardChar"/>
+                                    <field class="text-muted border px-2 py-1 rounded-2" name="web_page" readonly="1" widget="CopyClipboardChar"/>
                                 </div>
                             </page>
                         </notebook>


### PR DESCRIPTION
`script_external` is a computed `html` field used to show the livechat integration snippet in the backend so users can copy it.

Since 10a62f7d311d90ea5e0a7dadaa617c6d1292dbbc (`[REF] *: Run script to
replace t-esc by t-out`), readonly `CharField`s render their value with `t-out`. As `script_external` contains a `Markup` value, its `<script>` tags started being inserted into the DOM instead of being displayed to the user.

Introduce a new computed field, `script_external_text`, containing a plain string version of `script_external`, and use it in the form view so the snippet is escaped and shown literally again.

Refine the styling of the `web_page` and `script_external` fields to improve their visual appearance.

task-[6074434](https://www.odoo.com/odoo/project/1519/tasks/6074434)