### PR TITLE
[IMP] web: improve audio file support

### DIFF
--- a/addons/mail/static/tests/thread/attachment_list.test.js
+++ b/addons/mail/static/tests/thread/attachment_list.test.js
@@ -464,3 +464,27 @@ test("check actions in mobile view", async () => {
     await contains(".dropdown-item:text('Remove')");
     await contains(".dropdown-item:text('Download')");
 });
+
+test("view and play audio attachment", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        name: "test.ogg",
+        mimetype: "audio/ogg",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        body: "<p>Test</p>",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-AttachmentCard");
+    await click(".o-mail-AttachmentCard");
+    await contains(".o-FileViewer audio");
+});

--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -89,13 +89,35 @@ export const FileModelMixin = (T) =>
         }
 
         get isVideo() {
-            const videoMimeTypes = ["audio/mpeg", "video/x-matroska", "video/mp4", "video/webm"];
+            const videoMimeTypes = [
+                "video/mpeg",
+                "video/x-matroska",
+                "video/mp4",
+                "video/webm",
+                "video/ogg",
+            ];
             return videoMimeTypes.includes(this.mimetype);
+        }
+
+        get isAudio() {
+            const audioMimeTypes = [
+                "audio/mpeg",
+                "audio/ogg",
+                "audio/x-wav",
+                "audio/weba",
+                "audio/acc",
+            ];
+            return audioMimeTypes.includes(this.mimetype);
         }
 
         get isViewable() {
             return (
-                (this.isText || this.isImage || this.isVideo || this.isPdf || this.isUrlYoutube) &&
+                (this.isText ||
+                    this.isImage ||
+                    this.isVideo ||
+                    this.isAudio ||
+                    this.isPdf ||
+                    this.isUrlYoutube) &&
                 !this.uploading
             );
         }

--- a/addons/web/static/src/core/file_viewer/file_viewer.scss
+++ b/addons/web/static/src/core/file_viewer/file_viewer.scss
@@ -45,4 +45,10 @@
     &.o-isText {
         background: $white;
     }
+
+    // Remove the radius of the chrome audio player since it doesn't look good
+    // inside our squared file viewer
+    audio::-webkit-media-controls-enclosure {
+        border-radius: 0;
+    }
 }

--- a/addons/web/static/src/core/file_viewer/file_viewer.xml
+++ b/addons/web/static/src/core/file_viewer/file_viewer.xml
@@ -39,6 +39,14 @@
                     <video t-if="this.state.file.isVideo" class="o-FileViewer-view w-75 h-75" t-att-class="{ 'w-100 h-100': this.ui.isSmall }" t-on-click.stop="" controls="controls">
                         <source t-att-data-type="this.state.file.mimetype" t-att-src="this.state.file.defaultSource"/>
                     </video>
+                    <div t-if="this.state.file.isAudio" t-on-click.stop="" class="o-FileViewer-view w-25 h-25 d-flex flex-column bg-white" t-att-class="{ 'w-100 h-100': this.ui.isSmall }">
+                        <div class="d-flex justify-content-center align-items-center flex-grow-1 rounded-3 rounded-bottom-0">
+                            <div class="o_image w-50 h-50" role="menuitem" aria-label="Preview" tabindex="-1" data-mimetype="audio/mpeg"/>
+                        </div>
+                        <audio class="w-100 rounded-0" controls="controls">
+                            <source t-att-data-type="this.state.file.mimetype" t-att-src="this.state.file.defaultSource" />
+                        </audio>
+                    </div>
                 </div>
                 <div t-if="this.state.file.isImage" class="position-absolute bottom-0 d-flex" t-custom-ref="imageToolbar" role="toolbar">
                     <div class="o-FileViewer-toolbarButton p-3 rounded-0" t-on-click.stop="this.zoomIn" title="Zoom In (+)" role="button">


### PR DESCRIPTION
Before this PR, audio files were handled by the isVideo getter and displayed in the video player.

This PR updates the isVideo getter to support additional MIME types and introduces a dedicated <audio> element in the file viewer.

Desktop
<img width="1754" height="758" alt="image" src="https://github.com/user-attachments/assets/655f5b04-1f78-4c45-a189-23d8e87ded66" />

Chrome
<img width="914" height="937" alt="image" src="https://github.com/user-attachments/assets/706c7619-d92b-461a-8744-05fa14b1df1d" />

Mobile
<img width="528" height="954" alt="image" src="https://github.com/user-attachments/assets/3b222282-7de1-4cf8-8ef5-b14b7ec2397c" />
