### PR TITLE
[FIX] l10n_fr_account: ensure meaningful EcritureLib in FEC export

### DIFF
--- a/addons/l10n_fr_account/tests/test_fec_export.py
+++ b/addons/l10n_fr_account/tests/test_fec_export.py
@@ -16,6 +16,8 @@ class TestFECExport(AccountTestInvoicingCommon):
             ]
         })
         inv.action_post()
+        # Clear the label of the receivable line to test the fallback logic (partner_name - move_ref)
+        inv.line_ids.filtered(lambda l: l.display_type == 'payment_term').name = ''
         # Create a new FEC export
         fec_export = self.env['l10n_fr.fec.export.wizard'].create({
             'date_from': '2020-01-01',
@@ -25,11 +27,11 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             b''.join(result['file_content']).decode(),
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
-            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Profit or Loss Appropriation|||-|20200101|/|0,00| 000000000003000,00|||20200101||\r\n'
-            f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|/| 000000000003000,00|0,00|||20200101||\r\n'
+            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Profit or Loss Appropriation|||-|20200101|Balance initiale|0,00| 000000000003000,00|||20200101||\r\n'
+            f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|Balance initiale| 000000000003000,00|0,00|||20200101||\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000001000,00|||20200101|-000000000001000,00|USD\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000002000,00|||20200101|-000000000002000,00|USD\r\n'
-            f'INV|Sales|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
+            f'INV|Sales|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|partner_a - INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
         )
 
     def test_fec_sub_companies(self):
@@ -131,8 +133,8 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             b''.join(result['file_content']).decode(),
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
-            f'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|{account.code}|{account.name}|||-|20200601|/| 000000000000050,00|0,00|||20200601| 000000000000050,00|USD\r\n'
-            'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|400000|Product Sales|||-|20200601|/|0,00| 000000000000050,00|||20200601|-000000000000050,00|USD'
+            f'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|{account.code}|{account.name}|||-|20200601|MISC/2020/06/0001| 000000000000050,00|0,00|||20200601| 000000000000050,00|USD\r\n'
+            'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|400000|Product Sales|||-|20200601|MISC/2020/06/0001|0,00| 000000000000050,00|||20200601|-000000000000050,00|USD'
         )
 
     def test_fec_initial_balance_skips_zero_net_partner_openings(self):
@@ -172,6 +174,6 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             b''.join(result['file_content']).decode(),
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
-            f'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200601|/| 000000000000050,00|0,00|||20200601| 000000000000050,00|USD\r\n'
-            'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|400000|Product Sales|||-|20200601|/|0,00| 000000000000050,00|||20200601|-000000000000050,00|USD'
+            f'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200601|partner_a - MISC/2020/06/0001| 000000000000050,00|0,00|||20200601| 000000000000050,00|USD\r\n'
+            'MISC|Miscellaneous Operations|MISC/2020/06/0001|20200601|400000|Product Sales|||-|20200601|MISC/2020/06/0001|0,00| 000000000000050,00|||20200601|-000000000000050,00|USD'
         )

--- a/addons/l10n_fr_account/tests/test_fec_export.py
+++ b/addons/l10n_fr_account/tests/test_fec_export.py
@@ -16,6 +16,8 @@ class TestFECExport(AccountTestInvoicingCommon):
             ]
         })
         inv.action_post()
+        # Clear the label of the receivable line to test the fallback logic (partner_name - move_ref)
+        inv.line_ids.filtered(lambda l: l.display_type == 'payment_term').write({'name': ''})
         # Create a new FEC export
         fec_export = self.env['l10n_fr.fec.export.wizard'].create({
             'date_from': '2020-01-01',
@@ -25,11 +27,11 @@ class TestFECExport(AccountTestInvoicingCommon):
         self.assertEqual(
             b''.join(result['file_content']).decode(),
             'JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n'
-            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Undistributed Profits/Losses|||-|20200101|/|0,00| 000000000003000,00|||20200101||\r\n'
-            f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|/| 000000000003000,00|0,00|||20200101||\r\n'
+            'OUV|Balance initiale|OUVERTURE/2020|20200101|999999|Undistributed Profits/Losses|||-|20200101|Balance initiale|0,00| 000000000003000,00|||20200101||\r\n'
+            f'OUV|Balance initiale|OUVERTURE/2020|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|Balance initiale| 000000000003000,00|0,00|||20200101||\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000001000,00|||20200101|-000000000001000,00|USD\r\n'
             'INV|Sales|INV/2020/00001|20200101|400000|Product Sales|||-|20200101|test line|0,00| 000000000002000,00|||20200101|-000000000002000,00|USD\r\n'
-            f'INV|Sales|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
+            f'INV|Sales|INV/2020/00001|20200101|121000|Account Receivable|{self.partner_a.id}|partner_a|-|20200101|partner_a - INV/2020/00001| 000000000003000,00|0,00|||20200101| 000000000003000,00|USD'
         )
 
     def test_fec_sub_companies(self):

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
@@ -59,7 +59,7 @@ class L10n_FrFecExportWizard(models.TransientModel):
                 '' AS CompAuxLib,
                 '-' AS PieceRef,
                 %(formatted_date_from)s AS PieceDate,
-                '/' AS EcritureLib,
+                'Balance initiale' AS EcritureLib,
                 replace(CASE WHEN COALESCE(sum(account_move_line.balance), 0) <= 0 THEN '0,00' ELSE to_char(SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Debit,
                 replace(CASE WHEN COALESCE(sum(account_move_line.balance), 0) >= 0 THEN '0,00' ELSE to_char(-SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Credit,
                 '' AS EcritureLet,
@@ -167,7 +167,7 @@ class L10n_FrFecExportWizard(models.TransientModel):
                         '' AS CompAuxLib,
                         '-' AS PieceRef,
                         %(formatted_date_from)s AS PieceDate,
-                        '/' AS EcritureLib,
+                        'Balance initiale' AS EcritureLib,
                         replace(CASE WHEN sum(account_move_line.balance) <= 0 THEN '0,00' ELSE to_char(SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Debit,
                         replace(CASE WHEN sum(account_move_line.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Credit,
                         '' AS EcritureLet,
@@ -240,7 +240,7 @@ class L10n_FrFecExportWizard(models.TransientModel):
                         COALESCE(replace(account_move_line__partner_id.name, '|', '/'), '') AS CompAuxLib,
                         '-' AS PieceRef,
                         %(formatted_date_from)s AS PieceDate,
-                        '/' AS EcritureLib,
+                        'Balance initiale' AS EcritureLib,
                         replace(CASE WHEN sum(account_move_line.balance) <= 0 THEN '0,00' ELSE to_char(SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Debit,
                         replace(CASE WHEN sum(account_move_line.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(account_move_line.balance), '000000000000000D99') END, '.', ',') AS Credit,
                         '' AS EcritureLet,
@@ -304,9 +304,25 @@ class L10n_FrFecExportWizard(models.TransientModel):
                             ELSE REGEXP_REPLACE(replace(%(move_alias)s.ref, '|', '/'), '[\\t\\r\\n]', ' ', 'g')
                         END AS PieceRef,
                         TO_CHAR(COALESCE(%(move_alias)s.invoice_date, %(move_alias)s.date), 'YYYYMMDD') AS PieceDate,
-                        CASE WHEN account_move_line.name IS NULL OR account_move_line.name = '' THEN '/'
-                            WHEN account_move_line.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
-                            ELSE REGEXP_REPLACE(replace(account_move_line.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,
+                        REGEXP_REPLACE(replace(
+                            CASE
+                                WHEN NULLIF(BTRIM(account_move_line.name, ' \t\n\r'), '') IS NOT NULL
+                                    THEN account_move_line.name
+                                WHEN %(account_alias)s.account_type IN ('asset_receivable', 'liability_payable')
+                                    THEN CONCAT_WS(' - ',
+                                        NULLIF(%(partner_alias)s.name, ''),
+                                        COALESCE(
+                                            NULLIF(%(move_alias)s.ref, ''),
+                                            %(move_alias)s.name
+                                        )
+                                    )
+                                ELSE
+                                    COALESCE(
+                                        NULLIF(%(move_alias)s.ref, ''),
+                                        %(move_alias)s.name
+                                    )
+                            END
+                        , '|', '/'), '[\\t\\n\\r]', ' ', 'g') AS EcritureLib,
                         replace(CASE WHEN account_move_line.debit = 0 THEN '0,00' ELSE to_char(account_move_line.debit, '000000000000000D99') END, '.', ',') AS Debit,
                         replace(CASE WHEN account_move_line.credit = 0 THEN '0,00' ELSE to_char(account_move_line.credit, '000000000000000D99') END, '.', ',') AS Credit,
                         CASE WHEN %(full_alias)s.id IS NULL THEN ''::text ELSE %(full_alias)s.id::text END AS EcritureLet,


### PR DESCRIPTION
To improve compliance with French requirements for FEC exports. Now we avoid exporting empty or placeholder labels ('/') by improving the fallback logic for EcritureLib. So now we,
- Use existing line label when valid
- For receivable/payable lines, fallback to 'partner - reference'
- Otherwise fallback to move reference or name
- Replace '/' with 'Balance initiale' for opening entries

Related: https://github.com/odoo/enterprise/pull/112822

task-5346068