### PR TITLE
[FIX] tools: allow exporting uom names in translations

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -11,7 +11,7 @@ import io
 
 from odoo.exceptions import UserError
 from odoo.tools import sql
-from odoo.tools.translate import quote, unquote, xml_translate, html_translate, TranslationImporter, TranslationModuleReader
+from odoo.tools.translate import _push, quote, unquote, xml_translate, html_translate, TranslationImporter, TranslationModuleReader, TranslationReader
 from odoo.tests.common import TransactionCase, BaseCase, new_test_user, tagged
 
 _stats_logger = logging.getLogger('odoo.tests.stats')
@@ -397,6 +397,24 @@ class TranslationToolsTestCase(BaseCase):
         result = html_translate(lambda term: term, source)
         self.assertEqual(result, source)
 
+    def test_push_filters_no_letter_strings(self):
+        """Strings with no letters should not be exported for translation."""
+        terms = []
+
+        def callback(term, line):
+            return terms.append(term)
+        _push(callback, 'hello', 1)
+        _push(callback, '123', 1)
+        _push(callback, '!@#', 1)
+        _push(callback, '', 1)
+        self.assertEqual(terms, ['hello'])
+
+    def test_push_exports_one_letter_strings(self):
+        """One-letter strings should be exported (e.g. UoM abbreviations like 'g' for grams)."""
+        terms = []
+        _push(lambda term, line: terms.append(term), 'g', 1)
+        self.assertEqual(terms, ['g'])
+
 
 class TestLanguageInstall(TransactionCase):
     def test_language_install(self):
@@ -427,6 +445,23 @@ class TestTranslationExport(TransactionCase):
         """Read files of installed modules and export translatable terms"""
         with self.assertNoLogs('odoo.tools.translate', "ERROR"):
             TranslationModuleReader(self.env.cr)
+
+    def test_push_translation_filters_no_letter_strings(self):
+        """Strings with no letters should not be queued for translation export."""
+        reader = TranslationReader(self.env.cr)
+        reader._push_translation('module', 'model', 'res.partner,name', 1, 'hello')
+        reader._push_translation('module', 'model', 'res.partner,name', 2, '123')
+        reader._push_translation('module', 'model', 'res.partner,name', 3, '!@#')
+        reader._push_translation('module', 'model', 'res.partner,name', 4, '')
+        sources = [entry[1] for entry in reader._to_translate]
+        self.assertEqual(sources, ['hello'])
+
+    def test_push_translation_exports_one_letter_strings(self):
+        """One-letter strings should be queued for export (e.g. UoM abbreviations like 'g' for grams)."""
+        reader = TranslationReader(self.env.cr)
+        reader._push_translation('module', 'model', 'res.partner,name', 1, 'g')
+        sources = [entry[1] for entry in reader._to_translate]
+        self.assertEqual(sources, ['g'])
 
 
 class TestTranslation(TransactionCase):
@@ -1285,7 +1320,7 @@ class TestXMLTranslation(TransactionCase):
 
         self.assertEqual(view.arch_db, archf % terms_en)
         self.assertEqual(view.with_context(lang='fr_FR').arch_db, archf % terms_fr)
-        
+
         # change the order of the text term and the xml term and redo the previous test
         archf = '<form>%s<div>%s</div></form>'
         terms_en = ('<span invisible="1">Draft</span>', 'Draft')

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -943,8 +943,9 @@ def trans_export_records(lang, model_name, ids, buffer, format, cr):
 def _push(callback, term, source_line):
     """ Sanity check before pushing translation terms """
     term = (term or "").strip()
-    # Avoid non-char tokens like ':' '...' '.00' etc.
-    if len(term) > 8 or any(x.isalpha() for x in term):
+    # We only want to export strings that are likely to be translated.
+    # We avoid exporting strings that contain no letters, like `:`, `...`, `.00`, etc.
+    if any(x.isalpha() for x in term):
         callback(term, source_line)
 
 def _extract_translatable_qweb_terms(element, callback):
@@ -1079,14 +1080,11 @@ class TranslationReader:
         msgid "<source>"
         record_id is the database id of the record being translated
         """
-        # empty and one-letter terms are ignored, they probably are not meant to be
-        # translated, and would be very hard to translate anyway.
         sanitized_term = (source or '').strip()
-        # remove non-alphanumeric chars
-        sanitized_term = re.sub(r'\W+', '', sanitized_term)
-        if not sanitized_term or len(sanitized_term) <= 1:
-            return
-        self._to_translate.append((module, source, name, res_id, ttype, tuple(comments or ()), record_id, value))
+        # We only want to export strings that are likely to be translated.
+        # We avoid exporting strings that contain no letters, like `:`, `...`, `.00`, etc.
+        if any(x.isalpha() for x in sanitized_term):
+            self._to_translate.append((module, source, name, res_id, ttype, tuple(comments or ()), record_id, value))
 
     def _export_imdinfo(self, model: str, imd_per_id: dict[int, ImdInfo]):
         records = self._get_translatable_records(imd_per_id.values())


### PR DESCRIPTION
Single-letter strings (as used for units of measure, like `m`, `l`, `g`) are not exportable for translation, because the export of translation strings was filtering out different strings based on the type of the translation.

This commit harmonized the filtering to the single condition of a string containing at least one letter, which allows exporting single-letter strings while still filtering out non-meaningful strings like `:`, `...`, `.00`, etc.

Issue reported by one of our translators.