### PR TITLE
[FIX] web: avoid subpixel on small bs components

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -270,6 +270,17 @@ $-o-bg-colors-custom: null;
     background-color: inherit;
 }
 
+// Bootstrap uses line-height-base on its small variants of components but uses
+// the small font-size. This results in elements being rendered on subpixels.
+// This rounds the line-size (see secondary_variables.scss) to the nearest
+// integer. We then divide it by the small font-size to get the pixel perfect
+// line-height.
+.btn-sm, .form-control-sm, .form-select-sm, .pagination-sm,
+.input-group-sm > :is(.form-control, .form-select, .input-group-text, .btn) {
+    $line-height-sm-rounded: ceil($o-line-size-sm-px);
+    line-height: ($line-height-sm-rounded / $o-font-size-base-small-px);
+}
+
 // Alert
 // ==============================================================================
 .alert {

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -16,7 +16,8 @@ $o-webclient-color-scheme: bright !default;
 $o-root-font-size: 1rem !default;
 $o-font-size-base: o-to-rem(14px) !default;
 $o-font-size-base-touch: o-to-rem(16px) !default;
-$o-font-size-base-small: o-to-rem(13px) !default;
+$o-font-size-base-small-px: 13px !default;
+$o-font-size-base-small: o-to-rem($o-font-size-base-small-px) !default;
 $o-font-size-base-smaller: o-to-rem(12px) !default;
 $o-line-height-base: 1.5 !default; // This is BS default
 $o-line-height-sm : 1.25 !default;

--- a/addons/web/static/src/scss/secondary_variables.scss
+++ b/addons/web/static/src/scss/secondary_variables.scss
@@ -29,6 +29,7 @@ $o-sheet-cancel-bpadding: $o-horizontal-padding !default;
 // Computation of the total height of a single line,
 // useful to visually center elements eg. in a list view.
 $o-line-size: $o-line-height-base * $o-font-size-base !default;
+$o-line-size-sm-px: $o-line-height-base * $o-font-size-base-small-px !default;
 
 // Form
 


### PR DESCRIPTION
The small variations of our bootstrap components in bootstrap share the
same line-height than their regular sized ones.

We use a 13px font-size on our bootstrap small variants of components
which result in a total of 19.5 pixel once mulitplied by it's
line-height (13*1.5).

This causes various visual glitches due to subpixel rendering issues.

task-6089966

Quick example of visual glitch, misalignment of the checkbox input due to sidepanel button height.
<img width="1011" height="567" alt="image" src="https://github.com/user-attachments/assets/d1c95600-fd31-4044-9134-7e630f8d9148" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
