### PR TITLE
[FIX] stock_account: compute correct avg cost partially consigned

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3273,3 +3273,23 @@ class TestStockValuation(TestStockValuationCommon):
         self.company.with_user(accounting_user).action_close_stock_valuation(at_date=Date.today(), auto_post=True)
         report = self.env['stock_account.stock.valuation.report'].with_user(accounting_user)._get_report_data(date=Date.today())
         self.assertTrue(report)
+
+    def test_avg_cost_partially_consigned(self):
+        """Ensures the avg_cost is correctly computed when the product is partially
+        consigned (the consigned products are not taken into account in the computation).
+        """
+        self._make_in_move(self.product_avco, 1, 10)
+        self._make_in_move(self.product_avco, 1, 20, owner_id=self.vendor)
+        self.assertEqual(self.product_avco.avg_cost, 10)
+
+    def test_quants_values_partially_consigned(self):
+        """Ensures the value of the quants are correctly computed when the product is partially
+        consigned (the consigned products are not taken into account in the computation).
+        """
+        self._make_in_move(self.product_avco, 1, 10)
+        self._make_in_move(self.product_avco, 1, 20, owner_id=self.vendor)
+        quants = self.product_avco.stock_quant_ids
+        regular_quant = quants.filtered(lambda q: q.location_id == self.stock_location and not q.owner_id)
+        consigned_quant = quants.filtered(lambda q: q.location_id == self.stock_location and q.owner_id)
+        self.assertEqual(regular_quant.value, 10)
+        self.assertEqual(consigned_quant.value, 0)


### PR DESCRIPTION
edit : the issue was fixed by https://github.com/odoo/odoo/pull/257103
So this commit only contains these use cases tests

**Steps to reproduce:**
- enable consignement setting
- create a tracked avco product with a cost of 10
- click on the quantities smart button and then 
"update quantity" to open the quants view
- create one line with a quantity of 1 and no owner
- create one line with a quantity of 1 and an owner 
outside the company

**Current behavior:**
problem A: 
open the 'stock' view and look for your product, 
the unit cost is 5

problem B: 
navigate back to the quants view of the product, unhide
the value column, the value is 5 for the non consigned
quant

**Expected behavior:**
problem A: 
the unit cost should be 10 (because consigned product 
shouldn't be taken into account when computing the 
unit cost)

problem B: 
the non consigned quant value should be 10 
for the same reason 

**Cause of the issue:**
problem A: 
Inside _compute_value(), to compute total_value_by_company_id, 
we use _with_valuation_context()
https://github.com/odoo/odoo/blob/6c107cd70e2228d3428e53cf8095aba17f678d8a/addons/stock_account/models/product.py#L196-L203
which excludes consigned products
https://github.com/odoo/odoo/blob/6c107cd70e2228d3428e53cf8095aba17f678d8a/addons/stock_account/models/product.py#L362-L364
So when we iterate through 'products' and fetch 
qty_available for our product the value is 
going to be 1. 

But when computing avg_cost at the end of 
the method, we iterate through 'self', so we 
don't have this context anymore and the value 
of qty_available is 2. 
https://github.com/odoo/odoo/blob/6c107cd70e2228d3428e53cf8095aba17f678d8a/addons/stock_account/models/product.py#L271-L273
That's because qty_available is computed 
with _compute_quantities() which depends on 
context (including owner_id)
https://github.com/odoo/odoo/blob/53f7d1dd2f972921ba91f6083a49f50749a3f503/addons/stock/models/product.py#L148-L152

problem B: 
when computing the value of the quant, 
there is no context specifying that the consigned
quantities should be excluded
https://github.com/odoo/odoo/blob/53f7d1dd2f972921ba91f6083a49f50749a3f503/addons/stock_account/models/stock_quant.py#L61-L62

opw-6049413