### PR TITLE
[FIX] web_tour: tour_service start onboarding tour

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -225,6 +225,10 @@ export class TourService {
         const tourName = tourState.getCurrentTour();
         const tourConfig = tourState.getCurrentConfig();
         const tour = await this.getTour(tourName, tourConfig);
+        if (!tour) {
+            tourState.clear();
+            return;
+        }
 
         tour.steps.forEach((step) => this.validateStep(step));
 
@@ -258,8 +262,8 @@ export class TourService {
                 tourState.clear();
                 browser.console.log("tour succeeded");
                 let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
-                if (message) {
-                    message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
+                if (message && window.DOMPurify) {
+                    message = window.DOMPurify.sanitize(message);
                     this.effect.add({
                         type: "rainbow_man",
                         message: markup(message),

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -806,3 +806,25 @@ test("pointer hidden when trigger is behind overlay", async () => {
     // Finalize the dummy tour to avoid leaving in a dirty state
     await contains("button.foo").click();
 });
+
+test("start a tour that no longer exist should clear tourstate", async () => {
+    Tour._records = [{ name: "tour69" }];
+    registry.category("web_tour.tours").add("tour69", {
+        steps: () => [{ trigger: "button.foo", run: "click" }],
+    });
+    class Root extends Component {
+        static components = { Counter };
+        static template = xml/*html*/ `
+                <t>
+                    <Counter />
+                </t>
+            `;
+        static props = ["*"];
+    }
+    await mountWithCleanup(Root);
+    await getService("tour_service").startTour("tour69", { mode: "manual" });
+    expect(browser.localStorage.getItem("current_tour")).toBe("tour69");
+    registry.category("web_tour.tours").remove("tour69");
+    await getService("tour_service").startTour("tour69", { mode: "manual" });
+    expect(browser.localStorage.getItem("current_tour")).toBe(null);
+});


### PR DESCRIPTION
When the tour service starts, it looks for the last tour that was stored in localStorage. If the tour is not found, it triggers an error. This commit fixes that issue.

It also adds a condition to ensure that DOMPurify is available before displaying the rainbow message.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
