### PR TITLE
[FIX] point_of_sale: ensure unique picking sequence prefixes on warhouse

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -55,6 +55,7 @@
         'views/pos_session_sales_details.xml',
         'views/product_tag_views.xml',
         'views/stock_reference_views.xml',
+        'views/stock_warehouse_views.xml',
         'receipt/pos_receipt_common.xml',  # needed in the backend and frontend
         'receipt/pos_order_receipt.xml',  # needed in the backend and frontend
         'receipt/pos_order_change_receipt.xml',  # needed in the backend and frontend

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -12,8 +12,8 @@ class StockWarehouse(models.Model):
         sequence_values = super()._get_sequence_values(name=name, code=code)
         sequence_values.update({
             'pos_type_id': {
-                'name': _('%(name)s Picking POS', name=self.name),
-                'prefix': self.code + '/POS/',
+                'name': _('%(name)s Picking POS', name=name or self.name),
+                'prefix': (code or self.code) + '/POS/',
                 'padding': 5,
                 'company_id': self.company_id.id,
             }
@@ -40,6 +40,13 @@ class StockWarehouse(models.Model):
             }
         })
         return picking_type_create_values, max_sequence + 2
+
+    def _update_name_and_code(self, name=False, code=False):
+        super()._update_name_and_code(name, code)
+        for warehouse in self:
+            if warehouse.pos_type_id:
+                sequence_data = warehouse._get_sequence_values(name=name, code=code)
+                warehouse.pos_type_id.sequence_id.sudo().write(sequence_data['pos_type_id'])
 
     @api.model
     def _create_missing_pos_picking_types(self):

--- a/addons/point_of_sale/tests/test_pos_setup.py
+++ b/addons/point_of_sale/tests/test_pos_setup.py
@@ -126,3 +126,20 @@ class TestPoSSetup(TestPoSCommon):
         ], limit=1)
         self.assertTrue(card_pm)
         self.assertTrue(card_pm.outstanding_account_id)
+
+    def test_pos_sequence_update_on_warehouse_rename(self):
+        """ Test that point of sale sequence prefix is properly updated when warehouse is renamed. """
+        main_warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.company.id)], limit=1)
+        new_warehouse = main_warehouse.copy()
+
+        pos_picking_type = new_warehouse.pos_type_id
+        self.assertTrue(pos_picking_type, "POS picking type must be generated for the copied warehouse.")
+
+        new_warehouse.write({'name': 'Test Renamed', 'code': 'TSTRN'})
+
+        expected_prefix = 'TSTRN/POS/'
+        self.assertEqual(
+            pos_picking_type.sequence_id.prefix,
+            expected_prefix,
+            "The POS type sequence prefix was not correctly updated."
+        )

--- a/addons/point_of_sale/views/stock_warehouse_views.xml
+++ b/addons/point_of_sale/views/stock_warehouse_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warehouse_inherited" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherited.pos</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='xdock_type_id']" position="after">
+                <field name="pos_type_id" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_stock/__manifest__.py
+++ b/addons/pos_stock/__manifest__.py
@@ -14,6 +14,7 @@
         'views/pos_session_view.xml',
         'views/res_config_settings_views.xml',
         'views/stock_reference_views.xml',
+        'views/stock_warehouse_views.xml',
         'receipt/pos_order_receipt.xml',
         'security/ir.access.csv',
     ],

--- a/addons/pos_stock/models/stock_warehouse.py
+++ b/addons/pos_stock/models/stock_warehouse.py
@@ -10,8 +10,8 @@ class StockWarehouse(models.Model):
         sequence_values = super()._get_sequence_values(name=name, code=code)
         sequence_values.update({
             'pos_type_id': {
-                'name': self.env._('%(name)s Picking POS', name=self.name),
-                'prefix': self.code + '/POS/',
+                'name': self.env._('%(name)s Picking POS', name=name or self.name),
+                'prefix': (code or self.code) + '/POS/',
                 'padding': 5,
                 'company_id': self.company_id.id,
             }
@@ -38,6 +38,19 @@ class StockWarehouse(models.Model):
             }
         })
         return picking_type_create_values, max_sequence + 2
+
+    def _update_name_and_code(self, new_name=False, new_code=False):
+        super()._update_name_and_code(new_name, new_code)
+        for warehouse in self:
+            if warehouse.pos_type_id:
+                sequence_data = warehouse._get_sequence_values(name=new_name, code=new_code)
+                pos_sequence = warehouse.pos_type_id.sequence_id
+                if self.env.user.has_group('stock.group_stock_manager'):
+                    pos_sequence = pos_sequence.sudo()
+                pos_sequence.write({
+                    'name': sequence_data['pos_type_id']['name'],
+                    'prefix': sequence_data['pos_type_id']['prefix'],
+                })
 
     @api.model
     def _create_missing_pos_picking_types(self):

--- a/addons/pos_stock/tests/test_pos_stock.py
+++ b/addons/pos_stock/tests/test_pos_stock.py
@@ -16,3 +16,20 @@ class TestPosStock(TestPointOfSale):
             'module_pos_restaurant': False,
         })
         self.assertEqual(pos_config.warehouse_id.code, 'Sho')
+
+    def test_pos_sequence_update_on_warehouse_rename(self):
+        """ Test that point of sale sequence prefix is properly updated when warehouse is renamed. """
+        main_warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        new_warehouse = main_warehouse.copy()
+
+        pos_picking_type = new_warehouse.pos_type_id
+        self.assertTrue(pos_picking_type, "POS picking type must be generated for the copied warehouse.")
+
+        new_warehouse.write({'name': 'Test Renamed', 'code': 'TSTRN'})
+
+        expected_prefix = 'TSTRN/POS/'
+        self.assertEqual(
+            pos_picking_type.sequence_id.prefix,
+            expected_prefix,
+            "The POS type sequence prefix was not correctly updated."
+        )

--- a/addons/pos_stock/views/stock_warehouse_views.xml
+++ b/addons/pos_stock/views/stock_warehouse_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warehouse_inherited" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherited.pos</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='xdock_type_id']" position="after">
+                <field name="pos_type_id" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When a warehouse is duplicated or its `code` is changed, standard picking
type sequences (like IN, OUT, PICK) are automatically updated via the
`_update_name_and_code` method in `stock.warehouse`.

However, the sequence for the Point of Sale operation type (`pos_type_id`)
was missing this override. This resulted in sequence prefix collisions
(e.g., multiple POS operations sharing the `COPIE/POS/` prefix if a
warehouse was duplicated multiple times).

This commit extends `_update_name_and_code` in `point_of_sale` to properly
update the `pos_type_id` sequence prefix when the warehouse code changes.

Additionally, the PoS operation type has been added to the Warehouse form
view under the "Operation Types" section to improve visibility.

task-id: 6088339

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
