### PR TITLE
[FIX] mrp_account,pos_mrp: kit cost different uom

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
         total_price_unit = 0
         component_qty_per_kit = defaultdict(float)
         for line in exploded_lines:
-            component_qty_per_kit[line[0].product_id] += line[1]['qty']
+            component_qty_per_kit[line[0].product_id] += line[0].product_uom_id._compute_quantity(line[1]['qty'], line[0].product_id.uom_id, round=False)
         for component, valuated_moves in self.grouped('product_id').items():
             price_unit = super(StockMove, valuated_moves)._get_price_unit()
             qty_per_kit = component_qty_per_kit[component] / kit_bom.product_qty

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -370,6 +370,36 @@ class TestPosMrp(CommonPosMrpTest):
             {'product_id': product_1.id, 'total_cost': 10},
         ])
 
+    def test_bom_kit_different_uom_invoice_valuation_2(self):
+        """This test make sure that when a kit is made of product using UoM A but the bom line uses UoM B
+           the price unit is correctly computed on the invoice lines.
+        """
+        self.env.user.group_ids += self.env.ref('uom.group_uom')
+
+        # Edit kit product and component product
+        self.product_product_kit_one.categ_id = self.category_fifo_realtime
+        self.product_product_comp_one.standard_price = 12000
+        self.product_product_comp_one.uom_id = self.env.ref('uom.product_uom_dozen').id
+
+        # Edit kit product quantity
+        self.bom_one_line.bom_line_ids[0].product_qty = 1
+        self.bom_one_line.bom_line_ids[0].product_uom_id = self.env.ref('uom.product_uom_unit').id
+        self.bom_one_line.product_qty = 1
+
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'to_invoice': True,
+                'partner_id': self.partner_moda.id,
+            },
+            'line_data': [
+                {'product_id': self.product_product_kit_one.id, 'qty': 1},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
+        })
+        self.assertEqual(order.lines[0].total_cost, 1000.0)
+
 
 # TODO : Merge this test with the other class when it is not skipped anymore
 @odoo.tests.tagged('post_install', '-at_install')

--- a/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
@@ -135,3 +135,52 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
             {'debit': 0.0, 'credit': 1800},
             {'debit': 1800, 'credit': 0.0},
         ])
+
+    def test_kit_cost_calculation_3(self):
+        """ Check that the average cost price is correct with different UoM in BoM:
+            Product A UoM is pack of ten
+            Lovely KIT BOM for 1:
+                - 1 unit of Product A
+        """
+        kit = self._cls_create_product('Lovely Kit', self.uom_unit)
+        self.product_category.property_cost_method = 'average'
+        self.product_category.property_valuation = 'real_time'
+        self.component_a.uom_id = self.uom_ten
+        (kit + self.component_a).categ_id = self.product_category
+        self.env['mrp.bom'].create([
+            {
+                'product_tmpl_id': kit.product_tmpl_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'bom_line_ids': [
+                    Command.create({
+                        'product_id': self.component_a.id,
+                        'product_qty': 1.0,
+                        'product_uom_id': self.uom_unit.id,
+                    }),
+                ],
+            }
+        ])
+        self.component_a.standard_price = 10
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': kit.id,
+                'product_uom_qty': 1,
+            })]
+        })
+        so.action_confirm()
+        for move in so.picking_ids.move_ids:
+            move.quantity = move.product_uom_qty
+        so.picking_ids.button_validate()
+        # create an invoice to check that the cost price on the invoice line is correct
+        inv_1 = so._create_invoices()
+        inv_1.action_post()
+        self.assertEqual(inv_1.state, 'posted', 'invoice should be in posted state')
+        self.assertRecordValues(inv_1.line_ids, [
+            {'debit': 0.0, 'credit': 1.0},
+            {'debit': 0.0, 'credit': 0.15},
+            {'debit': 1.15, 'credit': 0.0},
+            {'debit': 0.0, 'credit': 1.0},
+            {'debit': 1.0, 'credit': 0.0}
+        ])


### PR DESCRIPTION
When selling a kit that use component with different UoM than the base component UoM, no conversion was done to compute the correct qty of component used in the kit, which lead to a wrong total cost on the pos order.

Steps to reproduce:
-------------------
* Create a component A with a cost of 12000€
* Set the UoM for the component A to "dozen"
* Create a kit product K with a BoM the use 1 "unit" of A
* At this point the cost of the kit K should be 1000€
* Now make a PoS order for 1 K and validate it
> Observation: The total cost of the kit is not correctly computed, it
  should be 1000€

Why the fix:
------------
When computing the qty_per_kit, we were not doing the conversion between the product UoM and the BoM line UoM.

opw-6039809