### PR TITLE
[IMP] website: SEO dialog improvements

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -413,6 +413,11 @@ class MetaKeywords extends Component {
 
         this.maxKeywords = 10;
 
+        this.translatedStrings = {
+            keywordsTooltip: _t("You should use max 10 unique keywords, keeping them highly relevant to the content. Too many or irrelevant keywords can hurt your SEO."),
+            removeAllKeywordsButton: _t("Remove all keywords"),
+        };
+
         onWillStart(async () => {
             this.languages = await rpc("/website/get_languages");
             this.state.language = this.getLanguage();
@@ -442,7 +447,7 @@ class MetaKeywords extends Component {
 
     addKeyword(keyword) {
         keyword = keyword.replaceAll(/,\s*/gi, " ").trim();
-        if (keyword && !this.isFull && !this.seoContext.keywords.includes(keyword)) {
+        if (keyword && !this.seoContext.keywords.includes(keyword)) {
             this.seoContext.keywords.push(keyword);
             this.state.keyword = "";
         }
@@ -450,6 +455,10 @@ class MetaKeywords extends Component {
 
     removeKeyword(keyword) {
         this.seoContext.keywords = this.seoContext.keywords.filter((kw) => kw !== keyword);
+    }
+
+    removeAllKeywords() {
+        this.seoContext.keywords = [];
     }
 }
 

--- a/addons/website/static/src/components/dialog/seo.xml
+++ b/addons/website/static/src/components/dialog/seo.xml
@@ -153,19 +153,30 @@
 
 <t t-name="website.MetaKeywords">
     <section class="mt-3">
-        <div t-if="!this.seoContext.keywords.length"><label>Keywords</label></div>
+        <div t-if="!this.seoContext.keywords.length">
+            <label>
+                Keywords <i class="fa fa-question-circle text-primary" data-tooltip-position="right" t-att-data-tooltip="this.keywordsTooltip"/>
+            </label>
+        </div>
         <div class="table-responsive mt16" t-if="this.seoContext.keywords.length">
             <table class="table table-sm mb-2">
                 <thead>
                     <tr>
-                        <th class="w-25">Keywords</th>
+                        <th class="w-25">
+                            Keywords <i class="fa fa-question-circle text-primary" data-tooltip-position="right" t-att-data-tooltip="this.translatedStrings.keywordsTooltip"/>
+                        </th>
                         <th class="text-center o_seo_mentioned_keyword"><abbr title="Used in page first level heading">H1</abbr></th>
                         <th class="text-center o_seo_mentioned_keyword"><abbr title="Used in page second level heading">H2</abbr></th>
                         <th class="text-center o_seo_mentioned_keyword"><abbr title="Used in page title">T</abbr></th>
                         <th class="text-center o_seo_mentioned_keyword"><abbr title="Used in page description">D</abbr></th>
                         <th class="text-center o_seo_mentioned_keyword"><abbr title="Used in page content">C</abbr></th>
                         <th title="Most searched topics related to your keyword, ordered by importance">Content ideas based on Google searches</th>
-                        <th class="text-center"></th>
+                        <th class="text-center" t-on-click="() => this.removeAllKeywords()">
+                            <button class="border-0 oe_remove text-danger" t-att-title="this.translatedStrings.removeAllKeywordsButton">
+                                <span class="visually-hidden" t-out="this.translatedStrings.removeAllKeywordsButton"/>
+                                <i class="fa fa-trash" aria-hidden="true"/>
+                            </button>
+                        </th>
                     </tr>
                 </thead>
                 <t t-foreach="this.seoContext.keywords" t-as="keyword" t-key="keyword">
@@ -174,17 +185,17 @@
             </table>
         </div>
         <div role="form" class="input-group w-50">
-            <t t-set="placeholderRemove">Remove a keyword first</t>
+            <t t-set="placeholderMoreThanTen">Avoid too many keywords</t>
             <t t-set="placeholderAdd">Add your keyword</t>
-            <input t-custom-model="this.state.keyword" type="text" class="form-control" t-att-placeholder="this.isFull ? placeholderRemove : placeholderAdd" t-att-readonly="this.isFull" t-on-keyup="this.onKeyup"/>
+            <input t-custom-model="this.state.keyword" type="text" class="form-control" t-att-placeholder="this.isFull ? placeholderMoreThanTen : placeholderAdd" t-on-keyup="this.onKeyup"/>
             <select t-if="this.languages.length > 1" title="The language of the keyword and related keywords."
                     t-custom-model="this.state.language" class="btn btn-outline-primary pe-5 form-select">
                 <t t-foreach="this.languages" t-as="lang" t-key="lang[0]">
                     <option t-att-value="lang[0]"><t t-out="lang[2]"/></option>
                 </t>
             </select>
-            <button t-on-click="() => this.addKeyword(this.state.keyword)" t-att-disabled="this.isFull" class="btn btn-primary" type="button">Add</button>
-            <button t-if="!this.seoContext.keywords.length" t-on-click="this.provideKeywords" class="btn btn-secondary" type="button">
+            <button t-on-click="() => this.addKeyword(this.state.keyword)" class="btn btn-primary" type="button">Add</button>
+            <button t-on-click="this.provideKeywords" class="btn btn-secondary" type="button">
                 Generate keywords
             </button>
         </div>


### PR DESCRIPTION
Before this commit:

- Users lost access to the "Generate Keywords" button after adding custom keywords.
- There was no option to remove all keywords at once.
- Users were not informed when a page was unpublished, unindexed, or had restricted visibility.
- There was no direct way to access page properties from the SEO dialog.

After this commit:

- Users can add custom keywords without losing access to the "Generate Keywords" button.
- Added a "Delete All" button to remove all keywords in a single action.
- The "Fill with AI" action now updates the alt tag with the image filename, except for decorative images and images that already have an alt tag.
- Added a warning banner in the SEO dialog when a page is unpublished, unindexed, or has restricted visibility.
- Added a shortcut to open page properties directly from the warning banner.
- Added a confirmation dialog when navigating to page properties with unsaved changes, allowing users to save and continue or return to the SEO dialog.

task-5952515

enterprise: https://github.com/odoo/enterprise/pull/122802

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
