### PR TITLE
[FIX] pos_self_order: self-orders leaking across PoS configs

### DIFF
--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -6,7 +6,7 @@ patch(PosStore.prototype, {
     async getServerOrders() {
         if (this.session._self_ordering) {
             await this.loadServerOrders([
-                ["company_id", "=", this.config.company_id.id],
+                ["config_id", "in", [this.config.id, ...this.config.raw.trusted_config_ids]],
                 ["state", "=", "draft"],
                 "|",
                 ["pos_reference", "ilike", "Kiosk"],


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create two PoS configs in the same company (e.g. Bar and Restaurant)
2. Enable self ordering for the Bar
3. Open Bar, go to its self-order mobile menu and make an order
4. Go back, open Restaurant, click on Orders tab

-> The Bar's self-order shows up in the Restaurant's order list.

What's happening
----------------
In the `getServerOrders` override added in 6782262a4d96, we were fetching self-orders without table by `company_id` instead of `config_id`. So it pulls in self-orders from ALL configs in the company.

The fix
-------
Replace `company_id` filter with `config_id in [config + trusted]`, same pattern used in the base `getServerOrders`.

opw-6068187