### PR TITLE
[FIX] web: re-render Many2OneReferenceField on model_field change

### DIFF
--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -539,8 +539,23 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             run: "fill test",
         },
         {
-            trigger:
-                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin):contains(test stage\nSearch more...)",
+            trigger: ".o-autocomplete--dropdown-item:contains(test stage)",
+            run: "click",
+        },
+        {
+            content: "Open select",
+            trigger: ".o_form_renderer #trigger_0",
+            run: "click",
+        },
+        // Because the tour runs too quickly, we cannot reliably detect the Many2OneReference re-rendering itself.
+        // To verify the update, we first use another model_field value to force the field to be destroyed,
+        // then switch to a value that recreates the Many2OneReference, and check that the field is present afterward.
+        {
+            trigger: ".o_select_menu_item:contains(User is set)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.o_field_widget[name='trg_field_ref']))",
         },
         {
             content: "Open select",
@@ -552,16 +567,12 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             run: "click",
         },
         {
-            trigger:
-                ".o_field_widget[name='trg_field_ref'] :not(:has(.o-autocomplete--dropdown-menu))",
-        },
-        {
             trigger: ".o_field_widget[name='trg_field_ref'] input",
             run: "fill test",
         },
         {
-            trigger:
-                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin):contains(test stage\nSearch more...)",
+            trigger: ".o-autocomplete--dropdown-item:contains(test tag)",
+            run: "click",
         },
         {
             trigger: ".o_form_button_cancel",

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -506,8 +506,7 @@ export function parseServerValue(field, value) {
             };
         }
         case "many2one_reference": {
-            if (value === 0) {
-                // unset many2one_reference fields' value is 0
+            if (!value) {
                 return false;
             }
             if (typeof value === "number") {

--- a/addons/web/static/src/views/fields/many2one_reference/many2one_reference_field.xml
+++ b/addons/web/static/src/views/fields/many2one_reference/many2one_reference_field.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="web.Many2OneReferenceField">
-        <Many2One t-props="this.m2oProps"/>
+        <Many2One t-props="this.m2oProps" t-key="relation"/>
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/fields/many2one_reference_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_reference_field.test.js
@@ -141,6 +141,20 @@ test("Many2OneReferenceField with model_field change in form view", async () => 
     expect(".o_field_widget[name=res_id] .o-autocomplete--dropdown-item").toHaveCount(4);
 });
 
+test("Many2OneReferenceField server value in form view", async () => {
+     await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="model"/>
+                <field name="res_id"/>
+            </form>`,
+    });
+
+    expect(".o_field_widget[name=res_id] .o_many2one").toHaveText("");
+});
+
 test.tags("desktop");
 test("Many2OneReferenceField edition: unset", async () => {
     expect.assertions(4);

--- a/addons/web/static/tests/views/fields/many2one_reference_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_reference_field.test.js
@@ -1,8 +1,9 @@
-import { expect, test } from "@odoo/hoot";
+import { animationFrame, expect, test } from "@odoo/hoot";
 import { queryAllTexts } from "@odoo/hoot-dom";
 import { runAllTimers } from "@odoo/hoot-mock";
 
 import {
+    clickFieldDropdown,
     clickFieldDropdownItem,
     clickSave,
     contains,
@@ -27,6 +28,7 @@ class Partner extends models.Model {
     _records = [
         { id: 1, model: "partner.type", res_id: 10 },
         { id: 2, res_id: false },
+        { id: 3 },
     ];
 }
 
@@ -40,7 +42,18 @@ class PartnerType extends models.Model {
     ];
 }
 
-defineModels([Partner, PartnerType]);
+class JobTitle extends models.Model {
+    id = fields.Integer();
+    name = fields.Char();
+
+    _records = [
+        { id: 20, name: "dev" },
+        { id: 24, name: "kitchen" },
+        { id: 27, name: "ba" },
+    ];
+}
+
+defineModels([Partner, PartnerType, JobTitle]);
 
 onRpc("has_group", () => true);
 
@@ -85,7 +98,7 @@ test("Many2OneReferenceField in list view", async () => {
             </list>`,
     });
 
-    expect(queryAllTexts(".o_data_cell")).toEqual(["gold", ""]);
+    expect(queryAllTexts(".o_data_cell")).toEqual(["gold", "", ""]);
 });
 
 test("Many2OneReferenceField with no_open option", async () => {
@@ -102,6 +115,30 @@ test("Many2OneReferenceField with no_open option", async () => {
 
     expect(".o_field_widget input").toHaveValue("gold");
     expect(".o_field_widget[name=res_id] .o_external_button").toHaveCount(0);
+});
+
+test.tags("desktop");
+test("Many2OneReferenceField with model_field change in form view", async () => {
+     await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 3,
+        arch: `
+            <form>
+                <field name="model"/>
+                <field name="res_id"/>
+            </form>`,
+    });
+
+    await contains(".o_field_widget[name=model] input").edit("partner.type");
+    await animationFrame();
+    await clickFieldDropdown("res_id");
+    expect(".o_field_widget[name=res_id] .o-autocomplete--dropdown-item").toHaveCount(3);
+
+    await contains(".o_field_widget[name=model] input").edit("job.title");
+    await animationFrame();
+    await clickFieldDropdown("res_id");
+    expect(".o_field_widget[name=res_id] .o-autocomplete--dropdown-item").toHaveCount(4);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
**Commit  1:**
When the model_field of a Many2OneReference changes, the underlying Many2One field fails to refresh its data source. This ensures the Many2One component re-renders to fetch data from the updated model.

Steps to reproduce:
- Create a new fields.Many2oneReference linked to a model_field
- Change the value of the model_field
> The values of the Many2oneReference field are not updated in the dropdown

**Commit 2:**
When the value for a Many2oneReference field coming from the API is false, it is not cleaned up by the web client, causing it to return an "Unnamed" result. This fix ensures that false values are correctly handled to prevent this display issue.

Steps to reproduce:
- Create a new fields.Many2oneReference linked to a model_field
- Select a model in the model_field
- Select a value in the Many2oneReference field
- Change the model_field to a different model.
- Save the record
> The Many2oneReference field displays "Unnamed" in both Form and List views

task-5993046