### PR TITLE
[IMP] l10n_ph: move RDO field from partner to company

### DIFF
--- a/addons/l10n_ph/models/res_company.py
+++ b/addons/l10n_ph/models/res_company.py
@@ -6,4 +6,4 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     branch_code = fields.Char(string='Company Branch Code', related='partner_id.branch_code')
-    l10n_ph_rdo = fields.Char(related='partner_id.l10n_ph_rdo', readonly=False)
+    l10n_ph_rdo = fields.Char("RDO", help="Revenue District Office")

--- a/addons/l10n_ph/models/res_partner.py
+++ b/addons/l10n_ph/models/res_partner.py
@@ -10,7 +10,6 @@ class ResPartner(models.Model):
     first_name = fields.Char("First Name")
     middle_name = fields.Char("Middle Name")
     last_name = fields.Char("Last Name")
-    l10n_ph_rdo = fields.Char("RDO", help="Revenue District Office")
 
     @api.model
     def _commercial_fields(self):

--- a/addons/l10n_ph/views/res_partner_views.xml
+++ b/addons/l10n_ph/views/res_partner_views.xml
@@ -7,7 +7,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="branch_code" invisible="'PH' not in fiscal_country_codes"/>
-                <field name="l10n_ph_rdo" invisible="'PH' not in fiscal_country_codes or not ref_company_ids"/>
                 <field name="first_name" invisible="'PH' not in fiscal_country_codes"/>
                 <field name="middle_name" invisible="'PH' not in fiscal_country_codes"/>
                 <field name="last_name" invisible="'PH' not in fiscal_country_codes"/>


### PR DESCRIPTION
[IMP] l10n_ph: move RDO field from partner to company

This commit moves the field `l10n_ph_rdo` from model `res.partner` to `res.company`
As the field is only ever used for export with the company datas, this will avoid to overload the db with a column poorly used

task-6071014
