### PR TITLE
[FIX] pos_restaurant: show floors using config floor_ids

### DIFF
--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -27,7 +27,7 @@ class RestaurantFloor(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image']
+        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image', 'active']
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -626,6 +626,7 @@ export class FloorScreen extends Component {
                     [
                         {
                             name: newName,
+                            active: true,
                             background_color: "#FFFFFF",
                             pos_config_ids: [this.pos.config.id],
                         },
@@ -652,6 +653,7 @@ export class FloorScreen extends Component {
         const copyFloor = await this.pos.data.create("restaurant.floor", [
             {
                 name: newFloorName,
+                active: true,
                 background_color: "#ACADAD",
                 pos_config_ids: [this.pos.config.id],
             },
@@ -828,8 +830,9 @@ export class FloorScreen extends Component {
 
         activeFloor.delete();
 
-        if (this.pos.models["restaurant.floor"].length > 0) {
-            this.selectFloor(this.pos.models["restaurant.floor"].getAll()[0]);
+        const remainingFloors = this.pos.config.floor_ids.filter((f) => f.active);
+        if (remainingFloors.length > 0) {
+            this.selectFloor(remainingFloors[0]);
         } else {
             this.pos.isEditMode = false;
             this.pos.floorPlanStyle = "default";

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -8,7 +8,7 @@
             <div class="d-flex flex-row flex-wrap justify-content-between border-bottom bg-light">
                 <!-- Left Side Div -->
                 <div class="floor-selector d-flex gap-2 p-2 align-items-center overflow-auto">
-                    <t t-foreach="pos.models['restaurant.floor'].getAll()" t-as="floor" t-key="floor.id">
+                    <t t-foreach="pos.config.floor_ids.filter((f) => f.active)" t-as="floor" t-key="floor.id">
                         <button class="button button-floor btn btn-outline-secondary btn-lg px-3 lh-lg text-nowrap" t-attf-class="{{ floor.id === state.selectedFloorId ? 'active' : '' }}" t-on-click="() => this.selectFloor(floor)">
                             <t t-esc="floor.name" />
                             <t t-set="changeCount" t-value="this.getFloorChangeCount(floor)"/>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -177,9 +177,9 @@ patch(PosStore.prototype, {
     async getServerOrders() {
         if (this.config.module_pos_restaurant) {
             const tableIds = [].concat(
-                ...this.models["restaurant.floor"].map((floor) =>
-                    floor.table_ids.map((table) => table.id)
-                )
+                ...this.config.floor_ids
+                    .filter((floor) => floor.active)
+                    .map((floor) => floor.table_ids.map((table) => table.id))
             );
             await this.syncAllOrders({ table_ids: tableIds });
         }


### PR DESCRIPTION
Floors loaded indirectly (e.g. via recursive loading of paid orders) could appear in the floor selector even if they belonged to a different PoS config. The selector was iterating over the full in-memory model store instead of the floors explicitly assigned to the current config.

opw-6025172

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
