### PR TITLE
[FIX] stock: Quants_Visibility_With_Multi_Company_Receipt

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1323,6 +1323,9 @@ class StockQuant(models.Model):
         if not self.env['ir.config_parameter'].sudo().get_param('stock.skip_quant_tasks'):
             self._quant_tasks()
         ctx = dict(self.env.context or {})
+        if not domain:
+            domain = []
+        domain += [('product_id.company_id', 'in', ctx.get('allowed_company_ids', []) + [False])]
         ctx['inventory_report_mode'] = True
         ctx.pop('group_by', None)
         action = {
@@ -1331,7 +1334,7 @@ class StockQuant(models.Model):
             'res_model': 'stock.quant',
             'type': 'ir.actions.act_window',
             'context': ctx,
-            'domain': domain or [],
+            'domain': domain,
             'help': """
                 <p class="o_view_nocontent_empty_folder">{}</p>
                 <p>{}</p>

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
 
+from odoo.osv import expression
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import TransactionCase, Form
 
@@ -693,3 +695,36 @@ class TestMultiCompany(TransactionCase):
                     'picking_type_id': self.warehouse_b.in_type_id.id,
                 })
             ]})
+
+    def test_quants_visibility_with_multi_company_receipt(self):
+        """Tests that validating a receipt with both companies selected
+        doesn't leak the negative vendor quant to Company B's reports.
+        """
+        product = self.env['product.product'].create({
+            'name': 'Test Storable Product',
+            'type': 'product',
+            'company_id': self.company_a.id,
+        })
+
+        supplier_location = self.env.ref('stock.stock_location_suppliers')
+        receipt = self.env['stock.picking'].with_company(self.company_a).create({
+            'picking_type_id': self.warehouse_a.in_type_id.id,
+            'location_id': supplier_location.id,
+            'location_dest_id': self.stock_location_a.id,
+            'move_ids': [Command.create({
+                'name': product.name,
+                'product_id': product.id,
+                'location_id': supplier_location.id,
+                'location_dest_id': self.stock_location_a.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        receipt.button_validate()
+
+        base_domain = [('product_id', '=', product.id)]
+        domain_a = expression.AND([base_domain, self.env['stock.quant'].with_company(self.company_a)._get_quants_action()['domain']])
+        domain_b = expression.AND([base_domain, self.env['stock.quant'].with_company(self.company_b)._get_quants_action()['domain']])
+        quants_company_a = self.env['stock.quant'].with_company(self.company_a).search(domain_a)
+        quants_company_b = self.env['stock.quant'].with_company(self.company_b).search(domain_b)
+        self.assertTrue(quants_company_a)
+        self.assertFalse(quants_company_b)


### PR DESCRIPTION
**Purpose:**
Since a stock.quant is a combination of the stock move lines of a product
and a location, it should be restricted by the product's company.

**Before this commit:**
In a multi-company environment. If a purchase order with product from
company 1 is being confirmed, received, and validated when company 2 is
being selected as the primary active company while company 1 is also
checked. It will create a stock.quant that is searchable for company 2.
However, it will raise an error when company 2 is trying to access it.

**After this commit:**
Even if the stock.quant is created when company 2 is the primary active
company, it will not be searchable for company 2 since the product's
company is company 1.

**Steps to Reproduce on Runbot:**

- Create a storable product exclusive to Company A
- Create & validate a receipt for that product in Company A.
- Switch to Company B -> Reporting > Locations > Remove all filters: The negative quant for the product in Partners/Vendors is visible.

opw-6082330

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
