### PR TITLE
[FIX] web: caching proxy should not store "load menus" responses

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -93,14 +93,9 @@ class Home(http.Controller):
             request.update_context(lang=lang)
 
         menus = request.env["ir.ui.menu"].load_web_menus(request.session.debug)
-        body = json.dumps(menus)
-        response = request.make_response(body, [
-            # this method must specify a content-type application/json instead of using the default text/html set because
-            # the type of the route is set to HTTP, but the rpc is made with a get and expects JSON
-            ('Content-Type', 'application/json'),
-            ('Cache-Control', 'public, max-age=' + str(http.STATIC_CACHE_LONG)),
+        return request.make_json_response(menus, [
+            ('Cache-Control', 'no-store'),
         ])
-        return response
 
     def _login_redirect(self, uid, redirect=None):
         return _get_login_redirect_url(uid, redirect)


### PR DESCRIPTION
Since odoo/odoo@ff53267db5d3, the `unique` parameters previously passed to `/web/webclient/load_menus` has been removed.

That commit, also instructed the browser not to store the result, but this is not sufficient; in case a caching proxy sits in between the user and Odoo, it will see the `Cache-Control: public` and still store the result.
  As a consequence, depending on the caching proxy configuration, it could happen to serve the same menus structure to all users.

This commit ensures the intermediaries proxies do not store the result.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
