### PR TITLE
[FIX] point_of_sale: remove undeterministicTour key

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -146,7 +146,6 @@ registry.category("web_tour.tours").add("OrderModificationAfterValidationError",
 });
 
 registry.category("web_tour.tours").add("test_tracking_number_closing_session", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/generic_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/generic_tour.js
@@ -8,7 +8,6 @@ import { registry } from "@web/core/registry";
 
 //This tour is meant to be run on all localizations
 registry.category("web_tour.tours").add("generic_localization_tour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps ) #245680
     steps: () =>
         [
             Chrome.startPoS().map((step) => ({ ...step, timeout: 20000 })),

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -11,7 +11,6 @@ import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 import { inLeftSide } from "./utils/common";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -60,7 +59,7 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
             // Multiple paymentlines
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickNumpad("1"),
-            PaymentScreen.fillPaymentLineAmountMobile("Cash", "1"),
+            PaymentScreen.fillPaymentLineAmountMobile("52.80", "1", 1),
             PaymentScreen.remainingIs("51.8"),
             PaymentScreen.validateButtonIsHighlighted(false),
             PaymentScreen.clickPaymentMethod("Bank"),
@@ -157,7 +156,6 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -215,7 +213,6 @@ registry.category("web_tour.tours").add("PaymentScreenInvoiceOrder", {
 });
 
 registry.category("web_tour.tours").add("test_pos_large_amount_confirmation_dialog", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -234,7 +231,6 @@ registry.category("web_tour.tours").add("test_pos_large_amount_confirmation_dial
 });
 
 registry.category("web_tour.tours").add("test_add_money_button_with_different_decimal_separator", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -193,7 +193,6 @@ registry.category("web_tour.tours").add("test_combo_refund_different_qty", {
 });
 
 registry.category("web_tour.tours").add("ProductComboMaxFreeQtyTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -209,6 +208,7 @@ registry.category("web_tour.tours").add("ProductComboMaxFreeQtyTour", {
             combo.select("Combo Product 5"),
             combo.checkProductQty("Combo Product 5", "1"),
             combo.select("Combo Product 5"),
+            combo.checkProductQty("Combo Product 5", "1"),
             combo.select("Combo Product 5"),
             // Check that we cannot exceed the combo 'max_qty' which is 2
             combo.checkProductQty("Combo Product 5", "2"),

--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -123,6 +123,7 @@ const test_pricelists_in_pos_steps = [
 
     // Test if post-loaded product with attribute open the configrator
     scan_barcode("cherry_3"),
+    ProductScreen.selectedOrderlineHas("Cherry", "1", "5.0", "MEDIUM"),
     Chrome.waitRequest(),
     {
         content: "Click hided product with attribute",
@@ -149,7 +150,6 @@ const test_pricelists_in_pos_steps = [
 ];
 
 registry.category("web_tour.tours").add("test_pricelists_in_pos", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -143,7 +143,6 @@ registry.category("web_tour.tours").add("test_attribute_order", {
 });
 
 registry.category("web_tour.tours").add("test_combo_variant_mix", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -155,7 +154,7 @@ registry.category("web_tour.tours").add("test_combo_variant_mix", {
             Dialog.is("Attribute selection"),
             ProductConfigurator.pickRadio("Blue"),
             Dialog.confirm("Add"),
-            Dialog.confirm(),
+            Dialog.confirm("Add to order"),
             inLeftSide(
                 [
                     Order.hasLine({

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -341,7 +341,6 @@ registry.category("web_tour.tours").add("test_pay_unpaid_order_from_kiosk", {
 });
 
 registry.category("web_tour.tours").add("refund_multiple_products_amounts_compliance", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -368,7 +367,6 @@ registry.category("web_tour.tours").add("refund_multiple_products_amounts_compli
 });
 
 registry.category("web_tour.tours").add("LotTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
@@ -54,18 +54,7 @@ export function clickQtyBtnMinus(productName) {
 export function checkProductQty(productName, expectedQty) {
     return {
         content: `Check that product ${productName} has quantity ${expectedQty}`,
-        trigger: `.modal article:has(.product-name:contains("${productName}")):has(input[name="pos_quantity"])`,
-        run: () => {
-            const article = [...document.querySelectorAll(".modal article")].find((el) =>
-                el.textContent.includes(productName)
-            );
-            const input = article.querySelector('input[name="pos_quantity"]');
-            if (input.value != expectedQty) {
-                throw new Error(
-                    `Expected ${expectedQty}, but got ${input.value} for "${productName}".`
-                );
-            }
-        },
+        trigger: `.modal article:has(.product-name:contains("${productName}")):has(input[name="pos_quantity"]:value(${expectedQty}))`,
     };
 }
 export function checkImgAndSelect(productName, checkImg = false) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -275,6 +275,10 @@ export function fillPaymentLineAmountMobile(lineName, keys, nth = null) {
             run: "click",
         })),
         {
+            isActive: ["mobile"],
+            trigger: `.modal .popup-input .input-value:contains(/^${keys}$/)`,
+        },
+        {
             ...Dialog.confirm(),
             isActive: ["mobile"],
             run: "click",


### PR DESCRIPTION
Fix undeterministic tours by making some triggers more precise in a few steps.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
