### PR TITLE
[FIX] pos_loyalty: crash when validating a shared draft order with loyalty

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -22,7 +22,7 @@ patch(PaymentScreen.prototype, {
             }
         }
         for (const line of this.currentOrder._get_reward_lines()) {
-            if (line.coupon_id.id < 1) {
+            if (!line.coupon_id || line.coupon_id.id < 1) {
                 continue;
             }
             if (!pointChanges[line.coupon_id.id]) {

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -356,7 +356,7 @@ patch(PosOrder.prototype, {
             won += points - this._getPointsCorrection(program);
             if (coupon_id !== 0) {
                 for (const line of this._get_reward_lines()) {
-                    if (line.coupon_id.id === coupon_id) {
+                    if (line.coupon_id?.id === coupon_id) {
                         spent += line.points_cost;
                     }
                 }

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -96,6 +96,12 @@ patch(PosStore.prototype, {
             return;
         }
         updateRewardsMutex.exec(() => {
+            // Remove stale reward lines from a draft order loaded from another POS session.
+            for (const line of order._get_reward_lines()) {
+                if (!line.coupon_id) {
+                    line.delete();
+                }
+            }
             return this.orderUpdateLoyaltyPrograms().then(async () => {
                 // Try auto claiming rewards
                 const claimableRewards = order.getClaimableRewards(false, false, true);
@@ -836,6 +842,9 @@ patch(PosStore.prototype, {
             return agg;
         }, {});
         for (const line of rewardLines) {
+            if (!line.coupon_id) {
+                continue;
+            }
             const reward = line.reward_id;
             const couponId = line.coupon_id.id;
             if (!couponData[couponId]) {

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -96,6 +96,12 @@ patch(PosStore.prototype, {
             return;
         }
         updateRewardsMutex.exec(() => {
+            // Remove stale reward lines from a draft order loaded from another POS session.
+            for (const line of order._get_reward_lines()) {
+                if (!line.coupon_id) {
+                    line.delete();
+                }
+            }
             return this.orderUpdateLoyaltyPrograms().then(async () => {
                 // Try auto claiming rewards
                 const claimableRewards = order.getClaimableRewards(false, false, true);
@@ -832,6 +838,9 @@ patch(PosStore.prototype, {
             return agg;
         }, {});
         for (const line of rewardLines) {
+            if (!line.coupon_id) {
+                continue;
+            }
             const reward = line.reward_id;
             const couponId = line.coupon_id.id;
             if (!couponData[couponId]) {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -719,7 +719,8 @@ registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos_make_order"
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA"),
             ProductScreen.addOrderline("Whiteboard Pen", "1", "100"),
-            PosLoyalty.pointsAwardedAre("100"),
+            PosLoyalty.hasRewardLine("10% on Whiteboard Pen", "-10.00"),
+            PosLoyalty.pointsAwardedAre("90"),
             ProductScreen.saveOrder(),
         ].flat(),
 });
@@ -732,6 +733,11 @@ registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos", {
             Chrome.clickMenuOption("Orders"),
             TicketScreen.selectOrder("-0001"),
             TicketScreen.loadSelectedOrder(),
-            PosLoyalty.pointsAwardedAre("100"),
+            PosLoyalty.hasRewardLine("10% on Whiteboard Pen", "-10.00"),
+            PosLoyalty.pointsAwardedAre("90"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -700,7 +700,8 @@ registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos_make_order"
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA"),
             ProductScreen.addOrderline("Whiteboard Pen", "1", "100"),
-            PosLoyalty.pointsAwardedAre("100"),
+            PosLoyalty.hasRewardLine("10% on Whiteboard Pen", "-10.00"),
+            PosLoyalty.pointsAwardedAre("90"),
             ProductScreen.saveOrder(),
         ].flat(),
 });
@@ -713,6 +714,11 @@ registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos", {
             Chrome.clickMenuOption("Orders"),
             TicketScreen.selectOrder("-0001"),
             TicketScreen.loadSelectedOrder(),
-            PosLoyalty.pointsAwardedAre("100"),
+            PosLoyalty.hasRewardLine("10% on Whiteboard Pen", "-10.00"),
+            PosLoyalty.pointsAwardedAre("90"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3250,7 +3250,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_race_conditions_update_program', login="pos_user")
 
     def test_loyalty_in_trusted_pos(self):
-        """This test ensures that when a order is loaded in trusted pos, loyalty is shown"""
+        """This test ensures that when a order is loaded in trusted pos, loyalty is shown and valide"""
         self.env['loyalty.program'].search([]).write({'active': False})
         trusted_pos_config = self.main_pos_config.copy()
         loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
@@ -3259,6 +3259,25 @@ class TestUi(TestPointOfSaleHttpCommon):
             'program_id': loyalty_program.id,
             'partner_id': partner.id,
             'points': 0,
+        })
+        self.env['loyalty.program'].create({
+            'name': 'Auto Discount 10%',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'unit',
+                'reward_point_amount': 1,
+                'product_ids': self.whiteboard_pen,
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+                'discount_product_ids': self.whiteboard_pen.ids,
+            })],
         })
         self.main_pos_config.trusted_config_ids += trusted_pos_config
         trusted_pos_config.trusted_config_ids += self.main_pos_config

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3243,7 +3243,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_race_conditions_update_program', login="pos_user")
 
     def test_loyalty_in_trusted_pos(self):
-        """This test ensures that when a order is loaded in trusted pos, loyalty is shown"""
+        """This test ensures that when a order is loaded in trusted pos, loyalty is shown and valide"""
         self.env['loyalty.program'].search([]).write({'active': False})
         trusted_pos_config = self.main_pos_config.copy()
         loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
@@ -3252,6 +3252,25 @@ class TestUi(TestPointOfSaleHttpCommon):
             'program_id': loyalty_program.id,
             'partner_id': partner.id,
             'points': 0,
+        })
+        self.env['loyalty.program'].create({
+            'name': 'Auto Discount 10%',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'unit',
+                'reward_point_amount': 1,
+                'product_ids': self.whiteboard_pen,
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+                'discount_product_ids': self.whiteboard_pen.ids,
+            })],
         })
         self.main_pos_config.trusted_config_ids += trusted_pos_config
         trusted_pos_config.trusted_config_ids += self.main_pos_config


### PR DESCRIPTION
When a draft POS order saved by another session is loaded in a trusted POS,
reward lines with an automatically applied discount cause a traceback.

Steps to reproduce:
-------------------
* In POS Settings, enable Trusted POS between two configs
* Create an automatically applied discount on a product
* In POS 1: add the product, select a customer, save the order for later
* In POS 2 (trusted): open the saved order, select a payment method and validate
> Observation:
TypeError: Cannot read properties of undefined (reading 'id')

Why the fix:
------------
When POS 1 serializes the draft order, temporary negative coupon IDs on reward lines are stripped to `undefined` (pos_order_line.js serialize()). When POS 2 loads the order and tries to validate it, several code paths access `.id` directly on `coupon_id` without guarding against `undefined`:

Additionally, `updateRewards()` keeps the stale reward line while the auto-claim creates a fresh one, so the order briefly holds two discount lines. The second `orderUpdateLoyaltyPrograms()` then computes loyalty points against both lines, producing a wrong result. Fixed by deleting stale reward lines (coupon_id = undefined) at the start of `updateRewardsMutex.exec()` so the auto-claim creates a single correct line.

opw-6049469