### PR TITLE
[IMP] pos_restaurant: ensure unique POS configuration per floor

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools import convert
 
 
@@ -18,6 +19,16 @@ class PosConfig(models.Model):
         forbidden_keys = super()._get_forbidden_change_fields()
         forbidden_keys.append('floor_ids')
         return forbidden_keys
+
+    @api.constrains('floor_ids')
+    def _check_floor_single_pos_config(self):
+        for config in self:
+            for floor in config.floor_ids:
+                if len(floor.pos_config_ids) > 1:
+                    raise ValidationError(_(
+                        "The floor '%(floor)s' is already linked to another Point of Sale.",
+                        floor=floor.name,
+                    ))
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -77,12 +88,6 @@ class PosConfig(models.Model):
         }])
         if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
-        config_floors = [(5, 0)]
-        if (floor_main := self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False)):
-            config_floors += [(4, floor_main.id)]
-        if (floor_patio := self.env.ref('pos_restaurant.floor_patio', raise_if_not_found=False)):
-            config_floors += [(4, floor_patio.id)]
-        config.update({'floor_ids': config_floors})
         config._load_bar_demo_data(with_demo_data)
         return {'config_id': config.id}
 

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools import convert
 
 
@@ -17,6 +18,16 @@ class PosConfig(models.Model):
         forbidden_keys = super()._get_forbidden_change_fields()
         forbidden_keys.append('floor_ids')
         return forbidden_keys
+
+    @api.constrains('floor_ids')
+    def _check_floor_single_pos_config(self):
+        for config in self:
+            for floor in config.floor_ids:
+                if len(floor.pos_config_ids) > 1:
+                    raise ValidationError(_(
+                        "The floor '%(floor)s' is already linked to another Point of Sale.",
+                        floor=floor.name,
+                    ))
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -57,6 +68,18 @@ class PosConfig(models.Model):
                 'floor_plan_layout': {'top': 100, 'left': 100, 'width': 130, 'height': 130, 'color': 'green', 'shape': 'square'},
             })
 
+    def _link_default_scenario_floors(self, config):
+        config.ensure_one()
+        config_floors = [(5, 0)]
+        for floor_xml_id in ('pos_restaurant.floor_main', 'pos_restaurant.floor_patio'):
+            floor = self.env.ref(floor_xml_id, raise_if_not_found=False)
+            if not floor:
+                continue
+            if floor.sudo().pos_config_ids:
+                floor = floor.sudo()._copy_floor_for_config(config)
+            config_floors.append((4, floor.id))
+        config.update({'floor_ids': config_floors})
+
     @api.model
     def load_onboarding_bar_scenario(self, with_demo_data=True):
         journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Bar', 'show_on_dashboard': False})
@@ -75,12 +98,7 @@ class PosConfig(models.Model):
         }])
         if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
-        config_floors = [(5, 0)]
-        if (floor_main := self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False)):
-            config_floors += [(4, floor_main.id)]
-        if (floor_patio := self.env.ref('pos_restaurant.floor_patio', raise_if_not_found=False)):
-            config_floors += [(4, floor_patio.id)]
-        config.update({'floor_ids': config_floors})
+        self._link_default_scenario_floors(config)
         config._load_bar_demo_data(with_demo_data)
         return {'config_id': config.id}
 
@@ -125,12 +143,7 @@ class PosConfig(models.Model):
             self.env.ref("point_of_sale.group_pos_preset").implied_by_ids |= self.env.ref("base.group_user")
         if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
-        config_floors = [(5, 0)]
-        if (floor_main := self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False)):
-            config_floors += [(4, floor_main.id)]
-        if (floor_patio := self.env.ref('pos_restaurant.floor_patio', raise_if_not_found=False)):
-            config_floors += [(4, floor_patio.id)]
-        config.update({'floor_ids': config_floors})
+        self._link_default_scenario_floors(config)
         config._load_restaurant_demo_data(with_demo_data)
         existing_session = self.env.ref('pos_restaurant.pos_closed_session_3', raise_if_not_found=False)
         if with_demo_data and self.env.company.id == self.env.ref('base.main_company').id and not existing_session:

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -7,7 +7,7 @@ from base64 import b64decode
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.mimetypes import guess_mimetype
 
 FLOOR_PLAN_SUPPORTED_IMAGE_MIMETYPES = {
@@ -34,6 +34,15 @@ class RestaurantFloor(models.Model):
     sequence = fields.Integer('Sequence', default=1)
     active = fields.Boolean(default=True)
     floor_plan_layout = fields.Json(string='Floor Plan Layout')
+
+    @api.constrains('pos_config_ids')
+    def _check_single_pos_config(self):
+        for floor in self:
+            if len(floor.pos_config_ids) > 1:
+                raise ValidationError(_(
+                    "The floor '%(floor)s' can only be linked to one Point of Sale.",
+                    floor=floor.name,
+                ))
 
     @api.model
     def _load_pos_data_domain(self, data, config):

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -7,7 +7,7 @@ from base64 import b64decode
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.mimetypes import guess_mimetype
 
 FLOOR_PLAN_SUPPORTED_IMAGE_MIMETYPES = {
@@ -29,11 +29,20 @@ class RestaurantFloor(models.Model):
     _inherit = ['pos.load.mixin']
 
     name = fields.Char('Floor Name', required=True)
-    pos_config_ids = fields.Many2many('pos.config', string='Point of Sales', domain="[('module_pos_restaurant', '=', True)]")
-    table_ids = fields.One2many('restaurant.table', 'floor_id', string='Tables')
+    pos_config_ids = fields.Many2many('pos.config', string='Point of Sales', domain="[('module_pos_restaurant', '=', True)]", copy=False)
+    table_ids = fields.One2many('restaurant.table', 'floor_id', string='Tables', copy=True)
     sequence = fields.Integer('Sequence', default=1)
     active = fields.Boolean(default=True)
     floor_plan_layout = fields.Json(string='Floor Plan Layout', copy=False)
+
+    @api.constrains('pos_config_ids')
+    def _check_single_pos_config(self):
+        for floor in self:
+            if len(floor.pos_config_ids) > 1:
+                raise ValidationError(_(
+                    "The floor '%(floor)s' can only be linked to one Point of Sale.",
+                    floor=floor.name,
+                ))
 
     @api.model
     def _load_pos_data_domain(self, data, config):
@@ -70,12 +79,26 @@ class RestaurantFloor(models.Model):
         return super().write(vals)
 
     def copy_data(self, default=None):
-        default = dict(default or {}, pos_config_ids=[(5, 0, 0)])
+        default = dict(default or {})
         vals_list = super().copy_data(default=default)
         if 'name' not in default:
             for floor, vals in zip(self, vals_list):
                 vals['name'] = _("%s (copy)", floor.name)
         return vals_list
+
+    def _copy_floor_for_config(self, config):
+        self.ensure_one()
+        new_floor = self.copy({
+            'name': self.name,
+            'floor_plan_layout': self.floor_plan_layout,
+        })
+        new_floor.pos_config_ids = [(4, config.id)]
+        # the copied tables inherited a parent_id pointing at the original floor's tables
+        table_map = dict(zip(self.table_ids.ids, new_floor.table_ids))
+        for new_table in new_floor.table_ids:
+            if new_table.parent_id:
+                new_table.parent_id = table_map.get(new_table.parent_id.id, False)
+        return new_floor
 
     def deactivate_floor(self, session_id):
         draft_orders = self.env['pos.order'].search([('session_id', '=', session_id), ('state', '=', 'draft'), ('table_id.floor_id', '=', self.id)])

--- a/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
+++ b/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
@@ -115,3 +115,39 @@ class TestPosRestaurantFlow(TestFrontendCommon):
 
         with self.assertRaises(UserError):
             product.action_archive()
+
+    def test_load_onboarding_restaurant_scenario_multiple(self):
+        res1 = self.env['pos.config'].load_onboarding_restaurant_scenario(with_demo_data=False)
+        config1 = self.env['pos.config'].browse(res1['config_id'])
+        self.assertEqual(len(config1.floor_ids), 2)
+        tables1_count = sum(len(f.table_ids) for f in config1.floor_ids)
+        self.assertGreater(tables1_count, 0)
+        res2 = self.env['pos.config'].load_onboarding_restaurant_scenario(with_demo_data=False)
+        config2 = self.env['pos.config'].browse(res2['config_id'])
+        self.assertEqual(len(config2.floor_ids), 2)
+        tables2_count = sum(len(f.table_ids) for f in config2.floor_ids)
+        self.assertEqual(tables1_count, tables2_count, "Duplicated floors should have the same number of tables")
+        self.assertFalse(config1.floor_ids & config2.floor_ids, "Floors should be independent per POS config")
+
+    def test_load_onboarding_bar_scenario_gets_default_floors(self):
+        res = self.env['pos.config'].load_onboarding_bar_scenario(with_demo_data=False)
+        config = self.env['pos.config'].browse(res['config_id'])
+        self.assertEqual(len(config.floor_ids), 2)
+        self.assertTrue(config.floor_ids.table_ids)
+
+    def test_copy_floor_for_config_remaps_table_parents(self):
+        parent, child = self.env['restaurant.table'].create([
+            {'table_number': 81, 'floor_id': self.main_floor.id, 'seats': 4},
+            {'table_number': 82, 'floor_id': self.main_floor.id, 'seats': 4},
+        ])
+        child.write({'parent_id': parent.id, 'parent_side': 'left'})
+        other_config = self.env['pos.config'].create({'name': 'Other', 'module_pos_restaurant': True})
+
+        new_floor = self.main_floor._copy_floor_for_config(other_config)
+
+        self.assertEqual(new_floor.pos_config_ids, other_config)
+        self.assertEqual(len(new_floor.table_ids), len(self.main_floor.table_ids))
+        self.assertFalse(new_floor.table_ids & self.main_floor.table_ids)
+        new_child = new_floor.table_ids.filtered(lambda t: t.table_number == 82)
+        new_parent = new_floor.table_ids.filtered(lambda t: t.table_number == 81)
+        self.assertEqual(new_child.parent_id, new_parent, "parent_id must point to the copied floor's table")


### PR DESCRIPTION
Add constraints to ensure that a restaurant floor can only be linked to a single Point of Sale configuration.

task-id:5221455

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
