### PR TITLE
[IMP] web: support lazy loading for search view filters

### DIFF
--- a/addons/web/static/src/core/dropdown/accordion_item.js
+++ b/addons/web/static/src/core/dropdown/accordion_item.js
@@ -21,10 +21,15 @@ export class AccordionItem extends Component {
             type: String,
             optional: true,
         },
+        onWillToggle: {
+            type: Function,
+            optional: true,
+        },
     };
     static defaultProps = {
         class: "",
         selected: false,
+        onWillToggle: () => {},
     };
 
     setup() {
@@ -35,5 +40,10 @@ export class AccordionItem extends Component {
         onPatched(() => {
             this.parentComponent?.accordionStateChanged?.();
         });
+    }
+
+    async toggle() {
+        await this.props.onWillToggle();
+        this.state.open = !this.state.open;
     }
 }

--- a/addons/web/static/src/core/dropdown/accordion_item.xml
+++ b/addons/web/static/src/core/dropdown/accordion_item.xml
@@ -8,7 +8,7 @@
                     t-attf-class="{{ this.props.class }}"
                     t-att-aria-expanded="this.state.open ? 'true' : 'false'"
                     t-out="this.props.description"
-                    t-on-click="() => this.state.open = !this.state.open"
+                    t-on-click="this.toggle"
             />
             <t t-if="this.state.open">
                 <div class="o_accordion_values ms-4 border-start">

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -76,7 +76,11 @@ export class SearchArchParser {
                     this.visitSeparator();
                     break;
                 case "field":
-                    this.visitField(node);
+                    if (this.optionsParams) {
+                        this.visitInnerField(node);
+                    } else {
+                        this.visitField(node);
+                    }
                     break;
                 case "filter":
                     if (this.optionsParams) {
@@ -314,6 +318,22 @@ export class SearchArchParser {
         preInnerFilterOption.description = node.getAttribute("string");
         preInnerFilterOption.domain = node.getAttribute("domain");
         this.optionsParams.customOptions.push(preInnerFilterOption);
+    }
+
+    visitInnerField(node) {
+        this.optionsParams.toBeLoaded = true;
+        this.optionsParams.fieldName = node.getAttribute("name");
+        this.optionsParams.domain = node.getAttribute("domain") || [];
+        this.optionsParams.fieldType = this.fields[this.optionsParams.fieldName]?.type;
+        this.optionsParams.customOptions = [];
+        if (
+            !this.optionsParams.fieldType ||
+            !["many2many", "many2one", "selection"].includes(this.optionsParams.fieldType)
+        ) {
+            throw new Error(
+                `Inner field should only consist in a many2one, many2many or selection field`
+            );
+        }
     }
 
     visitGroup(node, visitChildren) {

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -69,7 +69,7 @@ export class SearchBarMenu extends Component {
     // Filter Panel
     get filterItems() {
         return this.env.searchModel.getSearchItems((searchItem) =>
-            ["filter", "dateFilter", "parentFilter"].includes(searchItem.type)
+            ["filter", "dateFilter", "parentFilter", "lazyParentFilter"].includes(searchItem.type)
         );
     }
 
@@ -88,6 +88,18 @@ export class SearchBarMenu extends Component {
         } else {
             this.env.searchModel.toggleSearchItem(itemId);
         }
+    }
+
+    async onToggle({ itemId, optionsParams }) {
+        if (optionsParams.toBeLoaded) {
+            await this.env.searchModel.loadLazyParentFilter(itemId);
+            this.render();
+        }
+    }
+
+    async onLoadMoreOptions({ itemId }) {
+        await this.env.searchModel.loadMoreOptions(itemId);
+        this.render();
     }
 
     // GroupBy Panel

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -27,13 +27,18 @@
                                 <div class="dropdown-divider" role="separator"/>
                             </t>
                             <t t-if="item.options">
-                                <AccordionItem class="'text-truncate'" description="item.description" selected="item.isActive">
+                                <AccordionItem 
+                                    class="'text-truncate'" 
+                                    description="item.description" 
+                                    selected="item.isActive" 
+                                    onWillToggle="() => this.onToggle({ itemId: item.id, optionsParams: item.optionsParams })"
+                                >
                                     <t t-set="subGroup" t-value="null"/>
                                     <t t-foreach="item.options" t-as="option" t-key="option.id">
                                         <t t-if="subGroup !== null and subGroup !== option.groupNumber">
                                             <div class="dropdown-divider" role="separator"/>
                                         </t>
-                                        <CheckboxItem class="{ o_item_option: true, selected: option.isActive }"
+                                        <CheckboxItem class="{ o_item_option: true, selected: option.isActive, 'text-truncate': true }"
                                                             t-out="option.description"
                                                             checked="option.isActive"
                                                             closingMode="'none'"
@@ -41,6 +46,7 @@
                                         />
                                         <t t-set="subGroup" t-value="option.groupNumber"/>
                                     </t>
+                                    <DropdownItem t-if="item.optionsParams.limit and item.optionsParams.count > item.optionsParams.limit" class="'o_item_option'" closingMode="'none'" onSelected.bind="() => this.onLoadMoreOptions({ itemId: item.id })">More...</DropdownItem>
                                 </AccordionItem>
                             </t>
                             <t t-else="">

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -890,6 +890,68 @@ export class SearchModel extends EventBus {
         this._notify();
     }
 
+    async loadLazyParentFilter(itemId) {
+        const searchItem = this.searchItems[itemId];
+        if (searchItem.optionsParams.fieldType === "selection") {
+            const field = this.searchViewFields[searchItem.optionsParams.fieldName];
+            const values = field.selection;
+            const options = searchItem.optionsParams.customOptions;
+            for (const val of values) {
+                options.push({
+                    description: val[1],
+                    domain: Domain.and([
+                        searchItem.domain,
+                        `[('${searchItem.optionsParams.fieldName}', '=', '${val[0]}')]`,
+                    ]).toString(),
+                    id: `custom_${val[1].toLowerCase()}_${searchItem.optionsParams.fieldName}`,
+                    type: "innerFilter",
+                });
+            }
+        }
+        if (["many2many", "many2one"].includes(searchItem.optionsParams.fieldType)) {
+            await this.loadMoreOptions(itemId);
+        }
+        delete searchItem.optionsParams.toBeLoaded;
+    }
+
+    async loadMoreOptions(itemId) {
+        const searchItem = this.searchItems[itemId];
+        const field = this.searchViewFields[searchItem.optionsParams.fieldName];
+        if (searchItem.optionsParams.limit) {
+            searchItem.optionsParams.limit *= 2;
+        } else {
+            searchItem.optionsParams.limit = 8;
+        }
+        const res = await this.orm
+            .cache({ type: "disk" })
+            .webSearchRead(
+                field.relation,
+                new Domain(searchItem.optionsParams.domain).toList(this.context),
+                {
+                    specification: {
+                        id: {},
+                        display_name: {},
+                    },
+                    limit: searchItem.optionsParams.limit,
+                }
+            );
+        searchItem.optionsParams.count = res.length;
+        const values = res.records.map((r) => [r.id, r.display_name]);
+        const options = [];
+        for (const val of values) {
+            options.push({
+                description: val[1],
+                domain: Domain.and([
+                    searchItem.domain,
+                    `[('${searchItem.optionsParams.fieldName}', '=', ${val[0]})]`,
+                ]).toString(),
+                id: `custom_${val[1].toLowerCase()}_${searchItem.optionsParams.fieldName}`,
+                type: "innerFilter",
+            });
+        }
+        searchItem.optionsParams.customOptions = options;
+    }
+
     /**
      * Set the active value id of a given category.
      * @param {number} sectionId
@@ -1586,6 +1648,7 @@ export class SearchModel extends EventBus {
                 );
                 break;
             case "parentFilter":
+            case "lazyParentFilter":
                 enrichSearchItem.options = _enrichOptions(
                     searchItem.optionsParams.customOptions,
                     queryElements.map((queryElem) => queryElem.generatorId)

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -1153,3 +1153,132 @@ test(`Custom filter with "&"" as value`, async function () {
     expect(getFacetTexts()).toEqual([`Foo contains &`]);
     expect(searchBar.env.searchModel.domain).toEqual([["foo", "ilike", "&"]]);
 });
+
+test("lazy selection filter", async () => {
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Selection" name="selection_filter">
+                    <field name="selection"/>
+                </filter>
+            </search>
+        `,
+    });
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Selection");
+    await contains(`.o_accordion_toggle`).click();
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(3);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual(["ABC", "DEF", "GHI"]);
+    await toggleMenuItemOption("Selection", "ABC");
+    expect(searchBar.env.searchModel.domain).toEqual([["selection", "=", "abc"]]);
+});
+
+test("lazy many2one filter", async () => {
+    Partner._records = [
+        { id: 1, name: "John" },
+        { id: 2, name: "David" },
+        { id: 3, name: "Bertrand" },
+        { id: 4, name: "Christophe" },
+        { id: 5, name: "Jean-Edouard" },
+        { id: 6, name: "Serge" },
+        { id: 7, name: "Amelie" },
+        { id: 8, name: "Sarah" },
+        { id: 9, name: "Tristan" },
+        { id: 10, name: "Paul" },
+    ];
+    onRpc("partner", "web_search_read", ({ kwargs }) => {
+        expect(kwargs.specification).toEqual({
+            display_name: {},
+            id: {},
+        });
+        expect(kwargs.domain).toEqual([["bar", "!=", false]]);
+        expect.step(`web_search_read ${kwargs.limit} partners`);
+    });
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Bar" name="m2o">
+                    <field name="bar" domain="[('bar', '!=', False)]"/>
+                </filter>
+            </search>
+        `,
+    });
+    expect.verifySteps([]);
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Bar");
+    await contains(`.o_accordion_toggle`).click();
+    expect.verifySteps(["web_search_read 8 partners"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(9);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual([
+        "John",
+        "David",
+        "Bertrand",
+        "Christophe",
+        "Jean-Edouard",
+        "Serge",
+        "Amelie",
+        "Sarah",
+        "More...",
+    ]);
+    await toggleMenuItemOption("Bar", "Christophe");
+    expect(searchBar.env.searchModel.domain).toEqual([["bar", "=", 4]]);
+    await toggleMenuItemOption("Bar", "More...");
+    expect.verifySteps(["web_search_read 16 partners"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(10);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual([
+        "John",
+        "David",
+        "Bertrand",
+        "Christophe",
+        "Jean-Edouard",
+        "Serge",
+        "Amelie",
+        "Sarah",
+        "Tristan",
+        "Paul",
+    ]);
+});
+
+test("lazy many2one filter with multiple domains", async () => {
+    Partner._records = [
+        { id: 1, name: "John" },
+        { id: 2, name: "David" },
+    ];
+    onRpc("partner", "web_search_read", ({ kwargs }) => {
+        expect(kwargs.domain).toEqual([["bar", "!=", false]]);
+        expect.step(`web_search_read`);
+    });
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Bar" name="m2o" domain="[('foo', '!=', 'a')]">
+                    <field name="bar" domain="[('bar', '!=', False)]"/>
+                </filter>
+            </search>
+        `,
+    });
+    expect.verifySteps([]);
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Bar");
+    await contains(`.o_accordion_toggle`).click();
+    expect.verifySteps(["web_search_read"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(2);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual(["John", "David"]);
+    await toggleMenuItemOption("Bar", "David");
+    expect(searchBar.env.searchModel.domain).toEqual(["&", ["foo", "!=", "a"], ["bar", "=", 2]], {
+        message:
+            "domain on filter is combined with the option, field domain is applied to the option search",
+    });
+});

--- a/addons/web/static/tests/search/search_bar_menu/models.js
+++ b/addons/web/static/tests/search/search_bar_menu/models.js
@@ -10,6 +10,13 @@ export class Foo extends models.Model {
         definition_record: "parent_id",
         definition_record_field: "properties_definition",
     });
+    selection = fields.Selection({
+        selection: [
+            ["abc", "ABC"],
+            ["def", "DEF"],
+            ["ghi", "GHI"],
+        ],
+    });
 
     _views = {
         search: `

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -399,9 +399,12 @@
                 <!-- Supported in Search View -->
                 <rng:group>
                     <rng:attribute name="string"/>
-                    <rng:oneOrMore>
-                        <rng:ref name="filter"/>
-                    </rng:oneOrMore>
+                    <rng:choice>
+                        <rng:ref name="field" />
+                        <rng:oneOrMore>
+                            <rng:ref name="filter"/>
+                        </rng:oneOrMore>
+                    </rng:choice>
                 </rng:group>
             </rng:choice>
 


### PR DESCRIPTION
Adds support for lazy-loaded search filters by embedding a `<field>` tag directly inside a `<filter>` tag.

When applied to `selection`, `many2one`, or `many2many` fields, the filter options are fetched dynamically on click (with respect to the given domain attribute if any). Initial results for relational fields are capped at 8 items, with a "More..." option provided to progressively load additional records.

task-6047969
