### PR TITLE
[PERF] stock: Optimize _get_outgoing_domain in stock.move.line

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -320,7 +320,7 @@ class StockLot(models.Model):
     def _get_outgoing_domain(self):
         return [
             '|',
-            '|', ('picking_code', '=', 'outgoing'), ('move_id.picking_code', '=', 'outgoing'),
+            '|', ('picking_code', '=', 'outgoing'), ('picking_id.picking_type_id.code', '=', 'outgoing'),
             ('produce_line_ids', '!=', False),
         ]
 


### PR DESCRIPTION
### Description:

The `_get_outgoing_domain` method was using `move_id.picking_code` to filter outgoing moves. In SQL, the ORM translates this into a costly subquery/join involving the `stock.move` table. Given that both
`stock.move` and `stock.move.line` are high-cardinality tables, the Postgres planner often chooses an inefficient Merge Join or Seq Scan.

By using `picking_id.picking_type_id.code` instead, we bypass the `stock.move` table entirely. This uses the existing foreign key on the move line to reach the picking type directly, significantly reducing the number of rows processed in the join.

### Benchmark:

| N° of moves/mls  | Before  | After  |
|------------------|---------|--------|
|  8392140/8115085 |  45.53s |   67ms |

### Reference:

opw-6012452