### PR TITLE
[IMP] spreadsheet: sync sheet_id with URL in public readonly spreadsheet

### DIFF
--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -1,5 +1,6 @@
 import { useChildSubEnv, useState } from "@web/owl2/utils";
-import { Component, markRaw, onWillStart } from "@odoo/owl";
+import { Component, markRaw, onMounted, onWillStart, onWillUnmount } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
 
 import { useSpreadsheetNotificationStore } from "@spreadsheet/hooks";
@@ -17,6 +18,19 @@ spreadsheet.registries.topbarMenuRegistry.addChild("download_public_excel", ["fi
     isVisible: (env) => env.canDownloadExcel?.(),
     isEnabledOnLockedSheet: true,
 });
+
+function readSheetIdFromURL() {
+    const url = new URL(browser.location.href);
+    return url.searchParams.get("sheet_id");
+}
+
+function writeSheetIdToURL(sheetId) {
+    const url = new URL(browser.location.href);
+    if (url.searchParams.get("sheet_id") !== sheetId) {
+        url.searchParams.set("sheet_id", sheetId);
+        browser.history.replaceState(browser.history.state, null, url);
+    }
+}
 
 export class PublicReadonlySpreadsheet extends Component {
     static template = "spreadsheet.PublicReadonlySpreadsheet";
@@ -41,7 +55,16 @@ export class PublicReadonlySpreadsheet extends Component {
                 }),
             canDownloadExcel: () => Boolean(this.props.downloadExcelUrl),
         });
-        onWillStart(this.createModel.bind(this));
+        onWillStart(async () => {
+            await this.createModel();
+            this.syncSheetFromURL();
+        });
+        onMounted(() => {
+            this.model.on("command-dispatched", this, this.syncURLFromSheet);
+        });
+        onWillUnmount(() => {
+            this.model.off("command-dispatched", this);
+        });
     }
 
     get showFilterButton() {
@@ -76,6 +99,26 @@ export class PublicReadonlySpreadsheet extends Component {
             // eslint-disable-next-line no-import-assign
             spreadsheet.__DEBUG__ = spreadsheet.__DEBUG__ || {};
             spreadsheet.__DEBUG__.model = this.model;
+        }
+    }
+
+    syncSheetFromURL() {
+        const urlSheetId = readSheetIdFromURL();
+        const sheetIds = this.model.getters.getSheetIds();
+        const activeSheetId = this.model.getters.getActiveSheetId();
+        const targetSheetId = sheetIds.includes(urlSheetId) ? urlSheetId : sheetIds[0];
+        if (activeSheetId !== targetSheetId) {
+            this.model.dispatch("ACTIVATE_SHEET", {
+                sheetIdFrom: activeSheetId,
+                sheetIdTo: targetSheetId,
+            });
+        }
+        writeSheetIdToURL(targetSheetId);
+    }
+
+    syncURLFromSheet(cmd) {
+        if (cmd.type === "ACTIVATE_SHEET" && readSheetIdFromURL() !== cmd.sheetIdTo) {
+            writeSheetIdToURL(cmd.sheetIdTo);
         }
     }
 

--- a/addons/spreadsheet/static/tests/helpers/ui.js
+++ b/addons/spreadsheet/static/tests/helpers/ui.js
@@ -45,7 +45,7 @@ export async function mountSpreadsheet(model) {
 export async function mountPublicSpreadsheet(dataUrl, mode, downloadExcelUrl = "") {
     const env = getMockEnv();
     env.isFrozenSpreadsheet = () => true;
-    mountWithCleanup(PublicReadonlySpreadsheet, {
+    const component = await mountWithCleanup(PublicReadonlySpreadsheet, {
         props: {
             dataUrl,
             downloadExcelUrl,
@@ -55,7 +55,10 @@ export async function mountPublicSpreadsheet(dataUrl, mode, downloadExcelUrl = "
         env,
     });
     await animationFrame();
-    return getFixture();
+    return {
+        fixture: getFixture(),
+        model: component.model,
+    };
 }
 
 export async function doMenuAction(registry, path, env) {

--- a/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
@@ -1,12 +1,13 @@
-import { contains, mockService } from "@web/../tests/web_test_helpers";
+import { contains, mockService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
-import { expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 
 import { mountPublicSpreadsheet } from "@spreadsheet/../tests/helpers/ui";
 import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_filter";
 import { addGlobalFilter } from "@spreadsheet/../tests/helpers/commands";
 import { freezeOdooData } from "@spreadsheet/helpers/model";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import { browser } from "@web/core/browser/browser";
 
 defineSpreadsheetModels();
 
@@ -23,7 +24,7 @@ test("show spreadsheet in readonly mode", async function () {
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
     const filterButton = fixture.querySelector(".o-public-spreadsheet-filter-button");
     expect(filterButton).toBe(null);
 });
@@ -32,7 +33,7 @@ test("show dashboard in dashboard mode when there are global filters", async fun
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
     const filterButton = fixture.querySelector(".o-public-spreadsheet-filter-button");
     expect(filterButton).toBeVisible();
 });
@@ -40,7 +41,7 @@ test("show dashboard in dashboard mode when there are global filters", async fun
 test("show dashboard in dashboard mode when there are no global filters", async function () {
     const { model } = await createModelWithDataSource();
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
     const filterButton = fixture.querySelector(".o-public-spreadsheet-filter-button");
     expect(filterButton).toBe(null);
 });
@@ -49,7 +50,7 @@ test("click filter button can show all filters", async function () {
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
     await contains(".o-public-spreadsheet-filter-button").click();
     expect(fixture.querySelector(".o-public-spreadsheet-filters")).toBeVisible();
     expect(fixture.querySelector(".o-public-spreadsheet-filter-button")).toBe(null);
@@ -59,7 +60,7 @@ test("click close button in filter panel will close the panel", async function (
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "dashboard");
     await contains(".o-public-spreadsheet-filter-button").click();
     await contains(".o-public-spreadsheet-filters-close-button").click();
     expect(fixture.querySelector(".o-public-spreadsheet-filter-button")).toBeVisible();
@@ -70,7 +71,7 @@ test.tags("desktop");
 test("Hides the download button when the downloadExcelUrl is not provided", async function () {
     const { model } = await createModelWithDataSource();
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet", false);
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet", false);
     await contains(".o-topbar-menu[data-id='file']").click();
     expect(fixture.querySelector(".o-menu-item[data-name='download_public_excel']")).toBe(null);
 });
@@ -80,7 +81,53 @@ test("Disable copy button in public spreadsheets", async function () {
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
     data = await freezeOdooData(model);
-    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+    const { fixture } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
     await contains(".o-topbar-menu[data-id='edit']").click();
     expect(fixture.querySelector(".o-menu-item[data-name='copy']")).toHaveClass("disabled");
+});
+
+describe("sheet_id URL synchronization", () => {
+    beforeEach(async () => {
+        const { model } = await createModelWithDataSource({
+            spreadsheetData: {
+                sheets: [
+                    { id: "sheet1", name: "Sheet1" },
+                    { id: "sheet2", name: "Sheet2" },
+                ],
+            },
+        });
+        data = await freezeOdooData(model);
+    });
+
+    test("activates sheet from URL on initialization", async () => {
+        patchWithCleanup(browser.location, {
+            href: `${browser.location.href}?sheet_id=sheet2`,
+        });
+        const { model } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+        expect(model.getters.getActiveSheetId()).toBe("sheet2");
+    });
+
+    test("falls back to the first sheet and syncs the URL when sheet_id is invalid", async () => {
+        patchWithCleanup(browser.location, {
+            href: `${browser.location.href}?sheet_id=unknown`,
+        });
+        const { model } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+        expect(new URL(browser.location.href).searchParams.get("sheet_id")).toBe("sheet1");
+        expect(model.getters.getActiveSheetId()).toBe("sheet1");
+    });
+
+    test("falls back to the first sheet and syncs the URL when sheet_id is absent", async () => {
+        const { model } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+        expect(model.getters.getActiveSheetId()).toBe("sheet1");
+        expect(new URL(browser.location.href).searchParams.get("sheet_id")).toBe("sheet1");
+    });
+
+    test("syncs the URL when the active sheet changes", async () => {
+        const { model } = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet");
+        model.dispatch("ACTIVATE_SHEET", {
+            sheetIdFrom: "sheet1",
+            sheetIdTo: "sheet2",
+        });
+        expect(new URL(browser.location.href).searchParams.get("sheet_id")).toBe("sheet2");
+    });
 });


### PR DESCRIPTION
Add support for syncing the active sheet with the URL in public readonly spreadsheets.

On initialization, read `sheet_id` from the URL and activate the corresponding sheet if it exists. Fallback to the first sheet when the parameter is missing or invalid.

Update the URL when the active sheet changes, ensuring it stays in sync with user navigation.

This allows opening a specific sheet directly via URL and preserves the active sheet on page refresh in public readonly mode.

Task: [6068613](https://www.odoo.com/odoo/project/2328/tasks/6068613)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr