### PR TITLE
[PERF] tools: optimize hook dispatch (`safe_eval`)

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -707,7 +707,7 @@ class _SafeChecker:
         self.add_hook(type(d.values()), list)
 
     def add_hook(self, type_: type, hook: typing.Callable | None = None) -> None:
-        self.__hooks[type_] = hook
+        self.__hooks[type_] = hook or self._hook_nop
 
     @property
     def _encoder(self):
@@ -764,18 +764,17 @@ class _SafeChecker:
         """ Dispatch to the default check-serialisation function of `obj`. """
         t_obj = type(obj)
         try:
-            hook = self.__hooks[t_obj]
+            return self.__hooks[t_obj](obj)
         except KeyError:
             if isinstance(obj, type):
                 hook = self._hook_class
             else:
                 hook = self._hook_instance
             self.__hooks[t_obj] = hook
+            return hook(obj)
 
-        if not hook:
-            return None
-
-        return hook(obj)
+    def _hook_nop(self, obj):
+        return None
 
     def _hook_iterator(self, obj):
         return obj.__reduce__()


### PR DESCRIPTION
The dynamic analysis calls `_SafeChecker.check` for every call encountered. In large code, this adds significant overhead. This commit optimizes the "hot path" by removing branching and reducing bytecode instructions.

By introducing `_hook_nop` and ensuring `add_hook` always stores a callable, the interpreter now simply calls whatever it finds. Internal logic is much faster at "calling a function that does nothing" than "checking if a function exists before calling it."

Note:
- Before: for 688302 calls, 10.700 sec -> ~15.54 µs per call
- After: for 688776 calls, 7.179 sec -> ~10.42 µs per call

Gain: ~33% for the `check` method

Task-6075814