### PR TITLE
[FIX] pos_self_order: fix translation issues

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 from odoo.exceptions import UserError, ValidationError, AccessError
 
 from odoo import api, fields, models, _, service
+from odoo.tools.translate import get_translation
 from odoo.tools import file_open, split_every
 
 
@@ -151,17 +152,30 @@ class PosConfig(models.Model):
 
     def _prepare_self_order_custom_btn(self):
         for record in self:
-            exists = record.env['pos_self_order.custom_link'].search_count([
+            links = record.env['pos_self_order.custom_link'].search([
                 ('pos_config_ids', 'in', record.id),
                 ('url', '=', f'/pos-self/{record.id}/products')
             ])
 
-            if not exists:
-                record.env['pos_self_order.custom_link'].create({
-                    'name': _('Order Now'),
+            if not links:
+                links = record.env['pos_self_order.custom_link'].create({
+                    'name': 'Order Now',
                     'url': f'/pos-self/{record.id}/products',
                     'pos_config_ids': [(4, record.id)],
                 })
+
+            for link in links.filtered(lambda l: l.with_context(lang='en_US').name == 'Order Now'):
+                languages = {code for code in record.self_ordering_available_language_ids.mapped('code')}
+                if self.env.lang != 'en_US' and not self.env.lang in languages:
+                    languages.update({self.env.lang})
+
+                translations = {
+                    lang: get_translation('pos_self_order', lang, link.with_context(lang='en_US').name, ())
+                    for lang in languages
+                    if link.with_context(lang=lang).name == link.with_context(lang='en_US').name
+                }
+
+                link.update_field_translations('name', translations)
 
     def write(self, vals):
         self._prepare_self_order_splash_screen([vals])

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -259,7 +259,15 @@ class PosConfig(models.Model):
 
     def _get_self_order_route(self, table_id: Optional[int] = None) -> str:
         self.ensure_one()
-        base_route = f"/pos-self/{self.id}"
+        lang = self.self_ordering_default_language_id
+        lang_prefix = ""
+        if lang:
+            default_lang_code = self.env['ir.default'].sudo()._get('res.partner', 'lang')
+            if not default_lang_code:
+                default_lang_code = next(iter(self.env['res.lang']._get_active_by('code')))
+            if lang.code != default_lang_code:
+                lang_prefix = f"/{lang.url_code}"
+        base_route = f"{lang_prefix}/pos-self/{self.id}"
         table_route = ""
 
         if self.self_ordering_mode == 'consultation':

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 from odoo.exceptions import UserError, ValidationError, AccessError
 
 from odoo import api, fields, models, _, service
+from odoo.tools.translate import get_translation
 from odoo.tools import file_open, split_every
 
 
@@ -151,17 +152,25 @@ class PosConfig(models.Model):
 
     def _prepare_self_order_custom_btn(self):
         for record in self:
-            exists = record.env['pos_self_order.custom_link'].search_count([
+            links = record.env['pos_self_order.custom_link'].search([
                 ('pos_config_ids', 'in', record.id),
                 ('url', '=', f'/pos-self/{record.id}/products')
             ])
 
-            if not exists:
-                record.env['pos_self_order.custom_link'].create({
+            if not links:
+                links = record.env['pos_self_order.custom_link'].create({
                     'name': _('Order Now'),
                     'url': f'/pos-self/{record.id}/products',
                     'pos_config_ids': [(4, record.id)],
                 })
+
+            for link in links.filtered(lambda l: l.name == 'Order Now'):
+                translations = {
+                    lang.code: get_translation('pos_self_order', lang.code, link.name, ())
+                    for lang in record.self_ordering_available_language_ids
+                    if link.with_context(lang=lang.code).name == link.name
+                }
+                link.update_field_translations('name', translations)
 
     def write(self, vals):
         self._prepare_self_order_splash_screen([vals])


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Enable self ordering (QR + mobile) for a PoS restaurant/bar
2. Set the default language of self ordering to French
3. Go back to dashboard and click "Mobile Menu"

2 fixes in 2 commits:
---------------------

- First commit: [FIX] pos_self_order: fix default language not applied on first load
Fixes the case where the new selected language is only applied after a manual refresh of the self order page.

- Second commit: [FIX] pos_self_order: translate custom link names for available languages
Fixes the case where the custom self order button "Order Now" is not being translated to the newly selected language.

More details are in the respective commit messages.