### PR TITLE
[FIX] base: Add to checklist before file write

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -137,10 +137,10 @@ class IrAttachment(models.Model):
         fname, full_path = self._get_path(bin_value, checksum)
         if not os.path.exists(full_path):
             try:
-                with open(full_path, 'wb') as fp:
-                    fp.write(bin_value)
                 # add fname to checklist, in case the transaction aborts
                 self._mark_for_gc(fname)
+                with open(full_path, 'wb') as fp:
+                    fp.write(bin_value)
             except IOError:
                 _logger.info("_file_write writing %s", full_path, exc_info=True)
         return fname


### PR DESCRIPTION
If an error occurs during the file write operation, the file will not be marked for garbage collection, which can lead to orphaned files taking up disk space or blocking other same file to be written.

Step to reproduce the issue:
1. Create an attachment with a large file (e.g., 100MB) and save
2. During the file write operation, simulate an IOError (e.g., by filling up the disk space or changing file permissions)
3. The file will not be marked for garbage collection, and it will remain
4. Further attempts to create this same attachment will result in error: "The attachment collides with an existing file."

opw-6055037
opw-5907025