### PR TITLE
[FIX] rating, test_discuss_full: rating_stats access

### DIFF
--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -46,26 +46,29 @@ class MailMessage(models.Model):
         records_by_model = self._records_by_model_name()
         r_stats = {}
 
-        def has_rating_access(records):
-            return (
-                records
-                and issubclass(self.pool[records._name], self.pool["rating.mixin"])
-                and records.has_field_access(records._fields["rating_avg"], "read")
-            )
-
-        for records in records_by_model.values():
-            if has_rating_access(records) and records._allow_publish_rating_stats():
-                r_stats.update(records._rating_get_stats_per_record())
+        for model_name, records in records_by_model.items():
+            if not issubclass(self.pool[model_name], self.pool["rating.mixin"]):
+                continue
+            if records.has_access("read") and records._allow_publish_rating_stats():
+                # sudo: rating.rating - reading rating stats on readable records is allowed
+                r_stats.update(records.sudo()._rating_get_stats_per_record())
         res.many(
             "records",
             lambda res: (
-                res.extend(["rating_avg", "rating_count"]),
-                res.attr("rating_stats", lambda t: r_stats[t], predicate=lambda t: t in r_stats),
+                res.attr(
+                    "rating_avg",
+                    predicate=lambda r: r.has_field_access(r._fields["rating_avg"], "read"),
+                ),
+                res.attr(
+                    "rating_count",
+                    predicate=lambda r: r.has_field_access(r._fields["rating_avg"], "read"),
+                ),
+                res.attr("rating_stats", lambda r: r_stats[r], predicate=lambda r: r in r_stats),
             ),
             as_thread=True,
             only_data=True,
             value=lambda m: records_by_model.get(m.model),
-            predicate=lambda m: has_rating_access(records_by_model.get(m.model)),
+            predicate=lambda m: issubclass(self.pool[m.model], self.pool["rating.mixin"]),
         )
 
     def _is_empty(self):

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -26,7 +26,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search ir_rule (_get_rules)
         #       - search mail_message
         #   - fetch bus_bus (_bus_last_id)
-        #   30 store add message:
+        #   35 store add message:
         #       - search mail_message
         #       - fetch mail_message
         #       - search mail_message_schedule
@@ -56,17 +56,28 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - fetch res_users
         #           - fetch res_partner
         #       - fetch mail_message_subtype
-        #       6 rating stats computation:
-        #           - read group rating_rating (_rating_get_stats_per_record for slide.channel)
-        #           - read group rating_rating (_rating_get_stats_per_record for product.template)
+        #       8 rating stats computation:
+        #           3 check access read for slide.channel:
+        #               - search ir_rule (identify rules)
+        #               - fetch ir_rule (rule definitions)
+        #               - fetch slide_channel (verify records)
+        #           3 check access read for product.template:
+        #               - search ir_rule (identify rules)
+        #               - fetch ir_rule (rule definitions)
+        #               - fetch product_template (verify records)
         #           - compute message_needaction for slide.channel
         #           - compute message_needaction for product.template
         #       - select current db snapshot
         first_model_records = self.env["product.template"].create(
-            [{"name": "Product A1"}, {"name": "Product A2"}]
+            [{"name": "Product A1"}, {"name": "Product A2"}, {"name": "Product A3"}]
         )
         second_model_records = self.env["slide.channel"].create(
-            [{"name": "Course B1"}, {"name": "Course B2"}]
+            [
+                {"name": "Course B1"},
+                {"name": "Course B2"},
+                {"name": "Course B3"},
+                {"name": "Course B4"},
+            ]
         )
         for record in chain(first_model_records, second_model_records):
             record.message_post(
@@ -76,5 +87,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(41):
+        with self.assertQueryCount(45):
             self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})


### PR DESCRIPTION
A user may not have access to rating fields such as `rating_avg`, but they may still be able to access the record itself. For example, this could happen when a public user is viewing a public product page. 
The predicate to send the rating stats should be based on whether the current user can read the current record.
 This change separates the logic for sending the rating fields and the rating stats data. The extra query in the test comes from checking the ACL for each model for batched records.

