### PR TITLE
[REF] base: ir.cron._rollback_progress()

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6477,7 +6477,7 @@ class AccountMove(models.Model):
             self.env['ir.cron']._commit_progress(len(moves))
             return
         except UserError:  # if at least one move cannot be posted, handle moves one by one
-            self.env.cr.rollback()
+            self.env['ir.cron']._rollback_progress()
 
         for move in moves:
             try:
@@ -6487,7 +6487,7 @@ class AccountMove(models.Model):
                 move._post()
                 self.env['ir.cron']._commit_progress(1)
             except UserError as e:
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
                 msg = _('The move could not be posted for the following reason: %(error_message)s', error_message=e)
                 move.message_post(body=msg, message_type='comment')
                 self.env['ir.cron']._commit_progress()

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -1202,7 +1202,7 @@ class BaseAutomation(models.Model):
                     automation._process(record, trigger='time-based')
                 self.env.flush_all()
             except Exception as e:
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
                 _logger.exception("Error in time-based automation rule `%s`.", automation.name)
                 final_exception = e
                 continue

--- a/addons/cloud_storage_migration/models/ir_attachment.py
+++ b/addons/cloud_storage_migration/models/ir_attachment.py
@@ -173,7 +173,7 @@ class CloudStorageAttachmentMigration(models.Model):
                 _logger.info('uploaded attachment %s to cloud storage', attachment.id)
             except Exception as e:  # noqa: BLE001
                 _logger.warning('Failed to upload attachment %s to cloud storage: %s', attachment.id, e)
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
 
             if end_time < time.monotonic():
                 break

--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -132,7 +132,7 @@ class CrmLead(models.Model):
                     self.env['ir.cron']._commit_progress(remaining=0)
                     break
                 except Exception:
-                    self.env.cr.rollback()
+                    self.env['ir.cron']._rollback_progress()
                     _logger.error('A batch of leads could not be enriched: %s', repr(leads))
                     time_left = self.env['ir.cron']._commit_progress(len(leads))
                 if not time_left:
@@ -151,7 +151,7 @@ class CrmLead(models.Model):
                     break
                 except Exception:
                     if not modules.module.current_test:
-                        self.env.cr.rollback()
+                        self.env['ir.cron']._rollback_progress()
                     _logger.error('A batch of leads could not be enriched: %s', repr(leads))
 
     @api.model

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -305,6 +305,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         remaining_time = MailThread.env['ir.cron']._commit_progress(1)
                     except Exception:  # noqa: BLE001
                         MailThread.env.cr.rollback()
+                        self.env['ir.cron']._rollback_progress()
                         failed += 1
                         _logger.info('Failed to process mail from %s server %s.', *server_type_and_name, exc_info=True)
                         # mail failed, but still "seen", so one unit of work

--- a/odoo/addons/base/models/ir_autovacuum.py
+++ b/odoo/addons/base/models/ir_autovacuum.py
@@ -59,7 +59,7 @@ class IrAutovacuum(models.AbstractModel):
                 _logger.debug("%s.%s  took %.2fs", model, attr, time.monotonic() - start_time)
             except Exception:
                 _logger.exception("Failed %s.%s()", model, attr)
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
 
     @api.autovacuum
     def _gc_orm_signaling(self):

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -879,6 +879,8 @@ class IrCron(models.Model):
         :param deactivate: deactivate the cron after running it
         :return: remaining time (seconds) for the cron run
         """
+        # Typical use case:
+        # https://www.odoo.com/documentation/master/developer/reference/backend/actions.html#writing-cron-functions
         ctx = self.env.context
         progress = self.env['ir.cron.progress'].sudo().browse(ctx.get('ir_cron_progress_id'))
         if not progress:
@@ -900,6 +902,11 @@ class IrCron(models.Model):
         progress.write(vals)
         self.env.cr.commit()
         return max(ctx.get('cron_end_time', float('inf')) - time.monotonic(), 0)
+
+    @api.model
+    def _rollback_progress(self) -> None:
+        """The rollback with the same logic as the commit for cron jobs."""
+        self.env.cr.rollback()
 
     def action_open_parent_action(self):
         return self.ir_actions_server_id.action_open_parent_action()

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -71,7 +71,7 @@ class ResUsersDeletion(models.Model):
                 delete_request.state = 'done'
                 commit_progress(1)
             except Exception as e:
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
                 _logger.error(
                     "User #%i %r could not be deleted. Original request from %r. Related error: %s",
                     user.id, user_name, requester_name, e)
@@ -92,7 +92,7 @@ class ResUsersDeletion(models.Model):
                 if not commit_progress():
                     break
             except Exception as e:
-                self.env.cr.rollback()
+                self.env['ir.cron']._rollback_progress()
                 _logger.warning(
                     "Partner #%i %r could not be deleted. Original request from %r. Related error: %s",
                     partner.id, user_name, requester_name, e)


### PR DESCRIPTION
For the symmetry of the API, adding `_rollback_progress` to `_commit_progress`. This also allows us to check which commits or rollbacks are used in models, because using them in models outside of cron jobs breaks the transactional behaviour of Odoo.

https://github.com/odoo/enterprise/pull/112717
https://github.com/odoo/documentation/pull/17206



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
