### PR TITLE
[FIX] hr_holidays: add the feature to batch create time off for hourly leave types

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1698,3 +1698,74 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         self.assertEqual(leave.number_of_hours, 13.0)
+
+    def test_hourly_multi_employee_wizard(self):
+        """ Test hourly batch generation for multiple employees via wizard """
+
+        hourly_leave_type = self.env['hr.leave.type'].with_user(self.user_hrmanager_id).create({
+            'name': 'Hourly Leave Type',
+            'request_unit': 'hour',
+            'leave_validation_type': 'no_validation',
+            'requires_allocation': 'no',
+        })
+
+        employees = self.employee_emp | self.employee_hruser
+
+        # Requesting 3 hours: 14:00 to 17:00
+        wizard = self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id).create({
+            'allocation_mode': 'employee',
+            'employee_ids': [Command.set(employees.ids)],
+            'holiday_status_id': hourly_leave_type.id,
+            'date_from': date(2026, 4, 1),
+            'date_to': date(2026, 4, 1),
+            'hour_from': 14.0,
+            'hour_to': 17.0,
+        })
+
+        wizard.action_generate_time_off()
+
+        generated_leaves = self.env['hr.leave'].search([
+            ('holiday_status_id', '=', hourly_leave_type.id),
+            ('employee_id', 'in', employees.ids)
+        ])
+
+        self.assertEqual(len(generated_leaves), 2, "Should have created 2 hourly leaves")
+        for leave in generated_leaves:
+            self.assertTrue(leave.request_unit_hours)
+            self.assertEqual(leave.request_hour_from, 14)
+            self.assertEqual(leave.request_hour_to, 17)
+            self.assertEqual(leave.state, 'validate')
+
+    def test_halfday_multi_employee_wizard(self):
+        """ Test half-day batch generation for multiple employees via wizard """
+
+        half_day_type = self.env['hr.leave.type'].with_user(self.user_hrmanager_id).create({
+            'name': 'Half Day Type',
+            'request_unit': 'half_day',
+            'leave_validation_type': 'no_validation',
+            'requires_allocation': 'no',
+        })
+
+        employees = self.employee_emp | self.employee_hruser
+
+        wizard = self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id).create({
+            'allocation_mode': 'employee',
+            'employee_ids': [Command.set(employees.ids)],
+            'holiday_status_id': half_day_type.id,
+            'date_from': date(2026, 4, 2),
+            'date_to': date(2026, 4, 2),
+            'date_from_period': 'am',
+        })
+
+        wizard.action_generate_time_off()
+
+        generated_leaves = self.env['hr.leave'].search([
+            ('holiday_status_id', '=', half_day_type.id),
+            ('employee_id', 'in', employees.ids)
+        ])
+
+        self.assertEqual(len(generated_leaves), 2, "Should have created 2 half-day leaves")
+        for leave in generated_leaves:
+            self.assertTrue(leave.request_unit_half)
+            self.assertEqual(leave.request_date_from_period, 'am')
+            self.assertEqual(leave.number_of_days, 0.5)

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -31,6 +31,12 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
     category_id = fields.Many2one('hr.employee.category', string='Employee Tag')
     date_from = fields.Date('Start Date', required=True)
     date_to = fields.Date('End Date', required=True)
+    hour_from = fields.Float(string='Hour from')
+    hour_to = fields.Float(string='Hour to')
+    leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit')
+    date_from_period = fields.Selection([
+        ('am', 'Morning'), ('pm', 'Afternoon')],
+        string="Date Period Start", default='am')
 
     def _get_employees_from_allocation_mode(self):
         self.ensure_one()
@@ -47,25 +53,42 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
     def _prepare_employees_holiday_values(self, employees, date_from_tz, date_to_tz):
         self.ensure_one()
         work_days_data = employees._get_work_days_data_batch(date_from_tz, date_to_tz)
-        return [{
-            'name': self.name,
-            'holiday_status_id': self.holiday_status_id.id,
-            'date_from': date_from_tz,
-            'date_to': date_to_tz,
-            'request_date_from': self.date_from,
-            'request_date_to': self.date_to,
-            'number_of_days': work_days_data[employee.id]['days'],
-            'employee_id': employee.id,
-            'state': 'validate',
-        } for employee in employees if work_days_data[employee.id]['days']]
+        values = []
+        for employee in employees:
+            if work_days_data[employee.id]['days'] > 0:
+                employee_values = {
+                    'name': self.name,
+                    'holiday_status_id': self.holiday_status_id.id,
+                    'request_date_from': self.date_from,
+                    'request_date_to': self.date_to,
+                    'employee_id': employee.id,
+                    'state': 'validate',
+                }
+                if self.leave_type_request_unit == 'hour':
+                    employee_values.update({
+                        'request_hour_from': self.hour_from,
+                        'request_hour_to': self.hour_to,
+                        'request_unit_hours': True,
+                    })
+                if self.leave_type_request_unit == 'half_day':
+                    employee_values.update({
+                        'request_unit_half': True,
+                        'request_date_from_period': self.date_from_period,
+                    })
+                values.append(employee_values)
+        return values
 
     def action_generate_time_off(self):
         self.ensure_one()
         employees = self._get_employees_from_allocation_mode()
 
         tz = timezone(self.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC')
-        date_from_tz = tz.localize(datetime.combine(self.date_from, datetime.min.time())).astimezone(UTC).replace(tzinfo=None)
-        date_to_tz = tz.localize(datetime.combine(self.date_to, datetime.max.time())).astimezone(UTC).replace(tzinfo=None)
+        if self.leave_type_request_unit == 'hour':
+            date_from_tz = (datetime.combine(self.date_from, datetime.min.time(), tzinfo=tz) + timedelta(hours=self.hour_from)).astimezone(UTC).replace(tzinfo=None)
+            date_to_tz = (datetime.combine(self.date_to, datetime.min.time(), tzinfo=tz) + timedelta(hours=self.hour_to)).astimezone(UTC).replace(tzinfo=None)
+        else:
+            date_from_tz = datetime.combine(self.date_from, datetime.min.time(), tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
+            date_to_tz = datetime.combine(self.date_to, datetime.max.time(), tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
 
         conflicting_leaves = self.env['hr.leave'].with_context(
             tracking_disable=True,

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -20,6 +20,16 @@
                                 options="{'end_date_field': 'date_to'}"/>
                             <field name="date_to" invisible="1" />
                         </div>
+                        <!-- half day or custom hours-->
+                        <label for="date_from_period" invisible="leave_type_request_unit != 'half_day'" string="Day Period"/>
+                        <div class="o_row" invisible="leave_type_request_unit != 'half_day'">
+                            <field name="date_from_period" invisible="leave_type_request_unit != 'half_day'" required="leave_type_request_unit == 'half_day'" class="o_hr_narrow_field me-2"/>
+                        </div>
+                        <label for="hour_from" invisible="leave_type_request_unit != 'hour'" string="Hours"/>
+                        <div class="o_row" invisible="leave_type_request_unit != 'hour'">
+                            <field name="hour_from" required="leave_type_request_unit != 'hour'" widget="float_time_selection" class="o_hr_narrow_field me-2"/>
+                            <field name="hour_to" required="leave_type_request_unit != 'hour'" widget="float_time_selection" class="o_hr_narrow_field"/>
+                        </div>
                         <field name="name" widget="text" placeholder="e.g. Extra recuperation, Company unavailability, ..."/>
                     </group>
                 </group>


### PR DESCRIPTION
In 17.0 it was possible to create time off requests for multiple employees for hourly and halfday leave types. In 18.0 we introduced the batch creation wizard, which only creates full day leaves for all employees. The feature has been added back in 19.2, this PR is a backport of that change.

Will not be implementing the changes since it requires adding new fields in the stable version.

Task: 6080477

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
