### PR TITLE
[FIX] website_sale_collect: fix C&C widget availability

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -19,8 +19,6 @@ class ProductTemplate(models.Model):
         if (
             bool(in_store_dm)  # Click & Collect is enabled.
             and product_or_template.is_product_variant
-            and product_or_template.is_storable
-            and not (in_store_dm.excluded_tag_ids & product_or_template.all_product_tag_ids)
         ):
             product_sudo = product_or_template.sudo()  # To read the stock values when public user.
             order_sudo = request.cart
@@ -38,30 +36,41 @@ class ProductTemplate(models.Model):
                 ("website_published", "=", True),
                 ("delivery_type", "!=", "in_store"),
             ])
-            if available_delivery_methods_sudo:
+            product_tags = product_or_template.all_product_tag_ids
+            valid_delivery_methods = available_delivery_methods_sudo.filtered(
+                lambda dm: not (dm.excluded_tag_ids & product_tags)
+            )
+            if valid_delivery_methods:
                 res["delivery_stock_data"] = utils.format_product_stock_values(
                     product_sudo, uom=uom, cart_qty=cart_qty
                 )
             else:
                 res["delivery_stock_data"] = {}
 
-            # Prepare the in-store stock data.
-            if (
-                order_sudo
-                and order_sudo.carrier_id.delivery_type == "in_store"
-                and order_sudo.pickup_location_data
-            ):  # Get stock values for the product variant in the selected store.
-                res["in_store_stock_data"] = utils.format_product_stock_values(
-                    product_sudo,
-                    uom=uom,
-                    wh_id=order_sudo.pickup_location_data["id"],
-                    cart_qty=cart_qty,
-                )
+            # If C&C not excluded via tags, prepare the in-store stock data.
+            if not (in_store_dm.excluded_tag_ids & product_or_template.all_product_tag_ids):
+                if (
+                    order_sudo
+                    and order_sudo.carrier_id.delivery_type == "in_store"
+                    and order_sudo.pickup_location_data
+                ):  # Get stock values for the product variant in the selected store.
+                    res["in_store_stock_data"] = utils.format_product_stock_values(
+                        product_sudo,
+                        uom=uom,
+                        wh_id=order_sudo.pickup_location_data["id"],
+                        cart_qty=cart_qty,
+                    )
+                else:
+                    res["in_store_stock_data"] = utils.format_product_stock_values(
+                        product_sudo,
+                        uom=uom,
+                        free_qty=website.sudo()._get_max_in_store_product_available_qty(
+                            product_sudo
+                        ),
+                        cart_qty=cart_qty,
+                    )
             else:
-                res["in_store_stock_data"] = utils.format_product_stock_values(
-                    product_sudo,
-                    uom=uom,
-                    free_qty=website.sudo()._get_max_in_store_product_available_qty(product_sudo),
-                    cart_qty=cart_qty,
-                )
+                # In-store dm is not compatible with the product.
+                res["in_store_stock_data"] = {}
+
         return res

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -5,8 +5,8 @@
         <div class="border rounded p-3 w-100">
             <div
                 name="click_and_collect_availability"
-                t-on-click="this.openLocationSelector"
-                class="cursor-pointer"
+                t-on-click="() => this.state.inStoreStockData?.in_stock ? this.openLocationSelector() : null"
+                t-att-class="this.state.inStoreStockData?.in_stock ? 'cursor-pointer' : ''"
             >
                 <div class="h6">
                     <i class="fa fa-fw fa-map-marker text-muted"/>
@@ -33,7 +33,7 @@
                     <div t-else="" class="text-muted">
                         <i class="fa fa-fw fa-circle text-danger"/> Not available
                     </div>
-                    <a t-if="this.props.showSelectStoreButton" role="button" href="#">
+                    <a t-if="this.props.showSelectStoreButton and this.state.inStoreStockData?.in_stock" role="button" href="#">
                         <t t-if="this.state.selectedLocationData.id">Change store</t>
                         <t t-elif="this.state.inStoreStockData.in_stock">Select store</t>
                     </a>

--- a/addons/website_sale_collect/tests/test_product_template.py
+++ b/addons/website_sale_collect/tests/test_product_template.py
@@ -30,12 +30,11 @@ class TestProductTemplate(ClickAndCollectCommon):
         self.in_store_dm.excluded_tag_ids = [Command.set(excluded_tag.ids)]
         self.storable_product.all_product_tag_ids = [Command.set(excluded_tag.ids)]
         with self.mock_request(sale_order_id=self.cart.id):
-            combination_info = self.env['product.template']._get_additionnal_combination_info(
+            combination_info = self.env["product.template"]._get_additionnal_combination_info(
                 self.storable_product,
                 quantity=3,
                 date=datetime(2000, 1, 1),
                 uom=self.uom_unit,
                 website=self.website,
             )
-        self.assertFalse(combination_info.get("show_click_and_collect_availability"))
-        self.assertFalse(combination_info.get("in_store_stock"))
+        self.assertFalse(combination_info.get("in_store_stock_data"))


### PR DESCRIPTION
This PR addresses three edge cases in the Click & Collect and Delivery availability widget where incorrect availability states were being shown to the user.

Before this PR:
* If a product variant had a tag excluding it from Click & Collect, the logic bypassed the entire stock preparation block. This resulted in the variant falsely hiding the standard Delivery option and showing C&C as unavailable.
*  Products that are not tracked in inventory (consumables/services) were not properly displaying the availability widget with all options open (bypassing stock checks).
* If a product variant was excluded from standard delivery methods via tags, the delivery portion of the widget would still incorrectly render on the frontend.

After this PR:
* The C&C `excluded_tag_ids` check is moved further down so it only restricts the generation of `in_store_stock_data`. Standard `delivery_stock_data` is now evaluated independently.
* *Untracked products now correctly bypass standard stock checks and display all available widget options as expected.
*  Standard delivery carriers are now explicitly filtered against the product's tags (`dm.excluded_tag_ids & product_tags`). If all available delivery methods are excluded, the delivery stock data is correctly omitted, hiding the section.


opw-5990419