### PR TITLE
[FIX] base: parse str to bool for config tied to param

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -6,6 +6,7 @@ from ast import literal_eval
 
 from odoo import api, models, _
 from odoo.exceptions import AccessError, RedirectWarning, UserError
+from odoo.tools import str2bool
 
 _logger = logging.getLogger(__name__)
 
@@ -312,7 +313,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                         _logger.warning(WARNING_MESSAGE, value, field, icp)
                         value = 0.0
                 elif field.type == 'boolean':
-                    value = bool(value)
+                    value = str2bool(value, bool(value))
             res[name] = value
 
         res.update(self.get_values())

--- a/odoo/addons/base/tests/test_res_config.py
+++ b/odoo/addons/base/tests/test_res_config.py
@@ -162,6 +162,24 @@ class TestResConfigExecute(TransactionCase):
             _logger.info("Testing %s" % (config_settings.name))
             self.env[config_settings.name].create({}).execute()
 
+    def test_boolean_config_parameter(self):
+        ICP = self.env['ir.config_parameter'].sudo()
+        ResConfigTest = self.env['res.config.test']
+
+        # If no `ir.config_parameter` record exists yet for the config, value
+        # should be `False`
+        ICP.search([('key', '=', 'resConfigTest.parameterBool')]).unlink()
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertFalse(defaults['param_bool'])
+
+        ICP.set_param('resConfigTest.parameterBool', 'False')
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertFalse(defaults['param_bool'])
+
+        ICP.set_param('resConfigTest.parameterBool', 'True')
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertTrue(defaults['param_bool'])
+
     def test_settings_access(self):
         """Check that settings user are able to open & save settings
 

--- a/odoo/addons/test_testing_utilities/models.py
+++ b/odoo/addons/test_testing_utilities/models.py
@@ -355,6 +355,10 @@ class ResConfigTest(models.Model):
         'res.config',
         config_parameter="resConfigTest.parameter2")
 
+    param_bool = fields.Boolean(
+        string='Test boolean parameter',
+        config_parameter='resConfigTest.parameterBool')
+
 
 class Wide(models.Model):
     _name = _description = 'test_testing_utilities.wide'


### PR DESCRIPTION
When a boolean field on `res.config.setting` tied to `ir.config_parameter` via `config_param` attribute, the value is incorrectly parse as param store `False` as `"False"` and later being shown as `True` on the setting form.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
