### PR TITLE
[IMP] account: Use Vendor Prices in Vendor Bills if available

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1133,6 +1133,7 @@ class AccountMoveLine(models.Model):
                 document_type,
                 fiscal_position=line.move_id.fiscal_position_id,
                 product_uom=line.product_uom_id,
+                partner=line.move_id.partner_id
             )
 
     @api.depends('product_id', 'product_uom_id')

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -247,15 +247,14 @@ class ProductProduct(models.Model):
             if document_type == 'sale':
                 product_price_unit = product.with_company(company).lst_price
             elif document_type == 'purchase':
-                supplier_info_list = product._get_filtered_sellers(
-                    partner_id=partner, quantity=qty, date=fields.Date.context_today(self), uom_id=product_uom
-                ) if partner else False
-                if supplier_info_list:
-                    supplier_info = supplier_info_list[0]
-                    for item in supplier_info_list[1:]:
-                        if item.product_id:
-                            supplier_info = item
-                    product_price_unit = supplier_info[0].currency_id._convert(supplier_info[0].price_discounted, product_currency)
+                supplier_info = product._get_filtered_sellers(
+                    partner_id=partner,
+                    quantity=qty,
+                    date=fields.Date.context_today(self),
+                    uom_id=product_uom,
+                )[:1]
+                if supplier_info:
+                    product_price_unit = supplier_info.currency_id._convert(supplier_info.price_discounted, product_currency)
                 else:
                     product_price_unit = product.with_company(company).standard_price
             else:

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -221,7 +221,8 @@ class ProductProduct(models.Model):
 
     def _get_tax_included_unit_price(self, company, currency, document_date, document_type,
         is_refund_document=False, product_uom=None, product_currency=None,
-        product_price_unit=None, product_taxes=None, fiscal_position=None
+        product_price_unit=None, product_taxes=None, fiscal_position=None,
+        partner=None
     ):
         """ Helper to get the price unit from different models.
             This is needed to compute the same unit price in different models (sale order, account move, etc.) with same parameters.
@@ -244,7 +245,12 @@ class ProductProduct(models.Model):
             if document_type == 'sale':
                 product_price_unit = product.with_company(company).lst_price
             elif document_type == 'purchase':
-                product_price_unit = product.with_company(company).standard_price
+                supplier_info = self.env['product.supplierinfo'].search([
+                    ('company_id', '=', company.id),
+                    ('product_tmpl_id', '=', product.product_tmpl_id.id),
+                    ('partner_id', '=', partner.id),
+                ], limit=1) if partner else False
+                product_price_unit = supplier_info.price if supplier_info else product.with_company(company).standard_price
             else:
                 return 0.0
         if product_taxes is None:

--- a/addons/account/tests/test_product.py
+++ b/addons/account/tests/test_product.py
@@ -203,32 +203,37 @@ class TestProduct(AccountTestInvoicingCommon):
 
         self.env['product.supplierinfo'].create({
             'partner_id': vendor.id,
+            'product_id': product_cube_blue.id,
+            'price': 202.0,
+            'sequence': 1,
+        })
+        self.env['product.supplierinfo'].create({
+            'partner_id': vendor.id,
             'product_tmpl_id': product_tmpl_cube.id,
             'price': 101.0,
             'date_start': '2000-01-01',
             'date_end': '2100-01-01',
-        })
-        self.env['product.supplierinfo'].create({
-            'partner_id': vendor.id,
-            'product_id': product_cube_blue.id,
-            'price': 202.0
+            'sequence': 2,
         })
         self.env['product.supplierinfo'].create({
             'partner_id': vendor.id,
             'product_id': product_ball_red.id,
-            'price': 303.0
+            'price': 303.0,
+            'sequence': 3,
         })
         self.env['product.supplierinfo'].create({
             'partner_id': vendor.id,
             'product_id': product_ball_blue.id,
             'price': 404.0,
             'date_end': '2000-01-01',
+            'sequence': 4,
         })
         self.env['product.supplierinfo'].create({
             'partner_id': vendor.id,
             'product_id': product_ball_blue.id,
             'price': 405.0,
             'min_qty': 2.0,
+            'sequence': 5,
         })
 
         move_form = Form(self.env['account.move'].with_context({'default_move_type': 'in_invoice'}))


### PR DESCRIPTION
Adjusting price assignment for vendor products to check for `product.supplierinfo` records with prices set for this vendor-product combination instead of always using `standard_price`.
task-6076373

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
