### PR TITLE
[IMP] web,*: follow up for M3.1 style commit

### DIFF
--- a/addons/account/static/src/components/manyone_banks/many2one_banks.xml
+++ b/addons/account/static/src/components/manyone_banks/many2one_banks.xml
@@ -3,8 +3,8 @@
     <t t-name="account.Many2OneBank" t-inherit="web.Many2One">
         <xpath expr="//t[@t-if='this.props.readonly']" position="before">
             <t t-if="this.props.value.id">
-                <i t-if="this.props.value.allow_out_payment" class="fa fa-shield text-success align-self-center o_input_box_overlay_start" title="Trusted"/>
-                <i t-else="" class="fa fa-exclamation-circle text-danger o_input_box_overlay_start" title="Untrusted"/>
+                <i t-if="this.props.value.allow_out_payment" class="me-1 fa fa-shield text-success align-self-center" title="Trusted"/>
+                <i t-else="" class="me-1 fa fa-exclamation-circle text-danger align-self-center" title="Untrusted"/>
             </t>
         </xpath>
     </t>

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -28,11 +28,12 @@
                 />
             </t>
             <t t-else="">
-                <div class="o_input_box">
+                <div class="d-flex align-items-center gap-1">
                     <Many2One t-props="this.m2oProps" t-on-keydown="this.onM2oInputKeydown"/>
                     <t t-if="this.showLabelVisibilityToggler">
                         <button
-                            class="o_input_box_overlay_end btn btn-link fa fa-bars"
+                            class="btn fa fa-bars text-start o_external_button px-1"
+                            type="button"
                             id="labelVisibilityButtonId"
                             data-tooltip="Click or press enter to add a description"
                             t-on-click="() => this.switchLabelVisibility()"

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -132,29 +132,24 @@
                             <field name="stop" required="not allday" invisible="1" />
                             <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in many2many_attendees widget -->
                             <field name="allday" widget="boolean_toggle" force_save="1" options="{'autosave': False}" readonly="not user_can_edit"/>
-                            <label for="duration" class="fw-bold text-900 opacity-100" invisible="allday"/>
-                            <div class="o_input_box" invisible="allday">
-                                <field name="duration" widget="float_time" string="Duration" readonly="(id and recurrency) or not user_can_edit"/>
-                            </div>
+                            <field name="duration" widget="float_time" string="Duration" invisible="allday" readonly="(id and recurrency) or not user_can_edit"/>
                             <field name="location" placeholder="Online Meeting" readonly="not user_can_edit"/>
                             <label for="videocall_location" class="opacity-100"/>
-                            <div name="videocall_location_div">
-                                <div class="o_input_box">
-                                    <field name="videocall_location" string="Video Link" widget="CopyClipboardChar"
-                                        force_save="1" readonly="videocall_source == 'discuss' or not user_can_edit"/>
-                                    <button name="clear_videocall_location" type="object" class="btn btn-link o_input_box_overlay_end"
-                                        invisible="not videocall_location or not user_can_edit" context="{'recurrence_update': recurrence_update}">
-                                        <i title="Clear meeting" data-tooltip="Clear meeting" class="fa fa-times"/>
-                                    </button>
-                                    <button name="action_join_video_call" class="btn btn-link o_input_box_overlay_end" type="object"
-                                        invisible="not videocall_location or not user_can_edit">
-                                        <i title="Join Video Call" data-tooltip="Join video call" class="fa fa-sign-in"/>
-                                    </button>
-                                    <button name="set_discuss_videocall_location" type="object" class="btn btn-link o_input_box_overlay_end"
-                                        invisible="videocall_location or not user_can_edit" context="{'recurrence_update': recurrence_update}">
-                                        <span class="mx-1"><i class="fa fa-plus me-1"/>Odoo meeting</span>
-                                    </button>
-                                </div>
+                            <div name="videocall_location_div" class="d-flex flex-nowrap align-items-baseline">
+                                <field name="videocall_location" string="Video Link" widget="CopyClipboardChar"
+                                    force_save="1" class="d-inline-flex text-truncate" readonly="videocall_source == 'discuss' or not user_can_edit"/>
+                                <button name="clear_videocall_location" type="object" class="btn btn-link"
+                                    invisible="not videocall_location or not user_can_edit" context="{'recurrence_update': recurrence_update}">
+                                    <i title="Clear meeting" data-tooltip="Clear meeting" class="fa fa-times"/>
+                                </button>
+                                <button name="action_join_video_call" class="btn btn-link" type="object"
+                                    invisible="not videocall_location or not user_can_edit">
+                                    <i title="Join Video Call" data-tooltip="Join video call" class="fa fa-sign-in"/>
+                                </button>
+                                <button name="set_discuss_videocall_location" type="object" class="btn btn-link text-nowrap"
+                                    invisible="videocall_location or not user_can_edit" context="{'recurrence_update': recurrence_update}">
+                                    <span class="mx-1"><i class="fa fa-plus me-1"/>Odoo meeting</span>
+                                </button>
                             </div>
                             <field name="res_record"/>
                             <field name="res_model" invisible="1"/>
@@ -175,7 +170,7 @@
                             <div class="o_form_label">
                                 <field name="attendees_count" class="w-auto oe_inline" nolabel="1"/><span> guests</span>
                             </div>
-                            <div class="o_input_box w-100 p-2">
+                            <div class="w-100 p-2">
                                 <div class="d-flex text-muted fw-normal w-100 p-3">
                                     <span invisible="not accepted_count and not tentative_count and not declined_count and not awaiting_count">
                                         <span invisible="not accepted_count" class="me-1">
@@ -315,48 +310,48 @@
                     <field name="unavailable_partner_ids" widget="many2many_tags"/>
                 </div>
                 <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
-                <div class="o_input_box">
-                    <i class="o_input_box_overlay_start fa fa-tag" title="Booking Name"/>
-                    <field name="name" nolabel="1"
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2">
+                    <i class="fa fa-tag" title="Booking Name"/>
+                    <field name="name" nolabel="1" class="w-100"
                         placeholder="Add Title"
                     />
                 </div>
-                <div class="o_input_box  pt-1 pb-2 d-md-flex">
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2 flex-wrap">
                     <!--when "stop" is set manually, "duration" is computed. When "start" is changed
                     "stop" is computed based on the previously-computed "duration". Hence we need to
                     keep the last computed duration in the front-end model and send it with "start"
                     when it changes-->
                     <!--field is also used for custom behavior in default_get, check before removing-->
-                    <i class="o_input_box_overlay_start fa fa-clock-o d-touch-none mt-1" title="Dates"/>
+                    <i class="fa fa-clock-o mt-1" title="Dates"/>
                     <field name="duration" invisible="1" force_save="1"/>
-                    <field name="start" nolabel="1" class="d-block flex-grow-1"
+                    <field name="start" nolabel="1" class="text-nowrap flex-grow-1"
                         widget="daterange" options="{'end_date_field': 'stop'}"
                         placeholder="Dates"
                         invisible="allday"
                     />
-                    <field name="start_date" nolabel="1" class="d-block flex-grow-1"
+                    <field name="start_date" nolabel="1" class="text-nowrap flex-grow-1"
                         widget="daterange" options="{'end_date_field': 'stop_date'}"
                         placeholder="Dates"
                         invisible="not allday"
                     />
-                    <span class="d-flex text-nowrap justify-content-start align-items-center mx-3">
+                    <span class="text-nowrap w-auto">
                         <!-- This is needed so that show_as can be set as 'free' when creating all day events -->
                         <field name="show_as" invisible="1"/>
                         <label for="allday" string="All day" class="ms-md-3"/>
-                        <field name="allday" widget="boolean_toggle" class="mb-0 mt-1" title="All Day" nolabel="1"/>
+                        <field name="allday" widget="boolean_toggle" title="All Day" nolabel="1"/>
                     </span>
                     <field name="stop" invisible="1"/>
                 </div>
-                <div class="o_input_box w-100 mb-md-2">
-                    <i class="o_input_box_overlay_start fa fa-user" title="Participants"/>
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2">
+                    <i class="fa fa-user" title="Participants"/>
                     <field name="partner_ids" nolabel="1" class="w-100"
                         widget="many2many_tags"
                         placeholder="Participants"
                     />
                 </div>
-                <div class="o_input_box mb-md-2">
-                    <i class="o_input_box_overlay_start fa fa-map" title="Location"/>
-                    <field name="location" nolabel="1"
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2">
+                    <i class="fa fa-map" title="Location"/>
+                    <field name="location" nolabel="1" class="w-100"
                         placeholder="Room or Location"
                     />
                     <!--fields set via the fake front-end only actions must be force saved (see calendar_form)-->
@@ -364,27 +359,27 @@
                     <field name="access_token" force_save="1" invisible="1"/>
                     <field name="videocall_location" force_save="1" invisible="1"/>
                     <field name="videocall_source" force_save="1" invisible="1"/>
-                    <button name="set_discuss_videocall_location" type="object" class="o_input_box_overlay_end btn btn-link visible"
+                    <button name="set_discuss_videocall_location" type="object" class="btn btn-link visible text-nowrap"
                         invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
                         <span class="fa fa-plus me-1"/>Video conference
                     </button>
                 </div>
-                <div class="o_input_box mb-md-2" invisible="not videocall_location">
-                    <i class="o_input_box_overlay_start fa fa-video-camera" title="Videocall URL"/>
-                    <field name="videocall_location" nolabel="1" widget="CopyClipboardChar"/>
-                    <button name="clear_videocall_location" class="o_input_box_overlay_end btn btn-link"><i class="fa fa-remove" title="Remove"/></button>
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2" invisible="not videocall_location">
+                    <i class="fa fa-video-camera" title="Videocall URL"/>
+                    <field name="videocall_location" class="w-100 text-truncate" nolabel="1" widget="CopyClipboardChar"/>
+                    <button name="clear_videocall_location" class="btn btn-link p-1"><i class="fa fa-remove" title="Remove"/></button>
                 </div>
-                <div class="o_input_box mb-md-2">
-                    <i class="o_input_box_overlay_start fa fa-lock" title="Visibility"/>
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2">
+                    <i class="fa fa-lock" title="Visibility"/>
                     <field name="privacy_placeholder" invisible="1"/> <!-- Used to generate the privacy field's placeholder. -->
                     <field name="privacy" nolabel="1" options="{'placeholder_field': 'privacy_placeholder'}" class="w-100"/>
                 </div>
-                <div class="o_input_box mb-md-2">
-                    <i class="o_input_box_overlay_start fa fa-circle" title="Show as"/>
+                <div class="o_outlined d-flex align-items-baseline mb-3 gap-2">
+                    <i class="fa fa-circle" title="Show as"/>
                     <field name="show_as" nolabel="1" class="w-100"/>
                 </div>
-                <div class="o_input_box d-flex">
-                    <i class="o_input_box_overlay_start fa fa-sticky-note" title="Notes"/>
+                <div class="o_outlined d-flex align-items-center mb-3 gap-2">
+                    <i class="fa fa-sticky-note" title="Notes"/>
                     <field name="notes" nolabel="1" class="w-100" placeholder="Notes" widget="calendar_event_notes_html"/>
                 </div>
             </form>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -227,9 +227,9 @@
                                 <field name="user_id" context="{'default_sales_team_id': team_id}"
                                     widget="many2one_avatar_leader_user" teamField="team_id"/>
                                 <label for="date_deadline" invisible="type == 'lead'">Expected Closing</label>
-                                <div class="o_input_box" invisible="type == 'lead'">
+                                <div class="d-flex gap-3 align-items-center" invisible="type == 'lead'">
                                     <field name="date_deadline" nolabel="1" placeholder="No closing estimate"/>
-                                    <field name="priority" widget="priority" nolabel="1" class="o_input_box_overlay_end"/>
+                                    <field name="priority" widget="priority" nolabel="1" class="w-auto"/>
                                 </div>
                                 <field name="priority" widget="priority" invisible="type == 'opportunity'"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
@@ -390,10 +390,11 @@
             <field name="arch" type="xml">
                 <form>
                     <group class="crm_quick_create_opportunity_form_group">
-                        <div class="o_input_box" colspan="2">
-                            <i class="fa fa-user o_input_box_overlay_start" title="Contact"/>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-user" title="Contact"/>
                             <field name="partner_id"
                                 nolabel="1"
+                                class="o_field_highlight"
                                 placeholder='Contact'
                                 context="{
                                 'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
@@ -406,30 +407,27 @@
                                 'show_vat': True}"
                             />
                         </div>
-                        <div class="o_input_box" colspan="2">
-                            <i class="fa fa-briefcase o_input_box_overlay_start" title="Opportunity Name"/>
-                            <field name="name" nolabel="1" placeholder="Opportunity's Name"/>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-briefcase" title="Opportunity Name"/>
+                            <field name="name" nolabel="1" placeholder="Opportunity's Name" class="o_field_highlight"/>
                         </div>
-                        <div class="o_input_box" colspan="2">
-                            <i class="fa fa-envelope o_input_box_overlay_start" title="Contact Email"/>
-                            <field name="email_from" string="Contact Email" placeholder='Contact Email' nolabel="1"/>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-envelope" title="Contact Email"/>
+                            <field name="email_from" string="Contact Email" placeholder='Contact Email' nolabel="1" class="o_field_highlight"/>
                         </div>
-                        <div class="o_input_box" colspan="2">
-                            <i class="fa fa-mobile fa-lg o_input_box_overlay_start" title="Contact Phone"/>
-                            <field name="phone" string="Contact Phone" placeholder='Contact Phone' nolabel="1"/>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-mobile fa-lg" title="Contact Phone"/>
+                            <field name="phone" string="Contact Phone" placeholder='Contact Phone' nolabel="1" class="o_field_highlight"/>
                         </div>
-                        <div class="o_input_box" colspan="2">
-                            <i class="fa fa-money o_input_box_overlay_start" title="Expected Revenue"/>
-                            <field name="expected_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                            <field name="priority" class="o_input_box_overlay_end" nolabel="1" widget="priority"/>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-money" title="Expected Revenue"/>
+                            <field name="expected_revenue" class="o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                            <field name="priority" class="w-auto" nolabel="1" widget="priority"/>
                         </div>
-                        <div class="o_row" colspan="2">
-                            <div class="o_input_box" groups="crm.group_use_recurring_revenues">
-                                <button class="o_input_box_overlay_start btn btn-link fa fa-refresh" data-tooltip="Recurring Revenue" title="Recurring Revenue"/>
-                                <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                            </div>
-                            <field name="recurring_plan" placeholder='e.g. "Monthly"'
-                                required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
+                        <div class="d-flex align-items-center" colspan="2" groups="crm.group_use_recurring_revenues">
+                            <i class="fa fa-refresh" title="Recurring Revenue"/>
+                            <field name="recurring_revenue" class="o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                            <field name="recurring_plan" placeholder='e.g. "Monthly"' required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
                         </div>
                         <field name="company_currency" invisible="1"/>
                         <field name="company_id" invisible="1"/>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -32,13 +32,13 @@
                 <field name="encode_uom_in_days" invisible="1"/>
                 <field name="subtask_count" invisible="1"/>
                 <label for="allocated_hours" invisible="not allow_timesheets"/>
-                <div id="allocated_hours_container" class="o_input_box" invisible="not allow_timesheets">
-                    <field name="allocated_hours" widget="float_time" readonly="1"/>
-                    <span invisible="subtask_count == 0" class="o_input_box_overlay_end">
+                <div id="allocated_hours_container" class="d-flex align-items-baseline" invisible="not allow_timesheets">
+                    <field name="allocated_hours" class="oe_inline" widget="float_time" readonly="1"/>
+                    <span invisible="subtask_count == 0">
                         incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline mx-1"/> on
                         <span class="fw-bold ms-1">Sub-tasks</span>
                     </span>
-                    <field name="progress" invisible="not project_id" class="o_input_box_overlay_end" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>
+                    <field name="progress" invisible="not project_id" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>
                 </div>
             </xpath>
             <xpath expr="//notebook/page[@name='description_page']" position="after">

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -19,14 +19,14 @@
                     <field name="encode_uom_in_days" invisible="1"/>
                     <field name="subtask_count" invisible="1"/>
                     <label for="allocated_hours" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <div id="allocated_hours_container" class="o_input_box" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
-                        <field name="allocated_hours" class="o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
-                        <span invisible="subtask_count == 0" class="o_input_box_overlay_end">
+                    <div id="allocated_hours_container" class="d-flex align-items-baseline" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="allocated_hours" class="oe_inline o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
+                        <span invisible="subtask_count == 0">
                             incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline mx-1"/> on
                             <span class="fw-bold ms-1">Sub-tasks</span>
                         </span>
                          <span invisible="is_template or has_project_template">
-                            <field name="progress" invisible="not project_id" class="o_input_box_overlay_end" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>
+                            <field name="progress" invisible="not project_id" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>
                         </span>
                     </div>
                 </xpath>

--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
@@ -10,7 +10,6 @@
         </xpath>
         <xpath expr="//*[hasclass('o_field_input_buttons')]" position="attributes">
             <attribute name="style" add="visibility: visible;" separator=" " />
-            <attribute name="class" add="o_input_box_overlay_end" separator=" " />
         </xpath>
     </t>
 </templates>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -87,34 +87,34 @@
                         <group>
                             <field name="content_background" widget="image" class="w-25"/>
                             <label for="content_header"/>
-                            <div class="o_input_box align-items-center">
-                                <field name="content_header_dyn" title="Dynamic Field?" class="o_input_box_overlay_start"/>
+                            <div class="d-flex align-items-center gap-1">
+                                <field name="content_header_dyn" title="Dynamic Field?"/>
                                 <field name="content_header" invisible="content_header_dyn" placeholder="e.g. Join Odoo Experience 2024"/>
                                 <field name="content_header_path" invisible="not content_header_dyn" placeholder="Select a field" widget="field_selector" options="{'model': 'res_model'}"/>
-                                <field name="content_header_color" widget="color" class="o_input_box_overlay_end ms-auto mb-0" style="min-width: 40px; max-width: 40px;"/>
+                                <field name="content_header_color" widget="color" class="ms-auto" style="min-width: 40px; max-width: 40px;"/>
                             </div>
                             <label for="content_sub_header"/>
-                            <div class="o_input_box align-items-center">
-                                <field name="content_sub_header_dyn" class="o_input_box_overlay_start"/>
+                            <div class="d-flex align-items-center gap-1">
+                                <field name="content_sub_header_dyn"/>
                                 <field name="content_sub_header" invisible="content_sub_header_dyn" placeholder="e.g. Aug 24, Brussels Expo"/>
                                 <field name="content_sub_header_path" invisible="not content_sub_header_dyn" placeholder="Select a field" widget="field_selector" options="{'model': 'res_model'}"/>
-                                <field name="content_sub_header_color" widget="color" class="o_input_box_overlay_end ms-auto mb-0" style="min-width: 40px; max-width: 40px;"/>
+                                <field name="content_sub_header_color" widget="color" class="ms-auto" style="min-width: 40px; max-width: 40px;"/>
                             </div>
                             <label for="content_section"/>
-                            <div class="o_input_box align-items-center">
-                                <field name="content_section_dyn" class="o_input_box_overlay_start"/>
+                            <div class="d-flex align-items-center gap-1">
+                                <field name="content_section_dyn"/>
                                 <field name="content_section" invisible="content_section_dyn" placeholder="e.g. Sample Talk"/>
                                 <field name="content_section_path" invisible="not content_section_dyn" placeholder="Select a field" widget="field_selector" options="{'model': 'res_model'}"/>
                             </div>
                             <label for="content_sub_section1"/>
-                            <div class="o_input_box align-items-center">
-                                <field name="content_sub_section1_dyn" class="o_input_box_overlay_start"/>
+                            <div class="d-flex align-items-center gap-1">
+                                <field name="content_sub_section1_dyn"/>
                                 <field name="content_sub_section1" invisible="content_sub_section1_dyn" placeholder="e.g. By Lionel Messy"/>
                                 <field name="content_sub_section1_path" invisible="not content_sub_section1_dyn" placeholder="Select a field" widget="field_selector" options="{'model': 'res_model'}"/>
                             </div>
                              <label for="content_sub_section2"/>
-                            <div class="o_input_box align-items-center">
-                                <field name="content_sub_section2_dyn" class="o_input_box_overlay_start"/>
+                            <div class="d-flex align-items-center gap-1">
+                                <field name="content_sub_section2_dyn"/>
                                 <field name="content_sub_section2" invisible="content_sub_section2_dyn" placeholder="e.g. CFO Chief Football Officer"/>
                                 <field name="content_sub_section2_path" invisible="not content_sub_section2_dyn" placeholder="Select a field" widget="field_selector" options="{'model': 'res_model'}"/>
                             </div>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -171,7 +171,6 @@
                             <group>
                                 <group invisible="type == 'phantom'">
                                     <field name="picking_type_id" groups="stock.group_adv_location"/>
-                                    <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <field name="produce_delay" class="oe_inline"/>days
                                     <label for="days_to_prepare_mo"/>
                                     <div>
@@ -180,10 +179,11 @@
                                             <field name="json_popover" widget="mrp_bom_popover"/>
                                         </button>
                                     </div>
-                                    <field name="enable_batch_size" widget="boolean_toggle"/>
-                                    <div class="o_input_box" invisible="type != 'normal'">
-                                        <field name="batch_size" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
-                                        <field name="uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size" class="o_input_box_overlay_end o_input_box_inline"/>
+                                    <label for="batch_size" invisible="type != 'normal'"/>
+                                    <div class="o_row" invisible="type != 'normal'">
+                                        <field name="enable_batch_size"/>
+                                        <field name="batch_size" class="w-50" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
+                                        <field name="uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size"/>
                                     </div>
                                 </group>
                                 <group>

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -14,9 +14,8 @@
                             <field name="product_name"/>
                             <field name="product_code"/>
                             <label for="delay"/>
-                            <div class="o_input_box">
-                                <field name="delay" />
-                                <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
+                            <div>
+                                <field name="delay" class="oe_inline"/> days
                             </div>
                         </group>
                         <group string="Pricelist">
@@ -32,15 +31,11 @@
                             <div class="o_row">
                                 <field name="price" class="oe_inline" /><field name="currency_id" groups="base.group_multi_currency" options="{'no_open': True}"/>
                             </div>
+                            <label for="date_start" string="Validity"/>
                             <div class="o_row">
-                                <div class="o_cell">
-                                    <label for="date_start" string="Validity Start"/>
-                                    <field name="date_start"/>
-                                </div>
-                                <div class="o_cell">
-                                    <label for="date_end" string="to"/>
-                                    <field name="date_end"/>
-                                </div>
+                                <field name="date_start" class="oe_inline"/>
+                                to
+                                <field name="date_end" class="oe_inline"/>
                             </div>
                             <field name="discount"/>
                             <field name="company_id" options="{'no_create': True}"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -250,14 +250,14 @@
                             <group name="inventory">
                                 <group name="group_lots_and_weight" string="Logistics" invisible="type != 'consu'">
                                     <label for="weight" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                                    <div class="o_input_box" name="weight" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="weight"/>
-                                        <field name="weight_uom_name" class="o_input_box_overlay_end"/>
+                                    <div class="o_row" name="weight" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                                        <field name="weight" class="oe_inline" style="max-width: 7rem;"/>
+                                        <field name="weight_uom_name"/>
                                     </div>
                                     <label for="volume" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                                    <div class="o_input_box" name="volume" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="volume" string="Volume"/>
-                                        <field name="volume_uom_name" class="o_input_box_overlay_end"/>
+                                    <div class="o_row" name="volume" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                                        <field name="volume" string="Volume" class="oe_inline" style="max-width: 7rem;"/>
+                                        <field name="volume_uom_name"/>
                                     </div>
                                 </group>
                             </group>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -465,7 +465,7 @@
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                             <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id or has_template_ancestor or has_project_template"/>
                             <label for="date_deadline"/>
-                            <div id="date_deadline_and_recurring_task" class="o_input_box">
+                            <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100">
                                 <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
                                 <field name="recurring_task" nolabel="1" class="w-auto w-lg-100"
                                        widget="boolean_icon" options="{'icon': 'fa-repeat'}"

--- a/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.xml
+++ b/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="sale_timesheet.SoLineCreateButton">
-        <div class="o_input_box">
+        <div class="d-flex align-items-center gap-1">
             <Many2One t-props="this.m2oProps"/>
             <button
                 t-if="!this.props.readonly and !this.props.record.data.sale_line_id"
-                t-attf-class="btn btn-link o_input_box_overlay_end"
+                t-attf-class="btn btn-link"
                 tabindex="-1"
                 aria-label="Create Sales Order"
                 data-tooltip="Create Sales Order"

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -187,15 +187,17 @@
                     <!-- Replace the single line tacking + qty without stock with 2 individual lines with stock (tracking + tracking method // qty) -->
                     <field name="tracking" placeholder="None" invisible="type != 'consu'" groups="stock.group_production_lot"/>
                     <!-- Qty line if storable -->
-                    <label for="qty_available" invisible="not is_storable or not tracking" groups="stock.group_stock_user"/>
-                    <div name="qty_available_with_stock" class="o_input_box" invisible="not is_storable or not tracking" groups="stock.group_stock_user">
+                    <label for="qty_available" class="oe_inline" invisible="not is_storable or not tracking" groups="stock.group_stock_user"/>
+                    <div name="qty_available_with_stock" class="o_row" invisible="not is_storable or not tracking" groups="stock.group_stock_user">
                         <a type="object" name="action_open_quants"
                            invisible="not show_qty_update_button" groups="stock.group_stock_manager">
                             <field name="qty_available" readonly="True"/>
                         </a>
-                        <field name="qty_available" invisible="show_qty_update_button" groups="stock.group_stock_manager"/>
-                        <field name="qty_available" readonly="True" groups="!stock.group_stock_manager"/>
-                        <field groups="uom.group_uom" name="uom_name" class="o_input_box_overlay_end"/>
+                        <field name="qty_available" invisible="show_qty_update_button" groups="stock.group_stock_manager" style="max-width: fit-content;"/>
+                        <field name="qty_available" readonly="True" groups="!stock.group_stock_manager" style="max-width: fit-content;"/>
+                        <span name="uom_span" groups="uom.group_uom">
+                            <field name="uom_name" class="oe_inline"/>
+                        </span>
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='is_storable']" position="attributes">
@@ -205,9 +207,8 @@
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                     <label for="sale_delay" invisible="not sale_ok"/>
-                    <div class="o_input_box" invisible="not sale_ok">
-                        <field name="sale_delay"/>
-                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
+                    <div invisible="not sale_ok">
+                        <field name="sale_delay" class="oe_inline" style="vertical-align:baseline"/> days
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="before">
@@ -225,9 +226,9 @@
                 <xpath expr="//group[@name='group_lots_and_weight']" position="after">
                     <group string="Traceability" name="traceability" groups="stock.group_production_lot" invisible="tracking not in ['lot', 'serial']">
                         <label for="serial_prefix_format" string="Custom Lot/Serial"/>
-                        <div class="o_input_box">
-                            <field name="serial_prefix_format"/>
-                            <field class="o_input_box_overlay_end o_input_box_overlay_inline" name="next_serial"/>
+                        <div class="d-flex">
+                            <field name="serial_prefix_format" style="max-width: 150px;"/>
+                            <field name="next_serial" style="max-width: 150px;"/>
                         </div>
                     </group>
                      <group string="Counterpart Locations" name="stock_property" groups="base.group_no_one">

--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -4,7 +4,7 @@
     <t t-name="web.BinaryField">
         <t t-if="!this.props.readonly">
             <t t-if="this.props.record.data[this.props.name]">
-                <div class="w-100 d-inline-flex gap-1 o_input_box cursor-pointer">
+                <div class="w-100 d-inline-flex gap-1 cursor-pointer">
                     <FileUploader
                         acceptedFileExtensions="this.props.acceptedFileExtensions"
                         allowedMIMETypes="this.props.allowedMIMETypes"
@@ -12,7 +12,7 @@
                     >
                         <t name="download" t-if="this.props.record.resId and !this.props.record.dirty">
                             <button
-                                class="btn btn-link fa fa-download o_download_file_button o_input_box_overlay_end"
+                                class="btn btn-link fa fa-download o_download_file_button"
                                 data-tooltip="Download"
                                 aria-label="Download"
                                 t-on-click="this.onFileDownload"
@@ -27,7 +27,7 @@
                             </t>
                         </t>
                         <button
-                            class="btn btn-link fa fa-trash o_clear_file_button o_input_box_overlay_end"
+                            class="btn btn-link fa fa-trash o_clear_file_button"
                             data-tooltip="Clear"
                             aria-label="Clear"
                             t-on-click="() => this.update({})"
@@ -43,9 +43,9 @@
                         onUploaded.bind="this.update"
                     >
                         <t t-set-slot="toggler">
-                            <div class="o_input_box text-start">
+                            <div class="d-flex">
                                 Upload your file
-                                <button class="o_input_box_overlay_end btn btn-link fa fa-upload" />
+                                <button class="btn btn-link fa fa-upload ms-auto" />
                             </div>
                         </t>
                     </FileUploader>

--- a/addons/web/static/src/views/fields/char/char_field.scss
+++ b/addons/web/static/src/views/fields/char/char_field.scss
@@ -5,3 +5,39 @@
         width: inherit;
     }
 }
+
+.o_field_widget:has(.o_input + .o_field_input_buttons) {
+    position: relative;
+}
+
+.o_field_input_buttons {
+    position: absolute;
+    right: 0;
+    height: 100%;
+    display: inline-flex;
+    visibility: hidden;
+
+    .o_field_char & {
+        align-items: center;
+    }
+    .o_field_text & {
+        align-items: flex-start;
+    }
+
+    .btn.o_field_translate {
+        position: relative;
+        right: auto;
+        top: auto;
+
+        &:only-child {
+            padding-right: 10px;
+        }
+    }
+}
+
+.o_field_widget:hover,
+.o_field_widget:focus-within {
+    .o_field_input_buttons {
+        visibility: visible;
+    }
+}

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -24,7 +24,7 @@ class CopyClipboardField extends Component {
     }
 
     get copyButtonClassName() {
-        return `o_btn_${this.type}_copy btn-link o_input_box_overlay_end`;
+        return `o_btn_${this.type}_copy btn-link`;
     }
     get fieldProps() {
         return omit(this.props, "string", "disabledExpr");

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CopyClipboardField">
-        <div class="o_input_box">
+        <div class="d-flex w-100 text-truncate">
             <Field t-props="this.fieldProps"/>
             <CopyButton t-if="this.props.record.data[this.props.name]" className="this.copyButtonClassName" content="this.props.record.data[this.props.name]" icon="this.copyButtonIcon" successText="this.successText"/>
         </div>

--- a/addons/web/static/src/views/fields/percentage/percentage_field.xml
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.xml
@@ -6,7 +6,7 @@
             <span t-out="this.formattedValue"/>
         </t>
         <t t-else="">
-            <div class="o_input_box">
+            <div class="d-flex">
                 <input
                     t-custom-ref="numpadDecimal"
                     t-attf-class="o_input"
@@ -14,7 +14,7 @@
                     inputmode="decimal"
                     autocomplete="off"
                 />
-                <span t-if="!this.props.noSymbol" class="o_input_box_overlay_end">%</span>
+                <span t-if="!this.props.noSymbol">%</span>
             </div>
         </t>
     </t>

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -7,7 +7,7 @@
             <div class="progress" aria-valuemin="0" t-att-aria-valuemax="this.maxValue" t-att-aria-valuenow="this.currentValue" t-on-click="this.onProgressClick" t-att-style="this.isEditable ? 'cursor: pointer' : ''">
                 <div t-attf-class="{{ this.progressBarColorClass }}" t-att-style="'width: min(' + 100 * this.currentValue / this.maxValue + '%, 100%)'"></div>
             </div>
-            <div class="o_progressbar_value o_input_box w-25">
+            <div class="o_progressbar_value d-flex gap-1 flex-shrink-0 text-nowrap">
                 <t t-if="this.isPercentage">
                     <input
                         t-if="this.isEditable"
@@ -20,7 +20,7 @@
                         t-on-focus="this.onInputFocus"
                         t-on-blur="this.onInputBlur"
                     />
-                    <div t-attf-class="d-flex {{ this.isEditable ? 'o_input_box_overlay_inline o_input_box_overlay_end w-auto' : '' }} ">
+                    <div t-attf-class="d-flex {{ this.isEditable ? 'w-auto' : '' }} ">
                         <t t-if="!this.isEditable" t-out="this.formatCurrentValue(true)"/>
                         %
                     </div>
@@ -36,7 +36,7 @@
                         t-on-focus="this.onInputFocus"
                         t-on-blur="this.onInputBlur"
                     />
-                    <div t-attf-class="d-flex {{ this.isEditable ? 'o_input_box_overlay_inline o_input_box_overlay_end w-auto' : '' }} ">
+                    <div t-attf-class="d-flex {{ this.isEditable ? 'w-auto' : '' }} ">
                         <span t-if="!this.isEditable" t-out="this.formatCurrentValue(true)"/>
                         /
                         <span t-out="this.formatMaxValue(true)"/>

--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -76,7 +76,7 @@
         }
 
         .o_inner_group {
-            :is(.o_cell,.o_cell_custom):not(.o_wrap_label):not(.o_no_box) {
+            :is(.o_cell,.o_cell_custom):not(.o_wrap_label):not(.o_no_box):not(:has(.o_outlined)) {
                 @extend %-o-field-box;
 
                 &:has(.o_field_widget.o_readonly_modifier):not(:has(.o_field_widget:not(.o_readonly_modifier))) {
@@ -139,6 +139,21 @@
                     }
                 }
             }
+        }
+
+        .o_outlined {
+            @extend %-o-field-box;
+
+            .o_field_widget {
+                --fieldWidget-margin-bottom: 0px;
+            }
+        }
+
+        .o_form_label:has(+ .o_outlined) {
+            @extend %-o-field-label;
+            display: block;
+            width: max-content !important;
+            margin-bottom: calc(-1 * var(--body-font-size)) !important;
         }
     }
 }

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -176,12 +176,12 @@
                                 <group>
                                     <group>
                                         <label for="lang" />
-                                        <div class="o_input_box">
+                                        <div class="o_row">
                                             <field name="lang" required="1"/>
                                             <button
                                                 type="action"
                                                 name="%(base.action_view_base_language_install)d"
-                                                class="btn btn-link fa fa-globe o_input_box_overlay_end"
+                                                class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
                                                 groups="base.group_system"
                                                 aria-label="Add a language"
                                                 title="Add a language"/>
@@ -441,12 +441,12 @@
                                 <group>
                                     <group>
                                         <label for="lang"/>
-                                        <div class="o_input_box">
+                                        <div class="o_row">
                                             <field name="lang" required="1" readonly="0"/>
                                             <button
                                                 type="action"
                                                 name="%(base.action_view_base_language_install)d"
-                                                class="btn btn-link fa fa-globe o_input_box_overlay_end"
+                                                class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
                                                 aria-label="Add a language"
                                                 groups="base.group_system"
                                                 title="Add a language"


### PR DESCRIPTION
In some view outside the groups we want the boxes anyway so we introduce the `o_outlined` class.

This commit reverts the changes made for M3 to the arch, and bring back the previous template with some adaptation when needed.

Note:
* clipboard: more refactoring needed in some case icons are not visible
* M3: some class are still present

task-6054024

Co-authored-by: Luca Vitali <luvi@odoo.com>
Co-authored-by: Romain Estievenart <res@odoo.com>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
