### PR TITLE
[IMP] attendance/timesheet: more separated systray

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -23,6 +23,11 @@ class HrAttendance(http.Controller):
     @staticmethod
     def _get_user_attendance_data(employee):
         response = {}
+        # We need attendance_check_in and timesheet_check_in permissions to edit the systray UI accordingly
+        # e.g., when user can check in for both, the UI of systray will show both details of attendance and timesheet
+        user = request.env.user
+        attendance_check_in_permission = user.has_group('hr_attendance.group_hr_attendance_own_reader')
+        timesheet_check_in_permission = user.has_group('hr_timesheet.group_hr_timesheet_user')
         if employee:
             response = {
                 'id': employee.id,
@@ -33,6 +38,8 @@ class HrAttendance(http.Controller):
                 'last_attendance_worked_hours': float_round(employee.last_attendance_worked_hours, precision_digits=2),
                 'last_check_in': employee.last_check_in,
                 'attendance_state': employee.attendance_state,
+                'attendance_check_in_permission': attendance_check_in_permission,
+                'timesheet_check_in_permission': timesheet_check_in_permission,
                 'display_systray': employee.company_id.attendance_from_systray,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,
             }

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -75,7 +75,8 @@ class HrEmployee(models.Model):
             if vals['attendance_manager_id']:
                 officer = self.env['res.users'].browse(vals['attendance_manager_id'])
                 officers_group = self.env.ref('hr_attendance.group_hr_attendance_officer', raise_if_not_found=False)
-                if officers_group and not officer.has_group('hr_attendance.group_hr_attendance_officer'):
+                # We need to add the group_hr_attendance_officer group id directly, otherwise it causes a problem in attendance group permission selection in settings
+                if officers_group and officers_group.id not in officer.group_ids.ids:
                     officer.sudo().write({'group_ids': [(4, officers_group.id)]})
 
         res = super().write(vals)

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -6,20 +6,21 @@
         <field name="category_id" ref="base.module_category_human_resources"/>
     </record>
 
+
     <record id="group_hr_attendance_own_reader" model="res.groups">
-        <field name="name">User: Read his own attendances</field>
+        <field name="name">User</field>
+        <field name="sequence">3</field>
+        <field name="privilege_id" ref="res_groups_privilege_attendances"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="comment">The user will have access to his own attendances on his user / employee profile</field>
     </record>
 
-    <record id="base.group_user" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own_reader'))]"/>
-    </record>
 
     <record id="group_hr_attendance_own" model="res.groups">
         <field name="name">Self Attendance Edit</field>
-        <field name="sequence">0</field>
+        <field name="sequence">5</field>
         <field name="privilege_id" ref="res_groups_privilege_attendances"/>
-        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own_reader'))]"/>
         <field name="comment">Grants users permission to modify their own attendance entries that are pending approval.</field>
     </record>
 

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -51,8 +51,11 @@ export class ActivityMenu extends Component {
             return;
         }
 
+        this.state.attendanceCheckInPermission = this.employee.attendance_check_in_permission;
+        this.state.timesheetCheckInPermission = this.employee.timesheet_check_in_permission;
         this.employeeName = this.employee.name;
-        this.state.isDisplayed = this.employee.display_systray;
+        //Systray dot should be displayed if at least the user has attendance or timesheet check in permission
+        this.state.isDisplayed = this.employee.display_systray && (this.state.attendanceCheckInPermission || this.state.timesheetCheckInPermission);
         this.state.checkedIn = this.employee.attendance_state === "checked_in";
 
         this.hoursToday = formatFloatTime(this.employee.hours_today, { numeric: true });

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -62,7 +62,6 @@
                             </tbody>
                         </table>
                     </div>
-
                     <div class="o_wrap_btn_sign_out position-md-sticky bottom-0 p-3 z-2">
                         <button t-on-click="() => this.signInOut()"
                                 t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'primary' }} w-100">

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -321,7 +321,7 @@
         <field name="name">Attendances</field>
         <field name="path">attendances</field>
         <field name="res_model">hr.attendance</field>
-        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own')), (4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
+        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own_reader'))]"/>
         <field name="view_mode">list,form</field>
         <field name="context">
             {
@@ -464,7 +464,7 @@
 
     <!-- Menus -->
 
-    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer" web_icon="hr_attendance,static/description/icon.png"/>
+    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance_own_reader" web_icon="hr_attendance,static/description/icon.png"/>
 
     <menuitem id="menu_action_open_form" name="Kiosk Mode" action="open_kiosk_url" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance_user"/>
 
@@ -482,7 +482,7 @@
         parent="menu_hr_attendance_reporting"
         sequence="10"/>
 
-    <menuitem id="menu_hr_attendance_overview" name="Overview" parent="menu_hr_attendance_root" sequence="5" groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer"/>
+    <menuitem id="menu_hr_attendance_overview" name="Overview" parent="menu_hr_attendance_root" sequence="5" groups="hr_attendance.group_hr_attendance_own_reader"/>
 
     <menuitem id="menu_hr_attendance_view_dashboard" name="Dashboard" action="hr_attendance_action" parent="menu_hr_attendance_overview" sequence="1"/>
 

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -33,7 +33,7 @@ class TestHolidaysOvertime(HttpCase, TransactionCase):
             ],
             'name': 'Standard 40h/week',
         })
-        cls.user = new_test_user(cls.env, login='user', groups='base.group_user,hr_holidays.group_hr_holidays_employee', company_id=cls.company.id).with_company(cls.company)
+        cls.user = new_test_user(cls.env, login='user', groups='base.group_user,hr_holidays.group_hr_holidays_employee,hr_attendance.group_hr_attendance_own_reader', company_id=cls.company.id).with_company(cls.company)
         cls.user_manager = new_test_user(cls.env, login='manager', groups='base.group_user,hr_holidays.group_hr_holidays_user,hr_attendance.group_hr_attendance_manager', company_id=cls.company.id).with_company(cls.company)
 
         cls.manager = cls.env['hr.employee'].create({


### PR DESCRIPTION
[IMP] attendance/timesheet: more separated systray

1 - Normally, when the timesheet app is installed systray was always only including the timesheet, it was hiding attendance lines
    1.1 - Now, it can include timesheet, attendance and both

2 - New right "User" is added to attendance (check-in and access are both okay but cannot modify anything in attendance)

3 - Check-in separation
    3.1 - If no right for timesheet + attendance check in, no systray in the app
    3.2 - If no right for attendance but at least User: own timesheets only right for timesheet, timesheet check-in is possible
    3.3 - If no right for timesheet but at least User right for attendance, only attendance check-in possible from systray
    3.4 - Else, both check-in options are put into the systray UI.

task - 5942545

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
