### PR TITLE
[FIX] sale_expense: Sale order price unit set as 1

### DIFF
--- a/addons/sale_expense/models/account_move_line.py
+++ b/addons/sale_expense/models/account_move_line.py
@@ -33,7 +33,12 @@ class AccountMoveLine(models.Model):
         # Add expense quantity to sales order line and update the sales order price because it will be charged to the customer in the end.
         res = super()._sale_prepare_sale_line_values(order, price)
         if self.expense_id:
-            res['product_uom_qty'] = self.expense_id.quantity
+            res.update({
+                'product_uom_qty': 1,
+                'qty_delivered': 1,
+                'price_unit': self.expense_id.untaxed_amount_currency,
+                'tax_id': self.expense_id.tax_ids.ids,
+            })
         return res
 
     def _sale_create_reinvoice_sale_line(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
