### PR TITLE
[FIX] sale_project: fix tracebacks in actual margins report

### DIFF
--- a/addons/sale_project/models/account_analytic_line.py
+++ b/addons/sale_project/models/account_analytic_line.py
@@ -45,13 +45,13 @@ class AccountAnalyticLine(models.Model):
         self.ensure_one()
         if (self.so_line):
             return {
-                'res_model': self.so_line,
+                'res_model': self.so_line._name,
                 'type': 'ir.actions.act_window',
                 'views': [[False, "form"]],
                 'res_id': self.so_line.id,
             }
         return {
-            'res_model': self,
+            'res_model': self._name,
             'type': 'ir.actions.act_window',
             'views': [[False, "form"]],
             'res_id': self.id,

--- a/addons/sale_project/report/account_analytic_line_views.xml
+++ b/addons/sale_project/report/account_analytic_line_views.xml
@@ -34,7 +34,7 @@
         <field name="path">project-actual-margins</field>
         <field name="search_view_id" ref="account.view_account_analytic_line_filter_inherit_account"/>
         <field name="view_id" ref="view_account_analytic_line_inherit_sale_project_pivot"/>
-        <field name="view_mode">pivot,list,kanban,graph,grid</field>
+        <field name="view_mode">pivot,list,kanban,graph</field>
         <field name="context">{
             'search_default_month': 'custom_last_365_days',
         }</field>


### PR DESCRIPTION
Steps to reproduce:
-
Bug 1:
  1. Create a billable project linked to a Sales Order.
  2. Invoice the Sales Order.
  3. Open the "Actual Margins" report from the project.
  4. Click a value in "Revenues (Fixed Price)".
  5. Open a record from the list. 
- A traceback occurs with KeyError on account.analytic.line.

Bug 2:
  1. Open the "Actual Margins" report in Odoo Community edition.
- It throws a traceback: "View type grid not found in act_window action".

Cause:
-
Bug 1: In `action_open_account_analytic_line_origine`, the `res_model` in the action dict is set to a recordset instead of a model name string.

Bug 2: The `grid` view type (Enterprise only) was incorrectly included in the `view_mode` field of the Community action.

Fix:
-
Bug 1: Use `._name` to pass the model name instead of the recordset.

Bug 2: Remove `grid` from `view_mode` as the Enterprise module already adds it via an `ir.actions.act_window.view` record.

task-6085406
