### PR TITLE
[FIX] point_of_sale: prevent error when creating invoice for pos order

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -42,6 +42,19 @@ class AccountMove(models.Model):
         if self.state == 'draft':
             return lot_values
 
+        orders = self.sudo().pos_order_ids
+        all_lots = orders.lines.mapped('pack_lot_ids')
+
+        stock_lots = self.env['stock.lot'].search([
+            ('name', 'in', all_lots.mapped('lot_name')),
+            ('product_id', 'in', orders.lines.mapped('product_id').ids),
+        ])
+
+        stock_lot_map = {
+            (lot.name, lot.product_id.id): lot
+            for lot in stock_lots
+        }
+
         # user may not have access to POS orders, but it's ok if they have
         # access to the invoice
         for order in self.sudo().pos_order_ids:
@@ -49,13 +62,14 @@ class AccountMove(models.Model):
                 lots = line.pack_lot_ids or False
                 if lots:
                     for lot in lots:
+                        stock_lot = stock_lot_map.get((lot.lot_name, line.product_id.id))
                         lot_values.append({
                             'product_name': lot.product_id.name,
                             'quantity': line.qty if lot.product_id.tracking == 'lot' else 1.0,
                             'uom_name': line.product_uom_id.name,
                             'lot_name': lot.lot_name,
                             'pos_lot_id': lot.id,
-                        } | self._extract_extra_invoiced_lot_values(lot))
+                        } | self._extract_extra_invoiced_lot_values(stock_lot))
 
         return lot_values
 


### PR DESCRIPTION
When a user tries to create an invoice for a PoS order, a traceback occurs.

Steps to reproduce the error:
- Install ``point_of_sale`` and ``sale_stock_product_expiry`` with demo data
- Go to Settings > Enable Display Lots & Serial Numbers on Invoices
- Create a product > Tracking: By lots >
  Enable Expiration Date in Inventory tab > Save
- Create a lot number and add on hand quantity for the product
- Add the product into the Furniture Shops PoS Product Categories
- Open Register of Furniture Shop > Add the product > set customer >
  Payment > Uncheck invoice > Pay
- Go to Point of Sale > Orders > Orders > Open that Order > Click Invoice

Traceback:
```py
AttributeError: 'pos.pack.operation.lot' object has no attribute 'expiration_date'
```

https://github.com/odoo/odoo/blob/039c5139119c9f59bcd999afebf61145be1f5b27/addons/point_of_sale/models/account_move.py#L58
When the Invoice button is clicked, ``_extract_extra_invoiced_lot_values`` method is called.
But here, ``lot`` is a ``pos.pack.operation.lot`` record. which does not contain ``expiration_date`` field.

https://github.com/odoo/odoo/blob/039c5139119c9f59bcd999afebf61145be1f5b27/addons/sale_stock_product_expiry/models/account_move.py#L9-L12

The method ``_extract_extra_invoiced_lot_values`` is designed to work with ``stock.lot`` record.

Solution:
Ensure ``_extract_extra_invoiced_lot_values`` is called with the corresponding ``stock.lot`` record instead of ``pos.pack.operation.lot``.

sentry-7375746210

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
