### PR TITLE
[FIX] tools: allow amount in words in Czech

### DIFF
--- a/odoo/tools/_monkeypatches.py
+++ b/odoo/tools/_monkeypatches.py
@@ -90,10 +90,15 @@ def literal_eval(expr):
 ast.literal_eval = literal_eval
 
 if MIN_PY_VERSION >= (3, 12):
-    raise RuntimeError("The num2words monkey patch is obsolete. Bump the version of the library to the latest available in the official package repository, if it hasn't already been done, and remove the patch.")
+    raise RuntimeError("The num2words monkey patch for Arabic is obsolete. Bump the version of the library to the latest available in the official package repository, if it hasn't already been done, and remove the patch.")
+if MIN_PY_VERSION >= (3, 13):
+    raise RuntimeError("The num2words monkey patch for Czech is obsolete. Bump the version of the library to the latest available in the official package repository, if it hasn't already been done, and remove the patch.")
 
 if num2words:
     num2words.CONVERTER_CLASSES["ar"] = Num2Word_AR_Fixed()
+    if 'cz' in num2words.CONVERTER_CLASSES and not 'cs' in num2words.CONVERTER_CLASSES:
+        # There is a mistake in the Czech language code in versions < 0.5.14. Map it to the correct code here.
+        num2words.CONVERTER_CLASSES['cs'] = num2words.CONVERTER_CLASSES['cz']
 
 _soap_clients = {}
 


### PR DESCRIPTION
The `num2words` library has a bug in the language code they used for Czech (`cz` instead of `cs`). This commit adds a monkey patch to map the correct language code to the existing converter class, allowing the amount in words to work in Czech.

The issue was fixed in version 0.5.14 of the library, so this patch can be removed once we use Ubuntu >= 25.10 (Python >= 3.13), that contains the fixed version of the library.

[opw-6088697](https://www.odoo.com/odoo/project.task/6088697)