### PR TITLE
[FIX] point_of_sale: display attribute value for combo instant variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -50,7 +50,8 @@ export const computeComboItems = (
         comboItems.push({
             combo_item_id: comboItem,
             price_unit: totalPriceExtra,
-            attribute_value_ids,
+            attribute_value_ids:
+                attribute_value_ids || comboItem.product_id?.product_template_attribute_value_ids,
             attribute_custom_values: conf.configuration?.attribute_custom_values || {},
             qty: conf.qty,
         });
@@ -88,7 +89,8 @@ export const computeComboItems = (
         comboItems.push({
             combo_item_id: comboItem,
             price_unit: totalPriceExtra,
-            attribute_value_ids,
+            attribute_value_ids:
+                attribute_value_ids || comboItem.product_id?.product_template_attribute_value_ids,
             attribute_custom_values: extra.configuration?.attribute_custom_values || {},
             qty: extra.qty,
         });


### PR DESCRIPTION
Before this commit, the preparation printer did not display the attribute value for an instant variant added inside a combo choice. This occurred because the attribute value was not properly set on the variant order line.

Steps to reproduce:
* Create a PoS product with multiple variants.
* Create a combo product with a choice containing the variants.
* Configure a preparation printer.
* Open a PoS session and order the combo.
* The printer displays only the base product name.

opw-5949132
