### PR TITLE
[FIX] website_sale: show website-specific category in breadcrumbs

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -799,7 +799,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
         original_category = category
-        category = category or product.public_categ_ids[:1]
+        category = (
+            category or
+            product.public_categ_ids.filtered(
+                lambda c: not c.website_id or c.website_id == request.website
+            )[:1]
+        )
         if category:
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -513,3 +513,21 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
                 category=public_category,
             )
         self.assertIn('/category', values['keep'].path)
+
+    def test_multi_website_breadcrumb_category(self):
+        """Ensure that the breadcrumb category is correctly filtered by website."""
+        website_2 = self.env["website"].create({"name": "Website 2"})
+        category_1, category_2 = self.env["product.public.category"].create([
+            {"name": "Category 1", "website_id": self.website.id},
+            {"name": "Category 2", "website_id": website_2.id},
+        ])
+        self.product.product_tmpl_id.public_categ_ids = [
+            Command.set([category_1.id, category_2.id])
+        ]
+
+        for website, category in [(self.website, category_1), (website_2, category_2)]:
+            with MockRequest(self.env, website=website):
+                values = self.pc_controller._prepare_product_values(
+                    self.product.product_tmpl_id, category=None
+                )
+                self.assertEqual(values["category"], category)


### PR DESCRIPTION
Steps to produce:
---
- Install the `website_sale` module.
- Go to `Website > Configuration > Websites` and create a new website, placing it first in the sequence to make it the default.
- Create a product and assign 2 eCommerce categories under the Sales tab.
- Publish the product.
- Go to `Website > eCommerce > Products > eCommerce Categories`.
- Set Website 1 on Category 1 and Website 2 on Category 2.
- Open the shop in an incognito tab, search for the product, and open it.t.

Issue:
---
- The breadcrumb displays an incorrect category, as the category selection
  logic does not filter out categories that are not linked to the
  current website (it should only consider categories assigned
  to the current website or no website).

Solution:
---
- Filter product categories to include only those linked to the current
  website or no website when resolving the breadcrumb category.

opw-6039587

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
