### PR TITLE
[FIX] web: support for RTL language for M3.1

### DIFF
--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -48,7 +48,7 @@
 
         %-o-field-label {
             width: max-content;
-            transform: translate(var(--field-spacing-unit), calc(-.5 * var(--field-spacing-unit)));
+            transform: translate(calc(var(--field-spacing-unit)), calc(-.5 * var(--field-spacing-unit)));
             z-index: 1; // TODO finetune for quick create kanban
             padding: 0 calc(var(--field-spacing-unit) / 2) !important;
             background: $o-view-background-color;


### PR DESCRIPTION
RTLCSS automatically adds '-1 *' when in RTL but only in calc, so we wrap the variable with 'calc'.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
