### PR TITLE
[FIX] spreadsheet: list headers are not fetched

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -187,6 +187,11 @@ export class ListDataSource extends OdooViewsDataSource {
             this._triggerFetching();
             return LOADING_ERROR;
         }
+        if (!this.alreadyFetchedFieldPaths.has(fieldPath)) {
+            this.addFieldPathToFetch(fieldPath);
+            this._triggerFetching();
+            return LOADING_ERROR;
+        }
         this.assertIsValid();
         const field = this.fieldPathsToFieldMap[fieldPath];
         return field ? field.string : fieldPath;

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -105,7 +105,7 @@ test("Numeric/monetary fields are correctly loaded and displayed", async () => {
     expect(getFormattedValueGrid(model, "A2:C6")).toEqual({
         A2: "74.40€",    B2: "10.00",  C2: "1",
         A3: "$74.80",    B3: "11.00",  C3: "2",
-        A4: "4.00€",     B4: "95.00",  C4: "3",      
+        A4: "4.00€",     B4: "95.00",  C4: "3",
         A5: "$1,000.00", B5: "15.00",  C5: "4",
         A6: "$0.00",     B6: "0.00",   C6: "0",
     });
@@ -1289,4 +1289,14 @@ test("Chaining monetary fields includes the currency field", async function () {
     expect(getCellValue(model, "A1")).toBe(699.99);
     expect(getEvaluatedCell(model, "A1").formattedValue).toBe("$699.99");
     expect.verifySteps(["web_search_read"]);
+});
+
+test("List header labels are loaded even if there are no corresponding list values", async function () {
+    const { model } = await createSpreadsheetWithList();
+    const listId = model.getters.getListIds()[0];
+    setCellContent(model, "A1", `=ODOO.LIST.HEADER(${listId}, "currency_id")`);
+    setCellContent(model, "B1", `=ODOO.LIST.HEADER(${listId}, "product_id.template_id.name")`);
+    await animationFrame();
+    expect(getCellValue(model, "A1")).toBe("Currency");
+    expect(getCellValue(model, "B1")).toBe("Product Name");
 });


### PR DESCRIPTION
The `ODOO.LIST.HEADER` formula will display the technical name of the field instead of its albels if there are no `ODOO.LIST` formulas for that same field.

Since the introduction of chaining fields in list formulas, the fields we want to fetch should be added to `fieldPathsToFetch` in the data source. But this was only done for the `ODOO.LIST` formula, not for `ODOO.LIST.HEADER`.

Task: [5900769](https://www.odoo.com/web#id=5900769&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
