### PR TITLE
[REF] website: no direct _compute_domain

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -309,12 +309,11 @@ class WebsitePage(models.Model):
         results = most_specific_pages.filtered_domain(domain)  # already sudo
 
         def filter_page(search, page, all_pages):
-            # Exclude pages that do not pass ACL.
-            Rule = page.env['ir.rule'].sudo(False)
-            if not page.filtered_domain(Rule._compute_domain('website.page', 'read')):
-                return False
-            if not page.view_id.filtered_domain(Rule._compute_domain('ir.ui.view', 'read')):
-                return False
+            if not page.website_published:
+                # Exclude pages that do not pass ACL.
+                page_user = page.sudo(False)
+                if not (page_user.has_access('read') and page_user.view_id.has_access('read')):
+                    return False
             if search and with_description:
                 # Search might have matched words in the xml tags and parameters therefore we make
                 # sure the terms actually appear inside the text.


### PR DESCRIPTION
Remove the direct usages of `_compute_domain`, filter pages by checking access.

Published pages are always accessible.  To keep pages and views not
directly accessible to users (see ccc98e01691b88c2da9c484c0e6de235b9d18548),
we don't change access rules.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
