### PR TITLE
[IMP] stock: count all moves on in/out smart button

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -283,13 +283,15 @@ class ProductProduct(models.Model):
         incoming_moves = self.env['stock.move.line']._read_group([
                 ('product_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'incoming'),
+                ('location_id.warehouse_id', '=', False),
+                ('location_dest_id.warehouse_id', '!=', False),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         outgoing_moves = self.env['stock.move.line']._read_group([
                 ('product_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'outgoing'),
+                ('location_id.warehouse_id', '!=', False),
+                ('location_dest_id.warehouse_id', '=', False),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         res_incoming = {product.id: count for product, count in incoming_moves}
@@ -915,13 +917,15 @@ class ProductTemplate(models.Model):
         incoming_moves = self.env['stock.move.line']._read_group([
                 ('product_id.product_tmpl_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'incoming'),
+                ('location_id.warehouse_id', '=', False),
+                ('location_dest_id.warehouse_id', '!=', False),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         outgoing_moves = self.env['stock.move.line']._read_group([
                 ('product_id.product_tmpl_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'outgoing'),
+                ('location_id.warehouse_id', '!=', False),
+                ('location_dest_id.warehouse_id', '=', False),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         for product, count in incoming_moves:

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -282,13 +282,15 @@ class ProductProduct(models.Model):
         incoming_moves = self.env['stock.move.line']._read_group([
                 ('product_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'incoming'),
+                ('location_id.usage', '!=', 'internal'),
+                ('location_dest_id.usage', '=', 'internal'),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         outgoing_moves = self.env['stock.move.line']._read_group([
                 ('product_id', 'in', self.ids),
                 ('state', '=', 'done'),
-                ('picking_code', '=', 'outgoing'),
+                ('location_id.usage', '=', 'internal'),
+                ('location_dest_id.usage', '!=', 'internal'),
                 ('date', '>=', fields.Datetime.now() - relativedelta(years=1))
             ], ['product_id'], ['__count'])
         res_incoming = {product.id: count for product, count in incoming_moves}


### PR DESCRIPTION
The in/out smart button on a product form displays the number of stock moves
over the past 12 months. However, it only considered receipts and deliveries
and ignored other moves such as manufaturing moves and stock adjustments.
This provided an incomplete view.

Instead of filtering by `picking_code`, use locations for a more general
and robust approach.

task-4866335
