### PR TITLE
[IMP] calendar: improve chatter meeting activity

### DIFF
--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -25,6 +25,7 @@ If you need to manage your meetings, you should install the CRM module.
         'security/ir.model.access.csv',
         'security/calendar_security.xml',
         'data/calendar_cron.xml',
+        'data/mail_templates_chatter.xml',
         'data/mail_template_data.xml',
         'data/calendar_data.xml',
         'data/mail_activity_type_data.xml',
@@ -42,6 +43,7 @@ If you need to manage your meetings, you should install the CRM module.
     'application': True,
     'assets': {
         'web.assets_backend': [
+            'calendar/static/src/core/common/**/*',
             'calendar/static/src/**/*',
         ],
         # Unit test files
@@ -51,6 +53,15 @@ If you need to manage your meetings, you should install the CRM module.
         ],
         'web.assets_tests': [
             'calendar/static/tests/tours/**/*',
+        ],
+        'mail.assets_public': [
+            'calendar/static/src/core/common/**/*',
+        ],
+        'im_livechat.assets_embed_core': [
+            'calendar/static/src/core/common/**/*',
+        ],
+        'portal.assets_chatter_helpers': [
+            'calendar/static/src/core/common/**/*',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/calendar/data/mail_templates_chatter.xml
+++ b/addons/calendar/data/mail_templates_chatter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="message_meeting_activity_done" inherit_id="mail.message_activity_done">
+            <xpath expr="//span[@t-field='activity.summary']" position="attributes">
+                <attribute name="t-if" add="not activity.calendar_event_id" separator=" and "/>
+            </xpath>
+            <xpath expr="//span[@t-field='activity.summary']" position="after">
+                <a t-if="activity.summary and activity.calendar_event_id" t-attf-href="/odoo/calendar.event/{{activity.calendar_event_id.id}}" title="View Meeting">
+                    <span t-field="activity.summary"/>
+                </a>
+            </xpath>
+            <xpath expr="//div/p[hasclass('o_mail_activity_title')]" position="inside">
+                <t t-if="attendee_names">
+                    <br/>
+                    <span t-out="truncated_attendee_names" t-att-title="attendee_names" class="text-muted"/>
+                </t>
+            </xpath>
+            <xpath expr="//div[hasclass('o_mail_activity_note')]" position="attributes">
+                <attribute name="t-if" add="not activity.calendar_event_id" separator=" and "/>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -26,6 +26,7 @@ from odoo.addons.calendar.models.calendar_recurrence import (
     BYDAY_SELECTION
 )
 from odoo.addons.calendar.models.utils import interval_from_events
+from odoo.addons.mail.tools.discuss import Store
 from odoo.tools.intervals import intervals_overlap
 from odoo.tools.translate import _
 from odoo.tools.misc import get_lang, babel_locale_parse
@@ -1899,3 +1900,11 @@ class CalendarEvent(models.Model):
         res = res or ir_default_get('calendar.event', 'duration', company_id=True)
         res = res or ir_default_get('calendar.event', 'duration')
         return res or 1
+
+    # ------------------------------------------------------------
+    # DISCUSS
+    # ------------------------------------------------------------
+
+    def _store_calendar_event_fields(self, res: Store.FieldList):
+        res.extend(["name", "start", "stop", "location"])
+        res.many("partner_ids", ["name"])

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -2,7 +2,7 @@
 from datetime import UTC
 
 from odoo import models, fields, tools, _
-from odoo.tools import is_html_empty
+from odoo.tools import format_list, is_html_empty
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -67,6 +67,26 @@ class MailActivity(models.Model):
         events.unlink()
         return res
 
+    def _get_activity_done_message_extra_values(self, activity):
+        """Extra values for the chatter template send on activity marked as done."""
+        event = activity.calendar_event_id
+        if not event.partner_ids:
+            return {}
+        attendee_names = format_list(self.env, event.partner_ids.mapped("name"))
+        attendee_count = len(event.partner_ids)
+        return {
+            "attendee_names": attendee_names,
+            "truncated_attendee_names": (
+                format_list(self.env, [
+                    *event.partner_ids[:2].mapped("name"),
+                    self.env._("%s others", attendee_count - 2),
+                ])
+                if attendee_count > 3
+                else attendee_names
+            ),
+        }
+
     def _store_activity_fields(self, res: Store.FieldList):
         super()._store_activity_fields(res)
-        res.extend(["calendar_event_id", "res_name"])
+        res.attr("res_name")
+        res.one("calendar_event_id", "_store_calendar_event_fields")

--- a/addons/calendar/static/src/core/common/calendar_event_model.js
+++ b/addons/calendar/static/src/core/common/calendar_event_model.js
@@ -1,0 +1,15 @@
+import { fields, Record } from "@mail/model/export";
+
+export class CalendarEvent extends Record {
+    static _name = "calendar.event";
+    /** @type {number} */
+    id;
+    /** @type {String} */
+    name;
+    /** @type {String} */
+    location;
+    start = fields.Datetime();
+    stop = fields.Datetime();
+    partner_ids = fields.Many("res.partner");
+}
+CalendarEvent.register();

--- a/addons/calendar/static/src/core/web/activity_model_patch.js
+++ b/addons/calendar/static/src/core/web/activity_model_patch.js
@@ -1,12 +1,11 @@
 import { Activity } from "@mail/core/common/activity_model";
-import { assignIn } from "@mail/utils/common/misc";
+import { fields } from "@mail/model/export";
 import { patch } from "@web/core/utils/patch";
 
-patch(Activity, {
-    _insert(data) {
-        const activity = super._insert(...arguments);
-        assignIn(activity, data, ["calendar_event_id"]);
-        return activity;
+patch(Activity.prototype, {
+    setup() {
+        super.setup();
+        this.calendar_event_id = fields.One("calendar.event");
     },
 });
 

--- a/addons/calendar/static/src/core/web/activity_patch.js
+++ b/addons/calendar/static/src/core/web/activity_patch.js
@@ -1,11 +1,38 @@
 import { Activity } from "@mail/core/web/activity";
-import { useService } from "@web/core/utils/hooks";
+import { formatList } from "@web/core/l10n/utils";
+import { isToday } from "@mail/utils/common/dates";
 import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
 
 patch(Activity.prototype, {
     setup() {
         super.setup();
         this.orm = useService("orm");
+        this.isToday = isToday;
+    },
+    get attendeeNames() {
+        if (!this.meeting || !this.meeting.partner_ids) {
+            return false;
+        }
+        return formatList(this.meeting.partner_ids.map((p) => p.name));
+    },
+    get dateFormat() {
+        return luxon.DateTime.DATE_FULL;
+    },
+    get meeting() {
+        return this.props.activity.calendar_event_id;
+    },
+    get timeFormat() {
+        return luxon.DateTime.TIME_SIMPLE;
+    },
+    get truncatedAttendeeNames() {
+        return this.meeting.partner_ids.length > 3
+            ? formatList([
+                ...this.meeting.partner_ids.slice(0, 2).map((p) => p.name),
+                _t("%s others", this.meeting.partner_ids.length - 2),
+            ])
+            : this.attendeeNames;
     },
     async onClickReschedule() {
         await this.props.activity.rescheduleMeeting();

--- a/addons/calendar/static/src/core/web/activity_patch.xml
+++ b/addons/calendar/static/src/core/web/activity_patch.xml
@@ -2,12 +2,36 @@
 <templates id="template" xml:space="preserve">
 
     <t t-inherit="mail.Activity" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o-mail-Activity-note')]" position="attributes">
+            <attribute name="t-if">!this.props.activity.calendar_event_id</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('o-mail-Activity-note')]" position="after">
+            <div t-if="meeting" class="mt-1">
+                <t t-set="startToday" t-value="this.isToday(meeting.start)"/>
+                <t t-set="stopToday" t-value="this.isToday(meeting.stop)"/>
+                <div t-if="!startToday || !stopToday">
+                    <t t-if="startToday">Today</t>
+                    <t t-else="" t-out="meeting.start.toLocaleString(this.dateFormat)"/>
+                    <t t-if="meeting.stop > meeting.start.startOf('day').plus({days: 1})">
+                        -
+                        <t t-if="stopToday">Today</t>
+                        <t t-else="" t-out="meeting.stop.toLocaleString(this.dateFormat)"/>
+                    </t>
+                </div>
+                <div class="d-flex flex-nowrap gap-4">
+                    <t t-out="meeting.start.toLocaleString(this.timeFormat)"/> - <t t-out="meeting.stop.toLocaleString(this.timeFormat)"/>
+                    <span t-if="attendeeNames" t-out="truncatedAttendeeNames" t-att-title="attendeeNames" class="text-muted"/>
+                </div>
+                <t t-if="meeting.location" t-out="meeting.location"/>
+                <t t-else="">Online</t>
+            </div>
+        </xpath>
         <xpath expr="//button[hasclass('o-mail-Activity-edit')]" position="attributes">
             <attribute name="t-if">!this.props.activity.calendar_event_id</attribute>
         </xpath>
         <xpath expr="//button[hasclass('o-mail-Activity-edit')]" position="after">
             <button t-if="this.props.activity.calendar_event_id" class="btn btn-link p-0 me-3" t-on-click="this.onClickReschedule">
-                <i class="fa fa-calendar"/> Reschedule
+                <i class="fa fa-calendar"/> View
             </button>
         </xpath>
     </t>

--- a/addons/calendar/static/tests/activity.test.js
+++ b/addons/calendar/static/tests/activity.test.js
@@ -18,7 +18,7 @@ const { DateTime } = luxon;
 defineCalendarModels();
 preloadBundle("web.fullcalendar_lib");
 
-test("activity click on Reschedule", async () => {
+test("activity click on View", async () => {
     registerArchs({ "calendar.event,false,calendar": `<calendar date_start="start"/>` });
     const pyEnv = await startServer();
     const resPartnerId = pyEnv["res.partner"].create({});
@@ -45,7 +45,7 @@ test("activity click on Reschedule", async () => {
     });
     await start();
     await openFormView("res.partner", resPartnerId);
-    await click(".btn", { text: "Reschedule" });
+    await click(".btn", { text: "View" });
     await contains(".o_calendar_view");
 });
 
@@ -76,7 +76,7 @@ test("Can delete activity linked to an event", async () => {
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click(".o-mail-Activity .btn", { text: "Reschedule" });
+    await click(".o-mail-Activity .btn", { text: "View" });
     await contains(".o_calendar_view");
     await animationFrame();
     await clickEvent(calendaMeetingId);

--- a/addons/calendar/static/tests/mock_server/mock_models/calendar_event.js
+++ b/addons/calendar/static/tests/mock_server/mock_models/calendar_event.js
@@ -1,8 +1,11 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import { models, fields, serverState } from "@web/../tests/web_test_helpers";
 
 export class CalendarEvent extends models.ServerModel {
     _name = "calendar.event";
 
+    start = fields.Datetime();
+    stop = fields.Datetime();
     user_id = fields.Generic({ default: serverState.userId });
     partner_id = fields.Generic({ default: serverState.partnerId });
     partner_ids = fields.Generic({ default: [[6, 0, [serverState.partnerId]]] });
@@ -13,5 +16,9 @@ export class CalendarEvent extends models.ServerModel {
 
     get_default_duration() {
         return 3.25;
+    }
+
+    _store_calendar_event_fields() {
+        return ["start", "stop", mailDataHelpers.Store.many("partner_ids", ["name"])];
     }
 }

--- a/addons/calendar/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/calendar/static/tests/mock_server/mock_models/mail_activity.js
@@ -1,3 +1,4 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import { mailModels, openView } from "@mail/../tests/mail_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
 import { serializeDate, today } from "@web/core/l10n/dates";
@@ -29,20 +30,14 @@ export class MailActivity extends mailModels.MailActivity {
         return res;
     }
 
-    /** @param {number[]} ids */
-    _to_store(store) {
-        super._to_store(...arguments);
-        for (const activity of this) {
-            const fieldsToStore = ["calendar_event_id", "res_name"];
-            const storeData = fieldsToStore.reduce((acc, key) => {
-                if (key in activity) {
-                    acc[key] = activity[key];
-                }
-                return acc;
-            }, {});
-            if (Object.keys(storeData).length) {
-                store._add_record_fields(this.browse(activity.id), storeData);
-            }
-        }
+    get _to_store_defaults() {
+        return [
+            ...super._to_store_defaults,
+            "res_name",
+            mailDataHelpers.Store.one(
+                "calendar_event_id",
+                this.env["calendar.event"]._store_calendar_event_fields(...arguments)
+            ),
+        ];
     }
 }

--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -11,15 +11,15 @@
 
         <template id="message_activity_done">
 <div>
-    <p>
+    <p class="o_mail_activity_title">
         <span t-attf-class="fa #{activity.activity_type_id.icon} fa-fw"/><span t-field="activity.activity_type_id.name"/> done
         <t t-if="display_assignee"> (originally assigned to <span t-field="activity.user_id.name"/>)</t>
         <span t-if="activity.summary">: </span><span t-if="activity.summary" t-field="activity.summary"/>
     </p>
-    <t t-if="activity.note and activity.note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"><!-- <p></br></p> -->
+    <div t-if="activity.note and activity.note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'" class="o_mail_activity_note"><!-- <p></br></p> -->
         <div class="o_mail_note_title fw-bold">Original note:</div>
         <div t-field="activity.note"/>
-    </t>
+    </div>
     <div t-if="feedback">
         <div class="fw-bold">Feedback:</div>
         <t t-foreach="feedback.split('\n')" t-as="feedback_line">

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -626,7 +626,8 @@ class MailActivity(models.Model):
                         render_values={
                             'activity': activity,
                             'feedback': feedback,
-                            'display_assignee': activity.user_id != self.env.user
+                            'display_assignee': activity.user_id != self.env.user,
+                            **self._get_activity_done_message_extra_values(activity),
                         },
                         mail_activity_type_id=activity.activity_type_id.id,
                         subtype_xmlid='mail.mt_activities',
@@ -912,3 +913,7 @@ class MailActivity(models.Model):
         deadline_threshold_dt = datetime.now() - relativedelta(years=year_threshold)
         old_overdue_activities = self.env['mail.activity'].search([('date_deadline', '<', deadline_threshold_dt)], limit=10_000)
         old_overdue_activities.unlink()
+
+    def _get_activity_done_message_extra_values(self, activity):
+        """To ease passing new values to the mail.message_activity_done chatter template."""
+        return {}


### PR DESCRIPTION
Purpose
=======
Improve the display of activities linked to a calendar.event
in the chatter by adding more information about the meeting.

Specification
=============
Display the meeting location, date / time ranges and list of attendees.
When the meeting activity is done, add a link to the calendar.event record form.

Technically, the activity is stored in the mail store service and
only contains the id of its related calendar.event.
To retrieve the meeting information, making an orm read is messy and
takes some time, meaning we don't have the meeting information at hand when
rendering the activity template in the chatter.

=> Adding the activities related calendar.event to the store service as well.
The stored activity calendar_event_id will now directly contain
the meeting information as a proxy object.

Task-6065385


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
