### PR TITLE
[FIX] website_project: prevent error when submitting the Create a Task form

### DIFF
--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -58,7 +58,6 @@ class WebsiteForm(form.WebsiteForm):
                 ]
                 data['custom'] += "\n" + "\n".join(["%s : %s" % c for c in custom])
             else:
-                data['record']['email_cc'] = values['email_from']
                 if values.get('partner_phone'):
                     data['record']['partner_phone'] = values['partner_phone']
                 if values.get('partner_name'):

--- a/addons/website_project/tests/test_project_portal_access.py
+++ b/addons/website_project/tests/test_project_portal_access.py
@@ -56,3 +56,23 @@ class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
         # The description should not contain the partner_phone since it was not provided
         self.assertEqual(str(task.description), ('<p>Fix this</p><h4>Other Information</h4>Email : jean@michel.com<br>\n'
             'partner_name : Not Jean Michel<br>\npartner_company_name : foo'))
+
+    def test_portal_task_submission_without_existing_partner_email(self):
+        """
+        Test the creation of a project task via the website form when the
+        provided email does not match any existing partner.
+        """
+        ticket_data = {
+            'name': 'FIX',
+            'partner_name': 'Test demo',
+            'email_from': 'test@demo.com',
+            'description': 'Fix this',
+            'project_id': self.project_portal.id,
+        }
+        response = self.url_open('/website/form/project.task', data=ticket_data)
+        self.assertEqual(response.status_code, 200)
+
+        task = self.env['project.task'].browse(response.json().get('id'))
+        self.assertTrue(task.exists())
+        self.assertEqual(task.name, ticket_data['name'])
+        self.assertEqual(task.email_from, ticket_data['email_from'])


### PR DESCRIPTION
Currently, an error occurs when a user submits the Create a Task form.

**Steps to Reproduce:**

 - Install the `website_project` module.
 - Go to `website` > `Click on Edit` > `Drag and drop` form.
 - Click on the form and, set the action to `Create a Task`, then save.
 - Fill in the required data in the form.
 - In the `Email Address` field, enter an email that does not correspond to any 
   existing partner.
 - `Submit` the form, and the `error appears in the logs`.

`ValueError: Invalid field 'email_cc' in 'project.task'`

With this [recent commit], the email_cc field has been removed from project.task, along 
with the mail.thread.cc inheritance, because threads are now able to find CC recipients. 
so, when user submits the form with an email address that does not correspond to any 
existing partner, the system adds email_cc to the record [1], and when it attempts to 
create the record [2], it raises an error.

This commit ensures that email_cc is no longer added to the record.

[recent commit]: https://github.com/odoo/odoo/commit/3c26c0553754a75d9440097ad473be3cc8bcb320#diff-93ba226020add6481cfeab916e69980a59163e2925a5c2c9a3bc0aaceb484cdf

[1]- https://github.com/odoo/odoo/blob/21aa7e7eca0bf78978e0667cee43129985833166/addons/website_project/controllers/main.py#L61

[2]: https://github.com/odoo/odoo/blob/21aa7e7eca0bf78978e0667cee43129985833166/addons/project/models/project_task.py#L1167

sentry-7374084515

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
