### PR TITLE
[FIX] sale_timesheet: correct invoice quantity when using days uom

### DIFF
--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -172,14 +172,13 @@ class SaleOrderLine(models.Model):
         if end_date:
             domain = expression.AND([domain, [('date', '<=', end_date)]])
         mapping = lines_by_timesheet.sudo()._get_delivered_quantity_by_analytic(domain)
-        timesheet_uom = self.order_id.timesheet_encode_uom_id
+        uom_hour = self.env.ref('uom.product_uom_hour')
 
         for line in lines_by_timesheet:
             qty_to_invoice = mapping.get(line.id, 0.0)
-            is_different_uom_category = line.product_uom.category_id == timesheet_uom.category_id
             if qty_to_invoice:
                 unit_amount = sum(line.timesheet_ids.filtered(lambda ts: start_date <= ts.date <= end_date and not ts.timesheet_invoice_id).mapped('unit_amount'))
-                units_to_invoice = timesheet_uom._compute_quantity(unit_amount, line.product_uom, rounding_method='HALF-UP') if is_different_uom_category else unit_amount
+                units_to_invoice = uom_hour._compute_quantity(unit_amount, line.product_uom, rounding_method='HALF-UP', raise_if_failure=False)
                 line.qty_to_invoice = units_to_invoice
             else:
                 prev_inv_status = line.invoice_status

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1294,28 +1294,35 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
     def test_invoice_timesheet_uom_conversion_with_period(self):
         """
-        Ensure that invoice quantities are correctly computed when the
-        sale order line UoM differs from the timesheet UoM.
+        Ensure that invoice quantities are correctly computed when:
+        - SOL and timesheet UoMs differ
+        - SOL and timesheet UoMs are the same (days)
         """
+        uom_days = self.env.ref('uom.product_uom_day')
+
+        # Case 1: SOL in Days, Encoding in Hours
         self.env.company.timesheet_encode_uom_id = self.uom_hour.id
-        product = self.env['product.product'].create({
-            'name': "Test service product",
+        product_vals = {
             'standard_price': 30,
             'list_price': 90,
             'type': 'service',
             'service_policy': 'delivered_timesheet',
-            'invoice_policy': 'delivery',
-            'service_type': 'timesheet',
             'service_tracking': 'task_global_project',
             'project_id': self.project_global.id,
             'taxes_id': False,
-            'uom_id': self.uom_hour.id,
-        })
-        uom_days = self.env.ref('uom.product_uom_day')
+        }
+        product_uom_hour, product_uom_days = self.env['product.product'].create([
+            {**product_vals, 'name': "Test product(Hour)", 'uom_id': self.uom_hour.id},
+            {**product_vals, 'name': "Test product(Days)", 'uom_id': uom_days.id}
+        ])
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
             'order_line': [
-                Command.create({'product_id': product.id, 'product_uom_qty': 3, 'product_uom': uom_days.id}),
+                Command.create({
+                    'product_id': product_uom_hour.id,
+                    'product_uom_qty': 3,
+                    'product_uom': uom_days.id
+                }),
             ],
         })
         sale_order.action_confirm()
@@ -1331,7 +1338,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         })
         context = {
             'active_model': 'sale.order',
-            'active_ids': [sale_order.id],
+            'active_ids': sale_order.ids,
             'active_id': sale_order.id,
             'default_journal_id': self.company_data['default_journal_sale'].id
         }
@@ -1339,11 +1346,50 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'advance_payment_method': 'delivered',
             'date_start_invoice_timesheet': '2026-03-16',
             'date_end_invoice_timesheet': '2026-03-20',
-            'sale_order_ids': [(6, 0, sale_order.ids)],
+            'sale_order_ids': [Command.set(sale_order.ids)],
         })
         invoice_dict = wizard.create_invoices()
         invoice = self.env['account.move'].browse(invoice_dict['res_id'])
         self.assertEqual(invoice.invoice_line_ids.quantity, 2)
+
+        # Case 2: Both SOL and Encoding in Days
+        self.env.company.timesheet_encode_uom_id = uom_days.id
+        sale_order_days = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product_uom_days.id,
+                    'product_uom_qty': 1,
+                    'product_uom': uom_days.id
+                }),
+            ],
+        })
+        sale_order_days.action_confirm()
+        task = sale_order_days.tasks_ids
+        self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'date': '2026-04-02',
+            'project_id': task.project_id.id,
+            'task_id': task.id,
+            'unit_amount': 8,
+            'employee_id': self.employee_user.id,
+            'company_id': self.company_data['company'].id,
+        })
+        context = {
+            'active_model': 'sale.order',
+            'active_ids': sale_order_days.ids,
+            'active_id': sale_order_days.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id
+        }
+        wizard = self.env['sale.advance.payment.inv'].with_context(context).create({
+            'advance_payment_method': 'delivered',
+            'date_start_invoice_timesheet': '2026-04-02',
+            'date_end_invoice_timesheet': '2026-04-02',
+            'sale_order_ids': [Command.set(sale_order_days.ids)],
+        })
+        invoice_dict = wizard.create_invoices()
+        invoice_days = self.env['account.move'].browse(invoice_dict['res_id'])
+        self.assertEqual(invoice_days.invoice_line_ids.quantity, 1)
 
 @tagged('-at_install', 'post_install')
 class TestSaleTimesheetAnalyticPlan(TestCommonSaleTimesheet):


### PR DESCRIPTION
**Steps to reproduce:**
1. Install sale_timesheet.
2. Set timesheet encoding UoM to "Days".
3. Create a quotation with a timesheet-based product:
   - Set quantity = 1
   - Set UoM to "Days"
 (ensure both SOL and timesheet UoM are in the same category)
4. Confirm the quotation and open the "Recorded" smart button.
5. Log 1 day of timesheet.
6. Create an invoice using a timesheet period (starting from SO date).
7. Check the invoice quantity.

**Issue:**
The invoice quantity is incorrectly set to 8 days instead of 1.

**Cause:**
https://github.com/odoo/odoo/blob/426dc7d7164a95020c1435625801e291990c865c/addons/sale_timesheet/models/sale_order_line.py#L182
Since commit a1517de, the logic utilizes the **timesheet encoding UoM** as the reference unit for conversions. When the Sales Order Line (SOL) UoM and the timesheet UoM share the same category, the system calls `_compute_quantity` under the assumption that `unit_amount` is expressed in the timesheet UoM.

However, `unit_amount` actually stored time in hours regardless of the encoding UoM. When the timesheet UoM is set to "Days," the system treats the raw hour value (e.g., 8.0) as if it were already in days during the conversion process, bypassing the necessary hour-to-day conversion and resulting in inflated invoice quantities.
https://github.com/odoo/odoo/blob/426dc7d7164a95020c1435625801e291990c865c/addons/uom/models/uom_uom.py#L231-L232

**Solution:**
Use hours as the reference unit instead of the timesheet UoM when calling `_compute_quantity`,
ensuring the source unit matches the actual unit of `unit_amount`.

opw-6077311





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
