### PR TITLE
[FIX] calendar: preserve duration when opening full form from quick create

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -13,6 +13,8 @@ const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
     stop_date: { type: "date" },
     stop: { type: "datetime" },
     allday: { type: "boolean" },
+    // forwards the duration kept in the hidden, force_save'd field of the quick-create form
+    duration: { type: "float" },
     partner_ids: { type: "many2many" },
     videocall_location: { type: "string" },
     description: { type: "string" }

--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -13,6 +13,7 @@ const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
     stop_date: { type: "date" },
     stop: { type: "datetime" },
     allday: { type: "boolean" },
+    duration: { type: "float" },
     partner_ids: { type: "many2many" },
     videocall_location: { type: "string" },
     description: { type: "string" }


### PR DESCRIPTION
When creating a calendar event by dragging on the calendar view, modifying the end time in the quick-create popover, and then clicking "More Options", the duration shown in the full form is the original drag value instead of the value implied by the user's updated stop.

calendar's makeContextDefaults seeds default_start, default_stop, default_duration, and default_allday from the drag extent. In the quick-create popover, changing stop triggers _compute_duration on that record so its duration becomes correct. On "More Options", goToFullEvent extracts a whitelist of fields from the quick-create record as default_X and merges them with the original drag context.

https://github.com/odoo/odoo/blob/c82341c503ac/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js#L9-L19

duration is missing from that whitelist, so the merged context still carries the stale default_duration from the drag. In the full form, that default is applied to the duration field and _compute_duration does not run because a default was provided for a stored, writable field.

Adding duration to the whitelist forwards the quick-create's recomputed value as default_duration so the full form opens with the correct duration.

Steps to reproduce:
1. Open Calendar, drag to create a 2-hour event (e.g. 10:00-12:00)
2. In the quick-create popover, change the end time to 14:00
3. Click "More Options"
4. Check the Duration field in the full form

=> Duration shows the original drag value (02:00) instead of 04:00

opw-6087449

