### PR TITLE
[FIX] stock: correctly estimate component availability on MO

### DIFF
--- a/addons/stock/static/src/widgets/forecast_widget.js
+++ b/addons/stock/static/src/widgets/forecast_widget.js
@@ -22,8 +22,7 @@ export class ForecastWidgetField extends FloatField {
         const digits = fields.forecast_availability.digits;
         const options = { digits, thousandsSep: "", decimalPoint: "." };
         const forecast_availability = parseFloat(formatFloat(data.forecast_availability, options));
-        const product_qty = parseFloat(formatFloat(data.product_qty, options));
-        this.willBeFulfilled = forecast_availability >= product_qty;
+        this.willBeFulfilled = forecast_availability >= 0;
         this.state = data.state;
     }
 

--- a/addons/stock/static/tests/counted_quantity_widget.test.js
+++ b/addons/stock/static/tests/counted_quantity_widget.test.js
@@ -66,3 +66,61 @@ test("Test setting the inventory quantity to its default value of 0", async func
 
     expect("td[name=inventory_diff_quantity] div input").toHaveValue(-50);
 });
+
+class MockStockMove extends models.Model {
+    _name = "stock.move";
+
+    forecast_availability = fields.Float();
+    product_qty = fields.Float();
+    forecast_expected_date = fields.Date();
+    date_deadline = fields.Date();
+    state = fields.Selection({
+        selection: [
+            ["draft", "Draft"],
+            ["assigned", "Confirmed"],
+        ],
+    });
+
+    _records = [
+        {
+            id: 1,
+            forecast_availability: 5,
+            product_qty: 10,
+            state: "draft",
+        },
+        {
+            id: 2,
+            forecast_availability: -1,
+            product_qty: 10,
+            state: "draft",
+        },
+    ];
+}
+defineModels([MockStockMove]);
+
+test("Test that forecast_availability should be Available if availability is greater or equal to 0", async function () {
+    await mountView({
+        type: "form",
+        resModel: "stock.move",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="forecast_availability" widget="forecast_widget"/>
+                <field name="product_qty" invisible="1"/>
+            </form>`,
+    });
+    expect("div[name='forecast_availability'] span.badge").toHaveText("Available");
+});
+
+test("Test that forecast_availability should be 'Not Available' if availability is smaller than 0", async function () {
+    await mountView({
+        type: "form",
+        resModel: "stock.move",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="forecast_availability" widget="forecast_widget"/>
+            </form>`,
+    });
+    expect("div[name='forecast_availability'] span.badge").toHaveText("Not Available");
+});


### PR DESCRIPTION
The forecast availability widget tells that there is not enough material if the quantity to use is more than half of the available stock

Steps to reproduce:
-------------------
* Create a product "component" tracked by quantity
* Update the on hand quantity to 20
* Create a MO for a product and use "component" as component
* set the quantity to 11 "component" and save
-> the forecast is "not available"

Observation:
-------------
When modifying the quantity, it will trigger ```_compute_forecast_information```, there the forecast_availability will be calculated, considering the new quantity:
https://github.com/odoo/odoo/blob/12dd03fb678870ddd3f1f8dca66aa3f934aa7985/addons/stock/models/stock_move.py#L553
In forecast_widget.js, it will try to consider the product consumption again:
https://github.com/odoo/odoo/blob/12dd03fb678870ddd3f1f8dca66aa3f934aa7985/addons/stock/static/src/widgets/forecast_widget.js#L26
Since willBeFulfilled consider the quantity twice, if the consumed quantity is more than half it will consider that there is not enougth stock 
https://github.com/odoo/odoo/blob/9ef76a4d6010191ab7ab1a0d1085972901280dda/addons/stock/static/src/widgets/forecast_widget.xml#L9-L15

opw-5993179