### PR TITLE
[FIX] hr_holidays: correct batched leave date computation

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -130,11 +130,13 @@ class HrEmployee(models.Model):
             for employee_id, interval in work_intervals.items():
                 if employee_id not in min_dts or not interval._items:
                     continue
-                # start time of the earliest interval
-                d1 = interval._items[0][0].astimezone(UTC).replace(tzinfo=None)
-                d2 = result.get(employee_id)
-                if (not d2 or d1 < d2) and min_dts[employee_id] < d1:
-                    result[employee_id] = d1
+                for start, _stop, _meta in interval._items:
+                    d1 = start.astimezone(UTC).replace(tzinfo=None)
+                    if min_dts[employee_id] < d1:
+                        d2 = result.get(employee_id)
+                        if not d2 or d1 < d2:
+                            result[employee_id] = d1
+                        break
 
         remaining = self.browse(min_dts)
         remaining.version_ids.fetch()  # prefetch data

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -81,6 +81,26 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'formatted display name should show the "Back on" formatted date'
         )
 
+    @freeze_time('2024-06-04')
+    def test_leave_ooo_batched(self):
+        self.assertFalse(self.employee_emp.leave_date_to, 'first employee should not be on leave')
+        self.assertFalse(self.employee_hruser.leave_date_to, 'second employee should not be on leave')
+        employees = self.employee_emp | self.employee_hruser
+        leaves = self.env['hr.leave'].create([{
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': "2024-06-03",
+            'request_date_to': "2024-06-06",
+        }, {
+            'employee_id': self.employee_hruser.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': "2024-06-02",
+            'request_date_to': "2024-06-05",
+        }])
+        leaves.write({'state': 'validate'})
+        employees.invalidate_recordset(["leave_date_to"])
+        self.assertEqual(employees.mapped("leave_date_to"), [date(2024, 6, 7), date(2024, 6, 6)])
+
 
 @tagged('out_of_office')
 @tagged('at_install', '-post_install')  # LEGACY at_install


### PR DESCRIPTION
Before this commit, in `_get_first_working_interval_batch` the `collect_employees` helper only inspected the first item of each employee's work interval.

The batch calendar query starts from the global `min_dt` which is the earliest leave end across all employees in the batch. For an employee whose leave ends later, the first returned interval can therefore still fall before that employee's own threshold (`min_dts[employee_id]`). The old code would discard that interval and, since it never examined subsequent ones, silently skip the employee with no result.

This commit fixes the issue by replacing the single-item check with a loop that iterates over all of the employee's intervals and picks the first start time strictly after `min_dts[employee_id]`.