### PR TITLE
[IMP] mass_mailing: improve mass mailing editor

### DIFF
--- a/addons/html_builder/static/src/plugins/block_tab_plugin.js
+++ b/addons/html_builder/static/src/plugins/block_tab_plugin.js
@@ -1,0 +1,151 @@
+import { scrollTo } from "@html_builder/utils/scrolling";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { closest } from "@web/core/utils/ui";
+
+/**
+ * @typedef {import("@html_builder/core/drag_and_drop_plugin").DragState} DragState
+ */
+
+export class BlockTabPlugin extends Plugin {
+    static id = "blockTab";
+    static dependencies = ["operation", "history", "dropzone", "disableSnippets"];
+    static shared = ["insertSnippetGroup", "scrollToDroppedSnippet", "processDroppedSnippet"];
+
+    /**
+     * Opens and manages the snippet dialog after clicking on a snippet group,
+     * and inserts the selected snippet in the page.
+     *
+     * @param {Object} snippet the clicked snippet group
+     */
+    insertSnippetGroup(snippet) {
+        this.dependencies.operation.next(
+            async () => {
+                const cancelInsertion = this.dependencies.history.makeSavePoint();
+                let snippetEl;
+                await new Promise((resolve) => {
+                    this.config.snippetModel.openSnippetDialog(
+                        snippet,
+                        {
+                            onSelect: (snippet) => {
+                                snippetEl = snippet.content.cloneNode(true);
+
+                                // Add the dropzones corresponding to a section and
+                                // make them invisible.
+                                const selectors =
+                                    this.dependencies.dropzone.getSelectors(snippetEl);
+                                let dropzoneEls =
+                                    this.dependencies.dropzone.activateDropzones(selectors);
+                                dropzoneEls = dropzoneEls.filter(
+                                    (dropzoneEl) =>
+                                        !dropzoneEl.closest("[data-snippet]:not(:has(> .modal))")
+                                );
+                                this.editable
+                                    .querySelectorAll(".oe_drop_zone")
+                                    .forEach((dropzoneEl) => dropzoneEl.classList.add("invisible"));
+
+                                // Find the dropzone closest to the center of the
+                                // viewport and not located in the top quarter of
+                                // the viewport.
+                                const iframeWindow = this.document.defaultView;
+                                const viewPortCenterPoint = {
+                                    x: iframeWindow.innerWidth / 2,
+                                    y: iframeWindow.innerHeight / 2,
+                                };
+                                const validDropzoneEls = dropzoneEls.filter(
+                                    (el) =>
+                                        el.getBoundingClientRect().top >= viewPortCenterPoint.y / 2
+                                );
+                                const closestDropzoneEl =
+                                    closest(validDropzoneEls, viewPortCenterPoint) ||
+                                    dropzoneEls.at(-1);
+
+                                // Insert the selected snippet.
+                                closestDropzoneEl.after(snippetEl);
+                                this.dependencies.dropzone.removeDropzones();
+                                return snippetEl;
+                            },
+                            onClose: () => {
+                                resolve();
+                            },
+                        },
+                        this
+                    );
+                });
+
+                if (snippetEl) {
+                    await this.scrollToDroppedSnippet(snippetEl);
+                    await this.processDroppedSnippet(snippetEl, cancelInsertion);
+                }
+            },
+            {
+                withLoadingEffect: false,
+                shouldInterceptClick: true,
+                canTimeout: false,
+            }
+        );
+    }
+
+    /**
+     * Update the dropped snippet to build & adapt dynamic content right
+     * after adding it to the DOM.
+     *
+     * @param {HTMLElement} snippetEl
+     */
+    updateDroppedSnippet(snippetEl) {
+        // If the snippet is "drop in only", remove the attributes that make it
+        // a draggable snippet, so it becomes a simple HTML code.
+        if (snippetEl.classList.contains("o_snippet_drop_in_only")) {
+            snippetEl.classList.remove("o_snippet_drop_in_only");
+            if (snippetEl.classList.length === 0) {
+                snippetEl.removeAttribute("class");
+            }
+            delete snippetEl.dataset.snippet;
+            delete snippetEl.dataset.name;
+        }
+    }
+
+    /**
+     * @param {HTMLElement} snippetEl
+     * @param {Function} cancelInsertion
+     * @param {DragState} [dragState]
+     */
+    async processDroppedSnippet(snippetEl, cancelInsertion, dragState = {}) {
+        this.updateDroppedSnippet(snippetEl);
+        // Build the snippet.
+        for (const onSnippetDropped of this.getResource("on_snippet_dropped_handlers")) {
+            const cancel = await onSnippetDropped({ snippetEl, dragState });
+            // Cancel everything if the resource asked to.
+            if (cancel) {
+                cancelInsertion();
+                return;
+            }
+            // Update `snippetEl` (and `draggedEl` of `dragState`) if it was
+            // replaced in the handler.
+            if (dragState.replacedSnippetEl) {
+                if (dragState.draggedEl === snippetEl) {
+                    dragState.draggedEl = dragState.replacedSnippetEl;
+                }
+                snippetEl = dragState.replacedSnippetEl;
+                delete dragState.replacedSnippetEl;
+            }
+        }
+        this.config.updateInvisibleElementsPanel();
+        this.dependencies.disableSnippets.disableUndroppableSnippets();
+        this.dependencies.history.addStep();
+    }
+
+    /**
+     * Scroll to the dropped snippet and leave a space of 50px above to show
+     * what is above. If the snippet takes 100% of the screen height, we show it
+     * by not having an extra offset above it.
+     *
+     * @param {HTMLElement} snippetEl
+     */
+    async scrollToDroppedSnippet(snippetEl) {
+        const isFullScreenHeight = snippetEl.matches(".o_full_screen_height");
+        await scrollTo(snippetEl, { extraOffset: isFullScreenHeight ? 0 : 50 });
+    }
+}
+
+registry.category("builder-plugins").add(BlockTabPlugin.id, BlockTabPlugin);

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -8,7 +8,6 @@ import { closest } from "@web/core/utils/ui";
 import { useDragAndDrop } from "@html_editor/utils/drag_and_drop";
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { useSnippets } from "@html_builder/snippets/snippet_service";
-import { scrollTo } from "@html_builder/utils/scrolling";
 import { Snippet } from "./snippet";
 import { CustomInnerSnippet } from "./custom_inner_snippet";
 
@@ -70,75 +69,10 @@ export class BlockTab extends Component {
      *
      * @param {Object} snippet the clicked snippet group
      */
-    onSnippetGroupClick(snippet) {
-        this.shared.operation.next(
-            async () => {
-                this.cancelDragAndDrop = this.shared.history.makeSavePoint();
-                this.dragState = {};
-                let snippetEl;
-                this.state.ongoingInsertion = true;
-                await new Promise((resolve) => {
-                    this.snippetModel.openSnippetDialog(
-                        snippet,
-                        {
-                            onSelect: (snippet) => {
-                                snippetEl = snippet.content.cloneNode(true);
-
-                                // Add the dropzones corresponding to the snippet
-                                // and make them invisible.
-                                const selectors = this.shared.dropzone.getSelectors(snippetEl);
-                                let dropzoneEls = this.shared.dropzone.activateDropzones(selectors);
-                                dropzoneEls = dropzoneEls.filter(
-                                    (dropzoneEl) =>
-                                        !dropzoneEl.closest("[data-snippet]:not(:has(> .modal))")
-                                );
-
-                                this.editable
-                                    .querySelectorAll(".oe_drop_zone")
-                                    .forEach((dropzoneEl) => dropzoneEl.classList.add("invisible"));
-
-                                // Find the dropzone closest to the center of the
-                                // viewport and not located in the top quarter of
-                                // the viewport.
-                                const iframeWindow = this.document.defaultView;
-                                const viewPortCenterPoint = {
-                                    x: iframeWindow.innerWidth / 2,
-                                    y: iframeWindow.innerHeight / 2,
-                                };
-                                const validDropzoneEls = dropzoneEls.filter(
-                                    (el) =>
-                                        el.getBoundingClientRect().top >= viewPortCenterPoint.y / 2
-                                );
-                                const closestDropzoneEl =
-                                    closest(validDropzoneEls, viewPortCenterPoint) ||
-                                    dropzoneEls.at(-1);
-
-                                // Insert the selected snippet.
-                                closestDropzoneEl.after(snippetEl);
-                                this.shared.dropzone.removeDropzones();
-                                return snippetEl;
-                            },
-                            onClose: () => {
-                                resolve();
-                            },
-                        },
-                        this.env.editor
-                    );
-                });
-
-                if (snippetEl) {
-                    await this.scrollToDroppedSnippet(snippetEl);
-                    await this.processDroppedSnippet(snippetEl);
-                }
-                this.state.ongoingInsertion = false;
-                delete this.cancelDragAndDrop;
-            },
-            {
-                withLoadingEffect: false,
-                shouldInterceptClick: true,
-                canTimeout: false,
-            }
-        );
+    async onSnippetGroupClick(snippet) {
+        this.state.ongoingInsertion = true;
+        await this.shared.blockTab.insertSnippetGroup(snippet);
+        this.state.ongoingInsertion = false;
     }
 
     /**
@@ -149,7 +83,8 @@ export class BlockTab extends Component {
      * @param {Object} snippet the dropped snippet group
      * @param {HTMLElement} hookEl the placeholder snippet
      */
-    async onSnippetGroupDrop(snippet, hookEl) {
+    async onSnippetGroupDrop(snippet, cancelDragAndDrop, dragState) {
+        const { snippetEl: hookEl } = dragState;
         this.state.ongoingInsertion = true;
         // Exclude the snippets that are not allowed to be dropped at the
         // current position.
@@ -185,13 +120,16 @@ export class BlockTab extends Component {
         });
 
         if (selectedSnippetEl) {
-            await this.scrollToDroppedSnippet(selectedSnippetEl);
-            await this.processDroppedSnippet(selectedSnippetEl);
+            await this.shared.blockTab.scrollToDroppedSnippet(selectedSnippetEl);
+            await this.shared.blockTab.processDroppedSnippet(
+                selectedSnippetEl,
+                cancelDragAndDrop,
+                dragState
+            );
         } else {
-            this.cancelDragAndDrop();
+            cancelDragAndDrop();
         }
         this.state.ongoingInsertion = false;
-        delete this.cancelDragAndDrop;
     }
 
     /**
@@ -219,7 +157,7 @@ export class BlockTab extends Component {
         let dropzoneEls = [];
         let dragAndDropResolve;
 
-        let snippet, snippetEl, isSnippetGroup;
+        let snippet, snippetEl, isSnippetGroup, cancelDragAndDrop, dragState;
 
         const iframeWindow =
             this.document.defaultView !== window ? this.document.defaultView : false;
@@ -270,10 +208,10 @@ export class BlockTab extends Component {
                     canTimeout: false,
                 });
                 const restoreDragSavePoint = this.shared.history.makeSavePoint();
-                this.cancelDragAndDrop = () => {
+                cancelDragAndDrop = () => {
                     this.shared.dropzone.removeDropzones();
                     // Undo the changes needed to ease the drag and drop.
-                    this.dragState.restoreCallbacks?.forEach((restore) => restore());
+                    dragState.restoreCallbacks?.forEach((restore) => restore());
                     restoreDragSavePoint();
                 };
                 this.hideSnippetToolTip?.();
@@ -281,12 +219,12 @@ export class BlockTab extends Component {
                 this.document.body.classList.add("oe_dropzone_active");
                 this.state.ongoingInsertion = true;
 
-                this.dragState = {};
+                dragState = {};
                 dropzoneEls = [];
 
                 // Stop marking the elements with mutations as dirty and make
                 // some changes on the page to ease the drag and drop.
-                this.dragState.restoreCallbacks = this.env.editor
+                dragState.restoreCallbacks = this.env.editor
                     .trigger("on_prepare_drag_handlers")
                     .reverse();
 
@@ -346,7 +284,7 @@ export class BlockTab extends Component {
                     snippetEl.classList.add("o_snippet_previewing_on_drag");
                 }
                 // The dragged element may change while dragging.
-                Object.assign(this.dragState, { draggedEl: snippetEl, snippetEl, snippet });
+                Object.assign(dragState, { draggedEl: snippetEl, snippetEl, snippet });
 
                 // Add the dropzones.
                 const withGrids =
@@ -359,33 +297,33 @@ export class BlockTab extends Component {
 
                 this.env.editor.trigger("on_snippet_dragged_handlers", {
                     snippetEl,
-                    dragState: this.dragState,
+                    dragState,
                 });
             },
             dropzoneOver: ({ dropzone }) => {
                 const dropzoneEl = dropzone.el;
                 if (isSnippetGroup) {
                     dropzoneEl.classList.add("o_dropzone_highlighted");
-                    this.dragState.currentDropzoneEl = dropzoneEl;
+                    dragState.currentDropzoneEl = dropzoneEl;
                     return;
                 }
-                dropzoneEl.after(this.dragState.draggedEl);
+                dropzoneEl.after(dragState.draggedEl);
                 dropzoneEl.classList.add("invisible");
-                this.dragState.currentDropzoneEl = dropzoneEl;
+                dragState.currentDropzoneEl = dropzoneEl;
 
                 this.env.editor.trigger("on_snippet_over_dropzone_handlers", {
                     snippetEl,
-                    dragState: this.dragState,
+                    dragState,
                 });
             },
             onDrag: ({ x, y }) => {
-                if (!this.dragState.currentDropzoneEl) {
+                if (!dragState.currentDropzoneEl) {
                     return;
                 }
 
                 this.env.editor.trigger("on_snippet_move_handlers", {
                     snippetEl,
-                    dragState: this.dragState,
+                    dragState,
                     x,
                     y,
                 });
@@ -394,22 +332,22 @@ export class BlockTab extends Component {
                 const dropzoneEl = dropzone.el;
                 if (isSnippetGroup) {
                     dropzoneEl.classList.remove("o_dropzone_highlighted");
-                    this.dragState.currentDropzoneEl = null;
+                    dragState.currentDropzoneEl = null;
                     return;
                 }
 
                 this.env.editor.trigger("on_snippet_out_dropzone_handlers", {
                     snippetEl,
-                    dragState: this.dragState,
+                    dragState,
                 });
 
-                this.dragState.draggedEl.remove();
+                dragState.draggedEl.remove();
                 dropzoneEl.classList.remove("invisible");
-                this.dragState.currentDropzoneEl = null;
+                dragState.currentDropzoneEl = null;
             },
             onDragEnd: async ({ x, y, helper }) => {
                 this.document.body.classList.remove("oe_dropzone_active");
-                let currentDropzoneEl = this.dragState.currentDropzoneEl;
+                let currentDropzoneEl = dragState.currentDropzoneEl;
                 const isDroppedOver = !!currentDropzoneEl;
 
                 // If the snippet was dropped outside of a dropzone, find the
@@ -430,27 +368,27 @@ export class BlockTab extends Component {
                 }
 
                 if (currentDropzoneEl) {
-                    let draggedEl = this.dragState.draggedEl;
+                    let draggedEl = dragState.draggedEl;
 
                     // If a preview image was displayed during the drag, we remove it.
                     draggedEl.querySelector(".o_snippet_drag_preview")?.remove();
-                    this.dragState.snippetEl.classList.remove("o_snippet_previewing_on_drag");
+                    dragState.snippetEl.classList.remove("o_snippet_previewing_on_drag");
 
                     if (isDroppedOver) {
                         this.env.editor.trigger("on_snippet_dropped_over_handlers", {
                             droppedEl: draggedEl,
-                            dragState: this.dragState,
+                            dragState,
                         });
                     } else {
                         currentDropzoneEl.after(draggedEl);
                         this.env.editor.trigger("on_snippet_dropped_near_handlers", {
                             droppedEl: draggedEl,
                             dropzoneEl: currentDropzoneEl,
-                            dragState: this.dragState,
+                            dragState,
                         });
                     }
                     // The dragged element may have changed, so get it again.
-                    draggedEl = this.dragState.draggedEl;
+                    draggedEl = dragState.draggedEl;
 
                     // In order to mark only the concerned elements as dirty,
                     // remove the element, then replay the drop after
@@ -459,8 +397,8 @@ export class BlockTab extends Component {
 
                     // Undo the changes needed to ease the drag and drop and
                     // re-allow to mark dirty.
-                    this.dragState.restoreCallbacks.forEach((restore) => restore());
-                    this.dragState.restoreCallbacks = null;
+                    dragState.restoreCallbacks.forEach((restore) => restore());
+                    dragState.restoreCallbacks = null;
 
                     // Replay the drop.
                     currentDropzoneEl.after(draggedEl);
@@ -468,12 +406,19 @@ export class BlockTab extends Component {
 
                     // Process the dropped element.
                     if (!isSnippetGroup) {
-                        await this.processDroppedSnippet(snippetEl);
-                        delete this.cancelDragAndDrop;
+                        await this.shared.blockTab.processDroppedSnippet(
+                            snippetEl,
+                            cancelDragAndDrop,
+                            dragState
+                        );
                     } else {
                         this.shared.operation.next(
                             async () => {
-                                await this.onSnippetGroupDrop(snippet, snippetEl);
+                                await this.onSnippetGroupDrop(
+                                    snippet,
+                                    cancelDragAndDrop,
+                                    dragState
+                                );
                             },
                             {
                                 withLoadingEffect: false,
@@ -483,8 +428,7 @@ export class BlockTab extends Component {
                         );
                     }
                 } else {
-                    this.cancelDragAndDrop();
-                    delete this.cancelDragAndDrop;
+                    cancelDragAndDrop();
                 }
 
                 this.state.ongoingInsertion = false;
@@ -493,66 +437,6 @@ export class BlockTab extends Component {
         };
 
         this.draggableComponent = useDragAndDrop(dragAndDropOptions);
-    }
-
-    /**
-     * Scroll to the dropped snippet and leave a space of 50px above to show
-     * what is above. If the snippet takes 100% of the screen height, we show it
-     * by not having an extra offset above it.
-     *
-     * @param {HTMLElement} snippetEl
-     */
-    async scrollToDroppedSnippet(snippetEl) {
-        const isFullScreenHeight = snippetEl.matches(".o_full_screen_height");
-        await scrollTo(snippetEl, { extraOffset: isFullScreenHeight ? 0 : 50 });
-    }
-
-    /**
-     *
-     * @param {HTMLElement} snippetEl
-     */
-    async processDroppedSnippet(snippetEl) {
-        this.updateDroppedSnippet(snippetEl);
-        // Build the snippet.
-        for (const onSnippetDropped of this.env.editor.getResource("on_snippet_dropped_handlers")) {
-            const cancel = await onSnippetDropped({ snippetEl, dragState: this.dragState });
-            // Cancel everything if the resource asked to.
-            if (cancel) {
-                this.cancelDragAndDrop();
-                return;
-            }
-            // Update `snippetEl` (and `draggedEl` of `dragState`) if it was
-            // replaced in the handler.
-            if (this.dragState.replacedSnippetEl) {
-                if (this.dragState.draggedEl === snippetEl) {
-                    this.dragState.draggedEl = this.dragState.replacedSnippetEl;
-                }
-                snippetEl = this.dragState.replacedSnippetEl;
-                delete this.dragState.replacedSnippetEl;
-            }
-        }
-        this.env.editor.config.updateInvisibleElementsPanel();
-        this.shared.disableSnippets.disableUndroppableSnippets();
-        this.shared.history.addStep();
-    }
-
-    /**
-     * Update the dropped snippet to build & adapt dynamic content right
-     * after adding it to the DOM.
-     *
-     * @param {HTMLElement} snippetEl
-     */
-    updateDroppedSnippet(snippetEl) {
-        // If the snippet is "drop in only", remove the attributes that make it
-        // a draggable snippet, so it becomes a simple HTML code.
-        if (snippetEl.classList.contains("o_snippet_drop_in_only")) {
-            snippetEl.classList.remove("o_snippet_drop_in_only");
-            if (snippetEl.classList.length === 0) {
-                snippetEl.removeAttribute("class");
-            }
-            delete snippetEl.dataset.snippet;
-            delete snippetEl.dataset.name;
-        }
     }
 
     /**

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -505,9 +505,13 @@ export class LinkPlugin extends Plugin {
         );
     }
 
+    hasValidValue(attr, value) {
+        return Boolean(value);
+    }
+
     applyAttributes(el, attributes = {}) {
         for (const [attr, value] of Object.entries(attributes)) {
-            if (value) {
+            if (this.hasValidValue(attr, value)) {
                 el.setAttribute(attr, value);
             } else {
                 el.removeAttribute(attr);

--- a/addons/link_tracker/models/mail_render_mixin.py
+++ b/addons/link_tracker/models/mail_render_mixin.py
@@ -46,6 +46,13 @@ class MailRenderMixin(models.AbstractModel):
         link_nodes, urls_and_labels = find_links_with_urls_and_labels(
             root_node, base_url, skip_regex=rf'^{URL_SKIP_PROTOCOL_REGEX}', skip_prefix=short_schema,
             skip_list=blacklist)
+        if link_nodes:
+            filtered = [
+                (node, url)
+                for node, url in zip(link_nodes, urls_and_labels)
+                if self._should_track_node(node)
+            ]
+            link_nodes, urls_and_labels = zip(*filtered) if filtered else ((), ())
         if not link_nodes:
             return html
 
@@ -60,6 +67,10 @@ class MailRenderMixin(models.AbstractModel):
             new_html = markupsafe.Markup(new_html)
 
         return new_html
+
+    @api.model
+    def _should_track_node(self, node):
+        return True
 
     @api.model
     def _shorten_links_text(self, content, link_tracker_vals, blacklist=None, base_url=None):

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -185,6 +185,7 @@
             ('include', 'mass_mailing.assets_builder'),
             'mass_mailing/static/tests/mass_mailing_favourite_filter.test.js',
             'mass_mailing/static/tests/mass_mailing_html_field.test.js',
+            'mass_mailing/static/tests/mass_mailing_link_plugin.test.js',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/mass_mailing/models/mail_render_mixin.py
+++ b/addons/mass_mailing/models/mail_render_mixin.py
@@ -21,3 +21,9 @@ class MailRenderMixin(models.AbstractModel):
                     blacklist=['/unsubscribe_from_list', '/view', '/cards']
                 )
         return rendered
+
+    @api.model
+    def _should_track_node(self, node):
+        if node.attrib.has_key('data-no-tracking'):
+            return False
+        return super()._should_track_node(node)

--- a/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.js
+++ b/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.js
@@ -1,0 +1,9 @@
+import { Component } from "@odoo/owl";
+
+export class MassMailingBuilderSelectLabel extends Component {
+    static template = "mass_mailing.BuilderSelectLabel";
+    static props = {
+        label: { type: String },
+        description: { type: String },
+    };
+}

--- a/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.scss
+++ b/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.scss
@@ -1,0 +1,26 @@
+.o-hb-select-dropdown {
+    .o-hb-select-dropdown-font-item {
+        cursor: default;
+        background-color: var(--o-hb-select-bg-hover) !important;
+        font-weight: 500;
+        &:hover {
+            cursor: default !important;
+        }
+        padding-top: 6px !important;
+        padding-bottom: 6px !important;
+
+        .o-hb-select-dropdown-label {
+            font-size: 0.9rem;
+            font-weight: 600;
+            line-height: 1.2;
+        }
+
+        .o-hb-select-dropdown-description {
+            font-size: 10px;
+            font-weight: 400;
+            line-height: 1.2;
+            margin-top: 1px;
+            color: #adb5bd;
+        }
+    }
+}

--- a/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.xml
+++ b/addons/mass_mailing/static/src/builder/components/mass_mailing_builder_select_label.xml
@@ -1,0 +1,9 @@
+<templates>
+    <t t-name="mass_mailing.BuilderSelectLabel">
+        <div class="o-hb-select-dropdown-font-item d-flex flex-column dropdown-item"
+            role="presentation" tabindex="-1" t-att-data-tooltip="this.props.tooltip">
+            <div class="o-hb-select-dropdown-label" t-out="this.props.label"/>
+            <div class="o-hb-select-dropdown-description" t-out="this.props.description"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/fontfamily_picker.js
+++ b/addons/mass_mailing/static/src/builder/fontfamily_picker.js
@@ -1,6 +1,9 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
+import { MassMailingBuilderSelectLabel } from "./components/mass_mailing_builder_select_label";
+import { _t } from "@web/core/l10n/translation";
+import { GOOGLE_FONTS } from "../iframe/mass_mailing_iframe_utils";
 
-export const FONT_FAMILIES = {
+const EMAIL_SAFE_FONTS = {
     Arial: "Arial,Helvetica Neue,Helvetica,sans-serif",
     "Courier New": "Courier New,Courier,Lucida Sans Typewriter,Lucida Typewriter,monospace",
     Georgia: "Georgia,Times,Times New Roman,serif",
@@ -12,8 +15,36 @@ export const FONT_FAMILIES = {
     Verdana: "Verdana,Geneva,sans-serif",
 };
 
+const WEB_SUPPORTED_FONTS = {
+    "Lucida Sans": "Lucida Sans,Arial,sans-serif",
+    "Palatino Linotype": "Palatino Linotype,Georgia,serif",
+};
+
+const LIMITED_SUPPORT_FONTS = Object.fromEntries(
+    Object.entries(WEB_SUPPORTED_FONTS)
+        .concat(Object.entries(GOOGLE_FONTS))
+        .sort(([fontA], [fontB]) => fontA.localeCompare(fontB))
+);
+
+export const FONT_FAMILIES = {
+    mail: {
+        families: EMAIL_SAFE_FONTS,
+        label: _t("Email-safe fonts"),
+        description: _t("Supported by most popular email clients"),
+    },
+    google: {
+        families: LIMITED_SUPPORT_FONTS,
+        label: _t("Limited-support fonts"),
+        description: _t("A fallback font will be used for some email clients"),
+    },
+};
+
 export class FontFamilyPicker extends BaseOptionComponent {
     static template = "mass_mailing.FontFamilyPicker";
+    static components = {
+        ...BaseOptionComponent.components,
+        BuilderSelectLabel: MassMailingBuilderSelectLabel,
+    };
     static props = {
         action: String,
         actionParam: Object,

--- a/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
+++ b/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
@@ -2,7 +2,10 @@
     <t t-name="mass_mailing.FontFamilyPicker">
         <BuilderSelect className="this.props.extraClass" action="this.props.action" actionParam="this.props.actionParam">
             <t t-foreach="this.FONT_FAMILIES" t-as="fontFamily" t-key="fontFamily">
-                <BuilderSelectItem t-out="fontFamily" actionValue="fontFamily_value"/>
+                <BuilderSelectLabel label="fontFamily_value.label" description="fontFamily_value.description"/>
+                <t t-foreach="fontFamily_value.families" t-as="font" t-key="font">
+                    <BuilderSelectItem t-out="font" actionValue="font_value"/>
+                </t>
             </t>
         </BuilderSelect>
     </t>

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -44,6 +44,7 @@ export class MassMailingBuilder extends Component {
             "BannerPlugin",
             "CTABadgeOptionPlugin",
             "OperationPlugin",
+            "LinkPlugin",
         ];
         const massMailingPlugins = removePlugins(
             [

--- a/addons/mass_mailing/static/src/builder/plugins/empty_mailing_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_mailing_plugin.js
@@ -1,5 +1,4 @@
 import { Plugin } from "@html_editor/plugin";
-import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 
 export class EmptyMailingPlugin extends Plugin {
@@ -10,34 +9,25 @@ export class EmptyMailingPlugin extends Plugin {
         "disableSnippets",
         "history",
         "selection",
+        "blockTab",
     ];
 
-    resources = {
-        on_beforeinput_handlers: withSequence(1, this.ensureTextBlock.bind(this)),
-    };
+    setup() {
+        this.addDomListener(this.editable, "pointerdown", this.onMailWrapperClick.bind(this));
+    }
 
-    ensureTextBlock() {
-        const wrapperTd = this.editable.querySelector(".o_mail_wrapper_td");
-        if (!wrapperTd) {
+    onMailWrapperClick(ev) {
+        const wrapperId = ev.target.matches(".o_mail_wrapper_td:empty") ? ev.target : null;
+        if (!wrapperId) {
             return;
         }
-        const { anchorNode } = this.dependencies.selection.getEditableSelection();
-        if (anchorNode === wrapperTd && !wrapperTd.firstChild) {
-            const textSnippet = this.config.snippetModel
-                .getSnippetByName("snippet_structure", "s_text_block")
-                .content.cloneNode(true);
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            const container = textSnippet.querySelector(".container");
-            container.replaceChildren(baseContainer);
-            wrapperTd.replaceChildren(textSnippet);
-            this.dependencies.selection.setSelection({
-                anchorNode: baseContainer,
-                anchorOffset: 0,
-            });
-            this.dependencies.history.addStep();
-            this.dependencies.builderOptions.updateContainers(textSnippet);
-            this.dependencies.disableSnippets.disableUndroppableSnippets();
-        }
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        const snippet = this.config.snippetModel.snippetGroups.find(
+            (group) => group.groupName === "text"
+        );
+        this.dependencies.blockTab.insertSnippetGroup(snippet);
     }
 }
 

--- a/addons/mass_mailing/static/src/components/mass_mailing_link_popover/mailing_link_popover.xml
+++ b/addons/mass_mailing/static/src/components/mass_mailing_link_popover/mailing_link_popover.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="mass_mailing.MailingLinkPopover"
+       t-inherit="html_editor.linkPopover"
+       t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_advance_options_grid')]" position="inside">
+            <div t-if="shouldDisplayNoTrackingOption()" class="o_seo_option_row d-flex justify-content-between align-items-center py-1 gap-2">
+                <span t-att-title="state.noTracking.description" t-out="state.noTracking.label"/>
+                <CheckBox
+                    value="state.noTracking.isChecked"
+                    onChange.bind="toggleDisableLinkTracking"/>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/components/mass_mailing_link_popover/mass_mailing_link_popover.js
+++ b/addons/mass_mailing/static/src/components/mass_mailing_link_popover/mass_mailing_link_popover.js
@@ -1,0 +1,44 @@
+import { LinkPopover } from "@html_editor/main/link/link_popover";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * List of paths the URL of which will not have any effect when using the `notracking` option.
+ *
+ * @constant {string[]}
+ */
+const NON_TRACKABLE_URLS = ["/unsubscribe_from_list", "/view", "/cards"];
+
+export class MassMailingLinkPopover extends LinkPopover {
+    static template = "mass_mailing.MailingLinkPopover";
+
+    setup() {
+        super.setup();
+        this.linkElement = this.props.linkElement;
+        this.state.noTracking = {
+            label: "Disable Link Tracking",
+            description: _t("Send the original url instead of wrapping it into a tracking url."),
+            isChecked: this.linkElement.dataset.noTracking !== undefined,
+        };
+    }
+
+    toggleDisableLinkTracking() {
+        if (this.state.noTracking.isChecked) {
+            delete this.linkElement.dataset.noTracking;
+        } else {
+            this.linkElement.dataset.noTracking = "";
+        }
+        this.state.noTracking.isChecked = !this.state.noTracking.isChecked;
+    }
+
+    shouldDisplayNoTrackingOption() {
+        return !NON_TRACKABLE_URLS.includes(this.state.url);
+    }
+
+    prepareLinkParams() {
+        const params = super.prepareLinkParams();
+        if (this.state.noTracking.isChecked) {
+            params.attributes["data-no-tracking"] = "";
+        }
+        return params;
+    }
+}

--- a/addons/mass_mailing/static/src/editor/plugins/mass_mailing_link_plugin.js
+++ b/addons/mass_mailing/static/src/editor/plugins/mass_mailing_link_plugin.js
@@ -1,0 +1,56 @@
+import { withSequence } from "@html_editor/utils/resource";
+import { registry } from "@web/core/registry";
+import { MassMailingLinkPopover } from "../../components/mass_mailing_link_popover/mass_mailing_link_popover";
+import { LinkPlugin } from "@html_editor/main/link/link_plugin";
+import { _t } from "@web/core/l10n/translation";
+
+export class MassMailingLinkPlugin extends LinkPlugin {
+    resources = {
+        ...this.resources,
+        link_popovers: [
+            withSequence(10, {
+                PopoverClass: MassMailingLinkPopover,
+                isAvailable: (linkEl) => !linkEl || !this.isLinkImmutable(linkEl),
+                getProps: (props) => props,
+            }),
+        ],
+        advanced_popover_options: [
+            {
+                id: "noreferrer",
+                label: "noreferrer",
+                description: _t("Removes referrer information sent to the target site"),
+                attribute: "rel",
+                value: "noreferrer",
+                isMultiValueAttr: true,
+            },
+            {
+                id: "open_in_new_tab",
+                label: "Open in new tab",
+                description: _t("Opens the link in a new browser tab"),
+                attribute: "target",
+                value: "_blank",
+            },
+            {
+                id: "noopener",
+                label: "noopener",
+                description: _t(
+                    "Prevents the new page from accessing the original window (security)"
+                ),
+                attribute: "rel",
+                value: "noopener",
+                requires: "open_in_new_tab",
+                isMultiValueAttr: true,
+            },
+        ],
+    };
+
+    hasValidValue(attr, value) {
+        if (attr == "data-no-tracking") {
+            return true;
+        }
+        return super.hasValidValue(attr, value);
+    }
+}
+
+registry.category("basic-editor-plugins").add(MassMailingLinkPlugin.id, MassMailingLinkPlugin);
+registry.category("mass_mailing-plugins").add(MassMailingLinkPlugin.id, MassMailingLinkPlugin);

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -241,12 +241,9 @@ export class MassMailingHtmlField extends HtmlField {
         return {
             ...config,
             onEditorReady: () => this.commitChanges(),
-            Plugins: [
-                ...MAIN_EDITOR_PLUGINS,
-                ...DYNAMIC_FIELD_PLUGINS,
-                ...registry.category("basic-editor-plugins").getAll(),
-                PowerButtonsPlugin,
-            ].filter((P) => !["banner", "prompt"].includes(P.id)),
+            Plugins: [...MAIN_EDITOR_PLUGINS, ...DYNAMIC_FIELD_PLUGINS]
+                .filter((P) => !["banner", "prompt", "link"].includes(P.id))
+                .concat(registry.category("basic-editor-plugins").getAll()),
         };
     }
 

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -13,7 +13,6 @@ import { registry } from "@web/core/registry";
 import { effect } from "@web/core/utils/reactive";
 import { useChildRef, useService } from "@web/core/utils/hooks";
 import { batched } from "@web/core/utils/timing";
-import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
 import { useEmailHtmlConverter } from "@mail/convert_inline/hooks";
 import { fixInvalidHTML } from "@html_editor/utils/sanitize";
 

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -12,6 +12,7 @@ import { renderToFragment } from "@web/core/utils/render";
 import { closestScrollableY } from "@web/core/utils/scrolling";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { useComponent, useLayoutEffect, useRef, useState, useSubEnv } from "@web/owl2/utils";
+import { loadGoogleFonts } from "./mass_mailing_iframe_utils";
 
 const IFRAME_VALUE_SELECTOR = ".o_mass_mailing_value";
 
@@ -306,7 +307,10 @@ export class MassMailingIframe extends Component {
         } else {
             iframeBundles = ["mass_mailing.assets_inside_basic_editor_iframe"];
         }
-        return loadIframeBundles(this.iframeRef.el, iframeBundles);
+        return Promise.all([
+            loadIframeBundles(this.iframeRef.el, iframeBundles),
+            loadGoogleFonts(this.iframeRef.el.contentDocument),
+        ]);
     }
 
     renderHeadContent() {

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe_utils.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe_utils.js
@@ -1,0 +1,60 @@
+import { loadCSS } from "@web/core/assets";
+
+export const GOOGLE_FONTS = {
+    Aleo: "Aleo,Georgia,serif",
+    Anton: "Anton,Arial,sans-serif",
+    "Barlow Condensed": "Barlow Condensed,Arial,sans-serif",
+    Cabin: "Cabin,Arial,sans-serif",
+    Catamaran: "Catamaran,Arial,sans-serif",
+    Comfortaa: "Comfortaa,Arial,sans-serif",
+    "DM Sans": "DM Sans,Arial,sans-serif",
+    Dosis: "Dosis,Arial,sans-serif",
+    Epilogue: "Epilogue,Arial,sans-serif",
+    "Fira Sans": "Fira Sans,Arial,sans-serif",
+    Inter: "Inter,Arial,sans-serif",
+    "Josefin Sans": "Josefin Sans,Arial,sans-serif",
+    Karla: "Karla,Arial,sans-serif",
+    "Lucida Sans": "Lucida Sans,Arial,sans-serif",
+    Lato: "Lato,Arial,sans-serif",
+    Manrope: "Manrope,Arial,sans-serif",
+    Merriweather: "Merriweather,Georgia,serif",
+    Montserrat: "Montserrat,Arial,sans-serif",
+    Mukta: "Mukta,Arial,sans-serif",
+    Mulish: "Mulish,Arial,sans-serif",
+    "Noto Sans": "Noto Sans,Arial,sans-serif",
+    Nunito: "Nunito,Arial,sans-serif",
+    "Open Sans": "Open Sans,Arial,sans-serif",
+    Oswald: "Oswald,Arial,sans-serif",
+    "Palatino Linotype": "Palatino Linotype,Georgia,serif",
+    "Playfair Display": "Playfair Display,Georgia,serif",
+    Poppins: "Poppins,Arial,sans-serif",
+    Quicksand: "Quicksand,Arial,sans-serif",
+    Raleway: "Raleway,Arial,sans-serif",
+    Roboto: "Roboto,Arial,sans-serif",
+    Rubik: "Rubik,Arial,sans-serif",
+    Signika: "Signika,Arial,sans-serif",
+    "Source Sans Pro": "Source Sans Pro,Arial,sans-serif",
+    "Space Mono": "Space Mono,Courier New,monospace",
+    Ubuntu: "Ubuntu,Arial,sans-serif",
+};
+
+/**
+ * Loads a set of Google Fonts into the given document's <head>.
+ *
+ * @param {Document} contentDocument - The document to inject the fonts into,
+ *   typically `iframeElement.contentDocument`.
+ * @returns {Promise<void>}
+ */
+export async function loadGoogleFonts(contentDocument) {
+    try {
+        const fontUrl =
+            "https://fonts.googleapis.com/css2?" +
+            Object.keys(GOOGLE_FONTS)
+                .map((f) => `family=${encodeURIComponent(f)}`)
+                .join("&") +
+            "&display=swap";
+        return await loadCSS(fontUrl, { targetDoc: contentDocument });
+    } catch {
+        // Fail silently if fonts.googleapis.com is unreachable, as these fonts are destined to be an extra option (not required)
+    }
+}

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -70,13 +70,27 @@ html:has(.o_layout, .o_basic_theme) {
 
 html:has(.o_layout) {
     .editor_enable .o_mail_wrapper_td.oe_empty:empty {
+        cursor: pointer;
+        background-color: rgba(1, 186, 210, 0.5) !important;
+        &:not(:focus) {
+            &:before {
+                content: attr(data-editor-message);
+                pointer-events: none;
+                color: white;
+            }
+        }
+        &:hover {
+            background-color: rgba(1, 186, 210, 0.7) !important;
+        }
         width: 100% - 2 * $-editor-messages-margin-x;
+        text-align: center;
+        font-size: 20px;
+        display: block;
         padding: 12px 0;
         margin: 20px $-editor-messages-margin-x;
 
         &:not(:focus) {
             @include o-editor-messages;
-            background: $o-we-dropzone-bg-color !important;
 
             &:before {
                 pointer-events: none;

--- a/addons/mass_mailing/static/tests/mass_mailing_link_plugin.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_link_plugin.test.js
@@ -1,0 +1,50 @@
+import { expect, test } from "@odoo/hoot";
+import { setupEditor } from "@html_editor/../tests/_helpers/editor";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { MassMailingLinkPlugin } from "../src/editor/plugins/mass_mailing_link_plugin";
+
+const config = {
+    Plugins: [...MAIN_PLUGINS].filter((p) => p.id != "link").concat(MassMailingLinkPlugin),
+};
+
+defineMailModels();
+
+test("disable link tracking option should be shown and diable/enable link tracking when checked/unchecked respectively.", async () => {
+    const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>', {
+        config,
+    });
+    // Click on the link to open link popover
+    await waitFor(".o-we-linkpopover");
+    await click(".o_we_edit_link");
+    // Open advanced mode
+    await contains(".o_link_popover_container button[title='Advanced mode']").click();
+    // Check the disable link tracking option
+    await contains(
+        ".o_seo_option_row:has(span[title='Send the original url instead of wrapping it into a tracking url.']) input[type='checkbox']"
+    ).click();
+    // Go back to main popover view
+    await click("button.fa-angle-left");
+    // Apply
+    await contains("button.o_we_apply_link").click();
+
+    expect(el.querySelector("a")).toHaveAttribute("data-no-tracking");
+
+    // Click on the link to open link popover
+    await waitFor(".o-we-linkpopover");
+    await click(".o_we_edit_link");
+    // Open advanced mode
+    await contains(".o_link_popover_container button[title='Advanced mode']").click();
+    // Check the disable link tracking option
+    await contains(
+        ".o_seo_option_row:has(span[title='Send the original url instead of wrapping it into a tracking url.']) input[type='checkbox']"
+    ).click();
+    // Go back to main popover view
+    await click("button.fa-angle-left");
+    // Apply
+    await contains("button.o_we_apply_link").click();
+
+    expect(el.querySelector("a")).not.toHaveAttribute("data-no-tracking");
+});

--- a/addons/mass_mailing/tests/__init__.py
+++ b/addons/mass_mailing/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_mail_render_mixin
 from . import test_mailing_ab_testing
 from . import test_mailing_internals
 from . import test_mailing_list

--- a/addons/mass_mailing/tests/test_mail_render_mixin.py
+++ b/addons/mass_mailing/tests/test_mail_render_mixin.py
@@ -1,0 +1,57 @@
+from odoo.addons.mass_mailing.tests.common import MassMailCommon
+
+
+class TestMailRenderMixin(MassMailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._create_mailing_list()
+
+    def test_shorten_links(self):
+        # Prepare
+        mailing = self.env['mailing.mailing'].create({
+            'subject': 'TestShortener',
+            'body_html': """<!DOCTYPE html>
+            <html>
+                <head>
+                    <link type="text/css" rel="stylesheet" href="http://test.external.link/style1.css"/>
+                    <meta/>
+                    <script type="text/javascript" src="http://test.external.link/javascript1.js"></script>
+                </head>
+                <body>
+                    <img src="http://test.external.link/img.png" loading="lazy"/>
+                    <a id="url0" href="https://test.external.link/link">x</a>
+                    <div><a id="url1" href="https://test.cdn/web/content/local_link" data-no-tracking>x</a></div>
+                    <span style="background-image: url(&#39;http://test.cdn/web/image/2&#39;)">xxx</span>
+                    <div widget="html"><span class="toto">
+                            span<span class="fa"></span><img src="http://test.cdn/web/image/1" loading="lazy">
+                        </span></div>
+                </body>
+            </html>""",
+            'mailing_model_id': self.env['ir.model']._get('mailing.list').id,
+            'reply_to_mode': 'new',
+            'reply_to': self.email_reply_to,
+            'contact_list_ids': [(6, 0, self.mailing_list_1.ids)],
+            'keep_archives': True,
+        })
+
+        # Execute
+        with self.mock_mail_gateway():
+            mailing.action_send_mail()
+
+        # Assert
+        for contact in self.mailing_list_1.contact_ids:
+            new_mail = self._find_mail_mail_wrecord(contact)
+            for link_info in [('url0', 'https://test.external.link/link', True),
+                              ('url1', 'https://test.cdn/web/content/local_link', False)]:
+                link_params = {
+                    'utm_medium': 'Email',
+                    'utm_source': 'Mass Mailing',
+                    'utm_reference': f'mailing.mailing,{mailing.id}',
+                }
+                self.assertLinkShortenedHtml(
+                    new_mail.mail_message_id.body,
+                    link_info,
+                    link_params=link_params,
+                )

--- a/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
@@ -11,7 +11,7 @@ import {
 } from "@html_builder/../tests/helpers";
 import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "@html_editor/plugin";
-import { BlockTab } from "@html_builder/sidebar/block_tab";
+import { BlockTabPlugin } from "@html_builder/plugins/block_tab_plugin";
 
 defineWebsiteModels();
 
@@ -94,10 +94,12 @@ test("Check that all the `on_snippet_dropped_handlers` work with the correct sni
             }),
         };
     }
-    patchWithCleanup(BlockTab.prototype, {
-        async processDroppedSnippet(snippetEl) {
-            await super.processDroppedSnippet(snippetEl);
-            expect(this.dragState.draggedEl).toHaveClass("snippet-added");
+    patchWithCleanup(BlockTabPlugin.prototype, {
+        async processDroppedSnippet(snippetEl, cancelInsertion, dragState) {
+            await super.processDroppedSnippet(snippetEl, cancelInsertion, dragState);
+            expect.step(
+                dragState.draggedEl.classList.contains("snippet-added") ? "snippet-added" : ""
+            );
         },
     });
     addBuilderPlugin(AddClassOnSnippetDroppedPlugin);
@@ -121,5 +123,6 @@ test("Check that all the `on_snippet_dropped_handlers` work with the correct sni
     await new Promise((resolve) => setTimeout(resolve, 600));
     await contains(".o_select_media_dialog .o_button_area[aria-label='logo']").click();
     await waitSidebarUpdated();
+    await expect.waitForSteps(["snippet-added"]);
     expect(":iframe img").toHaveClass("snippet-added");
 });


### PR DESCRIPTION
This PR improves the user interface and the user experience of the editor of the email marketing app.

Briefly, the added features are (detailed description is found in each commit):
1.  **Disable link tracker on demand**: some websites do not accept link tracking/redirection, so we added an option to disable link tracking manually for the links in the html editor.
1. **Change the empty mailing kickoff workflow**: clicking on the `Drag blocks here` wrapper box must open the snippets library instead of changing into an editable area.
3. **Support more fonts**: add more fonts to the html editor/builder style options, including Google fonts. Note that some fonts are not supported by all mail clients and/or browsers.
4. **Add modularity to the `BlockTab` component**: this is a technical improvement, with no visual effect, aims at improving the architecture of the `BlockTab` component, by adding an associated plugin that can eventually be used/overriden by other plugins. 

Task-5358279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
