### PR TITLE
[FIX] point_of_sale: always apply category-list class in category selector

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.CategorySelector">
-        <div t-attf-class="{{this.pos.config.show_category_images ? 'category-list' : 'product-list'}} d-grid gap-1 gap-lg-2 p-2">
+        <div t-attf-class="product-list category-list d-grid gap-1 gap-lg-2 p-2">
             <t t-foreach="this.getCategoriesAndSub()" t-as="category" t-key="category.id">
                 <button t-on-click="() => this.pos.setSelectedCategory(category.id)"
                     t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_': ''}}{{category.color or 'none'}}"

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -584,6 +584,10 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            {
+                content: "category selector keeps category-list styling",
+                trigger: ".category-list",
+            },
             ProductScreen.verifyCategorySequence(["AAA", "AAB", "AAC"]),
             {
                 trigger: '.category-button:eq(1) > div span:contains("AAB")',


### PR DESCRIPTION
Before this commit:
====================
Previously, the `category-list` class was conditionally applied based on `show_category_images`, which caused inconsistent styling and layout issues.

After this commit:
=======================
This commit ensures that both `product-list` and `category-list` classes are always present, providing consistent rendering of the category selector.

Task-6092404

