### PR TITLE
[FIX] pos_hr: prevent singleton error during batch write

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -19,32 +19,37 @@ class PosConfig(models.Model):
         help='Employees linked to users with the PoS Manager role are automatically added to this list')
 
     def write(self, vals):
-        if 'advanced_employee_ids' not in vals:
-            vals['advanced_employee_ids'] = []
-        group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
-            lambda u: self.company_id in u.company_ids
-        )
-        allowed_employees = group_users.sudo().mapped('employee_id')
-        if not allowed_employees and group_users:
-            target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_id)[0]
-            target_user.action_create_employee()
-            allowed_employees = target_user.employee_id
+        sudo_vals = {}
+        for field_name in ('minimal_employee_ids', 'basic_employee_ids', 'advanced_employee_ids'):
+            if self.env.su:
+                continue
+            value = vals.get(field_name)
+            if isinstance(value, list) and all(isinstance(cmd, (list, tuple)) for cmd in value):
+                sudo_vals[field_name] = vals.pop(field_name)
 
-        # Update the vals list
-        vals['advanced_employee_ids'] += [(4, emp.id) for emp in allowed_employees]
+        res = True
+        for company in self.mapped('company_id'):
+            company_records = self.filtered(lambda r: r.company_id == company)
+            company_vals = dict(vals)
+            advanced_employees = list(company_vals.get('advanced_employee_ids') or [])
 
-        # write employees in sudo, because we have no access to these corecords
-        sudo_vals = {
-            field_name: vals.pop(field_name)
-            for field_name in ('minimal_employee_ids', 'basic_employee_ids', 'advanced_employee_ids')
-            if not self.env.su
-            if isinstance(vals.get(field_name), list)
-            if all(isinstance(cmd, (list, tuple)) for cmd in vals[field_name])
-        }
+            group_users = company_records.sudo()._get_group_pos_manager().user_ids.filtered(
+                lambda u: company in u.company_ids
+            )
+            allowed_employees = group_users.sudo().mapped('employee_id')
+            if not allowed_employees and group_users:
+                users_without_employee = group_users.with_company(company).filtered(lambda u: not u.employee_id)
+                if users_without_employee:
+                    target_user = users_without_employee[0]
+                    target_user.action_create_employee()
+                    allowed_employees = target_user.employee_id
 
-        res = super().write(vals)
-        if sudo_vals:
-            super(PosConfig, self.sudo()).write(sudo_vals)
+            advanced_employees += [(4, emp.id) for emp in allowed_employees]
+            company_vals['advanced_employee_ids'] = advanced_employees
+            res = super(PosConfig, company_records).write(company_vals) and res
+            if sudo_vals:
+                super(PosConfig, company_records.sudo()).write(sudo_vals)
+
         return res
 
     @api.onchange('minimal_employee_ids')

--- a/addons/pos_hr/tests/test_point_of_sale_flow.py
+++ b/addons/pos_hr/tests/test_point_of_sale_flow.py
@@ -3,7 +3,8 @@
 from unittest.mock import patch
 
 import odoo
-from odoo.addons.point_of_sale.tests.common import CommonPosTest
+from odoo import Command
+from odoo.addons.point_of_sale.tests.common import CommonPosTest, TestPoSCommon
 from odoo.exceptions import UserError
 
 
@@ -28,3 +29,28 @@ class TestPointOfSaleFlow(CommonPosTest):
 
         session.set_opening_control(0, None)
         self.assertEqual(int(session.name.split('/')[1]), int(current_session_name.split('/')[1]) + 1)
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPosHrBatchWrite(TestPoSCommon):
+
+    def test_batch_write_multi_company_singleton(self):
+        company_b = self.setup_other_company(name='Company B')
+
+        payment_method_b = self.env['pos.payment.method'].create({
+            'name': 'Cash B',
+            'receivable_account_id': company_b['default_account_receivable'].id,
+            'journal_id': company_b['default_journal_cash'].id,
+            'company_id': company_b['company'].id,
+        })
+        pos_config_b = self.env['pos.config'].create({
+            'name': 'Config B',
+            'company_id': company_b['company'].id,
+            'journal_id': company_b['default_journal_sale'].id,
+            'invoice_journal_id': company_b['default_journal_sale'].id,
+            'payment_method_ids': [Command.set([payment_method_b.id])],
+        })
+        configs = self.basic_config | pos_config_b
+        configs.write({'cash_rounding': False})
+
+        self.assertFalse(any(configs.mapped('cash_rounding')))


### PR DESCRIPTION
Since odoo/odoo@ab3fddb58f4329f4d95d45e0fbccec8c690a18fb, the write method uses `with_company(self.company_id)`. If `write` is called on a recordset containing multiple POS config belonging to diff companies, a ValueError (Expected singleton) is raised.

This scenario occurs when saving Settings (res.config.settings). The `set_values` method[^1] in `point_of_sale` can trigger a batch write on multiple `pos.config` records (e.g., when updating `cash_rounding`).

```py
  File "/home/odoo/src/odoo/19.0/addons/point_of_sale/models/res_config_settings.py", line 202, in set_values
    ]).cash_rounding = False
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1845, in __set__
    records.write({self.name: write_value})
  File "/home/odoo/src/enterprise/19.0/pos_urban_piper/models/pos_config.py", line 114, in write
    res = super().write(vals)
  File "/home/odoo/src/odoo/19.0/addons/pos_self_order/models/pos_config.py", line 187, in write
    res = super().write(vals)
  File "/home/odoo/src/odoo/19.0/addons/pos_restaurant/models/pos_config.py", line 51, in write
    return super().write(vals)
  File "/home/odoo/src/odoo/19.0/addons/pos_hr/models/pos_config.py", line 25, in write
    group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6005, in with_company
    company_id = int(company)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6655, in __int__
    return self.id or 0
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields_misc.py", line 114, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.company(1, 3, 7, 4, 11, 8)
```

This patch ensures the company-dependent logic is executed per-record.

opw-[6013433](https://www.odoo.com/odoo/70/tasks/6013433?debug=1)
upg-[3949467](https://upgrade.odoo.com/odoo/request/3949467?debug=1)

[^1]: https://github.com/odoo/odoo/blob/19.0/addons/point_of_sale/models/res_config_settings.py#L194-L202


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
