### PR TITLE
[FIX] account_peppol: fix branch company disconnecting from peppol in demo

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -418,6 +418,7 @@ class AccountEdiProxyClientUser(models.Model):
 
         self.env.ref('account_peppol.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
 
+    @handle_demo
     def _peppol_deregister_participant(self):
         self.ensure_one()
 

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -206,6 +206,11 @@ def _mock_check_company_on_peppol(func, self, *args, **kwargs):
     pass
 
 
+def _mock_peppol_deregister_participant(func, self, *args, **kwargs):
+    self.company_id._reset_peppol_configuration()
+    self.unlink()
+
+
 _demo_behaviour = {
     '_call_peppol_proxy': _mock_call_peppol_proxy,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
@@ -218,6 +223,7 @@ _demo_behaviour = {
     'button_check_peppol_verification_code': _mock_check_verification_code,
     'button_register_peppol_participant': _mock_user_creation,
     '_check_company_on_peppol': _mock_check_company_on_peppol,
+    '_peppol_deregister_participant': _mock_peppol_deregister_participant,
 }
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
V18.0 Only
When a branch company registers in demo mode, then tries to disconnect, the button that handles the disconnection was not added to the demo behavior so a real call was attempted, which was blocked by another safe guard resulting in an error, idealy in demo mode everything should work without having to make any external calls
task-none