### PR TITLE
[FIX] stock: log cancel activity only if the move is linked to a picking

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -452,7 +452,7 @@ class StockMove(models.Model):
             if not production:
                 continue
             cancelled_dests = move.move_dest_ids.filtered(lambda m: m.id in cancelled_ids)
-            if not cancelled_dests:
+            if not cancelled_dests.picking_id:
                 continue
             documents[move.production_id, move.production_id.user_id or self.env.user] = cancelled_dests
         return self.env['stock.picking']._log_activity(_render_note_exception_cancel_dest, documents)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5089,6 +5089,12 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(grandparent_production.move_raw_ids.product_uom_qty, 2)
         self.assertEqual(parent_production.product_qty, 2)
         self.assertEqual(child_production.product_qty, 2)
+        # Cancel the grandparent production, this should log a cancellation activity on the parent productions.
+        grandparent_production.action_cancel()
+        self.assertRegex(
+            parent_production.activity_ids[-1:].note,
+            fr"Exception\(s\) occurred on the manufacturing order\(s\):[\s\S]*{grandparent_production.name}.*\n\s*2\.0 Units of parent\n\s*cancelled"
+        )
 
     def test_workcenter_with_resource_calendar_from_another_company(self):
         """Test that only the resource calendars from the same


### PR DESCRIPTION
Steps to reproduce the bug:
- Unarchive the MTO route
- Create a storable product P1:
    - Route: MTO + Manufacture
    - BoM:
        - Component: 1 unit of X1

- Create a storable product X1:
    - Component: 1 unit of C1

- Create a manufacturing order for 1 unit of P1
- Confirm the MO -> A child MO is created

- Try to cancel the MO for P1

Problem:
A traceback is triggered:
IndexError: tuple index out of range

'origin_picking': moves.picking_id[0],

Explanation:
When the parent MO is cancelled, all the moves linked to this MO are
cancelled (finished moves and raw moves). While cancelling them, an
activity of type "cancel" is logged on the pickings linked to these
moves (if any), in order to warn the user that actions may be required
on those pickings.

However, we do not check whether the moves actually have a picking
linked before logging the activity. The code directly tries to access
the first picking linked to the move, which triggers the traceback when
there is none:
https://github.com/odoo/odoo/blob/796316c341c4346152ad9610c30679f47aaa2ff8/addons/mrp/models/stock_move.py#L442

When cancelling an MO, the method `_log_manufacture_exception` is already
called and logs an exception activity on the child MO.

Bug introduced by:
https://github.com/odoo/odoo/pull/254636/changes/7c68c3dbb29eaad4e09d59ef7c86bd525969caec