### PR TITLE
[FIX] stock_account: display total value at date

### DIFF
--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -97,7 +97,7 @@
                     }"/>
                     <field name="total_value" string="Total Value" optional="hide" options="{
                         'currency_field': 'company_currency_id',
-                    }"/>
+                    }" sum="Total Value"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
### Steps to reproduce:

- Inventory > Reporting > Stock
- Click Inventory at Date and select any date > Confirm
#### > The sum of the Total Value is no longer displayed in the views

opw-5918288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
