### PR TITLE
[FIX] l10n_cz: Do not change date automatically on posted moves

### DIFF
--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -20,7 +20,7 @@ class AccountMove(models.Model):
     def _compute_date(self):
         super()._compute_date()
         for move in self:
-            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft' and not move.statement_line_id:
+            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft' and not move.statement_line_id and not move.posted_before:
                 move.date = move.taxable_supply_date
 
     def _get_invoice_currency_rate_date(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This automatic date alignment make sense in case of new document, but when you work on document that was posted. User should change it manually. In Czech republic we have something like late tax deduction and in this case there is not alignment of dates.

Current behavior before PR:
When you change taxable_supply_date it automatically change date

Desired behavior after PR is merged:
Disable this calculation od moves that hase been posted.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
