### PR TITLE
[ADD] tools: adding a tool to generate and verify tokens

### DIFF
--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import datetime
 from dateutil.relativedelta import relativedelta
 import os.path
@@ -628,3 +629,35 @@ class TestUrlValidate(BaseCase):
         self.assertEqual(validate_url('/index.html'), 'http:///index.html')
         self.assertEqual(validate_url('?debug=1'), 'http://?debug=1')
         self.assertEqual(validate_url('#model=project.task&id=3603607'), 'http://#model=project.task&id=3603607')
+
+
+class TestMiscToken(TransactionCase):
+
+    def test_expired_token(self):
+        payload = {'test': True, 'value': 123456, 'some_string': 'hello', 'some_dict': {'name': 'New Dict'}}
+        expiration = datetime.datetime.now() - datetime.timedelta(days=1)
+        token = misc.hash_sign(self.env, 'test', payload, expiration=expiration)
+        self.assertIsNone(misc.verify_hash_signed(self.env, 'test', token))
+
+    def test_long_payload(self):
+        payload = {'test': True, 'value': 123456, 'some_string': 'hello', 'some_dict': {'name': 'New Dict'}}
+        token = misc.hash_sign(self.env, 'test', payload, expiration_hours=24)
+        self.assertEqual(misc.verify_hash_signed(self.env, 'test', token), payload)
+
+    def test_None_payload(self):
+        with self.assertRaises(Exception):
+            misc.hash_sign(self.env, 'test', None, expiration_hours=24)
+
+    def test_list_payload(self):
+        payload = ["str1", "str2", "str3", 4, 5]
+        token = misc.hash_sign(self.env, 'test', payload, expiration_hours=24)
+        self.assertEqual(misc.verify_hash_signed(self.env, 'test', token), payload)
+
+    def test_modified_payload(self):
+        payload = ["str1", "str2", "str3", 4, 5]
+        token = base64.urlsafe_b64decode(misc.hash_sign(self.env, 'test', payload, expiration_hours=24) + '===')
+        new_timestamp = datetime.datetime.now() + datetime.timedelta(days=7)
+        new_timestamp = int(new_timestamp.timestamp())
+        new_timestamp = new_timestamp.to_bytes(8, byteorder='little')
+        token = base64.urlsafe_b64encode(token[:1] + new_timestamp + token[9:]).decode()
+        self.assertIsNone(misc.verify_hash_signed(self.env, 'test', token))

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -5,6 +5,7 @@
 """
 Miscellaneous tools used by OpenERP.
 """
+import base64
 import cProfile
 import collections
 import contextlib
@@ -14,6 +15,7 @@ import hmac as hmac_lib
 import hashlib
 import io
 import itertools
+import json
 import logging
 import os
 import pickle as pickle_
@@ -1819,6 +1821,58 @@ def hmac(env, scope, message, hash_function=hashlib.sha256):
         message.encode(),
         hash_function,
     ).hexdigest()
+
+
+def hash_sign(env, scope, message_values, expiration=None, expiration_hours=None):
+    """ Generate an urlsafe payload signed with the HMAC signature for an iterable set of data.
+    This feature is very similar to JWT, but in a more generic implementation that is inline with out previous hmac implementation.
+
+    :param env: sudo environment to use for retrieving config parameter
+    :param scope: scope of the authentication, to have different signature for the same
+        message in different usage
+    :param message_values: values to be encoded inside the payload
+    :param expiration: optional, a datetime or timedelta
+    :param expiration_hours: optional, a int representing a number of hours before expiration. Cannot be set at the same time as expiration
+    :return: the payload that can be used as a token
+    """
+    assert not (expiration and expiration_hours)
+    assert message_values is not None
+
+    if expiration_hours:
+        expiration = datetime.datetime.now() + datetime.timedelta(hours=expiration_hours)
+    else:
+        if isinstance(expiration, datetime.timedelta):
+            expiration = datetime.datetime.now() + expiration
+    expiration_timestamp = 0 if not expiration else int(expiration.timestamp())
+    message_strings = json.dumps(message_values)
+    hash_value = hmac(env, scope, f'1:{message_strings}:{expiration_timestamp}', hash_function=hashlib.sha256)
+    token = b"\x01" + expiration_timestamp.to_bytes(8, 'little') + bytes.fromhex(hash_value) + message_strings.encode()
+    return base64.urlsafe_b64encode(token).decode().rstrip('=')
+
+
+def verify_hash_signed(env, scope, payload):
+    """ Verify and extract data from a given urlsafe  payload generated with hash_sign()
+
+    :param env: sudo environment to use for retrieving config parameter
+    :param scope: scope of the authentication, to have different signature for the same
+        message in different usage
+    :param payload: the token to verify
+    :return: The payload_values if the check was successful, None otherwise.
+    """
+
+    token = base64.urlsafe_b64decode(payload.encode() + b'===')
+    version = token[:1]
+    if version != b'\x01':
+        raise ValueError('Unknown token version')
+
+    expiration_value, hash_value, message = token[1:9], token[9:41].hex(), token[41:].decode()
+    expiration_value = int.from_bytes(expiration_value, byteorder='little')
+    hash_value_expected = hmac(env, scope, f'1:{message}:{expiration_value}', hash_function=hashlib.sha256)
+
+    if consteq(hash_value, hash_value_expected) and (expiration_value == 0 or datetime.datetime.now().timestamp() < expiration_value):
+        message_values = json.loads(message)
+        return message_values
+    return None
 
 
 ADDRESS_REGEX = re.compile(r'^(.*?)(\s[0-9][0-9\S]*)?(?: - (.+))?$', flags=re.DOTALL)


### PR DESCRIPTION
Backport of fd94042de04682895b90624c0a27639cfa7694bf

Add a tool to generate signed payload to be used as token. The main purpose is to stop storing every token.

Two functions are added:

`odoo.tools.misc.hash_sign()`
This functions takes as required arguments, a json dumpable payload, a scope as a string, a sudo environnement, and finally either and expiration as datetime.datetime, or expiration_hours as an int.

`odoo.tools.misc.verify_hash_signed()`
This function takes as arguments, a sudo environnement, a scope as a string (must be the same as the encoding scope), and a token generated by hash_sign()
