### PR TITLE
[IMP] mass_mailing: improve mass mailing UI/UX

### DIFF
--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -7,7 +7,7 @@
             <field name="model">link.tracker</field>
             <field name="arch" type="xml">
                 <search string="Links">
-                    <field name="url" string="Link Tracker" filter_domain="['|', ('title', 'ilike', self), ('url', 'ilike', self)]"/>
+                    <field name="url" filter_domain="['|', ('title', 'ilike', self), ('url', 'ilike', self)]"/>
                     <field name="label"/>
                     <field name="campaign_id"/>
                     <field name="medium_id"/>

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -156,6 +156,8 @@
         'web.assets_backend': [
             'mass_mailing/static/src/components/**/*',
             'mass_mailing/static/src/views/mailing_preview_form_view.js',
+            'mass_mailing/static/src/views/format_utils.js',
+            'mass_mailing/static/src/views/fields/**/*',
             'mass_mailing/static/src/editor/**/*',
             'mass_mailing/static/src/fields/**/*',
             'mass_mailing/static/src/themes/*',

--- a/addons/mass_mailing/models/link_tracker.py
+++ b/addons/mass_mailing/models/link_tracker.py
@@ -15,6 +15,8 @@ class LinkTrackerClick(models.Model):
 
     mailing_trace_id = fields.Many2one('mailing.trace', string='Mail Statistics', index='btree_not_null')
     mass_mailing_id = fields.Many2one('mailing.mailing', string='Mass Mailing', index='btree_not_null')
+    email = fields.Char(string="Email", related="mailing_trace_id.email", help="The email address of the entity that clicked the link")
+    url = fields.Char(string='URL', related='link_id.url')
 
     def _prepare_click_values_from_route(self, **route_values):
         click_values = super(LinkTrackerClick, self)._prepare_click_values_from_route(**route_values)

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -20,6 +20,7 @@ from odoo import api, fields, models, modules, tools, _
 from odoo.addons.base_import.models.base_import import ImportValidationError
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Datetime, Domain
+from odoo.tools import SQL
 from odoo.tools.float_utils import float_round
 from odoo.tools.image import ImageProcess
 
@@ -41,7 +42,7 @@ class MailingMailing(models.Model):
                 'mail.activity.mixin',
                 'mail.render.mixin',
     ]
-    _order = 'calendar_date DESC'
+    _order = 'state ASC, calendar_date DESC, write_date DESC'
     _rec_name = "subject"
     _systray_view = 'list'
 
@@ -244,6 +245,24 @@ class MailingMailing(models.Model):
         "CHECK(email_from IS NOT NULL OR mailing_type != 'mail')",
         "email from is required for mailing"
     )
+
+    def _order_field_to_sql(self, table, field_expr, direction, nulls):
+        # Override the ORDER BY logic for the `state` field from draft to sent
+        # whatever the key name and label
+        if field_expr == "state":
+            sql_field = table.state
+            table._query._order_groupby.append(sql_field)
+            return SQL("""
+                CASE %s
+                    WHEN 'draft' THEN 1
+                    WHEN 'in_queue' THEN 2
+                    WHEN 'sending' THEN 3
+                    WHEN 'done' THEN 4
+                    ELSE 99
+                END %s %s
+            """, sql_field, direction, nulls)
+
+        return super()._order_field_to_sql(table, field_expr, direction, nulls)
 
     @api.constrains('mailing_model_id', 'mailing_filter_id')
     def _check_mailing_filter_model(self):
@@ -718,68 +737,89 @@ class MailingMailing(models.Model):
         return action
 
     def action_view_clicked(self):
-        return self._action_view_documents_filtered('clicked')
+        return self._action_view_mailing_statistics_filtered('clicked')
 
     def action_view_opened(self):
-        return self._action_view_documents_filtered('open')
+        return self._action_view_mailing_statistics_filtered('open')
 
     def action_view_replied(self):
-        return self._action_view_documents_filtered('reply')
+        return self._action_view_mailing_statistics_filtered('reply')
 
     def action_view_bounced(self):
-        return self._action_view_documents_filtered('bounce')
+        return self._action_view_mailing_statistics_filtered('bounce')
 
     def action_view_delivered(self):
-        return self._action_view_documents_filtered('delivered')
+        return self._action_view_mailing_statistics_filtered('delivered')
 
-    def _action_view_documents_filtered(self, view_filter):
-        def _fetch_trace_res_ids(trace_domain):
-            trace_domain &= Domain('mass_mailing_id', '=', self.id)
-            return self.env['mailing.trace'].search_fetch(domain=trace_domain, field_names=['res_id']).mapped('res_id')
-
-        model_name = self.env['ir.model']._get(self.mailing_model_real).display_name
+    def _action_view_mailing_statistics_filtered(self, view_filter):
+        if view_filter == "clicked":
+            view_mode = "list,graph"
+        else:
+            view_mode = "graph,list"
         helper_header = None
         helper_message = None
+        domain = Domain('mass_mailing_id', '=', self.id)
+        views = False
+        context = {
+            **self.env.context,
+            'create': False,
+            'graph_mode': 'bar',
+            'stacked': True,
+        }
         if view_filter == 'reply':
-            res_ids = _fetch_trace_res_ids(Domain('trace_status', '=', 'reply'))
-            helper_header = _("No %s replied to your mailing yet!", model_name)
+            action_name = _('Mailing Statistics')
+            res_model = 'mailing.trace'
+            domain &= Domain('trace_status', '=', 'reply')
+            context = {**context, 'search_default_group_reply_date': True}
+            helper_header = _("No Recipient replied to your mailing yet!")
             helper_message = _("To track how many replies this mailing gets, make sure "
                                "its reply-to address belongs to this database.")
         elif view_filter == 'bounce':
-            res_ids = _fetch_trace_res_ids(Domain('trace_status', '=', 'bounce'))
-            helper_header = _("No %s address bounced yet!", model_name)
+            action_name = _('Mailing Statistics')
+            res_model = 'mailing.trace'
+            domain &= Domain('trace_status', '=', 'bounce')
+            helper_header = _("No Recipient address bounced yet!")
             helper_message = _("Bounce happens when a mailing cannot be delivered (fake address, "
                                "server issues, ...). Check each record to see what went wrong.")
         elif view_filter == 'clicked':
-            res_ids = _fetch_trace_res_ids(Domain('links_click_ids', '!=', False))
-            helper_header = _("No %s clicked your mailing yet!", model_name)
+            action_name = _('Link Clicks')
+            res_model = 'link.tracker.click'
+            context = {**context, 'search_default_groupby_email': True, 'stacked': False, 'graph_mode': 'pie'}
+            views = [(self.env.ref('mass_mailing.link_tracker_click_view_list_simplified').id, 'list'), (False, 'graph')]
+            helper_header = _("No Recipient clicked your mailing yet!")
             helper_message = _(
                 "Come back once your mailing has been sent to track who clicked on the embedded links.")
         elif view_filter == 'open':
-            res_ids = _fetch_trace_res_ids(Domain('trace_status', 'in', ('open', 'reply')))
-            helper_header = _("No %s opened your mailing yet!", model_name)
+            action_name = _('Mailing Statistics')
+            res_model = 'mailing.trace'
+            domain &= Domain('trace_status', 'in', ('open', 'reply'))
+            context = {**context, 'search_default_group_open_date': True}
+            helper_header = _("No Recipient opened your mailing yet!")
             helper_message = _("Come back once your mailing has been sent to track who opened your mailing.")
         elif view_filter == 'delivered':
-            res_ids = _fetch_trace_res_ids(Domain('trace_status', 'in', ('sent', 'open', 'reply')))
-            helper_header = _("No %s received your mailing yet!", model_name)
+            action_name = _('Mailing Statistics')
+            res_model = 'mailing.trace'
+            domain &= Domain('trace_status', 'in', ('sent', 'open', 'reply'))
+            helper_header = _("No Recipient received your mailing yet!")
             helper_message = _("Wait until your mailing has been sent to check how many recipients you managed to reach.")
         elif view_filter == 'sent':
-            res_ids = _fetch_trace_res_ids(Domain('sent_datetime', '!=', False))
-        else:
-            res_ids = []
+            action_name = _('Mailing Statistics')
+            res_model = 'mailing.trace'
+            domain &= Domain('sent_datetime', '!=', False)
 
         action = {
-            'name': model_name,
+            'name': action_name,
             'type': 'ir.actions.act_window',
-            'view_mode': 'list,form',
-            'res_model': self.mailing_model_real,
-            'domain': [('id', 'in', res_ids)],
-            'context': dict(self.env.context, create=False),
+            'view_mode': view_mode,
+            'res_model': res_model,
+            'views': views,
+            'domain': domain,
+            'context': context,
         }
         if helper_header and helper_message:
             action['help'] = Markup('<p class="o_view_nocontent_smiling_face">%s</p><p>%s</p>') % (
                 helper_header, helper_message,
-            ),
+            )
         return action
 
     def action_import_mailing_contacts(self):

--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -30,7 +30,7 @@
             <field name="model">mailing.trace.report</field>
             <field name="arch" type="xml">
                 <pivot string="Mass Mailing Statistics" disable_linking="1" sample="1">
-                    <field name="name" type="row"/>
+                    <field name="scheduled_date" type="row"/>
                     <field name="sent" type="measure"/>
                     <field name="scheduled" type="measure"/>
                     <field name="delivered" type="measure"/>
@@ -88,7 +88,7 @@
            <field name="name">Mailing Analysis</field>
            <field name="res_model">mailing.trace.report</field>
            <field name="domain">[('mailing_type', '=', 'mail')]</field>
-           <field name="view_mode">graph,pivot,list</field>
+           <field name="view_mode">pivot,graph,list</field>
            <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No Mailing Data yet!

--- a/addons/mass_mailing/static/src/builder/components/builder_row.scss
+++ b/addons/mass_mailing/static/src/builder/components/builder_row.scss
@@ -1,0 +1,3 @@
+.o_view_in_browser_label {
+    flex: none !important;
+}

--- a/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
@@ -27,7 +27,7 @@ export class DesignTabPlugin extends Plugin {
                 OPTION_POSITIONS.BODY,
                 this.getDesignOptionBlock("design-body", {
                     template: "mass_mailing.DesignBodyOption",
-                    title: _t("Body"),
+                    title: _t("Mailing"),
                 })
             ),
             withSequence(

--- a/addons/mass_mailing/static/src/builder/plugins/view_in_browser_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/view_in_browser_option_plugin.js
@@ -1,0 +1,82 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+const LAYOUT_CLASS = "o_layout";
+const VIEW_IN_BROWSER_LINK_CLASS = "o_snippet_view_in_browser";
+const VIEW_IN_BROWSWER_SNIPPET_NAME = "s_mail_block_header_view";
+
+export class ViewInBrowserOptionPlugin extends Plugin {
+    static id = "viewInBrowserOptionPlugin";
+    static shared = ["getViewInBrowserLink", "insertViewInBrowserLink", "removeViewInBrowserLink"];
+    static dependencies = ["history", "color"];
+
+    resources = {
+        builder_actions: {
+            ToggleViewInBrowserAction,
+        },
+    };
+
+    setup() {
+        this.snippet = this.config.snippetModel.snippetStructures.find(
+            (s) => s.name === VIEW_IN_BROWSWER_SNIPPET_NAME
+        );
+        this.snippet.isDisabled = true; // Hide the snippet from the snippet library
+    }
+
+    insertViewInBrowserLink() {
+        if (this.getViewInBrowserLink()) {
+            return;
+        }
+
+        const layoutElement = this.editable.querySelector(`.${LAYOUT_CLASS}`);
+        const linkElement = this.snippet.content.cloneNode(true);
+        let color;
+        if (layoutElement?.style.backgroundColor) {
+            ({ backgroundColor: color } = this.dependencies.color.getElementColors(layoutElement));
+        }
+        this.editable.querySelector(".o_mail_wrapper_td").prepend(linkElement);
+        if (color) {
+            this.dependencies.color.colorElement(linkElement, color, "backgroundColor");
+        }
+        this.dependencies.history.addStep();
+    }
+
+    removeViewInBrowserLink() {
+        const link = this.getViewInBrowserLink();
+        if (!link) {
+            return;
+        }
+        link.remove();
+        this.dependencies.history.addStep();
+    }
+
+    getViewInBrowserLink() {
+        return this.editable.querySelector(`.${VIEW_IN_BROWSER_LINK_CLASS}`);
+    }
+}
+
+export class ToggleViewInBrowserAction extends BuilderAction {
+    static id = "toggleViewInBrowserAction";
+    static dependencies = ["viewInBrowserOptionPlugin"];
+
+    setup() {
+        this.preview = false;
+    }
+
+    apply() {
+        if (!this.isApplied(...arguments)) {
+            this.dependencies["viewInBrowserOptionPlugin"].insertViewInBrowserLink();
+        } else {
+            this.dependencies["viewInBrowserOptionPlugin"].removeViewInBrowserLink();
+        }
+    }
+
+    isApplied() {
+        return Boolean(this.dependencies["viewInBrowserOptionPlugin"].getViewInBrowserLink());
+    }
+}
+
+registry
+    .category("mass_mailing-plugins")
+    .add(ViewInBrowserOptionPlugin.id, ViewInBrowserOptionPlugin);

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -19,6 +19,11 @@
 </t>
 
 <t t-name="mass_mailing.DesignBodyOption">
+        <BuilderRow label.translate='Show "View in Browser"' extraLabelClass="'pe-2 o_view_in_browser_label'">
+            <div class="o_snippet_view_in_browser">
+                <BuilderCheckbox action="'toggleViewInBrowserAction'"/>
+            </div>
+        </BuilderRow>
     <BuilderRow label.translate="Body Width">
         <BuilderButtonGroup>
             <BuilderButton classAction="'o_mail_small'" applyTo="'.o_mail_wrapper'">

--- a/addons/mass_mailing/static/src/views/fields/full_range_percentage_field.js
+++ b/addons/mass_mailing/static/src/views/fields/full_range_percentage_field.js
@@ -1,0 +1,44 @@
+import { registry } from "@web/core/registry";
+import { percentageField, PercentageField } from "@web/views/fields/percentage/percentage_field";
+import { parsePercentage } from "@web/views/fields/parsers";
+import { useInputField } from "@web/views/fields/input_field_hook";
+import { formatFullRangePercentage } from "../format_utils";
+
+/**
+ * This widget allows to render values in range `[0..100]`
+ * as percentages in the list view.
+ * Eg: given value `49` the rendered result will be `49%`.
+ *
+ * The base `PercentageField` only renders values in range
+ * `[0..1]` and scales them to 100.
+ * Eg: given value `0.49` the rendered result will be `49%`.
+ */
+export class FullRangePercentageField extends PercentageField {
+    setup() {
+        super.setup();
+        useInputField({
+            getValue: () =>
+                formatFullRangePercentage(this.props.record.data[this.props.name], {
+                    digits: this.props.digits,
+                    noSymbol: true,
+                    field: this.props.record.fields[this.props.name],
+                }),
+            refName: "numpadDecimal",
+            parse: (v) => parsePercentage(v),
+        });
+    }
+
+    get formattedValue() {
+        return formatFullRangePercentage(this.props.record.data[this.props.name], {
+            digits: this.props.digits,
+            field: this.props.record.fields[this.props.name],
+        });
+    }
+}
+
+export const fullRangePercentageField = {
+    ...percentageField,
+    component: FullRangePercentageField,
+};
+
+registry.category("fields").add("full_range_percentage", fullRangePercentageField);

--- a/addons/mass_mailing/static/src/views/format_utils.js
+++ b/addons/mass_mailing/static/src/views/format_utils.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { formatFloat } from "@web/core/utils/numbers";
+
+export function formatFullRangePercentage(value, options = {}) {
+    value = value || 0;
+    options = Object.assign({ trailingZeros: false, thousandsSep: "" }, options);
+    if (!options.digits && options.field) {
+        options.digits = options.field.digits;
+    }
+    const formatted = formatFloat(value, options);
+    return `${formatted}${options.noSymbol ? "" : "%"}`;
+}
+
+/**
+ * Add the format function to the global `formatters` as it will be used by the
+ * `ListRenderer.computeAggregates` when trying to format the value provided by
+ * the `full_range_percentage` widget.
+ */
+registry.category("formatters").add("full_range_percentage", formatFullRangePercentage);

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -837,5 +837,6 @@ class TestMassMailingActions(MassMailCommon):
             }
         ])
         results = mass_mailings[0].action_view_opened()
-        results_partner = self.env["res.partner"].search(results['domain'])
+        results_trace = self.env["mailing.trace"].search(results['domain'])
+        results_partner = self.env["res.partner"].search([('id', 'in', results_trace.res_id)])
         self.assertEqual(results_partner, self.partner_admin, "Trace leaked from mass_mailing_2 to mass_mailing_1")

--- a/addons/mass_mailing/views/link_tracker_views.xml
+++ b/addons/mass_mailing/views/link_tracker_views.xml
@@ -34,6 +34,9 @@
             <xpath expr="//field[@name='campaign_id']" position="before">
                 <field name="mass_mailing_id" optional="hide"/>
             </xpath>
+            <xpath expr="//field[@name='url']" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
         </field>
     </record>
 
@@ -43,12 +46,18 @@
             <field name="model">link.tracker.click</field>
         <field name="inherit_id" ref="link_tracker.link_tracker_click_view_search"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='link_id']" position="after">
+                <field name="email"/>
+            </xpath>
             <xpath expr="//field[@name='country_id']" position="after">
                 <field name="campaign_id"/>
                 <field name="mass_mailing_id"/>
             </xpath>
             <xpath expr="//filter[@name='groupby_country_id']" position="after">
                 <filter string="Mass Mailing" name="groupby_mass_mailing_id" context="{'group_by': 'mass_mailing_id'}"/>
+            </xpath>
+            <xpath expr="//filter[@name='groupby_mass_mailing_id']" position="after">
+                <filter string="Clicked By" name="groupby_email" context="{'group_by': 'email'}"/>
             </xpath>
         </field>
     </record>
@@ -75,6 +84,20 @@
                 <field name="campaign_id"/>
                 <field name="mass_mailing_id"/>
             </xpath>
+        </field>
+    </record>
+
+    <record id="link_tracker_click_view_list_simplified" model="ir.ui.view">
+        <field name="name">link.tracker.click.view.list.simplified</field>
+        <field name="model">link.tracker.click</field>
+        <field name="priority" eval="25"/>
+        <field name="arch" type="xml">
+            <list string="Links Clicks">
+                <field name="url"/>
+                <field name="create_date" string="Clicked On"/>
+                <field name="campaign_id" optional="hide"/>
+                <field name="mass_mailing_id" optional="hide"/>
+            </list>
         </field>
     </record>
 

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -44,12 +44,12 @@
                     <field name="ab_testing_enabled" string="A/B Test" groups="mass_mailing.group_mass_mailing_campaign"/>
                     <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
                     <field name="sent" sum="Total" />
-                    <field name="received_ratio" class="d-flex align-items-center ps-0" widget="progressbar" string="Delivered (%)" avg="Average"/>
-                    <field name="opened_ratio" class="d-flex align-items-center ps-0" widget="progressbar" string="Opened (%)" avg="Average"/>
-                    <field name="bounced_ratio" string="Bounced (%)" optional="hide" avg="Average"/>
-                    <field name="clicks_ratio" string="Clicked (%)" avg="Average"/>
-                    <field name="replied_ratio" string="Replied (%)" avg="Average"/>
-                    <field name="state" decoration-info="state in ['draft', 'in_queue']" decoration-success="state == 'sending' or state == 'done'" widget="badge"/>
+                    <field name="received_ratio" widget="full_range_percentage" string="Delivered"/>
+                    <field name="opened_ratio" widget="full_range_percentage" string="Opened"/>
+                    <field name="bounced_ratio" widget="full_range_percentage" string="Bounced" optional="hide"/>
+                    <field name="clicks_ratio" widget="full_range_percentage" string="Clicked"/>
+                    <field name="replied_ratio" widget="full_range_percentage" string="Replied"/>
+                    <field name="state" decoration-info="state in ['in_queue']" decoration-success="state == 'sending' or state == 'done'" widget="badge"/>
                 </list>
             </field>
         </record>
@@ -179,14 +179,6 @@
                                 invisible="state in ('draft', 'test')"
                                 class="oe_stat_button">
                                 <field name="clicks_ratio" string="Clicked" widget="percentpie"/>
-                            </button>
-                            <button name="action_view_delivered"
-                                id="button_view_delivered"
-                                type="object"
-                                context="{'search_default_filter_delivered': True}"
-                                invisible="state in ('draft', 'test')"
-                                class="oe_stat_button">
-                                <field name="received_ratio" string="Received" widget="percentpie"/>
                             </button>
                             <button name="action_view_bounced"
                                 type="object"

--- a/addons/mass_mailing/views/mailing_templates_portal_management.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_management.xml
@@ -57,7 +57,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 
         <style type="text/css">
-            <!-- Hide the link view online as it is displayed online -->
+            <!-- Hide the link View in Browser as it is displayed online -->
             .o_snippet_view_in_browser {
                 display: none;
             }

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -23,8 +23,9 @@
                 <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', True)]"/>
                 <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'trace_status'}"/>
-                    <filter string="Open Date" name="group_open_date" domain="[('trace_status', 'in', ['open', 'reply'])]" context="{'group_by': 'open_datetime:day'}"/>
-                    <filter string="Reply Date" name="group_reply_date" domain="[('trace_status', '=', 'reply')]" context="{'group_by': 'reply_datetime:day'}"/>
+                    <filter string="Opened On" name="group_open_date" domain="[('trace_status', 'in', ['open', 'reply'])]" context="{'group_by': 'open_datetime:day'}"/>
+                    <filter string="Clicked On" name="group_click_date" domain="[('links_click_datetime', '!=', False)]" context="{'group_by': 'links_click_datetime:month'}"/>
+                    <filter string="Replied On" name="group_reply_date" domain="[('trace_status', '=', 'reply')]" context="{'group_by': 'reply_datetime:day'}"/>
                     <filter string="Last State Update" name="state_update" domain="[]" context="{'group_by': 'write_date'}"/>
                     <filter string="Mass Mailing" name="mass_mailing" domain="[]" context="{'group_by': 'mass_mailing_id'}"/>
                 </group>
@@ -135,6 +136,7 @@
             <graph string="Mail Statistics" sample="1">
                 <field name="write_date" interval="day"/>
                 <field name="trace_status"/>
+                <field name="mail_mail_id_int" invisible="1"/> <!-- Hide it from the graph view's measures -->
             </graph>
         </field>
     </record>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -117,7 +117,7 @@
             <t t-snippet="mass_mailing.s_pricelist_boxed" string="Pricelist Boxed" group="text"/>
             <t t-snippet="mass_mailing.s_blog_title" string="Blog Title" group="text"/>
 
-            <t t-snippet="mass_mailing.s_mail_block_header_view" string="View Online" group="website"/>
+            <t t-snippet="mass_mailing.s_mail_block_header_view" string="View in Browser" group="website"/>
             <t t-snippet="mass_mailing.s_centered_cta_badge" string="Centered CTA" group="website"/>
             <t t-snippet="mass_mailing.s_special_offer_cta" string="Special Offer CTA" group="website"/>
             <t t-snippet="mass_mailing.s_section_mobile" string="Section Mobile" group="website"/>
@@ -154,10 +154,10 @@
     </section>
 </template>
 
-<template id="s_mail_block_header_view" name="View Online">
-    <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb16" data-name="View Online" data-vxml="001">
+<template id="s_mail_block_header_view" name="View in Browser">
+    <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb16" data-name="View in Browser" data-vxml="001">
         <p style="text-align: center" class="mb-0">
-            <a href="/view">View Online</a>
+            <a href="/view">View in Browser</a>
         </p>
     </section>
 </template>

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -33,12 +33,12 @@
                                 groups="mass_mailing.group_mass_mailing_campaign"
                                 column_invisible="parent.ab_testing_mailings_count == 0"/>
                             <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
-                            <field name="received_ratio" string="Delivered (%)" avg="Average of Delivered"/>
-                            <field name="opened_ratio" string="Opened (%)" avg="Average of Opened"/>
-                            <field name="bounced_ratio" string="Bounced (%)" optional="hide" avg="Average of Bounced"/>
-                            <field name="clicks_ratio" string="Clicked (%)" avg="Average of Clicked"/>
-                            <field name="replied_ratio" string="Replied (%)" avg="Average of Replied"/>
-                            <field name="state" decoration-info="state in ('draft', 'in_queue')" decoration-success="state in ('sending', 'done')" widget="badge"/>
+                            <field name="received_ratio" widget="full_range_percentage" string="Delivered"/>
+                            <field name="opened_ratio" widget="full_range_percentage" string="Opened"/>
+                            <field name="bounced_ratio" widget="full_range_percentage" string="Bounced" optional="hide"/>
+                            <field name="clicks_ratio" widget="full_range_percentage" string="Clicked"/>
+                            <field name="replied_ratio" widget="full_range_percentage" string="Replied"/>
+                            <field name="state" decoration-info="state in ('in_queue')" decoration-success="state in ('sending', 'done')" widget="badge"/>
                             <button name="action_duplicate" type="object" string="Duplicate"/>
                         </list>
                     </field>

--- a/addons/mass_mailing_crm/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_crm/views/mailing_mailing_views.xml
@@ -5,12 +5,12 @@
         <field name="model">mailing.mailing</field>
         <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
         <field name="arch" type="xml">
-    		<xpath expr="//button[@id='button_view_delivered']" position="before">
+    		<xpath expr="//button[@name='action_view_clicked']" position="after">
                 <button name="action_redirect_to_leads_and_opportunities"
                     type="object"
                     icon="fa-star"
                     class="oe_stat_button"
-                    invisible="state == 'draft'">
+                    invisible="state == 'draft' or crm_lead_count == 0">
                     <div class="o_field_widget o_stat_info">
                         <field name="use_leads" invisible="1"/>
                         <span class="o_stat_value"><field nolabel="1" name="crm_lead_count"/></span>

--- a/addons/mass_mailing_sale/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sale/views/mailing_mailing_views.xml
@@ -5,19 +5,19 @@
         <field name="model">mailing.mailing</field>
         <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
         <field name="arch" type="xml">
-    		<xpath expr="//button[@id='button_view_delivered']" position="before">
+    		<xpath expr="//button[@name='action_view_clicked']" position="after">
                 <button name="action_redirect_to_quotations"
                     type="object"
                     icon="fa-pencil-square-o"
                     class="oe_stat_button"
-                    invisible="state == 'draft'">
+                    invisible="state == 'draft' or sale_quotation_count == 0">
                     <field name="sale_quotation_count" string="Quotations" widget="statinfo"/>
                 </button>
                 <button name="action_redirect_to_invoiced"
                     type="object"
                     icon="fa-dollar"
                     class="oe_stat_button"
-                    invisible="state == 'draft'" >
+                    invisible="state == 'draft' or sale_invoiced_amount == 0" >
                     <field name="sale_invoiced_amount" string="Invoiced" widget="statinfo"/>
                 </button>
     		</xpath>

--- a/addons/mass_mailing_sms/views/mailing_trace_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_trace_views.xml
@@ -13,6 +13,17 @@
         </field>
     </record>
 
+    <record id="mailing_trace_view_graph" model="ir.ui.view">
+        <field name="name">mailing.trace.view.graph.inherit.sms</field>
+        <field name="model">mailing.trace</field>
+        <field name="inherit_id" ref="mass_mailing.view_mail_mail_statistics_graph"/>
+        <field name="arch" type="xml">
+           <xpath expr="//field[@name='mail_mail_id_int']" position="after">
+                <field name="sms_id_int" invisible="1"/> <!-- Hide it from the graph view's measures -->
+            </xpath>
+        </field>
+    </record>
+
     <record id="mailing_trace_view_tree" model="ir.ui.view">
         <field name="name">mailing.trace.view.list.inherit.sms</field>
         <field name="model">mailing.trace</field>

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -706,7 +706,7 @@
                     </div>
                     <div class="col-md-8 o_mail_header_social" style="text-align:right;">
                         <a href="/view">
-                            <span style="font-weight: bolder;">View online</span>&amp;nbsp;<span class="fa fa-external-link" />
+                            <span style="font-weight: bolder;">View in Browser</span>&amp;nbsp;<span class="fa fa-external-link" />
                         </a>
                     </div>
                 </div>
@@ -974,8 +974,8 @@
                 --btn-secondary-border-color: #CE0000;
             }
         </style>
-        <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb0" style="text-align: left; padding-left: 15px; padding-right: 15px;" data-vxml="001" data-snippet="s_mail_block_header_view" data-name="View Online">
-            <p><a href="/view" class="" target="_blank" data-bs-original-title="" title="">View Online</a> - <font style="color: rgb(183, 191, 199);"><span style="font-size: 12.25px" t-out="datetime.datetime.now().strftime('%B %d %Y')"/></font></p>
+        <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb0" style="text-align: left; padding-left: 15px; padding-right: 15px;" data-vxml="001" data-name="View in Browser">
+            <p><a href="/view" class="" target="_blank" data-bs-original-title="" title="">View in Browser</a> - <font style="color: rgb(183, 191, 199);"><span style="font-size: 12.25px" t-out="datetime.datetime.now().strftime('%B %d %Y')"/></font></p>
         </section>
         <section class="s_title o_mail_snippet_general pt32 pb32" data-vxml="001" data-snippet="s_title" data-name="Title" style="background-color: rgb(255, 255, 255) !important;">
             <div class="container s_allow_columns">

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -100,7 +100,7 @@ class TestMailingTest(TestMassMailCommon):
                 Hello <a href="http://www.example.com/view">World<a/>
                     <div class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb16" style="text-align: center; padding-left: 15px; padding-right: 15px;">
                         <a href="/view">
-                            View Online
+                            View in Browser
                         </a>
                     </div>
                     <div class="o_mail_footer_links">


### PR DESCRIPTION
This PR improves the UI/UX of the email marketing app.

Briefly, the added features are (detailed description is found in each commit):
1. Enhance the `Mailings` list view: change the result display of the stat buttons (click, open, etc..), change the ordering of the mailings based on the state, calendar_date, and last updated, etc..
2. Change the `View in Browser` (previously described as `View Online`) from a snippet into a builder option under the design tab.

Task-5358279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
