### PR TITLE
Master Support groupby on aggregations

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -407,7 +407,16 @@ class AccountReportLine(models.Model):
     )
     sequence = fields.Integer(string="Sequence")
     code = fields.Char(string="Code", help="Unique identifier for this line.")
-    foldable = fields.Boolean(string="Foldable", help="By default, we always unfold the lines that can be. If this is checked, the line won't be unfolded by default, and a folding button will be displayed.")
+    foldability = fields.Selection(
+        selection=[
+            ('always_unfolded', 'Always Unfolded'),
+            ('never_unfolded', 'Never Unfolded'),
+            ('foldable', 'Foldable'),
+        ],
+        compute='_compute_foldability',
+        store=True,
+        readonly=False,
+    )
     print_on_new_page = fields.Boolean('Print On New Page', help='When checked this line and everything after it will be printed on a new page.')
     action_id = fields.Many2one(string="Action", comodel_name='ir.actions.actions', help="Setting this field will turn the line into a link, executing the action when clicked.")
     hide_if_zero = fields.Boolean(string="Hide if Zero", help="This line and its children will be hidden when all of their columns are 0.")
@@ -444,6 +453,21 @@ class AccountReportLine(models.Model):
             if report_line.parent_id:
                 report_line.horizontal_split_side = report_line.parent_id.horizontal_split_side
 
+    @api.depends('create_date')
+    def _compute_foldability(self):
+        for line in self:
+            if line.foldability:
+                continue
+            has_groupby = bool(line.groupby or line.user_groupby or line.report_id.groupby or line.report_id.user_groupby)
+            if line.children_ids:
+                line.foldability = 'always_unfolded'
+            elif has_groupby and all(expr.engine not in ('aggregation', 'external') for expr in line.expression_ids):
+                line.foldability = 'foldable'
+            elif any(expr.engine in ('aggregation', 'external') for expr in line.expression_ids):
+                line.foldability = 'never_unfolded'
+            else:
+                line.foldability = 'always_unfolded'
+
     @api.depends('groupby', 'expression_ids.engine')
     def _compute_user_groupby(self):
         for report_line in self:
@@ -453,6 +477,11 @@ class AccountReportLine(models.Model):
                 report_line._validate_groupby()
             except UserError:
                 report_line.user_groupby = report_line.groupby
+
+    @api.onchange('user_groupby')
+    def _onchange_user_groupby(self):
+        if self.user_groupby and self.foldability == 'never_unfolded':
+            self.foldability = 'foldable'
 
     @api.constrains('parent_id')
     def _validate_groupby_no_child(self):

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -758,7 +758,7 @@ class AccountReportExpression(models.Model):
     @api.constrains('engine', 'report_line_id')
     def _validate_engine(self):
         for expression in self:
-            if expression.engine in ('aggregation', 'external') and (expression.report_line_id.groupby or expression.report_line_id.user_groupby):
+            if expression.engine == 'external' and (expression.report_line_id.groupby or expression.report_line_id.user_groupby):
                 engine_description = dict(expression._fields['engine']._description_selection(self.env))
                 raise ValidationError(_(
                     "Groupby feature isn't supported by '%(engine)s' engine. Please remove the groupby value on '%(report_line)s'",
@@ -870,7 +870,7 @@ class AccountReportExpression(models.Model):
         for expr in self:
             expr.display_name = f'{expr.report_line_name} [{expr.label}]'
 
-    def _expand_aggregations(self):
+    def _expand_aggregations(self, no_cross_report_expansion=False):
         """Return self and its full aggregation expression dependency"""
         result = self
 
@@ -886,6 +886,8 @@ class AccountReportExpression(models.Model):
                     labels_by_code = candidate_expr._get_aggregation_terms_details()
 
                     if candidate_expr.subformula and candidate_expr.subformula.startswith('cross_report'):
+                        if no_cross_report_expansion:
+                            continue
                         subformula_match = CROSS_REPORT_REGEX.match(candidate_expr.subformula)
                         if not subformula_match:
                             raise UserError(_(

--- a/addons/l10n_au/data/bas_a.xml
+++ b/addons/l10n_au/data/bas_a.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_a_gst_owed" model="account.report.line">
                         <field name="name">1. Sales amount</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_a_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_a_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_a_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_a_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_a_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_a_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_a_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_a_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_a_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_a_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_a_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_a_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_a_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -596,7 +551,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -609,7 +563,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -622,7 +575,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -641,7 +593,6 @@
                                 <field name="name">7: Deferred Instalment</field>
                                 <field name="code">7</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_7_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -656,7 +607,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -669,7 +619,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -682,7 +631,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_a_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -698,7 +646,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_a_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_c.xml
+++ b/addons/l10n_au/data/bas_c.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_c_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_c_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_c_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_c_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_c_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_c_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_c_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_c_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_c_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_c_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_c_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_c_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_c_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Fringe Benefits Tax</field>
                 <field name="code">FBT</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_c_f1" model="account.report.line">
                         <field name="name">F1: Fringe Benefits Tax Instalment amount</field>
                         <field name="code">F1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_f1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -597,7 +552,6 @@
                         <field name="name">F2: Estimated FBT for the year</field>
                         <field name="code">F2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_f2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -611,7 +565,6 @@
                         <field name="name">F3: Varied amount payable</field>
                         <field name="code">F3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_f3_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -630,7 +583,6 @@
                         <field name="name">F4: Reason Code for Variation</field>
                         <field name="code">F4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_f4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -646,13 +598,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_c_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -665,7 +615,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -678,7 +627,6 @@
                                 <field name="name">1C: Wine Equalisation Tax</field>
                                 <field name="code">1C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -691,7 +639,6 @@
                                 <field name="name">1E: Luxury Car Tax</field>
                                 <field name="code">1E</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1e_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -704,7 +651,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -717,7 +663,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -736,7 +681,6 @@
                                 <field name="name">6A: FBT Instalment</field>
                                 <field name="code">6A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_6a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -755,7 +699,6 @@
                                 <field name="name">7: Deferred Company/Fund Instalment</field>
                                 <field name="code">7</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_7_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -770,7 +713,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -783,7 +725,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -796,7 +737,6 @@
                                 <field name="name">1D: Wine Equalisation tax Refundable</field>
                                 <field name="code">1D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -809,7 +749,6 @@
                                 <field name="name">1F: Luxury car tax refundable</field>
                                 <field name="code">1F</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_1f_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -822,7 +761,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -836,7 +774,6 @@
                                 <field name="name">6B: Credit from FBT Instalment Variation</field>
                                 <field name="code">6B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_c_6b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -852,7 +789,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_c_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_d.xml
+++ b/addons/l10n_au/data/bas_d.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_d_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_d_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_d_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_d_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_d_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_d_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_d_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_d_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_d_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_d_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_d_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_d_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_d_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_d_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_d_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_d_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_d_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -393,7 +362,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_d_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -406,7 +374,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_d_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -421,7 +388,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_d_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_f.xml
+++ b/addons/l10n_au/data/bas_f.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_f_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_f_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_f_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_f_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_f_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_f_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_f_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_f_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_f_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_f_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_f_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_f_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_f_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -456,7 +420,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -469,7 +432,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -484,7 +446,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -497,7 +458,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_f_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -512,7 +472,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_f_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_g.xml
+++ b/addons/l10n_au/data/bas_g.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_g_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_g_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_g_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_g_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_g_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_g_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_g_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_g_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_g_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_g_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_g_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_g_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_g_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Fringe Benefits Tax</field>
                 <field name="code">FBT</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_g_f1" model="account.report.line">
                         <field name="name">F1: Fringe Benefits Tax Instalment amount</field>
                         <field name="code">F1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_f1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -597,7 +552,6 @@
                         <field name="name">F2: Estimated FBT for the year</field>
                         <field name="code">F2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_f2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -611,7 +565,6 @@
                         <field name="name">F3: Varied amount payable</field>
                         <field name="code">F3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_f3_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -630,7 +583,6 @@
                         <field name="name">F4: Reason Code for Variation</field>
                         <field name="code">F4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_f4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -646,13 +598,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_g_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -665,7 +615,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -678,7 +627,6 @@
                                 <field name="name">1C: Wine Equalisation Tax</field>
                                 <field name="code">1C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -691,7 +639,6 @@
                                 <field name="name">1E: Luxury Car Tax</field>
                                 <field name="code">1E</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1e_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -704,7 +651,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -723,7 +669,6 @@
                                 <field name="name">6A: FBT Instalment</field>
                                 <field name="code">6A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_6a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -742,7 +687,6 @@
                                 <field name="name">7: Deferred Company/Fund Instalment</field>
                                 <field name="code">7</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_7_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -755,7 +699,6 @@
                                 <field name="name">7A: Deferred GST</field>
                                 <field name="code">7A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_7a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -770,7 +713,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -783,7 +725,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -796,7 +737,6 @@
                                 <field name="name">1D: Wine Equalisation tax Refundable</field>
                                 <field name="code">1D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -809,7 +749,6 @@
                                 <field name="name">1F: Luxury car tax refundable</field>
                                 <field name="code">1F</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_1f_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -822,7 +761,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -836,7 +774,6 @@
                                 <field name="name">6B: Credit from FBT Instalment Variation</field>
                                 <field name="code">6B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_g_6b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -852,7 +789,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_g_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_u.xml
+++ b/addons/l10n_au/data/bas_u.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_u_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_u_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_u_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_u_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_u_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_u_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_u_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_u_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_u_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_u_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_u_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_u_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_u_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_u_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -596,7 +551,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -609,7 +563,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -622,7 +575,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -641,7 +593,6 @@
                                 <field name="name">7C: Fuel tax credit over claim (Do not claim in litres)</field>
                                 <field name="code">7C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_7c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -656,7 +607,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -669,7 +619,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -682,7 +631,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -696,7 +644,6 @@
                                 <field name="name">7D: Fuel tax credit (Do not claim in litres)</field>
                                 <field name="code">7D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_u_7d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -711,7 +658,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_u_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_v.xml
+++ b/addons/l10n_au/data/bas_v.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_v_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_v_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_v_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_v_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_v_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_v_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_v_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_v_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_v_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_v_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_v_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_v_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_v_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Fringe Benefits Tax</field>
                 <field name="code">FBT</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_v_f1" model="account.report.line">
                         <field name="name">F1: Fringe Benefits Tax Instalment amount</field>
                         <field name="code">F1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_f1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -597,7 +552,6 @@
                         <field name="name">F2: Estimated FBT for the year</field>
                         <field name="code">F2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_f2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -611,7 +565,6 @@
                         <field name="name">F3: Varied amount payable for the Quarter</field>
                         <field name="code">F3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_f3_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -630,7 +583,6 @@
                         <field name="name">F4: Reason Code for Variation</field>
                         <field name="code">F4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_f4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -646,13 +598,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_v_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -665,7 +615,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -678,7 +627,6 @@
                                 <field name="name">1C: Wine Equalisation Tax</field>
                                 <field name="code">1C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -691,7 +639,6 @@
                                 <field name="name">1E: Luxury Car Tax</field>
                                 <field name="code">1E</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1e_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -704,7 +651,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -717,7 +663,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -736,7 +681,6 @@
                                 <field name="name">6A: FBT Instalment</field>
                                 <field name="code">6A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_6a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -755,7 +699,6 @@
                                 <field name="name">7C: Fuel tax credit over claim (Do not claim in litres)</field>
                                 <field name="code">7C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_7c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -770,7 +713,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -783,7 +725,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -796,7 +737,6 @@
                                 <field name="name">1D: Wine Equalisation tax Refundable</field>
                                 <field name="code">1D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -809,7 +749,6 @@
                                 <field name="name">1F: Luxury car tax refundable</field>
                                 <field name="code">1F</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_1f_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -822,7 +761,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -836,7 +774,6 @@
                                 <field name="name">6B: Credit from FBT Instalment Variation</field>
                                 <field name="code">6B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_6b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -850,7 +787,6 @@
                                 <field name="name">7D: Fuel tax credit (Do not claim in litres)</field>
                                 <field name="code">7D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_v_7d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -865,7 +801,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_v_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_w.xml
+++ b/addons/l10n_au/data/bas_w.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_w_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_w_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_w_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_w_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_w_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_w_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_w_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_w_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_w_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_w_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_w_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_w_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_w_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -391,7 +360,6 @@
                                 <field name="name">7C: Fuel tax credit over claim (Do not claim in litres)</field>
                                 <field name="code">7C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_7c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -406,7 +374,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_w_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -419,7 +386,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -432,7 +398,6 @@
                                 <field name="name">7D: Fuel tax credit (Do not claim in litres)</field>
                                 <field name="code">7D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_w_7d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -447,7 +412,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_w_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_x.xml
+++ b/addons/l10n_au/data/bas_x.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_x_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_x_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_x_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_x_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_x_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_x_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_x_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_x_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_x_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_x_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_x_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_x_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_x_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -456,7 +420,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -469,7 +432,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -482,7 +444,6 @@
                                 <field name="name">7C: Fuel tax credit over claim (Do not claim in litres)</field>
                                 <field name="code">7C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_7c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -497,7 +458,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -510,7 +470,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -523,7 +482,6 @@
                                 <field name="name">7D: Fuel tax credit (Do not claim in litres)</field>
                                 <field name="code">7D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_x_7d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -538,7 +496,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_x_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_au/data/bas_y.xml
+++ b/addons/l10n_au/data/bas_y.xml
@@ -19,19 +19,16 @@
                 <field name="name">Goods and Services Tax</field>
                 <field name="code">GST</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_y_gst_owed" model="account.report.line">
                         <field name="name">GST amounts you owe the Tax Office from sales</field>
                         <field name="code">GST_OWED</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_y_g1" model="account.report.line">
                                 <field name="name">G1: Total Sales (including any GST)</field>
                                 <field name="code">G1</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_g1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +41,6 @@
                                         <field name="name">G2: Export sales</field>
                                         <field name="code">G2</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g2_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -57,7 +53,6 @@
                                         <field name="name">G3: Other GST-free sales</field>
                                         <field name="code">G3</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                                         <field name="name">G4: Input taxed sales</field>
                                         <field name="code">G4</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -87,13 +81,11 @@
                         <field name="name">GST amounts the Tax Office owes you from purchases</field>
                         <field name="code">GST_PAID</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_y_g10" model="account.report.line">
                                 <field name="name">G10: Capital purchases (including any GST)</field>
                                 <field name="code">G10</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_g10_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +98,6 @@
                                 <field name="name">G11: Non-capital purchases (including GST)</field>
                                 <field name="code">G11</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_g11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -121,19 +112,16 @@
                         <field name="name">GST Calculations</field>
                         <field name="code">GST_CALC</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_au_bas_y_gst_owed_calc" model="account.report.line">
                                 <field name="name">GST Collected Calculation</field>
                                 <field name="code">GST_OWED_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_y_g5" model="account.report.line">
                                         <field name="name">G5: G2 + G3 + G4</field>
                                         <field name="code">G5</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -146,7 +134,6 @@
                                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                                         <field name="code">G6</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g6_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -159,7 +146,6 @@
                                                 <field name="name">G7: Adjustments (if applicable)</field>
                                                 <field name="code">G7</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_y_g7_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -174,7 +160,6 @@
                                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                                         <field name="code">G8</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -187,7 +172,6 @@
                                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                                         <field name="code">G9</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -202,13 +186,11 @@
                                 <field name="name">GST Paid Calculation</field>
                                 <field name="code">GST_PAID_CALC</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_au_bas_y_g12" model="account.report.line">
                                         <field name="name">G12: G10 + G11</field>
                                         <field name="code">G12</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -221,7 +203,6 @@
                                         <field name="name">G16: G13 + G14 + G15</field>
                                         <field name="code">G16</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -234,7 +215,6 @@
                                                 <field name="name">G13: Purchases for making input taxed sales</field>
                                                 <field name="code">G13</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_y_g13_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +227,6 @@
                                                 <field name="name">G14: Purchases without GST in the price</field>
                                                 <field name="code">G14</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_y_g14_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -260,7 +239,6 @@
                                                 <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
                                                 <field name="code">G15</field>
                                                 <field name="hierarchy_level">9</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_au_bas_y_g15_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -275,7 +253,6 @@
                                         <field name="name">G17: Total purchases subject to GST (G12 minus G16)</field>
                                         <field name="code">G17</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -288,7 +265,6 @@
                                         <field name="name">G18: Adjustments (if applicable)</field>
                                         <field name="code">G18</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -301,7 +277,6 @@
                                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18)</field>
                                         <field name="code">G19</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -314,7 +289,6 @@
                                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                                         <field name="code">GP</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_gp_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -327,7 +301,6 @@
                                         <field name="name">GST only purchases</field>
                                         <field name="code">ONLY</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_only_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -340,7 +313,6 @@
                                         <field name="name">G20: GST on purchases</field>
                                         <field name="code">G20</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_au_bas_y_g20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -359,13 +331,11 @@
                 <field name="name">PAYG Tax Withheld</field>
                 <field name="code">PAYGW</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_y_w1" model="account.report.line">
                         <field name="name">W1: Total salaries, wages and other payments</field>
                         <field name="code">W1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_w1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +348,6 @@
                         <field name="name">W2: Amounts withheld from W1</field>
                         <field name="code">W2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -391,7 +360,6 @@
                         <field name="name">W4: Amounts withheld where no ABN is quoted</field>
                         <field name="code">W4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_w4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                         <field name="name">W3: Other amounts withheld (not shown at W2 or W4)</field>
                         <field name="code">W3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_w3_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -422,7 +389,6 @@
                         <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
                         <field name="code">W5</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_w5_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -437,13 +403,11 @@
                 <field name="name">PAYG Income Tax Instalment</field>
                 <field name="code">PAYGI</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_y_t7" model="account.report.line">
                         <field name="name">T7: PAYG Income Instalment</field>
                         <field name="code">T7</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t7_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -457,7 +421,6 @@
                         <field name="name">T8: Estimated tax for the year</field>
                         <field name="code">T8</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t8_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -471,7 +434,6 @@
                         <field name="name">T9: Varied amount payable for the Quater</field>
                         <field name="code">T9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t9_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -490,7 +452,6 @@
                         <field name="name">T1: PAYG Instalment Income</field>
                         <field name="code">T1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t1_sub_balance" model="account.report.expression">
                                 <field name="label">sub_balance</field>
@@ -515,7 +476,6 @@
                         <field name="name">T2: Tax Rate</field>
                         <field name="code">T2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -529,7 +489,6 @@
                         <field name="name">T3: New Varied Tax Rate</field>
                         <field name="code">T3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -543,7 +502,6 @@
                         <field name="name">T11: PAYG Income tax Instalment</field>
                         <field name="code">T11</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t11_account_balance" model="account.report.expression">
                                 <field name="label">account_balance</field>
@@ -561,7 +519,6 @@
                         <field name="name">T4: Reason Code for Variation</field>
                         <field name="code">T4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_t4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -577,13 +534,11 @@
                 <field name="name">Fringe Benefits Tax</field>
                 <field name="code">FBT</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_y_f1" model="account.report.line">
                         <field name="name">F1: Fringe Benefits Tax Instalment amount</field>
                         <field name="code">F1</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_f1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -597,7 +552,6 @@
                         <field name="name">F2: Estimated FBT for the year</field>
                         <field name="code">F2</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_f2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -611,7 +565,6 @@
                         <field name="name">F3: Varied amount payable for the Quarter</field>
                         <field name="code">F3</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_f3_quarter_perc" model="account.report.expression">
                                 <field name="label">quarter_perc</field>
@@ -630,7 +583,6 @@
                         <field name="name">F4: Reason Code for Variation</field>
                         <field name="code">F4</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_f4_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -646,13 +598,11 @@
                 <field name="name">Summary</field>
                 <field name="code">SUMMARY</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_au_bas_y_8a" model="account.report.line">
                         <field name="name">8A: Amounts owed to ATO</field>
                         <field name="code">8A</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_8a_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -665,7 +615,6 @@
                                 <field name="name">1A: GST on sales</field>
                                 <field name="code">1A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -678,7 +627,6 @@
                                 <field name="name">1C: Wine Equalisation Tax</field>
                                 <field name="code">1C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -691,7 +639,6 @@
                                 <field name="name">1E: Luxury Car Tax</field>
                                 <field name="code">1E</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1e_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -704,7 +651,6 @@
                                 <field name="name">4: PAYG Tax Withheld</field>
                                 <field name="code">4</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -717,7 +663,6 @@
                                 <field name="name">5A: PAYG Income Tax Instalment</field>
                                 <field name="code">5A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_5a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -736,7 +681,6 @@
                                 <field name="name">6A: FBT Instalment</field>
                                 <field name="code">6A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_6a_sub_balance" model="account.report.expression">
                                         <field name="label">sub_balance</field>
@@ -755,7 +699,6 @@
                                 <field name="name">7C: Fuel tax credit over claim (Do not claim in litres)</field>
                                 <field name="code">7C</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_7c_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -768,7 +711,6 @@
                                 <field name="name">7A: Deferred GST</field>
                                 <field name="code">7A</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_7a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -783,7 +725,6 @@
                         <field name="name">8B: Amounts owed by ATO</field>
                         <field name="code">8B</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_8b_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -796,7 +737,6 @@
                                 <field name="name">1B: GST on purchases</field>
                                 <field name="code">1B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -809,7 +749,6 @@
                                 <field name="name">1D: Wine Equalisation tax Refundable</field>
                                 <field name="code">1D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -822,7 +761,6 @@
                                 <field name="name">1F: Luxury car tax refundable</field>
                                 <field name="code">1F</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_1f_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -835,7 +773,6 @@
                                 <field name="name">5B: Credit from PAYG income tax instalment variation</field>
                                 <field name="code">5B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_5b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -849,7 +786,6 @@
                                 <field name="name">6B: Credit from FBT Instalment Variation</field>
                                 <field name="code">6B</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_6b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -863,7 +799,6 @@
                                 <field name="name">7D: Fuel tax credit (Do not claim in litres)</field>
                                 <field name="code">7D</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_au_bas_y_7d_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -878,7 +813,6 @@
                         <field name="name">9: Liability to ATO</field>
                         <field name="code">9</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_au_bas_y_9_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -124,7 +124,7 @@
                                 <field name="name@de">46 - Steuerfreie innergemeinschaftliche Lieferungen und ABC-Geschäfte</field>
                                 <field name="code">c46</field>
                                 <field name="aggregation_formula">c46L.balance + c46T.balance</field>
-                                <field name="foldable" eval="True"/>
+                                <field name="foldability">foldable</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_46L" model="account.report.line">
                                         <field name="name">46L - Exempted intra-Community deliveries</field>
@@ -177,7 +177,7 @@
                                 <field name="name@de">48 - Gutschriften, die sich auf Umsätze in den Rastern [44] und [46] beziehen</field>
                                 <field name="code">c48</field>
                                 <field name="aggregation_formula">c48s44.balance + c48s46L.balance + c48s46T.balance</field>
-                                <field name="foldable" eval="True"/>
+                                <field name="foldability">foldable</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_48s44" model="account.report.line">
                                         <field name="name">48s44 - Credit notes for operations in grid [44]</field>

--- a/addons/l10n_bh/data/tax_report_simplified.xml
+++ b/addons/l10n_bh/data/tax_report_simplified.xml
@@ -41,7 +41,7 @@
                 <field name="name">2. Zero rated (including exports)</field>
                 <field name="name@ar">2. التصنيف الصفري (بما في ذلك الصادرات)</field>
                 <field name="code">bh_simp_2</field>
-                 <field name="foldable" eval="True"/>
+                 <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="l10n_bh_tax_report_simplified_2_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -91,7 +91,7 @@
                 <field name="name">3. Other and exempt sales</field>
                 <field name="name@ar">3. المبيعات الأخرى والمبيعات المعفاة</field>
                 <field name="code">bh_simp_3</field>
-                 <field name="foldable" eval="True"/>
+                 <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="l10n_bh_tax_report_simplified_3_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -147,7 +147,7 @@
                 <field name="name">14. Total purchases</field>
                 <field name="name@ar">14. إجمالي المشتريات</field>
                 <field name="code">bh_simp_14</field>
-                 <field name="foldable" eval="True"/>
+                 <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="l10n_bh_tax_report_simplified_14_base" model="account.report.expression">
                         <field name="label">base</field>

--- a/addons/l10n_es/data/mod111.xml
+++ b/addons/l10n_es/data/mod111.xml
@@ -51,7 +51,6 @@
                                 <field name="name@es">[02] Importe de las percepciones</field>
                                 <field name="code">aeat_mod_111_02</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_02_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -65,7 +64,6 @@
                                 <field name="name@es">[03] Importe de las retenciones</field>
                                 <field name="code">aeat_mod_111_03</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_03_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -101,7 +99,6 @@
                                 <field name="name@es">[05] Valor percepciones en especie</field>
                                 <field name="code">aeat_mod_111_05</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_05_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -115,7 +112,6 @@
                                 <field name="name@es">[06] Importe de los ingresos a cuenta</field>
                                 <field name="code">aeat_mod_111_06</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_06_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -159,7 +155,6 @@
                                 <field name="name@es">[08] Importe de las percepciones</field>
                                 <field name="code">aeat_mod_111_08</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_08_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -173,7 +168,6 @@
                                 <field name="name@es">[09] Importe de las retenciones</field>
                                 <field name="code">aeat_mod_111_09</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_09_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -209,7 +203,6 @@
                                 <field name="name@es">[11] Valor percepciones en especie</field>
                                 <field name="code">aeat_mod_111_11</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_11_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -223,7 +216,6 @@
                                 <field name="name@es">[12] Importe de los ingresos a cuenta</field>
                                 <field name="code">aeat_mod_111_12</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_12_balance" model="account.report.expression">
                                         <field name="label">balance</field>

--- a/addons/l10n_es/data/mod115.xml
+++ b/addons/l10n_es/data/mod115.xml
@@ -46,7 +46,6 @@
                         <field name="name@es">[02] Base retenciones</field>
                         <field name="code">aeat_mod_115_02</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_115_casilla_02_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -60,7 +59,6 @@
                         <field name="name@es">[03] Retenciones</field>
                         <field name="code">aeat_mod_115_03</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_115_casilla_03_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_es/data/mod130.xml
+++ b/addons/l10n_es/data/mod130.xml
@@ -31,7 +31,6 @@
                             <field name="name@es">[01] Ingresos</field>
                             <field name="code">aeat_mod_130_01</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_130_casilla_01_balance" model="account.report.expression">
                                     <field name="label">balance</field>
@@ -47,7 +46,6 @@
                             <field name="name@es">[02] Suministros</field>
                             <field name="code">aeat_mod_130_02</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_130_casilla_02_balance" model="account.report.expression">
                                     <field name="label">balance</field>
@@ -107,7 +105,6 @@
                             <field name="name@es">[06] Suma de las retenciones</field>
                             <field name="code">aeat_mod_130_06</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_130_casilla_06_tax_tags" model="account.report.expression">
                                     <field name="label">tags</field>
@@ -149,7 +146,6 @@
                             <field name="name@es">[08] Ingresos</field>
                             <field name="code">aeat_mod_130_08</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_130_casilla_08_balance" model="account.report.expression">
                                     <field name="label">balance</field>
@@ -184,7 +180,6 @@
                             <field name="name@es">[10] Suma de las retenciones</field>
                             <field name="code">aeat_mod_130_10</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_130_casilla_10_tax_tags" model="account.report.expression">
                                     <field name="label">tags</field>

--- a/addons/l10n_es/data/mod303.xml
+++ b/addons/l10n_es/data/mod303.xml
@@ -36,7 +36,6 @@
                                 <field name="name@es">[150] Base imponible 0 %</field>
                                 <field name="code">aeat_mod_303_150</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_150_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -50,7 +49,6 @@
                                 <field name="name@es">[152] Cuota 0 %</field>
                                 <field name="code">aeat_mod_303_152</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_152_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -64,7 +62,6 @@
                                 <field name="name@es">[165] Base imponible 2 %</field>
                                 <field name="code">aeat_mod_303_165</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_165_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -78,7 +75,6 @@
                                 <field name="name@es">[167] Cuota 2 %</field>
                                 <field name="code">aeat_mod_303_167</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_167_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -92,7 +88,6 @@
                                 <field name="name@es">[01] Base imponible 4 %</field>
                                 <field name="code">aeat_mod_303_01</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_01_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -106,7 +101,6 @@
                                 <field name="name@es">[03] Cuota 4 %</field>
                                 <field name="code">aeat_mod_303_03</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_03_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -120,7 +114,6 @@
                                 <field name="name@es">[153] Base imponible 5 %</field>
                                 <field name="code">aeat_mod_303_153</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_153_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -134,7 +127,6 @@
                                 <field name="name@es">[155] Cuota 5 %</field>
                                 <field name="code">aeat_mod_303_155</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_155_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -148,7 +140,6 @@
                                 <field name="name@es">[04] Base imponible 10 %</field>
                                 <field name="code">aeat_mod_303_04</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_04_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -162,7 +153,6 @@
                                 <field name="name@es">[06] Cuota 10 %</field>
                                 <field name="code">aeat_mod_303_06</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_06_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -176,7 +166,6 @@
                                 <field name="name@es">[07] Base imponible 21 %</field>
                                 <field name="code">aeat_mod_303_07</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_07_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -190,7 +179,6 @@
                                 <field name="name@es">[09] Cuota 21 %</field>
                                 <field name="code">aeat_mod_303_09</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_09_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -209,7 +197,6 @@
                                         <field name="name@es">[10] Base imponible</field>
                                         <field name="code">aeat_mod_303_10</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_10_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -223,7 +210,6 @@
                                         <field name="name@es">[11] Cuota</field>
                                         <field name="code">aeat_mod_303_11</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_11_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -244,7 +230,6 @@
                                         <field name="name@es">[12] Base imponible</field>
                                         <field name="code">aeat_mod_303_12</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -258,7 +243,6 @@
                                         <field name="name@es">[13] Cuota</field>
                                         <field name="code">aeat_mod_303_13</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_13_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -320,7 +304,6 @@
                                         <field name="name@es">[156] Base imponible 1,75 %</field>
                                         <field name="code">aeat_mod_303_156</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_156_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -334,7 +317,6 @@
                                         <field name="name@es">[158] Cuota 1,75 %</field>
                                         <field name="code">aeat_mod_303_158</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_158_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -348,7 +330,6 @@
                                         <field name="name@es">[168] Base imponible 0,26 %</field>
                                         <field name="code">aeat_mod_303_168</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_168_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -362,7 +343,6 @@
                                         <field name="name@es">[170] Cuota 0,26 %</field>
                                         <field name="code">aeat_mod_303_170</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_170_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -376,7 +356,6 @@
                                         <field name="name@es">[16] Base imponible 1%</field>
                                         <field name="code">aeat_mod_303_16</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -390,7 +369,6 @@
                                         <field name="name@es">[18] Cuota 1 %</field>
                                         <field name="code">aeat_mod_303_18</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_18_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -404,7 +382,6 @@
                                         <field name="name@es">[19] Base imponible 1,4 %</field>
                                         <field name="code">aeat_mod_303_19</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -418,7 +395,6 @@
                                         <field name="name@es">[21] Cuota 1,4 %</field>
                                         <field name="code">aeat_mod_303_21</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_21_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -432,7 +408,6 @@
                                         <field name="name@es">[22] Base imponible 5,2 %</field>
                                         <field name="code">aeat_mod_303_22</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_22_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -446,7 +421,6 @@
                                         <field name="name@es">[24] Cuota 5,2 %</field>
                                         <field name="code">aeat_mod_303_24</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_24_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -467,7 +441,6 @@
                                         <field name="name@es">[25] Base imponible</field>
                                         <field name="code">aeat_mod_303_25</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_25_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -481,7 +454,6 @@
                                         <field name="name@es">[26] Cuotas</field>
                                         <field name="code">aeat_mod_303_26</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_26_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -515,7 +487,6 @@
                                         <field name="name@es">[28] Base</field>
                                         <field name="code">aeat_mod_303_28</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_28_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -529,7 +500,6 @@
                                         <field name="name@es">[29] Cuotas</field>
                                         <field name="code">aeat_mod_303_29</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_29_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -550,7 +520,6 @@
                                         <field name="name@es">[30] Base</field>
                                         <field name="code">aeat_mod_303_30</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_30_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -564,7 +533,6 @@
                                         <field name="name@es">[31] Cuotas</field>
                                         <field name="code">aeat_mod_303_31</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_31_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -585,7 +553,6 @@
                                         <field name="name@es">[32] Base</field>
                                         <field name="code">aeat_mod_303_32</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_32_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -599,7 +566,6 @@
                                         <field name="name@es">[33] Cuotas</field>
                                         <field name="code">aeat_mod_303_33</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_33_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -620,7 +586,6 @@
                                         <field name="name@es">[34] Base</field>
                                         <field name="code">aeat_mod_303_34</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_34_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -634,7 +599,6 @@
                                         <field name="name@es">[35] Cuotas</field>
                                         <field name="code">aeat_mod_303_35</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_35_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -655,7 +619,6 @@
                                         <field name="name@es">[36] Base</field>
                                         <field name="code">aeat_mod_303_36</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_36_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -669,7 +632,6 @@
                                         <field name="name@es">[37] Cuotas</field>
                                         <field name="code">aeat_mod_303_37</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_37_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -690,7 +652,6 @@
                                         <field name="name@es">[38] Base</field>
                                         <field name="code">aeat_mod_303_38</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_38_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -704,7 +665,6 @@
                                         <field name="name@es">[39] Cuotas</field>
                                         <field name="code">aeat_mod_303_39</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_39_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -725,7 +685,6 @@
                                         <field name="name@es">[40] Base</field>
                                         <field name="code">aeat_mod_303_40</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_40_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -739,7 +698,6 @@
                                         <field name="name@es">[41] Cuotas</field>
                                         <field name="code">aeat_mod_303_41</field>
                                         <field name="groupby">account_id</field>
-                                        <field name="foldable" eval="True"/>
                                         <field name="expression_ids">
                                             <record id="mod_303_casilla_41_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -755,7 +713,6 @@
                                 <field name="name@es">[42] Compensaciones Régimen especial A. G. y P. - Cuota compras</field>
                                 <field name="code">aeat_mod_303_42</field>
                                 <field name="groupby">account_id</field>
-                                <field name="foldable" eval="True"/>
                                 <field name="expression_ids">
                                     <record id="mod_303_casilla_42_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -817,7 +774,6 @@
                         <field name="name@es">[59] Entregas intracomunitarias de bienes y servicios - Base ventas</field>
                         <field name="code">aeat_mod_303_59</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_59_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -831,7 +787,6 @@
                         <field name="name@es">[60] Exportaciones y operaciones asimiladas - Base ventas</field>
                         <field name="code">aeat_mod_303_60</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_60_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -845,7 +800,6 @@
                         <field name="name@es">[120] Operaciones no sujetas por reglas de localización (excepto las incluidas en la casilla 123)</field>
                         <field name="code">aeat_mod_303_120</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_120_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -859,7 +813,6 @@
                         <field name="name@es">[122] Operaciones sujetas con inversión del sujeto pasivo</field>
                         <field name="code">aeat_mod_303_122</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_122_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -873,7 +826,6 @@
                         <field name="name@es">[123] Operaciones no sujetas por reglas de localización acogidas a los régimenes especiales de ventanilla única</field>
                         <field name="code">aeat_mod_303_123</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_123_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -887,7 +839,6 @@
                         <field name="name@es">[124] Operaciones sujetas y acogidas a los régimenes especiales de ventanilla única</field>
                         <field name="code">aeat_mod_303_124</field>
                         <field name="groupby">account_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_303_casilla_124_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_es/data/mod420.xml
+++ b/addons/l10n_es/data/mod420.xml
@@ -36,7 +36,6 @@
                             <field name="name@es">[1] 0 %</field>
                             <field name="code">atc_mod_420_1_3</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_1_base" model="account.report.expression">
                                     <field name="label">base</field>
@@ -50,7 +49,6 @@
                             <field name="name@es">[4]-[6] 3 % / 5 %</field>
                             <field name="code">atc_mod_420_4_6</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_4" model="account.report.expression">
                                     <field name="label">base</field>
@@ -69,7 +67,6 @@
                             <field name="name@es">[7]-[9] 7 %</field>
                             <field name="code">atc_mod_420_7_9</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_7" model="account.report.expression">
                                     <field name="label">base</field>
@@ -88,7 +85,6 @@
                             <field name="name@es">[10]-[12] 9,5 %</field>
                             <field name="code">atc_mod_420_10_12</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_10" model="account.report.expression">
                                     <field name="label">base</field>
@@ -107,7 +103,6 @@
                             <field name="name@es">[13]-[15] 15 %</field>
                             <field name="code">atc_mod_420_13_15</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_13" model="account.report.expression">
                                     <field name="label">base</field>
@@ -126,7 +121,6 @@
                             <field name="name@es">[16]-[18] 20 %</field>
                             <field name="code">atc_mod_420_16_18</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_16" model="account.report.expression">
                                     <field name="label">base</field>
@@ -145,7 +139,6 @@
                             <field name="name@es">[19]-[20] ISP</field>
                             <field name="code">atc_mod_420_isp</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_19" model="account.report.expression">
                                     <field name="label">base</field>
@@ -164,7 +157,6 @@
                             <field name="name@es">[21]-[22] Modificación de bases y cuotas</field>
                             <field name="code">atc_mod_420_modif</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_21" model="account.report.expression">
                                     <field name="label">base</field>
@@ -183,7 +175,6 @@
                             <field name="name@es">[23]-[24] Cuotas devueltas en régimen de viajeros</field>
                             <field name="code">atc_mod_420_reav</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_23" model="account.report.expression">
                                     <field name="label">base</field>
@@ -224,7 +215,6 @@
                             <field name="name@es">[26]-[27] Operaciones interiores bienes y servicios corrientes</field>
                             <field name="code">atc_mod_420_deduc</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_26" model="account.report.expression">
                                     <field name="label">base</field>
@@ -243,7 +233,6 @@
                             <field name="name@es">[28]-[29] Operaciones interiores bienes de inversión</field>
                             <field name="code">atc_mod_420_deduc_inv</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_28" model="account.report.expression">
                                     <field name="label">base</field>
@@ -262,7 +251,6 @@
                             <field name="name@es">[30]-[31] Importaciones de bienes corrientes</field>
                             <field name="code">atc_mod_420_deduc_imp</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_30" model="account.report.expression">
                                     <field name="label">base</field>
@@ -281,7 +269,6 @@
                             <field name="name@es">[32]-[33] Importaciones de bienes de inversión</field>
                             <field name="code">atc_mod_420_deduc_imp_inv</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_32" model="account.report.expression">
                                     <field name="label">base</field>
@@ -300,7 +287,6 @@
                             <field name="name@es">[34]-[35] Rectificación de deducciones</field>
                             <field name="code">atc_mod_420_deduc_modif</field>
                             <field name="groupby">account_id</field>
-                            <field name="foldable" eval="True"/>
                             <field name="expression_ids">
                                 <record id="mod_420_casilla_34" model="account.report.expression">
                                     <field name="label">base</field>

--- a/addons/l10n_fi/data/account_tax_report_line.xml
+++ b/addons/l10n_fi/data/account_tax_report_line.xml
@@ -27,7 +27,7 @@
                         <field name="name">25.5% tax + 24% tax</field>
                         <field name="name@fi">25.5 %:n vero + 24 %:n vero</field>
                         <field name="code">sale_25_5_and_24</field>
-                        <field name="foldable">True</field>
+                        <field name="foldability">foldable</field>
                         <field name="aggregation_formula">sale_25_5.balance + sale_24.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_sales_25_5" model="account.report.line">
@@ -60,7 +60,7 @@
                         <field name="name">14% tax + 13.5% tax</field>
                         <field name="name@fi">14 %:n vero + 13.5 %:n vero</field>
                         <field name="code">sale_14_and_13_5</field>
-                        <field name="foldable">True</field>
+                        <field name="foldability">foldable</field>
                         <field name="aggregation_formula">sale_14.balance + sale_13_5.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_sales_14" model="account.report.line">

--- a/addons/l10n_it/data/tax_report/annual_report_sections/ve.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/ve.xml
@@ -28,7 +28,7 @@
                         <field name="name">Contributions of agricultural products and transfers from exempt farmers (in case of exceeding 1/3)</field>
                         <field name="name@it">Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in caso di superamento di 1/3)</field>
                         <field name="code">VE_section1</field>
-                        <field name="foldable" eval="True"/>
+                        <field name="foldability">foldable</field>
                         <field name="children_ids">
                             <record id="tax_annual_report_line_ve1" model="account.report.line">
                                 <field name="name">VE1 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 2%</field>
@@ -223,7 +223,7 @@
                         <field name="name">Agricultural taxable transactions (Article 34 paragraph 1) and commercial and professional taxable transactions</field>
                         <field name="name@it">Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili commerciali e professionali</field>
                         <field name="code">VE_section2</field>
-                        <field name="foldable" eval="True"/>
+                        <field name="foldability">foldable</field>
                         <field name="children_ids">
                             <record id="tax_annual_report_line_ve20" model="account.report.line">
                                 <field name="name">VE20 - Taxable transactions rate 4%</field>
@@ -299,7 +299,7 @@
                         <field name="name">Total taxable income and tax</field>
                         <field name="name@it">Totale imponibile e imposta</field>
                         <field name="code">VE_section3</field>
-                        <field name="foldable" eval="True"/>
+                        <field name="foldability">foldable</field>
                         <field name="children_ids">
                             <record id="tax_annual_report_line_ve24" model="account.report.line">
                                 <field name="name">VE24 - Total lines VE1 to VE11 and lines VE20 to VE23</field>
@@ -340,7 +340,7 @@
                         <field name="name">Other operations</field>
                         <field name="name@it">Altre operazioni</field>
                         <field name="code">VE_section4</field>
-                        <field name="foldable" eval="True"/>
+                        <field name="foldability">foldable</field>
                         <field name="children_ids">
                             <record id="tax_annual_report_line_ve30" model="account.report.line">
                                 <field name="name">VE30 - Transactions that contribute to the formation of the ceiling</field>

--- a/addons/l10n_jo/data/account_tax_report_data.xml
+++ b/addons/l10n_jo/data/account_tax_report_data.xml
@@ -52,7 +52,7 @@
                 <field name="name@ar_001">2. المشتريات المحلية الخاضعة للمعدل القياسي عند</field>
                 <field name="code">jo_2</field>
                 <field name="sequence">3</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_vat_domestic_purchase_base_aggregation" model="account.report.expression">
                         <field name="label">base</field>
@@ -176,7 +176,7 @@
                 <field name="name@ar_001">3. الواردات الخاضعة للمعدل القياسي عند</field>
                 <field name="code">jo_3</field>
                 <field name="sequence">10</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_vat_import_purchase_base_aggregation" model="account.report.expression">
                         <field name="label">base</field>
@@ -357,7 +357,7 @@
                 <field name="name@ar_001">6. المبيعات المحلية الخاضعة للمعدلات القياسية في</field>
                 <field name="code">jo_6</field>
                 <field name="sequence">21</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_vat_sales_base_aggregation" model="account.report.expression">
                         <field name="label">base</field>
@@ -552,7 +552,7 @@
                 <field name="name@ar_001">C. التعديلات</field>
                 <field name="sequence">33</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_tax_adjustment_partner" model="account.report.line">
                         <field name="name">12. Adjustment for the registered person</field>

--- a/addons/l10n_kh/data/form_t7001.xml
+++ b/addons/l10n_kh/data/form_t7001.xml
@@ -23,13 +23,11 @@
                 <field name="name">II. Total Amount of Taxes</field>
                 <field name="code">KH_T7001_2</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_kh_t7001_kh_t7001_2_1" model="account.report.line">
                         <field name="name">1. Value Added Tax</field>
                         <field name="code">KH_T7001_2_1</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -49,13 +47,11 @@
                         <field name="name">2. Value Added Tax (State Charge)</field>
                         <field name="code">KH_T7001_2_2</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_2a" model="account.report.line">
                                 <field name="name">Credit Carried Forward</field>
                                 <field name="code">KH_T7001_2_2A</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_2_2a_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -69,7 +65,6 @@
                                 <field name="name">VAT State Charge</field>
                                 <field name="code">KH_T7001_2_2B</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_2_2b_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -85,7 +80,6 @@
                         <field name="name">3. Prepayment of Tax on Income</field>
                         <field name="code">KH_T7001_2_3</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_3_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -105,7 +99,6 @@
                         <field name="name">4. Public Lighting Tax</field>
                         <field name="code">KH_T7001_2_4</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_4_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -118,7 +111,6 @@
                         <field name="name">5. Specific Tax on Certain Marchandises and Services</field>
                         <field name="code">KH_T7001_2_5</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_5_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -131,7 +123,6 @@
                         <field name="name">6. Accomodation Tax</field>
                         <field name="code">KH_T7001_2_6</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_6_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -144,7 +135,6 @@
                         <field name="name">7. Other Taxes</field>
                         <field name="code">KH_T7001_2_7</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_t7001_kh_t7001_2_7_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -160,19 +150,16 @@
                 <field name="name">III Total Transaction</field>
                 <field name="code">KH_T7001_3</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_kh_t7001_kh_t7001_3_1" model="account.report.line">
                         <field name="name">1. Prepayment of Tax on Income</field>
                         <field name="code">KH_T7001_3_1</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_kh_t7001_kh_t7001_3_1_1" model="account.report.line">
                                 <field name="name">Current month of Prepayment of tax on income</field>
                                 <field name="code">KH_T7001_3_1_1</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_1_1_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -186,7 +173,6 @@
                                 <field name="name">Credit last month</field>
                                 <field name="code">KH_T7001_3_1_2</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_1_2_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -200,7 +186,6 @@
                                 <field name="name">PPI to be paid</field>
                                 <field name="code">KH_T7001_3_1_3</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_1_3_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -214,7 +199,6 @@
                                 <field name="name">Credit Forward</field>
                                 <field name="code">KH_T7001_3_1_4</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_1_4_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -230,25 +214,21 @@
                         <field name="name">2. Value Added Tax</field>
                         <field name="code">KH_T7001_3_2</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_kh_t7001_kh_t7001_3_2_1" model="account.report.line">
                                 <field name="name">Monthly Purchases of Goods and Services</field>
                                 <field name="code">KH_T7001_3_2_1</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_1" model="account.report.line">
                                         <field name="name">1. Local Purchase include VAT 10% </field>
                                         <field name="code">KH_T7001_3_2_1_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_1_1a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_1_1A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_1a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -268,13 +248,11 @@
                                         <field name="name">2. Import 10%</field>
                                         <field name="code">KH_T7001_3_2_1_2</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_1_2a" model="account.report.line">
                                                 <field name="name">Overseas Suppliers</field>
                                                 <field name="code">KH_T7001_3_2_1_2A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_2a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -294,13 +272,11 @@
                                         <field name="name">3. Purchase Exclusive of VAT</field>
                                         <field name="code">KH_T7001_3_2_1_3</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_1_3a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_1_3A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_3a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -313,7 +289,6 @@
                                                 <field name="name">Non-Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_1_3B</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_3b_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -328,13 +303,11 @@
                                         <field name="name">4. Non Creditable Purchase</field>
                                         <field name="code">KH_T7001_3_2_1_4</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_1_4a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_1_4A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_4a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -347,7 +320,6 @@
                                                 <field name="name">Non-Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_1_4B</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_1_4b_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -362,7 +334,6 @@
                                         <field name="name">Total amount of input taxes</field>
                                         <field name="code">KH_T7001_3_2_1_T</field>
                                         <field name="hierarchy_level">3</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_1_t_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -377,19 +348,16 @@
                                 <field name="name">Monthly Sales of Goods and Services</field>
                                 <field name="code">KH_T7001_3_2_2</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_1" model="account.report.line">
                                         <field name="name">1. Sales Include VAT 10%</field>
                                         <field name="code">KH_T7001_3_2_2_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_2_1a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_2_1A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_1a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -407,7 +375,6 @@
                                                 <field name="name">Non-Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_2_1B</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_1b_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -427,13 +394,11 @@
                                         <field name="name">2. Export 0%</field>
                                         <field name="code">KH_T7001_3_2_2_2</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_2_2a" model="account.report.line">
                                                 <field name="name">Overseas Customer</field>
                                                 <field name="code">KH_T7001_3_2_2_2A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_2a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -448,13 +413,11 @@
                                         <field name="name">3. Sales Exclude of VAT</field>
                                         <field name="code">KH_T7001_3_2_2_3</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_2_3a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_2_3A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_3a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -467,7 +430,6 @@
                                                 <field name="name">Non-Taxable Person</field>
                                                 <field name="code">KH_T7001_3_2_2_3B</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_2_2_3b_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -482,7 +444,6 @@
                                         <field name="name">Total amount of output taxes</field>
                                         <field name="code">KH_T7001_3_2_2_T</field>
                                         <field name="hierarchy_level">3</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_2_2_t_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -497,7 +458,6 @@
                                 <field name="name">VAT to be paid</field>
                                 <field name="code">KH_T7001_3_2_TA</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_2_ta_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -511,7 +471,6 @@
                                 <field name="name">Credit forward</field>
                                 <field name="code">KH_T7001_3_2_TB</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_2_tb_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -527,25 +486,21 @@
                         <field name="name">3. Value Added Tax (State charge)</field>
                         <field name="code">KH_T7001_3_3</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_kh_t7001_kh_t7001_3_3_1" model="account.report.line">
                                 <field name="name">Monthly Purchases of Goods and Services</field>
                                 <field name="code">KH_T7001_3_3_1</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_3_1_1" model="account.report.line">
                                         <field name="name">1. Local Purchase include VAT 10% </field>
                                         <field name="code">KH_T7001_3_3_1_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_3_1_1a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_3_1_1A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_3_1_1a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -565,13 +520,11 @@
                                         <field name="name">2. Import 10%</field>
                                         <field name="code">KH_T7001_3_3_1_2</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_3_1_2a" model="account.report.line">
                                                 <field name="name">Overseas Suppliers</field>
                                                 <field name="code">KH_T7001_3_3_1_2A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_3_1_2a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -591,7 +544,6 @@
                                         <field name="name">Total amount of input taxes</field>
                                         <field name="code">KH_T7001_3_3_1_T</field>
                                         <field name="hierarchy_level">3</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_3_1_t_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -606,19 +558,16 @@
                                 <field name="name">Monthly Sales of Goods and Services</field>
                                 <field name="code">KH_T7001_3_3_2</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_3_2_1" model="account.report.line">
                                         <field name="name">1. Sales Include VAT 10%</field>
                                         <field name="code">KH_T7001_3_3_2_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="children_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_3_2_1a" model="account.report.line">
                                                 <field name="name">Taxable Person</field>
                                                 <field name="code">KH_T7001_3_3_2_1A</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_3_2_1a_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -636,7 +585,6 @@
                                                 <field name="name">Non-Taxable Person</field>
                                                 <field name="code">KH_T7001_3_3_2_1B</field>
                                                 <field name="hierarchy_level">7</field>
-                                                <field name="foldable" eval="False"/>
                                                 <field name="expression_ids">
                                                     <record id="l10n_kh_t7001_kh_t7001_3_3_2_1b_balance" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -656,7 +604,6 @@
                                         <field name="name">Total amount of output taxes</field>
                                         <field name="code">KH_T7001_3_3_2_T</field>
                                         <field name="hierarchy_level">3</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_kh_t7001_kh_t7001_3_3_2_t_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -671,7 +618,6 @@
                                 <field name="name">VAT state charge</field>
                                 <field name="code">KH_T7001_3_3_TA</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_3_ta_tax" model="account.report.expression">
                                         <field name="label">tax</field>
@@ -685,7 +631,6 @@
                                 <field name="name">Credit forward</field>
                                 <field name="code">KH_T7001_3_3_TB</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_t7001_kh_t7001_3_3_tb_tax" model="account.report.expression">
                                         <field name="label">tax</field>

--- a/addons/l10n_kh/data/form_wt003.xml
+++ b/addons/l10n_kh/data/form_wt003.xml
@@ -23,13 +23,11 @@
                 <field name="name">Withholding Tax</field>
                 <field name="code">KH_WT003_WHT</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_kh_wt003_kh_wt003_wht_1" model="account.report.line">
                         <field name="name">Withholding tax on resident</field>
                         <field name="code">KH_WT003_WHT_1</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_wt003_kh_wt003_wht_1_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -47,7 +45,6 @@
                                 <field name="name">01 Performance of Service and Royalty for intangibles, interests in minerals</field>
                                 <field name="code">KH_WT003_WHT_1_1</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -65,7 +62,6 @@
                                 <field name="name">02 Payment of interest to non-bank or saving institution taxpayers</field>
                                 <field name="code">KH_WT003_WHT_1_2</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_2_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -83,7 +79,6 @@
                                 <field name="name">03 Payment of interest to taxpayers who have fixed term deposit accounts</field>
                                 <field name="code">KH_WT003_WHT_1_3</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_3_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -101,7 +96,6 @@
                                 <field name="name">04 Payment of interest to taxpayers who have non-fixed term saving</field>
                                 <field name="code">KH_WT003_WHT_1_4</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -119,7 +113,6 @@
                                 <field name="name">05 Payment of rental/lease of movable and immovable property - Legal Person</field>
                                 <field name="code">KH_WT003_WHT_1_5</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_5_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -137,7 +130,6 @@
                                 <field name="name">06 Payment of rental/lease of movable and immovable property - Physical Person</field>
                                 <field name="code">KH_WT003_WHT_1_6</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_1_6_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -157,7 +149,6 @@
                         <field name="name">Withholding tax on non-resident</field>
                         <field name="code">KH_WT003_WHT_2</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_kh_wt003_kh_wt003_wht_2_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -175,7 +166,6 @@
                                 <field name="name">01 Payment of interest</field>
                                 <field name="code">KH_WT003_WHT_2_1</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_2_1_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -193,7 +183,6 @@
                                 <field name="name">02 Payment of royalty, rental/leasing, and income related to the use of property</field>
                                 <field name="code">KH_WT003_WHT_2_2</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_2_2_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -211,7 +200,6 @@
                                 <field name="name">03 Payment of management fee and technical services</field>
                                 <field name="code">KH_WT003_WHT_2_3</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_2_3_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -229,7 +217,6 @@
                                 <field name="name">04 Payment of dividend</field>
                                 <field name="code">KH_WT003_WHT_2_4</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_2_4_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -247,7 +234,6 @@
                                 <field name="name">05 Service</field>
                                 <field name="code">KH_WT003_WHT_2_5</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_kh_wt003_kh_wt003_wht_2_5_balance" model="account.report.expression">
                                         <field name="label">balance</field>

--- a/addons/l10n_lk/data/form_vat001.xml
+++ b/addons/l10n_lk/data/form_vat001.xml
@@ -598,7 +598,7 @@
                                 <field name="name">R3: Allowed Deemed Input Credit on Wholesale and Retail R2 R3=(R3B+R3F) = Lesser amount of cage 2 or {Cage 16 – (R+R1+R2}</field>
                                 <field name="code">LK_VAT_001E_R3</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="True" />
+                                <field name="foldability" >foldable</field>
                                 <field name="expression_ids">
                                     <record id="l10n_lk_vat001_lk_vat_001e_r3_balance_c" model="account.report.expression">
                                         <field name="label">balance_c</field>

--- a/addons/l10n_mn/data/vat_report.xml
+++ b/addons/l10n_mn/data/vat_report.xml
@@ -425,7 +425,6 @@
                         <field name="name">· Total amount of VAT paid on purchased goods, works and services (42=33*10%)</field>
                         <field name="code">VAT_LINE42</field>
                         <field name="groupby" eval="False"/>
-                        <field name="foldable" eval="False"/>
                     </record>
                     <record id="vat_report_line42" model="account.report.line">
                         <field name="aggregation_formula">VAT_LINE33.balance * 0.10</field>
@@ -518,7 +517,6 @@
                     <record id="vat_report_line51" model="account.report.line">
                         <field name="name">Revenue from similar transaction services such as factoring and forfeiting (51)</field>
                         <field name="code">VAT_LINE51</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="vat_report_line51_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -531,7 +529,6 @@
                         <field name="name">Charged VAT (52=(50+51)*10%)</field>
                         <field name="code">VAT_LINE52</field>
                         <field name="groupby" eval="False"/>
-                        <field name="foldable" eval="False"/>
                     </record>
                     <record id="vat_report_line52" model="account.report.line">
                         <field name="aggregation_formula">(VAT_LINE50.balance + VAT_LINE51.balance) * 0.10</field>

--- a/addons/l10n_mx/data/account_report_diot.xml
+++ b/addons/l10n_mx/data/account_report_diot.xml
@@ -156,6 +156,7 @@
                 <field name="name">DIOT</field>
                 <field name="name@es_419">DIOT</field>
                 <field name="hierarchy_level">0</field>
+                <field name="foldability">always_unfolded</field>
                 <field name="expression_ids">
                     <record id="tax_report_mx_diot_paid_8_tag" model="account.report.expression">
                         <field name="label">paid_8</field>

--- a/addons/l10n_ph/data/account_tax_report_data.xml
+++ b/addons/l10n_ph/data/account_tax_report_data.xml
@@ -22,13 +22,11 @@
                 <field name="name">Part II - Total Tax Payable</field>
                 <field name="code">2550Q_TTP</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_ph_2550Q_2550q_15" model="account.report.line">
                         <field name="name">15 Net VAT Payable(Excess Input Tax)</field>
                         <field name="code">2550Q_15</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_15_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -41,13 +39,11 @@
                         <field name="name">Less: Tax Credits/Payments</field>
                         <field name="code">2550Q_LTC</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_ph_2550Q_2550q_16" model="account.report.line">
                                 <field name="name">16 Creditable VAT Withheld</field>
                                 <field name="code">2550Q_16</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_16_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -60,7 +56,6 @@
                                 <field name="name">17 Advance VAT Payments</field>
                                 <field name="code">2550Q_17</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_17_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -74,7 +69,6 @@
                                 <field name="name">18 VAT paid in return previously filed, if this is an amended return</field>
                                 <field name="code">2550Q_18</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_18_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -88,7 +82,6 @@
                                 <field name="name">19 Other Credits/Payment</field>
                                 <field name="code">2550Q_19</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_19_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -104,7 +97,6 @@
                         <field name="name">20 Total Tax Credits/Payment</field>
                         <field name="code">2550Q_20</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_20_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -119,7 +111,6 @@
                 <field name="name">21 Tax Still Payable/(Excess Credits)</field>
                 <field name="code">2550Q_21</field>
                 <field name="hierarchy_level">1</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_ph_2550Q_2550q_21_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -132,13 +123,11 @@
                 <field name="name">Add: Penalties</field>
                 <field name="code">2550Q_APEN</field>
                 <field name="hierarchy_level">1</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_ph_2550Q_2550q_22" model="account.report.line">
                         <field name="name">22 Surcharge</field>
                         <field name="code">2550Q_22</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_22_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -152,7 +141,6 @@
                         <field name="name">23 Interest</field>
                         <field name="code">2550Q_23</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_23_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -166,7 +154,6 @@
                         <field name="name">24 Compromise</field>
                         <field name="code">2550Q_24</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_24_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -180,7 +167,6 @@
                         <field name="name">25 Total Penalties</field>
                         <field name="code">2550Q_25</field>
                         <field name="hierarchy_level">3</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_25_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -195,7 +181,6 @@
                 <field name="name">26 TOTAL AMOUNT PAYABLE/(Excess Credits)</field>
                 <field name="code">2550Q_26</field>
                 <field name="hierarchy_level">1</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_ph_2550Q_2550q_26_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -208,13 +193,11 @@
                 <field name="name">Part IV - Details of VAT Computation</field>
                 <field name="code">2550Q_DOVC</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_ph_2550Q_2550q_31" model="account.report.line">
                         <field name="name">31 VATable Sales</field>
                         <field name="code">2550Q_31</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_31_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -232,7 +215,6 @@
                         <field name="name">32 Zero-Rated Sales</field>
                         <field name="code">2550Q_32</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_32_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -245,7 +227,6 @@
                         <field name="name">33 Exempt Sales</field>
                         <field name="code">2550Q_33</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_33_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -258,7 +239,6 @@
                         <field name="name">34 Total Sales &amp; Output Tax Due</field>
                         <field name="code">2550Q_34</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_34_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -276,7 +256,6 @@
                         <field name="name">35 Less: Output VAT on Uncollected Receivables</field>
                         <field name="code">2550Q_35</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_35_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -289,7 +268,6 @@
                         <field name="name">36 Add: Output VAT on Recovered Uncollected Receivables Previously Deducted </field>
                         <field name="code">2550Q_36</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_36_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -303,7 +281,6 @@
                         <field name="name">37 Total Adjusted Output Tax Due</field>
                         <field name="code">2550Q_37</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_37_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -316,13 +293,11 @@
                         <field name="name">Less: Allowable Input Tax</field>
                         <field name="code">2550Q_AIT</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_ph_2550Q_2550q_38" model="account.report.line">
                                 <field name="name">38 Input Tax Carried Over from Previous Quarter</field>
                                 <field name="code">2550Q_38</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_38_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -336,7 +311,6 @@
                                 <field name="name">39 Input Tax Deferred on Capital Goods Exceeding P1 Million from Previous Quarter (From Part V - Schedule 1 Col E)</field>
                                 <field name="code">2550Q_39</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_39_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -350,7 +324,6 @@
                                 <field name="name">40 Transitional Input Tax</field>
                                 <field name="code">2550Q_40</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_40_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -364,7 +337,6 @@
                                 <field name="name">41 Presumptive Input Tax</field>
                                 <field name="code">2550Q_41</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_41_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -377,7 +349,6 @@
                                 <field name="name">42 Others</field>
                                 <field name="code">2550Q_42</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_42_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -393,7 +364,6 @@
                         <field name="name">43 Total</field>
                         <field name="code">2550Q_43</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_43_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -406,7 +376,6 @@
                         <field name="name">44 Domestic Purchases</field>
                         <field name="code">2550Q_44</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_44__vat_base_1" model="account.report.expression">
                                 <field name="label">_vat_base_1</field>
@@ -459,7 +428,6 @@
                         <field name="name">45 Services Rendered by Non-residents</field>
                         <field name="code">2550Q_45</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_45_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -477,7 +445,6 @@
                         <field name="name">46 Importations</field>
                         <field name="code">2550Q_46</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_46_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -495,7 +462,6 @@
                         <field name="name">47 Others</field>
                         <field name="code">2550Q_47</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_47_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -515,7 +481,6 @@
                         <field name="name">48 Domestic Purchases with No Input Tax</field>
                         <field name="code">2550Q_48</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_48__exempt_base" model="account.report.expression">
                                 <field name="label">_exempt_base</field>
@@ -538,7 +503,6 @@
                         <field name="name">49 VAT-Exempt Importations</field>
                         <field name="code">2550Q_49</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_49_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -551,7 +515,6 @@
                         <field name="name">50 Total Current Purchase/Input Tax</field>
                         <field name="code">2550Q_50</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_50_tax_base" model="account.report.expression">
                                 <field name="label">tax_base</field>
@@ -569,7 +532,6 @@
                         <field name="name">51 Total Available Input Tax</field>
                         <field name="code">2550Q_51</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_51_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -582,13 +544,11 @@
                         <field name="name">Less: Adjustment/Deductions from Input Tax</field>
                         <field name="code">2550Q_LTCIT</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_ph_2550Q_2550q_52" model="account.report.line">
                                 <field name="name">52 Input Tax on Purchases/Importation of Capital Goods exceeding P1 Million deferred for the succeeding period</field>
                                 <field name="code">2550Q_52</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_52_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -602,7 +562,6 @@
                                 <field name="name">53 Input Tax Attributable to VAT Exempt Sales</field>
                                 <field name="code">2550Q_53</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_53_tax_base" model="account.report.expression">
                                         <field name="label">tax_base</field>
@@ -621,7 +580,6 @@
                                 <field name="name">54 VAT refund/TCC claimed</field>
                                 <field name="code">2550Q_54</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_54_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -635,7 +593,6 @@
                                 <field name="name">55 Input VAT on Unpaid Payables</field>
                                 <field name="code">2550Q_55</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_55_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -648,7 +605,6 @@
                                 <field name="name">56 Others</field>
                                 <field name="code">2550Q_56</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_ph_2550Q_2550q_56_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -664,7 +620,6 @@
                         <field name="name">57 Total Deductions from Input Tax</field>
                         <field name="code">2550Q_57</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_57_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -677,7 +632,6 @@
                         <field name="name">58 Add: Input VAT on Settled Unpaid Payables Previously Deducted</field>
                         <field name="code">2550Q_58</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_58_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -691,7 +645,6 @@
                         <field name="name">59 Adjusted Deductions from Input Tax</field>
                         <field name="code">2550Q_59</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_59_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -704,7 +657,6 @@
                         <field name="name">60 Total Allowable Input Tax</field>
                         <field name="code">2550Q_60</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_60_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -717,7 +669,6 @@
                         <field name="name">61 Net VAT Payable/(Excess Input Tax)</field>
                         <field name="code">2550Q_61</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_ph_2550Q_2550q_61_balance" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_sa/data/account_tax_report_data.xml
+++ b/addons/l10n_sa/data/account_tax_report_data.xml
@@ -25,7 +25,6 @@
                 <field name="name">1. Standard rated sales</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_1</field>
-                <field name="foldable">True</field>
                 <field name="expression_ids">
                     <record id="tax_report_line_standard_rated_sale_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -112,7 +111,6 @@
                 <field name="name">7. Standard rated domestic purchases</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_7</field>
-                <field name="foldable">True</field>
                 <field name="expression_ids">
                     <record id="tax_report_line_standard_rated_domestic_purchase_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -130,7 +128,6 @@
                 <field name="name">8. Imports subject to VAT paid at customs</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_8</field>
-                <field name="foldable">True</field>
                 <field name="expression_ids">
                     <record id="tax_report_line_imports_subject_to_vat_paid_at_customs_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -148,7 +145,6 @@
                 <field name="name">9. Imports subject to VAT accounted for through reverse charge mechanism</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_9</field>
-                <field name="foldable">True</field>
                 <field name="expression_ids">
                     <record id="tax_report_line_imports_subject_to_vat_reverse_charge_base" model="account.report.expression">
                         <field name="label">base</field>

--- a/addons/l10n_sa/data/account_tax_report_withholding_data.xml
+++ b/addons/l10n_sa/data/account_tax_report_withholding_data.xml
@@ -21,7 +21,7 @@
                 <field name="name"> 1. Rent (5%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_1w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_rent_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -73,7 +73,7 @@
                 <field name="name"> 2. Air tickets, Air freight and Maritime freight (5%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_2w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_at_af_mf_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -125,7 +125,7 @@
                 <field name="name">3. Technical and consulting services and international telecommunication services (5%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_3w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_technical_and_consulting_services_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -177,7 +177,7 @@
                 <field name="name">4. Dividends (5%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_4w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_dividends_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -229,7 +229,7 @@
                 <field name="name">5. Interest on loan, insurance and reinsurance premium (5%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_5w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_interest_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -281,7 +281,7 @@
                 <field name="name">6. Royalty (15%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_6w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_royalties_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -333,7 +333,7 @@
                 <field name="name">7. Any other payments (15%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_7w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_other_payments_base" model="account.report.expression">
                         <field name="label">base</field>
@@ -385,7 +385,7 @@
                 <field name="name">8. Management fees (20%)</field>
                 <field name="hierarchy_level">1</field>
                 <field name="code">sa_8w</field>
-                <field name="foldable">True</field>
+                <field name="foldability">foldable</field>
                 <field name="expression_ids">
                     <record id="tax_report_withholding_tax_line_management_fees_base" model="account.report.expression">
                         <field name="label">base</field>

--- a/addons/l10n_tw/data/tax_report_401.xml
+++ b/addons/l10n_tw/data/tax_report_401.xml
@@ -23,28 +23,24 @@
                 <field name="name@zh_TW">銷項</field>
                 <field name="code">TW_401_S</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_ot" model="account.report.line">
                         <field name="name">Output - Sales &amp; Tax</field>
                         <field name="name@zh_TW">產出 - 銷售和稅收</field>
                         <field name="code">TW_401_OT</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_5_vat" model="account.report.line">
                                 <field name="name">5% VAT Sales</field>
                                 <field name="name@zh_TW">5% 增值稅銷售額</field>
                                 <field name="code">TW_401_5_VAT</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_401_tw_401_1" model="account.report.line">
                                         <field name="name">1 Triplicate Invoices / E-Invoices</field>
                                         <field name="name@zh_TW">1 三聯式發票、電子計算機發票</field>
                                         <field name="code">TW_401_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_1_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -63,7 +59,6 @@
                                         <field name="name@zh_TW">5 收銀機發票(三聯式)及電子發票</field>
                                         <field name="code">TW_401_5</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -82,7 +77,6 @@
                                         <field name="name@zh_TW">9 二聯式發票、收銀機發票(二聯式)</field>
                                         <field name="code">TW_401_9</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -101,7 +95,6 @@
                                         <field name="name@zh_TW">13 免用發票</field>
                                         <field name="code">TW_401_13</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_13_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -120,7 +113,6 @@
                                         <field name="name@zh_TW">17 減：退回及折讓</field>
                                         <field name="code">TW_401_17</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -139,7 +131,6 @@
                                         <field name="name@zh_TW">21 合計 ①</field>
                                         <field name="code">TW_401_21</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_21_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -153,7 +144,6 @@
                                         <field name="name@zh_TW">22 合計稅額 ②</field>
                                         <field name="code">TW_401_22</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_22_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -169,14 +159,12 @@
                                 <field name="name@zh_TW">零稅率銷售額</field>
                                 <field name="code">TW_401_ZS</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_401_tw_401_3" model="account.report.line">
                                         <field name="name">3 Triplicate Invoices / E-Invoices</field>
                                         <field name="name@zh_TW">3 三聯式發票、電子計算機發票</field>
                                         <field name="code">TW_401_3</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -190,7 +178,6 @@
                                         <field name="name@zh_TW">7 收銀機發票(三聯式)及電子發票</field>
                                         <field name="code">TW_401_7</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_7_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -204,7 +191,6 @@
                                         <field name="name@zh_TW">11 二聯式發票、收銀機發票(二聯式)</field>
                                         <field name="code">TW_401_11</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_11_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -218,7 +204,6 @@
                                         <field name="name@zh_TW">15 免用發票</field>
                                         <field name="code">TW_401_15</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_15_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -232,7 +217,6 @@
                                         <field name="name@zh_TW">19 減：退回及折讓</field>
                                         <field name="code">TW_401_19</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -246,7 +230,6 @@
                                         <field name="name@zh_TW">23 合計 ③</field>
                                         <field name="code">TW_401_23</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_401_tw_401_23_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -264,7 +247,6 @@
                         <field name="name@zh_TW">25 銷售額總計 (①＋③) ⑦</field>
                         <field name="code">TW_401_25</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_25_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -278,7 +260,6 @@
                         <field name="name@zh_TW">27 元(內含銷售固定資產)</field>
                         <field name="code">TW_401_27</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_27_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -294,14 +275,12 @@
                 <field name="name@zh_TW">進項</field>
                 <field name="code">TW_401_P</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_28" model="account.report.line">
                         <field name="name">28 Unified Invoice Deduction / Standard Invoice Credit - Purchase &amp; Costs</field>
                         <field name="name@zh_TW">28 統一發票扣抵聯(包括一般稅額計算之電子計算機發票扣抵聯) - 進貨及費用</field>
                         <field name="code">TW_401_28</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_28_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -320,7 +299,6 @@
                         <field name="name@zh_TW">30 統一發票扣抵聯(包括一般稅額計算之電子計算機發票扣抵聯) - 固 定 資 產</field>
                         <field name="code">TW_401_30</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_30_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -339,7 +317,6 @@
                         <field name="name@zh_TW">32 三聯式收銀機發票扣抵聯及一般稅額計算之電子發票 - 進貨及費用</field>
                         <field name="code">TW_401_32</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_32_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -358,7 +335,6 @@
                         <field name="name@zh_TW">34 三聯式收銀機發票扣抵聯及一般稅額計算之電子發票 - 固定資產</field>
                         <field name="code">TW_401_34</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_34_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -377,7 +353,6 @@
                         <field name="name@zh_TW">36 載有稅額之其他憑證(包括二聯式收銀機發票) - 進貨及費用</field>
                         <field name="code">TW_401_36</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_36_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -396,7 +371,6 @@
                         <field name="name@zh_TW">38 載有稅額之其他憑證(包括二聯式收銀機發票) - 固定資產</field>
                         <field name="code">TW_401_38</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_38_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -415,7 +389,6 @@
                         <field name="name@zh_TW">78 海關代徵營業稅繳納證扣抵聯 - 進貨及費用</field>
                         <field name="code">TW_401_78</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_78_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -434,7 +407,6 @@
                         <field name="name@zh_TW">80 海關代徵營業稅繳納證扣抵聯 - 固定資產</field>
                         <field name="code">TW_401_80</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_80_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -453,7 +425,6 @@
                         <field name="name@zh_TW">40 減：退出、折讓及海關退還溢繳稅款 - 進貨及費用</field>
                         <field name="code">TW_401_40</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_40_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -472,7 +443,6 @@
                         <field name="name@zh_TW">42 減：退出、折讓及海關退還溢繳稅款 - 固定資產</field>
                         <field name="code">TW_401_42</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_42_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -491,7 +461,6 @@
                         <field name="name@zh_TW">44 合計 - 進貨及費用</field>
                         <field name="code">TW_401_44</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_44_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -505,7 +474,6 @@
                         <field name="name@zh_TW">45 合計稅額 - 進貨及費用 ⑨</field>
                         <field name="code">TW_401_45</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_45_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -519,7 +487,6 @@
                         <field name="name@zh_TW">46 合計 - 固定資產</field>
                         <field name="code">TW_401_46</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_46_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -533,7 +500,6 @@
                         <field name="name@zh_TW">47 合計稅額 - 固定資產 ⑩</field>
                         <field name="code">TW_401_47</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_47_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -547,7 +513,6 @@
                         <field name="name@zh_TW">48 進項總金額 (包括不得扣抵憑證及普通收據) - 進貨及費用</field>
                         <field name="code">TW_401_48</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_48_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -576,7 +541,6 @@
                         <field name="name@zh_TW">49 進項總金額 (包括不得扣抵憑證及普通收據) - 固定資產</field>
                         <field name="code">TW_401_49</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_49_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -602,7 +566,6 @@
                 <field name="name@zh_TW">73 進口免稅貨物</field>
                 <field name="code">TW_401_73</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_73_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -616,7 +579,6 @@
                 <field name="name@zh_TW">74 購買國外勞務給付額 ⑬</field>
                 <field name="code">TW_401_74</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_74_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -630,14 +592,13 @@
                 <field name="name@zh_TW">稅額計算</field>
                 <field name="code">TW_401_TC</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_101" model="account.report.line">
                         <field name="name">101 Total Output Tax for the Current Period (Month) (2)</field>
                         <field name="name@zh_TW">101 稅額計算 ②</field>
                         <field name="code">TW_401_101</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_101_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -651,7 +612,6 @@
                         <field name="name@zh_TW">107 得扣抵進項稅額合計 ⑫</field>
                         <field name="code">TW_401_107</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_107_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -665,7 +625,6 @@
                         <field name="name@zh_TW">108 上期(月)累積留抵稅額</field>
                         <field name="code">TW_401_108</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_108_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -679,7 +638,6 @@
                         <field name="name@zh_TW">110 小計(7.+8.)</field>
                         <field name="code">TW_401_110</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_110_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -693,7 +651,6 @@
                         <field name="name@zh_TW">111 本期(月)應實繳稅額(1.－10.)</field>
                         <field name="code">TW_401_111</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_111_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -707,7 +664,6 @@
                         <field name="name@zh_TW">112 本期(月)申報留抵稅額(10.－1.)</field>
                         <field name="code">TW_401_112</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_112_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -722,7 +678,6 @@
                         <field name="name@zh_TW">113 得退稅限額合計③×5%＋⑩</field>
                         <field name="code">TW_401_113</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_113_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -737,7 +692,6 @@
                         <field name="name@zh_TW">114 本期(月)應退稅額(如 12.＞13. 則為 13. / 13.＞12. 則為 12.)</field>
                         <field name="code">TW_401_114</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_114_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -757,7 +711,6 @@
                         <field name="name@zh_TW">115 本期(月)累積留抵稅額(12.－14.)</field>
                         <field name="code">TW_401_115</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_401_tw_401_115_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -773,7 +726,6 @@
                 <field name="name@zh_TW">82 保稅區營業人按進口報關程序銷售貨物至固定資產我國境內課稅區之免開立統一發票銷售額</field>
                 <field name="code">TW_401_82</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_401_tw_401_82_balance" model="account.report.expression">
                         <field name="label">balance</field>

--- a/addons/l10n_tw/data/tax_report_403.xml
+++ b/addons/l10n_tw/data/tax_report_403.xml
@@ -23,28 +23,24 @@
                 <field name="name@zh_TW">銷項</field>
                 <field name="code">TW_403_S</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_ot" model="account.report.line">
                         <field name="name">Output - Sales &amp; Tax</field>
                         <field name="name@zh_TW">產出 - 銷售和稅收</field>
                         <field name="code">TW_403_OT</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_5_vat" model="account.report.line">
                                 <field name="name">5% VAT Sales</field>
                                 <field name="name@zh_TW">5% 增值稅銷售額</field>
                                 <field name="code">TW_403_5_VAT</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_403_tw_403_1" model="account.report.line">
                                         <field name="name">1 Triplicate Invoices / E-Invoices</field>
                                         <field name="name@zh_TW">1 三聯式發票、電子計算機發票</field>
                                         <field name="code">TW_403_1</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_1_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -63,7 +59,6 @@
                                         <field name="name@zh_TW">5 收銀機發票(三聯式)及電子發票</field>
                                         <field name="code">TW_403_5</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_5_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -82,7 +77,6 @@
                                         <field name="name@zh_TW">9 二聯式發票、收銀機發票(二聯式)</field>
                                         <field name="code">TW_403_9</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_9_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -101,7 +95,6 @@
                                         <field name="name@zh_TW">13 免用發票</field>
                                         <field name="code">TW_403_13</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_13_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -120,7 +113,6 @@
                                         <field name="name@zh_TW">17 減：退回及折讓</field>
                                         <field name="code">TW_403_17</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_17_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -139,7 +131,6 @@
                                         <field name="name@zh_TW">21 合計 ①</field>
                                         <field name="code">TW_403_21</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_21_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -153,7 +144,6 @@
                                         <field name="name@zh_TW">22 合計稅額 ②</field>
                                         <field name="code">TW_403_22</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_22_tax" model="account.report.expression">
                                                 <field name="label">tax</field>
@@ -169,14 +159,12 @@
                                 <field name="name@zh_TW">零稅率銷售額</field>
                                 <field name="code">TW_403_ZS</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_403_tw_403_3" model="account.report.line">
                                         <field name="name">3 Triplicate Invoices / E-Invoices</field>
                                         <field name="name@zh_TW">3 三聯式發票、電子計算機發票</field>
                                         <field name="code">TW_403_3</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_3_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -190,7 +178,6 @@
                                         <field name="name@zh_TW">7 收銀機發票(三聯式)及電子發票</field>
                                         <field name="code">TW_403_7</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_7_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -204,7 +191,6 @@
                                         <field name="name@zh_TW">11 二聯式發票、收銀機發票(二聯式)</field>
                                         <field name="code">TW_403_11</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_11_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -218,7 +204,6 @@
                                         <field name="name@zh_TW">15 免用發票</field>
                                         <field name="code">TW_403_15</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_15_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -232,7 +217,6 @@
                                         <field name="name@zh_TW">19 減：退回及折讓</field>
                                         <field name="code">TW_403_19</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_19_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -246,7 +230,6 @@
                                         <field name="name@zh_TW">23 合計 ③</field>
                                         <field name="code">TW_403_23</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_23_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -262,14 +245,12 @@
                                 <field name="name@zh_TW">免稅銷售額</field>
                                 <field name="code">TW_403_VE</field>
                                 <field name="hierarchy_level">3</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_403_tw_403_4" model="account.report.line">
                                         <field name="name">4 Triplicate Invoices / E-Invoices</field>
                                         <field name="name@zh_TW">4 三聯式發票、電子計算機發票</field>
                                         <field name="code">TW_403_4</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_4_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -283,7 +264,6 @@
                                         <field name="name@zh_TW">8 收銀機發票(三聯式)及電子發票</field>
                                         <field name="code">TW_403_8</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_8_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -297,7 +277,6 @@
                                         <field name="name@zh_TW">12 二聯式發票、收銀機發票(二聯式)</field>
                                         <field name="code">TW_403_12</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_12_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -311,7 +290,6 @@
                                         <field name="name@zh_TW">16 免用發票</field>
                                         <field name="code">TW_403_16</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_16_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -325,7 +303,6 @@
                                         <field name="name@zh_TW">20 減：退回及折讓</field>
                                         <field name="code">TW_403_20</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_20_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -339,7 +316,6 @@
                                         <field name="name@zh_TW">24 合計 ④</field>
                                         <field name="code">TW_403_24</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_24_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -355,14 +331,12 @@
                                 <field name="name@zh_TW">特種稅額</field>
                                 <field name="code">TW_403-GBRT</field>
                                 <field name="hierarchy_level">1</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="children_ids">
                                     <record id="l10n_tw_tax_report_403_tw_403_52" model="account.report.line">
                                         <field name="name">52 25% Special Dining Industry</field>
                                         <field name="name@zh_TW">52 25% 特種飲食業</field>
                                         <field name="code">TW_403_52</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_52_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -381,7 +355,6 @@
                                         <field name="name@zh_TW">54 15% 特種飲食業</field>
                                         <field name="code">TW_403_54</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_54_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -400,7 +373,6 @@
                                         <field name="name@zh_TW">84 5% 銀行業、保險業經營銀行、保險本業收入</field>
                                         <field name="code">TW_403_84</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_84_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -419,7 +391,6 @@
                                         <field name="name@zh_TW">56 2% 銀行業、保險業及信託投資業經營前項以外專屬金融本業入</field>
                                         <field name="code">TW_403_56</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_56_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -438,7 +409,6 @@
                                         <field name="name@zh_TW">60 1% 再保收入</field>
                                         <field name="code">TW_403_60</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_60_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -457,7 +427,6 @@
                                         <field name="name@zh_TW">62 免稅收入</field>
                                         <field name="code">TW_403_62</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_62_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -472,7 +441,6 @@
                                         <field name="name@zh_TW">63 減：退回及折讓</field>
                                         <field name="code">TW_403_63</field>
                                         <field name="hierarchy_level">5</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_63_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -491,7 +459,6 @@
                                         <field name="name@zh_TW">65 合計 ⑤</field>
                                         <field name="code">TW_403_65</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_65_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -505,7 +472,6 @@
                                         <field name="name@zh_TW">66 合計稅額</field>
                                         <field name="code">TW_403_66</field>
                                         <field name="hierarchy_level">7</field>
-                                        <field name="foldable" eval="False"/>
                                         <field name="expression_ids">
                                             <record id="l10n_tw_tax_report_403_tw_403_66_balance" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -523,7 +489,6 @@
                         <field name="name@zh_TW">25 銷售額總計 (①＋③＋④＋⑤) ⑦</field>
                         <field name="code">TW_403_25</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_25_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -537,7 +502,6 @@
                         <field name="name@zh_TW">26 元(內含銷售土地) ⑧</field>
                         <field name="code">TW_403_26</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_26_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -551,7 +515,6 @@
                         <field name="name@zh_TW">27 元(其他固定資產)</field>
                         <field name="code">TW_403_27</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_27_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -566,7 +529,6 @@
                         <field name="name@zh_TW">50 不得扣抵比例 (④＋⑤－⑧)/(⑦－⑧) ⑪</field>
                         <field name="code">TW_403_50</field>
                         <field name="hierarchy_level">0</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_50_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -592,7 +554,6 @@
                         <field name="name@zh_TW">51 得扣抵之進項稅額 ( ⑨ ＋ ⑩ ) × ( 1 － ⑪ )</field>
                         <field name="code">TW_403_51</field>
                         <field name="hierarchy_level">0</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_51_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -618,14 +579,12 @@
                 <field name="name@zh_TW">進項</field>
                 <field name="code">TW_403_P</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_28" model="account.report.line">
                         <field name="name">28 Unified Invoice Deduction / Standard Invoice Credit - Purchase &amp; Costs</field>
                         <field name="name@zh_TW">28 統一發票扣抵聯 (包括一般稅額計算之電子計算機發票扣抵聯) - 進貨及費用</field>
                         <field name="code">TW_403_28</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_28_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -644,7 +603,6 @@
                         <field name="name@zh_TW">30 統一發票扣抵聯 (包括一般稅額計算之電子計算機發票扣抵聯) - 固定資產</field>
                         <field name="code">TW_403_30</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_30_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -663,7 +621,6 @@
                         <field name="name@zh_TW">32 三聯式收銀機發票扣抵聯及一般稅額計算之電子發票 - 進貨及費用</field>
                         <field name="code">TW_403_32</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_32_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -682,7 +639,6 @@
                         <field name="name@zh_TW">34 三聯式收銀機發票扣抵聯及一般稅額計算之電子發票 - 固定資產</field>
                         <field name="code">TW_403_34</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_34_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -701,7 +657,6 @@
                         <field name="name@zh_TW">36 載有稅額之其他憑證 (包括二聯式收銀機發票) - 進貨及費用</field>
                         <field name="code">TW_403_36</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_36_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -720,7 +675,6 @@
                         <field name="name@zh_TW">38 載有稅額之其他憑證 (包括二聯式收銀機發票) - 固定資產</field>
                         <field name="code">TW_403_38</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_38_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -739,7 +693,6 @@
                         <field name="name@zh_TW">78 海關代徵營業稅繳納證扣抵聯 - 進貨及費用</field>
                         <field name="code">TW_403_78</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_78_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -758,7 +711,6 @@
                         <field name="name@zh_TW">80 海關代徵營業稅繳納證扣抵聯 - 固定資產</field>
                         <field name="code">TW_403_80</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_80_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -777,7 +729,6 @@
                         <field name="name@zh_TW">40 減：退出、折讓及海關退還溢繳稅款 - 進貨及費用</field>
                         <field name="code">TW_403_40</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_40_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -796,7 +747,6 @@
                         <field name="name@zh_TW">42 減：退出、折讓及海關退還溢繳稅款 - 固定資產</field>
                         <field name="code">TW_403_42</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_42_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -815,7 +765,6 @@
                         <field name="name@zh_TW">44 合計 - 進貨及費用</field>
                         <field name="code">TW_403_44</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_44_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -829,7 +778,6 @@
                         <field name="name@zh_TW">45 合計稅額 - 進貨及費用 ⑨</field>
                         <field name="code">TW_403_45</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_45_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -843,7 +791,6 @@
                         <field name="name@zh_TW">46 合計 - 固定資產</field>
                         <field name="code">TW_403_46</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_46_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -857,7 +804,6 @@
                         <field name="name@zh_TW">47 合計稅額 - 固定資產 ⑩</field>
                         <field name="code">TW_403_47</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_47_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -871,7 +817,6 @@
                         <field name="name@zh_TW">48 進項總金額 (包括不得扣抵憑證及普通收據) - 進貨及費用</field>
                         <field name="code">TW_403_48</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_48_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -900,7 +845,6 @@
                         <field name="name@zh_TW">49 進項總金額 (包括不得扣抵憑證及普通收據) - 固定資產</field>
                         <field name="code">TW_403_49</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_49_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -926,7 +870,6 @@
                 <field name="name@zh_TW">73 進口免稅貨物</field>
                 <field name="code">TW_403_73</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_73_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -940,7 +883,6 @@
                 <field name="name@zh_TW">74 購買國外勞務給付額 ⑬</field>
                 <field name="code">TW_403_74</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_74_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -954,7 +896,6 @@
                 <field name="name@zh_TW">75 營業稅額 ⑭ ＝ ⑬ × 稅率</field>
                 <field name="code">TW_403_75</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_75_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -968,7 +909,6 @@
                 <field name="name@zh_TW">76 應納稅額 ⑮ ＝ ⑭ × ⑪ ⑱</field>
                 <field name="code">TW_403_76</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_76_balance" model="account.report.expression">
                         <field name="label">balance</field>
@@ -982,14 +922,13 @@
                 <field name="name@zh_TW">稅額計算</field>
                 <field name="code">TW_403_TC</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="True"/>
+                <field name="foldability">foldable</field>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_101" model="account.report.line">
                         <field name="name">101 Total Output Tax for the Current Period (Month) ②</field>
                         <field name="name@zh_TW">101 稅額計算 ②</field>
                         <field name="code">TW_403_101</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_101_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1003,7 +942,6 @@
                         <field name="name@zh_TW">103 購買國外勞務應納稅額 ⑱</field>
                         <field name="code">TW_403_103</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_103_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1017,7 +955,6 @@
                         <field name="name@zh_TW">104 特種稅額計算之應納稅額 ⑥</field>
                         <field name="code">TW_403_104</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_104_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1031,7 +968,6 @@
                         <field name="name@zh_TW">105 中途歇業年底調整補徵應繳稅額(詳附表)</field>
                         <field name="code">TW_403_105</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_105_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1046,7 +982,6 @@
                         <field name="name@zh_TW">106 小計(1.+3.+4.+5.)</field>
                         <field name="code">TW_403_106</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_106_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1060,7 +995,6 @@
                         <field name="name@zh_TW">107 得扣抵進項稅額合計 ⑫</field>
                         <field name="code">TW_403_107</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_107_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1084,7 +1018,6 @@
                         <field name="name@zh_TW">108 上期(月)累積留抵稅額</field>
                         <field name="code">TW_403_108</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_108_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1099,7 +1032,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">109 中途歇業/年底調整應退稅額(詳附表)</field>
                         <field name="code">TW_403_109</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_109_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1114,7 +1046,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">110 小計(7.+8.+9.)</field>
                         <field name="code">TW_403_110</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_110_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1128,7 +1059,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">111 本期(月)應實繳稅額(6.－10.)</field>
                         <field name="code">TW_403_111</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_111_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1142,7 +1072,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">112 本期(月)申報留抵稅額(10.－6.)</field>
                         <field name="code">TW_403_112</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_112_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1157,7 +1086,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">113 得退稅限額合計③×5%＋⑩</field>
                         <field name="code">TW_403_113</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_113_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1171,7 +1099,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">114 本期(月)應退稅額(如 12.＞13. 則為 13. / 13.＞12. 則為 12.)</field>
                         <field name="code">TW_403_114</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_114_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1191,7 +1118,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                         <field name="name@zh_TW">115 本期(月)累積留抵稅額(12.－14.)</field>
                         <field name="code">TW_403_115</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_403_tw_403_115_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1207,7 +1133,6 @@ Year-end adjustment of tax refund (see attached table)</field>
                 <field name="name@zh_TW">82 保稅區營業人按進口報關程序銷售貨物至 固 定 資 產 我國境內課稅區之免開立統一發票銷售額</field>
                 <field name="code">TW_403_82</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_403_tw_403_82_balance" model="account.report.expression">
                         <field name="label">balance</field>

--- a/addons/l10n_tw/data/tax_report_404.xml
+++ b/addons/l10n_tw/data/tax_report_404.xml
@@ -23,21 +23,18 @@
                 <field name="name@zh_TW">銷項</field>
                 <field name="code">TW_404_S</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_404_tw_404-gbrt" model="account.report.line">
                         <field name="name">Special Industry Tax Items (GBRT)</field>
                         <field name="name@zh_TW">特種稅額</field>
                         <field name="code">TW_404-GBRT</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="children_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_52" model="account.report.line">
                                 <field name="name">52 25% Special Dining Industry</field>
                                 <field name="name@zh_TW">52 25% 特種飲食業</field>
                                 <field name="code">TW_404_52</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_52_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -56,7 +53,6 @@
                                 <field name="name@zh_TW">54 15% 特種飲食業</field>
                                 <field name="code">TW_404_54</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_54_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -75,7 +71,6 @@
                                 <field name="name@zh_TW">84 5% 銀行業、保險業經營銀行、保險本業收入</field>
                                 <field name="code">TW_404_84</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_84_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -94,7 +89,6 @@
                                 <field name="name@zh_TW">56 2% 銀行業、保險業及信託投資業經營前項以外專屬金融本業入</field>
                                 <field name="code">TW_404_56</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_56_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -113,7 +107,6 @@
                                 <field name="name@zh_TW">58 5% 非專屬本業收入</field>
                                 <field name="code">TW_404_58</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_58_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -132,7 +125,6 @@
                                 <field name="name@zh_TW">60 1% 再保收入</field>
                                 <field name="code">TW_404_60</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_60_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -151,7 +143,6 @@
                                 <field name="name@zh_TW">62 免稅收入</field>
                                 <field name="code">TW_404_62</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_62_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -166,7 +157,6 @@
                                 <field name="name@zh_TW">63 減：退回及折讓</field>
                                 <field name="code">TW_404_63</field>
                                 <field name="hierarchy_level">5</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_63_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -185,7 +175,6 @@
                                 <field name="name@zh_TW">65 合計 ⑤</field>
                                 <field name="code">TW_404_65</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_65_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -199,7 +188,6 @@
                                 <field name="name@zh_TW">66 合計稅額</field>
                                 <field name="code">TW_404_66</field>
                                 <field name="hierarchy_level">7</field>
-                                <field name="foldable" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="l10n_tw_tax_report_404_tw_404_66_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -217,14 +205,12 @@
                 <field name="name@zh_TW">進項</field>
                 <field name="code">TW_404_P</field>
                 <field name="hierarchy_level">0</field>
-                <field name="foldable" eval="False"/>
                 <field name="children_ids">
                     <record id="l10n_tw_tax_report_404_tw_404_67" model="account.report.line">
                         <field name="name">67 1% Reinsurance Premium Income for Foreign Insurance Companies</field>
                         <field name="name@zh_TW">67 1% 外國保險業再保費收入</field>
                         <field name="code">TW_404_67</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_67_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -243,7 +229,6 @@
                         <field name="name@zh_TW">69 2% 第 11 條各業專屬本業勞務 (不含銀行業、保險業經營銀行、保險本業收入)</field>
                         <field name="code">TW_404_69</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_69_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -262,7 +247,6 @@
                         <field name="name@zh_TW">71 5% 其他 (含銀行業、保險業經營銀行、保險本業收入)</field>
                         <field name="code">TW_404_71</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_71_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -281,7 +265,6 @@
                         <field name="name@zh_TW">74 合計 ⑬</field>
                         <field name="code">TW_404_74</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_74_balance" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -296,7 +279,6 @@
                         <field name="name@zh_TW">76 合計稅額 - 進貨及費用 ⑱</field>
                         <field name="code">TW_404_76</field>
                         <field name="hierarchy_level">1</field>
-                        <field name="foldable" eval="False"/>
                         <field name="expression_ids">
                             <record id="l10n_tw_tax_report_404_tw_404_76_tax" model="account.report.expression">
                                 <field name="label">tax</field>
@@ -312,7 +294,6 @@
                 <field name="name@zh_TW">111 本期應實繳稅額 ⑥＋⑱</field>
                 <field name="code">TW_404_111</field>
                 <field name="hierarchy_level">1</field>
-                <field name="foldable" eval="False"/>
                 <field name="expression_ids">
                     <record id="l10n_tw_tax_report_404_tw_404_111_balance" model="account.report.expression">
                         <field name="label">balance</field>

--- a/odoo/upgrade_code/19.3-00-account-report-foldable.py
+++ b/odoo/upgrade_code/19.3-00-account-report-foldable.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import logging
+import typing
+
+from odoo.upgrade_code.tools_etree import update_etree
+
+if typing.TYPE_CHECKING:
+    from odoo.cli.upgrade_code import FileManager
+
+_logger = logging.getLogger(__name__)
+
+SHORTHAND_FORMULA_ENGINES = {
+    'domain_formula': 'domain',
+    'aggregation_formula': 'aggregation',
+    'account_codes_formula': 'account_codes',
+    'external_formula': 'external',
+    'tax_tags_formula': 'tax_tags',
+}
+
+
+def _get_is_foldable(foldable_node):
+    """Interpret the foldable value from the XML field node. Returns True or False."""
+    eval_attr = foldable_node.get('eval')
+    if eval_attr is not None:
+        val = eval_attr.strip()
+        if val in ('True', '1'):
+            return True
+        elif val in ('False', '0', 'None', ''):
+            return False
+    text = (foldable_node.text or '').strip()
+    if text in ('True', '1'):
+        return True
+    elif text in ('False', '0', ''):
+        return False
+    return False
+
+
+def _find_parent_report(record_node):
+    """Walk up the XML tree to find the ancestor account.report record."""
+    node = record_node.getparent()
+    while node is not None:
+        if node.tag == 'record' and node.get('model') == 'account.report':
+            return node
+        node = node.getparent()
+    return None
+
+
+def _has_groupby(node):
+    """Check whether an XML record node has a non-empty groupby field."""
+    if node is None:
+        return False
+    groupby_field = node.find("field[@name='groupby']")
+    return groupby_field is not None and (
+        (groupby_field.text and groupby_field.text.strip()) or groupby_field.get('eval')
+    )
+
+
+def _has_user_groupby(node):
+    """Check whether an XML record node has a non-empty user_groupby field."""
+    if node is None:
+        return False
+    user_groupby_field = node.find("field[@name='user_groupby']")
+    return user_groupby_field is not None and (
+        (user_groupby_field.text and user_groupby_field.text.strip()) or user_groupby_field.get('eval')
+    )
+
+
+def _compute_foldability_from_xml(record_node):
+    """Replicate _compute_foldable logic using only the XML record structure."""
+    # Check for children_ids
+    children_field = record_node.find("field[@name='children_ids']")
+    has_children = (
+        children_field is not None
+        and len(children_field.findall("record[@model='account.report.line']")) > 0
+    )
+
+    # Collect expression engines
+    expression_engines = set()
+
+    expressions_field = record_node.find("field[@name='expression_ids']")
+    if expressions_field is not None:
+        for expr_record in expressions_field.findall("record[@model='account.report.expression']"):
+            engine_field = expr_record.find("field[@name='engine']")
+            if engine_field.text:
+                expression_engines.add(engine_field.text.strip())
+
+    for field_name, engine in SHORTHAND_FORMULA_ENGINES.items():
+        field_node = record_node.find(f"field[@name='{field_name}']")
+        if field_node is not None and (field_node.text or field_node.get('eval')):
+            expression_engines.add(engine)
+
+    has_line_groupby = _has_groupby(record_node)
+    has_line_user_groupby = _has_user_groupby(record_node)
+
+    # Check the parent report's groupby (report_line.report_id.groupby)
+    report_node = _find_parent_report(record_node)
+    has_report_groupby = _has_groupby(report_node)
+    has_report_user_groupby = _has_user_groupby(report_node)
+    has_groupby = has_line_groupby or has_line_user_groupby or has_report_user_groupby or has_report_groupby
+
+    if has_children:
+        return 'always_unfolded'
+    elif has_groupby and all(e not in ('external', 'aggregation') for e in expression_engines):
+        return 'foldable'
+    elif any(e in ('external', 'aggregation') for e in expression_engines):
+        return 'never_unfoldable'
+    else:
+        return 'always_unfolded'
+
+
+def _foldable_matches_compute(is_foldable, computed_value):
+    """Check if the XML foldable value is consistent with _compute_foldability."""
+    # Old Boolean True = "this line is foldable" -> matches 'foldable'
+    if is_foldable is True and computed_value == 'foldable':
+        return True
+    # Old Boolean False = "this line is NOT foldable" -> matches 'never_unfoldable' or 'always_unfolded'
+    return is_foldable is False and computed_value in ('never_unfoldable', 'always_unfolded')
+
+
+def _remove_element(node):
+    """Remove an element from its parent, properly bridging the surrounding whitespace."""
+    prev = node.getprevious()
+    if prev is not None:
+        prev.tail = (prev.tail or '').rstrip() + (node.tail or '')
+    else:
+        parent = node.getparent()
+        parent.text = (parent.text or '').rstrip() + (node.tail or '')
+    node.getparent().remove(node)
+
+
+def upgrade(file_manager: FileManager):
+    files = [f for f in file_manager if f.path.suffix == '.xml']
+    if not files:
+        return
+
+    inconsistencies = []
+
+    for fileno, file in enumerate(files, start=1):
+        if '<field name="foldable"' not in file.content:
+            file_manager.print_progress(fileno, len(files), file.path)
+            continue
+
+        def process(root, _file=file):
+            for record in root.iter('record'):
+                if record.get('model') != 'account.report.line':
+                    continue
+                foldable_node = record.find("field[@name='foldable']")
+                if foldable_node is None:
+                    continue
+
+                is_foldable = _get_is_foldable(foldable_node)
+                computed_value = _compute_foldability_from_xml(record)
+
+                if _foldable_matches_compute(is_foldable, computed_value):
+                    _remove_element(foldable_node)
+                elif is_foldable:
+                    # Old Boolean True doesn't match compute; replace with
+                    # the explicit selection value to preserve the intent.
+                    foldable_node.text = 'foldable'
+                    foldable_node.set('name', 'foldability')
+                    for attr in list(foldable_node.attrib):
+                        if attr != 'name':
+                            del foldable_node.attrib[attr]
+                else:
+                    record_id = record.get('id', 'unknown')
+                    inconsistencies.append(
+                        f"  {_file.path}: record '{record_id}' has "
+                        f"foldable='{is_foldable}' but compute gives '{computed_value}'"
+                    )
+
+        file.content = update_etree(file.content, process)
+        file_manager.print_progress(fileno, len(files), file.path)
+
+    if inconsistencies:
+        summary = "Foldability inconsistencies found:\n" + "\n".join(inconsistencies)
+        file_manager.add_to_summary(summary)


### PR DESCRIPTION
### [IMP] account: foldability as selection field
* After the groupby on the  report<sup>1</sup> was added and support of groupby on
aggregation being added, we don't want to have the groupby being applied
by default on the aggregation lines otherwise the report will be
unreadable.
   Therefore, changing the foldable boolean to a computed stored selection
field, allowing for default behaviour to be as intended while enabling
the user to change them on the line if needed.

* In upgrade_code: removing the unnecessary foldable field in reports data files if they
will be correctly computed.

* For inconsistencies reported by the script, manually set the foldability values
on the reports.

<sup>1</sup> : https://github.com/odoo/odoo/commit/05f1d84347c294f35b239d024e3b3c82bb6a9fb6

### [IMP] account: support groupby on aggregations
Added no_cross_report_expansion to _expand_aggregations for collecting
them to be computed alone with the correct date scope when expanded from an aggregation line that has groupby on it.

task-5891053

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
