### PR TITLE
[FIX] quality_control: keep selected lots in MO consumption

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -972,7 +972,10 @@ class MrpProduction(models.Model):
                     production.name = picking_type.sequence_id.next_by_id()
                     moves_to_reassign |= production.move_raw_ids
 
-        res = super().write(vals)
+        if 'qty_producing' in vals:
+            res = super(MrpProduction, self.with_context(auto_conso=True)).write(vals)
+        else:
+            res = super().write(vals)
 
         for production in self:
             if 'date_start' in vals and not self.env.context.get('force_date', False):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -471,6 +471,13 @@ class StockMove(models.Model):
                 self = other_move + updated_product_move
         if self.env.context.get('force_manual_consumption'):
             vals['manual_consumption'] = True
+        if (
+            not self.env.context.get("auto_conso")
+            and any(cmd[0] == Command.CREATE for cmd in vals.get("move_line_ids", []))
+            and all(move.raw_material_production_id for move in self)
+        ):
+            vals['manual_consumption'] = True
+            vals['picked'] = True
         if 'product_uom_qty' in vals and 'move_line_ids' in vals:
             # first update lines then product_uom_qty as the later will unreserve
             # so possibly unlink lines

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -1,7 +1,7 @@
 import copy
 
 from odoo.exceptions import UserError
-from odoo.tests import common, tagged, Form
+from odoo.tests import common, Command, tagged, Form
 
 
 class TestConsumeComponentCommon(common.TransactionCase):
@@ -464,6 +464,38 @@ class TestConsumeComponent(TestConsumeComponentCommon):
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
         ])
 
+    def test_multi_lot_component_consumption(self):
+        """
+        Check that indicated lot on raw move lines are conserved even if the first
+        lot has enough quantity on hand
+        """
+        self.bom_serial_lines[0].unlink()
+        self.bom_serial_lines[2].unlink()
+
+        quants = self.create_quant(self.raw_lot, 2)
+        quants |= self.create_quant(self.raw_lot, 2, offset=1)
+        quants.action_apply_inventory()
+
+        mo = self.create_mo(self.mo_serial_tmpl, 1)
+        mo.action_confirm()
+        mo.move_raw_line_ids.quantity = 1
+        mo.move_raw_ids.write({
+            'move_line_ids': [
+                Command.create({
+                    'quantity': 1,
+                    'product_id': self.raw_lot.id,
+                    'product_uom_id': self.raw_lot.uom_id.id,
+                    'lot_id': quants[1].lot_id.id
+                })
+            ]
+        })
+        mo.button_mark_done()
+        mo.invalidate_recordset()
+        self.assertRecordValues(mo.move_raw_line_ids, [
+            {'quantity': 1.0},
+            {'quantity': 1.0},
+        ])
+
     def test_no_component_consumption_on_lot_removal(self):
         """
         If we have a manufacturing order (MO) for a product tracked by lot, and we assign a lot number
@@ -488,3 +520,59 @@ class TestConsumeComponent(TestConsumeComponentCommon):
             {'quantity': 0.0, 'picked': False},
             {'quantity': 0.0, 'picked': False},
         ])
+
+    def test_reservation_method_for_outgoing(self):
+        """ Test the functional flow when the reservation method for outgoing picking types is set to 'manual' """
+        outgoing_picking_type = self.env['stock.picking.type'].search([('code', '=', 'outgoing')], limit=1)
+
+        outgoing_picking_type.reservation_method = 'manual'
+
+        quant_none = self.create_quant(self.raw_none, 3)
+        quant_lot = self.create_quant(self.raw_lot, 2)
+        (quant_none + quant_lot).action_apply_inventory()
+
+        with Form(self.env['stock.picking']) as picking_form:
+            picking_form.picking_type_id = outgoing_picking_type
+
+            with picking_form.move_ids_without_package.new() as move_form:
+                move_form.product_id = self.raw_none
+                move_form.product_uom_qty = 3
+
+            with picking_form.move_ids_without_package.new() as move_form:
+                move_form.product_id = self.raw_lot
+                move_form.product_uom_qty = 2
+
+        picking = picking_form.save()
+
+        self.assertEqual(len(picking.move_ids), 2)
+        picking.action_confirm()
+
+        move_track_none, move_track_lot = picking.move_ids
+
+        self.assertEqual(move_track_none.quantity, 0)
+        self.assertEqual(move_track_lot.quantity, 0)
+
+        move_track_none.quantity = 3
+
+        # Simulate the form view of the burger button (detail of a move) for serial/lot tracking
+        with (
+            Form(move_track_lot, self.env.ref('stock.view_stock_move_operations')) as move_form,
+            move_form.move_line_ids.new() as move_line_form,
+        ):
+            move_line_form.quantity = 2
+            move_line_form.lot_id = quant_lot.lot_id
+
+        # Check stock move lines creation for each move
+        self.assertEqual(len(move_track_none.move_line_ids), 1)
+        self.assertEqual(move_track_none.move_line_ids.quantity, 3)
+
+        self.assertEqual(len(move_track_lot.move_line_ids), 1)
+        self.assertEqual(move_track_lot.move_line_ids.quantity, 2)
+        self.assertTrue(move_track_lot.move_line_ids.lot_id)
+
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+
+        # Check quantity available in stock for each product
+        self.assertEqual(self.raw_none.qty_available, 0)
+        self.assertEqual(self.raw_lot.qty_available, 0)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2357,7 +2357,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         @param qty: quantity in the UoM of move.product_uom
         """
         existing_smls = self.move_line_ids
-        self.move_line_ids = self._set_quantity_done_prepare_vals(qty)
+        self.with_context(auto_conso=True).move_line_ids = self._set_quantity_done_prepare_vals(qty)
         # `_set_quantity_done_prepare_vals` may return some commands to create new SMLs
         # These new SMLs need to be redirected thanks to putaway rules
         (self.move_line_ids - existing_smls)._apply_putaway_strategy()


### PR DESCRIPTION
**Issue**
Lots manually indicated on stock move lines can be overridden when producing a Manufacturing Order.

**Steps to reproduce**
- Create a storable product P tracked by lot
- Create two lots for product P with 2 units each
- Create a MO for a product consuming two units P and confirm it
- On the raw move, manually set 1 unit for each lot
- Click on "Produce All"
- Check the move line associated to the product P -> 2 units associated to the first lot consumed instead of 1 unit each

**Cause**
While producing:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/mrp/models/mrp_production.py#L2109-L2110 It sets the quantities:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/mrp/models/mrp_production.py#L2246 This calls `_set_quantity_done_prepare_vals` with a qty of 2: https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2264 which will, for each move line:
- Take the quantity indicated by move line: https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2274 https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2296-L2297
- Then take all the available quantity left for the lot associated to the move line: https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2302-L2309 https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2326-L2327 Instead of first taking all the quantity indicated by the move line, before checking available quantity

**Solution**
Assume that raw move lines being created in mrp without changing the producing quantity are manually created

opw-5946439