### PR TITLE
[FIX] base_vat: rectify vat label for vat error message

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -231,7 +231,7 @@ class ResPartner(models.Model):
             company = self.env.company
 
         vat_label = _("VAT")
-        if country_code and company.country_id and country_code == company.country_id.code.lower() and company.country_id.vat_label:
+        if country_code and company.country_id and country_code == company.country_id.code and company.country_id.vat_label:
             vat_label = company.country_id.vat_label
 
         expected_format = _ref_vat.get(country_code.lower())

--- a/addons/l10n_uy/tests/test_check_vat.py
+++ b/addons/l10n_uy/tests/test_check_vat.py
@@ -63,7 +63,7 @@ class CheckUyVat(AccountTestInvoicingCommon):
             self._create_partner("it_nie", "ABC 93:402. asas 010-1")
 
     def test_invalid_rut(self):
-        common_msg = "The VAT number.*does not seem to be valid."
+        common_msg = "The RUT number.*does not seem to be valid."
         with self.assertRaisesRegex(ValidationError, common_msg, msg="invalid number"):
             self._create_partner("it_rut", "215521750018")
         with self.assertRaisesRegex(ValidationError, common_msg, msg="do not accept dot ('.') character"):


### PR DESCRIPTION
Before this **PR**, instead of the VAT label of each country, 'VAT' appeared in the error message. This was due to a mismatch in the matching of country codes.
