### PR TITLE
[FIX] l10n_ro_edi_stock: Modify Send to eTransport button visibility

### DIFF
--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -375,7 +375,7 @@ class Picking(models.Model):
         for picking in self:
             picking.l10n_ro_edi_stock_enable_send = (
                     picking.l10n_ro_edi_stock_enable
-                    and picking.state == 'done'
+                    and picking.state in ('assigned', 'done')
                     and picking.l10n_ro_edi_stock_state in (False, 'stock_sending_failed')
                     and not picking._l10n_ro_edi_stock_get_last_document('stock_validated')
             )

--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
@@ -6,19 +6,14 @@ class Picking(models.Model):
 
     @api.depends('batch_id', 'company_id', 'picking_type_code')
     def _compute_l10n_ro_edi_stock_enable(self):
-        # OVERRIDES 'l10n_ro_edi_stock'
+        super()._compute_l10n_ro_edi_stock_enable()
         for picking in self:
-            picking.l10n_ro_edi_stock_enable = (
-                (not picking.batch_id or picking.batch_id.state != 'done')
-                and picking.picking_type_code != 'internal'
-                and picking.company_id.country_id.code == 'RO'
-            )
+            picking.l10n_ro_edi_stock_enable &= not picking.batch_id
 
     @api.model
     def _l10n_ro_edi_stock_validate_carrier_filter(self, picking):
-        # OVERRIDE l10n_ro_edi_stock
-
-        # Override for when the batch picking calls this function to validate the carriers
         validate_carrier = self.env.context.get('l10n_ro_edi_stock_validate_carrier', False)
-
-        return picking.company_id.account_fiscal_country_id.code == 'RO' and (picking.l10n_ro_edi_stock_enable or validate_carrier)
+        return (
+            super()._l10n_ro_edi_stock_validate_carrier_filter(picking)
+            or (picking.company_id.account_fiscal_country_id.code == 'RO' and validate_carrier)
+        )

--- a/addons/l10n_ro_edi_stock_batch/tests/test_batch_stock_etransport.py
+++ b/addons/l10n_ro_edi_stock_batch/tests/test_batch_stock_etransport.py
@@ -55,8 +55,8 @@ class TestBatchStockETransport(TestETransportFlows):
         batch.action_confirm()
 
         self.assertRecordValues(pickings.sorted('sale_id'), [
-            {'sale_id': self.sale_orders[0].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
-            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
+            {'sale_id': self.sale_orders[0].id, 'l10n_ro_edi_stock_enable': False, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
+            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': False, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
         ])
         self.assertRecordValues(batch, [
             {'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': True, 'picking_ids': pickings.ids},
@@ -89,8 +89,8 @@ class TestBatchStockETransport(TestETransportFlows):
 
         # Can send the batch but not the individual pickings
         self.assertRecordValues(pickings.sorted('sale_id'), [
-            {'sale_id': self.sale_orders[0].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
-            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
+            {'sale_id': self.sale_orders[0].id, 'l10n_ro_edi_stock_enable': False, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
+            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': False, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
         ])
         self.assertRecordValues(batch, [
             {'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': True, 'picking_ids': pickings.ids},
@@ -102,7 +102,7 @@ class TestBatchStockETransport(TestETransportFlows):
             # Can send as Done and not in the batch anymore
             {'sale_id': self.sale_orders[0].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': True, 'picking_type_code': 'outgoing'},
             # In the batch so should be sent in the batch
-            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
+            {'sale_id': self.sale_orders[1].id, 'l10n_ro_edi_stock_enable': False, 'l10n_ro_edi_stock_enable_send': False, 'picking_type_code': 'outgoing'},
         ])
         self.assertRecordValues(batch, [
             {'l10n_ro_edi_stock_enable': True, 'l10n_ro_edi_stock_enable_send': True, 'picking_ids': pickings[1].ids},


### PR DESCRIPTION
Currently, the Send to eTransport button on `stock.picking` is only visible when picking is done.
This PR fixes this behaviour and makes it visible when picking is ready or done both.

task-5930984

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
