### PR TITLE
[FIX] project: fix private task losing "Private" label after page refresh

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -511,7 +511,7 @@
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
-                                    <field name="project_id" string="Project" optional="hide" required="1" options="{'no_open': 1}" widget="project"/>
+                                    <field name="project_id" string="Project" optional="hide" required="parent_id or child_ids or is_template" options="{'no_open': 1}" widget="project"/>
                                     <field name="milestone_id"
                                         optional="hide"
                                         context="{'default_project_id': project_id}"


### PR DESCRIPTION
Steps to reproduce
1. Create a to-do from the To-do app (no project set, appears as "Private")
2. Open the Project app, go to My Tasks, open the to-do
3. The "Private" label shows correctly
4. Refresh the page

Issue
After refresh, the "Private" label vanishes and the project field becomes required (red), making the record unsavable.

The web client merges (ORs) the `required` attribute of fields sharing the same name across view nesting levels. Commit 46adf760a3a33 introduced `required="1"` on the sub-task `project_id` inside the `child_ids` One2many list: https://github.com/odoo/odoo/blob/46adf760a3a33e48d34fe99c565a8c6c1194fb65/addons/project/views/project_task_views.xml#L479

This causes the main form's `project_id` required expression (`parent_id or child_ids or is_template`) to be ORed with `1`, always evaluating to true. On initial navigation the sub-task list is not yet loaded so it works, but on a full page refresh all field attributes are merged at once, making the main task's project field unconditionally required.

Solution
Change the sub-task's `project_id` required expression to `parent_id or child_ids or is_template`, matching the main form's field. This still evaluates to true for sub-tasks (they always have a `parent_id`) while no longer forcing true on standalone to-dos that have no project.

opw-6008266