### PR TITLE
[FIX] base: avoid duplicating output after individual PDF generation

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -955,6 +955,7 @@ class IrActionsReport(models.Model):
                     for res_id in res_ids_wo_stream:
                         individual_collected_stream = self._render_qweb_pdf_prepare_streams(report_ref=report_ref, data=data, res_ids=[res_id])
                         collected_streams[res_id]['stream'] = individual_collected_stream[res_id]['stream']
+                    return collected_streams
             collected_streams[False] = {'stream': pdf_content_stream, 'attachment': None}
 
         return collected_streams


### PR DESCRIPTION
When generating PDF reports with multiple records, the system tries to
split the concatenated PDF using outlines. In cases where the number of
outlines doesn't match the number of records or outlines are missing, it
falls back to generating individual PDFs per record.

Steps to reproduce:
- Create an invoice
- Add in terms section a couple of lines and a heading, so that the
  invoice span over multiple page and the heading will be positioned on
  a separate page
- Select multiple invoices, including the created one
- Download > PDF Without Payment
- Open the resulting merged PDF.

Issue: The final PDF contains duplicated pages.

Analysis: Because of the outline moved to the following page, the number
of outlines does not match the number of res_ids. This makes the
outlines structure not valid for splitting.  When the system falls back
to individual PDF generation, it successfully collected the individual
streams but also include the original bulk stream to the return value
that will be merged together, effectively duplicating the pages in the
final output.

opw-5394156