### PR TITLE
[FIX] account: Fix flaky account_tour

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -134,6 +134,14 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
+        isActive: ["auto"],
+        trigger: `body${accountTourSteps.postedInvoiceSelector} .o-mail-RecipientsInputTagsListPopover input`,
+        content: "Wait for animation frame",
+        async run(helpers) {
+            await helpers.animationFrame();
+        },
+    },
+    {
         // RecipientsInputTagsListPopover will not display if the customer already has an email address
         // unless it's possible to have optional steps, we will only use it for tests at the moment.
         isActive: ["auto"],


### PR DESCRIPTION
Since this PR https://github.com/odoo/odoo/pull/252877 the tour `account_tour` has become non-deterministic.

Reason:
The `onWillStart` method of `AccountMoveSendAttachmentsSelector` now loads `account.move` attachments, making the component loading much heavier than before. The heavy component (which is loaded as part of `account_tour`) is causing the tour to fail because the tour attempts to interact with the component before the browser has finished rendering it.

Fix:
Added a step to the tour before interaction with the account move send wizard to wait for the animation frame, which ensures that the browser has completed the paint cycle, preventing the non-deterministic behavior.

build_error-242317

