### PR TITLE
[FIX] timesheet_grid: prevent off overtime indication calculation

### DIFF
--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -580,13 +580,13 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          number_of_accrued_days - leave.number_of_days,
                          "All the remaining days of the allocation will expire")
 
-        # Days between the target date and the expiration date (accrual_plan's carryover date)
-        remaining_days_before_expiration = (allocation._get_carryover_date(target_date) - target_date).days
-        working_days_equivalent_needed = remaining_days_before_expiration * 24 / self.flex_40h_calendar.hours_per_day
-    
-        # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
+        # The flexible hours algorithm creates one working-day interval per
+        # calendar day in the range [target_date, carryover_date] (inclusive).
+        working_days_equivalent_needed = (allocation._get_carryover_date(target_date) - target_date).days + 1
+
+        # Assert the closest allocation duration (number of working days remaining before the allocation expires)
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
-                            "The closest allocation duration should be the number of working days equivalent (8 hours/day) remaining before the allocation expires")
+                            "The closest allocation duration should be the number of working days remaining before the allocation expires")
 
     @users('enguerran')
     def test_no_carried_over_leaves_for_fully_flexible_resource(self):

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -384,9 +384,8 @@ class ResourceCalendar(models.Model):
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
                     # and weekly range for time offs and overtime calculations and work entry generation
-                    start_date = start_datetime.date()
-                    end_datetime_adjusted = end_datetime - relativedelta(seconds=1)
-                    end_date = end_datetime_adjusted.date()
+                    start_date = start_dt.date()
+                    end_date = (end_dt - relativedelta(seconds=1)).date()
 
                     calendar = resource_calendars[resource] if resource else self
 


### PR DESCRIPTION
**problem:**
On timesheets, the overtime indication next to an employee's name is incorrect when using flexible work schedules. for example: a "Flexible 20h" schedule (4h a day) shows 1h of negative overtime even when the employee has logged exactly 20h for the week.

**steps to reproduce:**
1. Create a new working schedule with flexible hours enabled for example (20h/week, 4h/day average)
2. Assign this schedule to an employee
3. Go to Timesheets, search for the employee
4. Navigate to a past week
5. Enter 4h on each working day
6. Observe the overtime indication shows incorrect value (-01:00)

**cause:**
In `resource/models/resource_calendar.py`, the flexible hours algorithm that determines the date range by converts UTC boundaries to the employee's timezone. When the employee's timezone has a positive UTC offset (UTC+1, like in brussels time zone), `Sun 23:59:59 UTC` becomes `Mon 00:59:59 CET`, pushing `end_date` to the next Monday. This creates an 8 day range instead of 7. The algorithm then starts a new weekly budget for the spillover day and allocates 1 extra hour, making `allocated_hours` 20.9999998 instead of 20.

**fix:**
- Use the UTC date before conversion to the employee's timezone when determining the flexible date range.


**note:**
Updating the test (test_no_carried_over_leaves_for_flexible_resource) in hr_holidays/tests/test_expiring_leaves.py expected duration logic, is to match the corrected inclusive day range and prevent asserting the
previous spillover behavior.

link to the enterprise PR: odoo/enterprise#112879

opw-5970511

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
