### PR TITLE
[FIX] l10n_pl: Avoiding modification of account's `reconcilable` flag during upgrade

### DIFF
--- a/addons/l10n_pl/migrations/2.1/end-migrate.py
+++ b/addons/l10n_pl/migrations/2.1/end-migrate.py
@@ -5,4 +5,9 @@ def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'pl'), ('parent_id', '=', False)]):
         Template = env['account.chart.template'].with_company(company)
-        Template._load_data({'account.account': Template._get_account_account('pl')})
+
+        template_data = Template._get_chart_template_data('pl').get('template_data', {})
+        data = {'account.account': Template._get_account_account('pl')}
+
+        Template._pre_reload_data(company, template_data, data, True)
+        Template._load_data(data)


### PR DESCRIPTION
<h2>Context</h2>

Clients can have some existing accounts with `reconcilable` flag set as True. Some of these accounts also have partially reconcilated transactions. In Odoo 19.0, it is not authorized to toggle the `reconcilable` flag from True to False on accounts that contain partially reconcilated transactions.

When the migration script `l10n_pl/migrations/2.1/end-migrate.py` is executed, it tries to update the CoA by adding/updating accounts, using the accounts in the file `l10n_pl/data/template/account.account-pl.csv`. This CSV file contains a reconcilable flag per account.

<h2>Problem</h2>

Before this modification, the upgrade script was trying to update the CoA using `_load_data`, which tries to overwrite the reconcilation flag of accounts in the client DB. A traceback occurs during the upgrade if an account's `reconcilable` flag is toggled from True to False during the update of the CoA, while it still contains partially reconciled transactions.
<details>

<summary>Traceback</summary>

```
File "/home/odoo/src/odoo/19.0/addons/l10n_pl/migrations/2.1/end-migrate.py", line 8, in migrate
    Template._load_data({'account.account': Template._get_account_account('pl')})
  File "/tmp/tmpm8z3nlb0/migrations/account/0.0.0/pre-ensure-deferred-accounts.py", line 36, in _load_data
    return super()._load_data(data, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/addons/account/models/chart_template.py", line 697, in _load_data
    created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5171, in _load_records
    data['record']._load_records_write(data['values'])
  File "/home/odoo/src/odoo/19.0/addons/account/models/account_account.py", line 1122, in _load_records_write
    super()._load_records_write(values)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5092, in _load_records_write
    self.write(values)
  File "/home/odoo/src/odoo/19.0/addons/account/models/account_account.py", line 1045, in write
    self.filtered(lambda r: r.reconcile)._toggle_reconcile_to_false()
  File "/home/odoo/src/odoo/19.0/addons/account/models/account_account.py", line 975, in _toggle_reconcile_to_false
    raise UserError(_('You cannot switch an account to prevent the reconciliation '
odoo.exceptions.UserError: You cannot switch an account to prevent the reconciliation if some partial reconciliations are still pending.
```

</details>

<h2>Solution</h2>

I have sanitized the dict `data` using the `_pre_reload_data` method, so that the traceback does not appear anymore when upgrading. 

<h3>Notes</h3>

`_pre_reload_data` method sanitizes the dict `data` by avoiding the creation of duplicated accounts, the creation of duplicated fields for a given record, the toggling of the `reconcilable` flag, etcs.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
