### PR TITLE
[FIX] hr_recruitment: do not flag refuse email as internal communication

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -173,7 +173,9 @@ class ApplicantGetRefuseReason(models.TransientModel):
         return {
             'body': body,
             'email_from': email_from,
+            'message_type': 'comment',
             'subject': subject,
+            'subtype_xmlid': 'mail.mt_comment',
             'author_id': self.env.user.partner_id.id,
             'scheduled_date': self.scheduled_date,
             'attachment_ids': [(4, att.id) for att in self.attachment_ids],

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -168,7 +168,9 @@ class ApplicantGetRefuseReason(models.TransientModel):
         return {
             'body': body,
             'email_from': email_from,
+            'message_type': 'comment',
             'subject': subject,
+            'subtype_xmlid': 'mail.mt_comment',
             'author_id': self.env.user.partner_id.id,
             'scheduled_date': self.scheduled_date,
             'attachment_ids': [(4, att.id) for att in self.attachment_ids],


### PR DESCRIPTION
Candidates receive the refusal email with "Internal communication:" in their mailbox preview.

### Steps to reproduce

1. Refuse an applicant with a refuse reason that has an email template.
2. Check the candidate's mailbox preview.

### Cause

`_prepare_mail_values()` did not specify a subtype, so `message_post()` defaulted to `mail.mt_note`, which is marked as internal. The email layout template prepends "Internal communication:" to the preview text of any message with an internal subtype.

### Fix

Pass `subtype_xmlid='mail.mt_comment'` and `message_type='comment'` in the mail values so the email is treated as an external communication.

opw-6038229