### PR TITLE
[IMP] account_reports: relation on external values

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -17,6 +17,7 @@ FIGURE_TYPE_SELECTION_VALUES = [
     ('datetime', "Datetime"),
     ('boolean', 'Boolean'),
     ('string', 'String'),
+    ('many2one', 'Many2One'),
 ]
 
 DOMAIN_REGEX = re.compile(r'(-?sum)\((.*)\)')
@@ -609,10 +610,17 @@ class AccountReportExpression(models.Model):
             ('external', "External Value"),
             ('custom', "Custom Python Function"),
             ('text', "Plain Text"),
+            ('reference', "Record Reference"),
         ],
         required=True
     )
     formula = fields.Text(string="Formula", required=True)
+    model_id = fields.Many2one(
+        string="Model",
+        comodel_name="ir.model",
+        compute="_compute_model_id",
+        inverse="_inverse_model_id",
+    )
     subformula = fields.Text(string="Subformula")
     date_scope = fields.Selection(
         string="Date Scope",
@@ -690,6 +698,26 @@ class AccountReportExpression(models.Model):
         auditable_engines = self._get_auditable_engines()
         for expression in self:
             expression.auditable = expression.engine in auditable_engines
+
+    @api.depends('engine', 'formula')
+    def _compute_model_id(self):
+        for expression in self:
+            if expression.engine == "reference" and expression.formula:
+                expression.model_id = self.env["ir.model"].search([("model", "=", expression.formula)], limit=1)
+            else:
+                expression.model_id = False
+
+    @api.onchange('model_id')
+    def _inverse_model_id(self):
+        for expression in self:
+            if expression.engine == "reference":
+                expression.formula = expression.model_id.model
+
+    @api.onchange('engine')
+    def _set_figure_type_for_reference_engine(self):
+        for expression in self:
+            if expression.engine == "reference":
+                expression.figure_type = "many2one"
 
     @api.constrains('engine', 'report_line_id')
     def _validate_engine(self):

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -141,3 +141,4 @@ access_account_report_external_value_ac_user,account.report.external.value.ac.us
 
 access_account_merge_wizard_manager,account.merge.wizard,model_account_merge_wizard,account.group_account_manager,1,1,1,1
 access_account_merge_wizard_line_manager,account.merge.wizard.line,model_account_merge_wizard_line,account.group_account_manager,1,1,1,1
+access_ir_model_account_reports,access.ir.model.account.reports,base.model_ir_model,account.group_account_manager,1,0,0,0


### PR DESCRIPTION
External values should be linkable to an existing model. For example, in the french accounting report "Liasse Fiscale", users have to manually fill a lot of fields. For that purpose, external values are used.
However, sometimes, the required info are already known in Odoo. Users currently need to rewrite everything manually. It comes with a high risks of errors and time lost encoding data. As those type of forms will become more and more frequent in Odoo, we improve it in generic for everyone.

task-5951888
