### PR TITLE
Fix preview dynamic category snippet

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
@@ -64,4 +64,19 @@ registry
 
 registry
     .category("public.interactions.preview")
-    .add('website_sale.dynamic_snippet_category', {Interaction: DynamicSnippetCategory});
+    .add("website_sale.dynamic_snippet_category", {
+        Interaction: DynamicSnippetCategory,
+        mixin: (I) => class extends I {
+            getQWebRenderOptions() {
+                const options = super.getQWebRenderOptions(...arguments);
+                // The row sizes in `SIZE_CONFIG` have the `vh` unit, thus the
+                // height is relative to the viewport height, and does not
+                // scale down with the scaling applied by the iframe of the
+                // snippet preview dialog. This reduces the size by a similar
+                // factor to keep the appearance of the snippet in the preview
+                // similar to the dropped version.
+                const scale = this.el.getBoundingClientRect().height / this.el.offsetHeight;
+                return Object.assign(options, { rowSize: `calc(${options.rowSize} * ${scale})` });
+            }
+        },
+    });

--- a/addons/website_sale/static/src/website_builder/snippet_model.js
+++ b/addons/website_sale/static/src/website_builder/snippet_model.js
@@ -1,0 +1,12 @@
+import { registry } from "@web/core/registry";
+
+registry
+    .category("html_builder.snippetsPreprocessor")
+    .add("website_sale_snippets", (namespace, snippets) => {
+        if (namespace === "website.snippets") {
+            // This should be empty in master, it is used to fix snippets in stable.
+            snippets
+                .querySelector(".s_dynamic_snippet_category_list .dynamic_snippet_template > *")
+                ?.classList.add("s_dialog_preview");
+        }
+    });


### PR DESCRIPTION
### [FIX] website_sale: keep preview data of dynamic category snippet

Commit 08c41255d70ccbb35eff20e0a12671ffdfba3dfe loads the interaction for dynamic category snippet to show its dynamic content in snippet preview dialog.

Commit 5cd8ba3b5abcad5a119bb879a9892e0bcfe27d9f changed the condition to avoid replacing the preview data.

The dynamic category snippet's preview data does not have the class `s_dialog_preview` to mark them as preview data. Thus the interaction was started and cleared the content (but could not fill it as the snippet does not have a valid configuration yet).

This commit uses a `html_builder.snippetsPreprocessor` to add the class on the preview data of that specific snippet in the loaded snippets.

Steps to reproduce:
- Open website builder
- Click on "Catalog" snippets category
- Bug: the dynamic snippet containing categories is missing its preview data part

task-6088029

### [FIX] website_sale: scale down height of dynamic category snippet's item

Commit 08c41255d70ccbb35eff20e0a12671ffdfba3dfe enables preview of custom dynamic category snippets.

But the height of the item is not adapted to the downscaling of the iframe. Thus they looked 3 times too tall.

This commits adds a patch to the interaction when loaded in this context to adapt the computed value for the height.

Steps to reproduce:
- Open website builder
- Click on "Catalog" snippets category
- Add the dynamic category snippet
- Select the added snippet
- Save this snippet as a custom snippet
- Click on "Custom" snippets category
- Bug: the items int the snippet looks way too big

task-6088029

