### PR TITLE
[FIX] base: allow semicolon in `@import` of CSS assets

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -51,7 +51,7 @@ class AssetNotFound(AssetError):
 
 
 class AssetsBundle(object):
-    rx_css_import = re.compile("(@import[^;{]+;?)", re.M)
+    rx_css_import = re.compile(r"""(@import(\surl\(['"].*['"]\)|[^;{]+);?)""", re.M)
     rx_preprocess_imports = re.compile(r"""(@import\s?['"]([^'"]+)['"](;?))""")
     rx_css_split = re.compile(r"\/\*\! ([a-f0-9-]+) \*\/")
 

--- a/odoo/addons/test_assetsbundle/static/src/css/test_cssfile1.css
+++ b/odoo/addons/test_assetsbundle/static/src/css/test_cssfile1.css
@@ -1,3 +1,5 @@
+@import url("https://www.example.com/?param=with;semicolon");
+
 .rule1 {
     color: black;
 }

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1619,11 +1619,13 @@ class TestAssetsManifest(AddonManifestPatched):
         self.assertStringEqual(
             css_content,
             '''
+            @import url("https://www.example.com/?param=with;semicolon");
+
             /* /test_assetsbundle/static/src/css/test_cssfile3.css */
             .rule4{color: green;}
 
             /* /test_assetsbundle/static/src/css/test_cssfile1.css */
-            .rule1{color: black;}.rule2{color: yellow;}.rule3{color: red;}
+             .rule1{color: black;}.rule2{color: yellow;}.rule3{color: red;}
 
             /* /test_assetsbundle/static/src/css/test_cssfile2.css */
             .rule4{color: blue;}


### PR DESCRIPTION
__Before commit__
If a semicolon was inside the url of an `@import` directive, the line would be cut in the middle. Breaking the whole asset.

__Steps to reproduce__
1. Go to the website
2. Go to Site > HTML / CSS Editor
3. Click on the dropdown to show SCSS files
4. Paste this (valid) SCSS in `user_custom_rules.scss`:
  ```scss
  @import url('https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600;700&display=swap');
  ```
5. Save => The website CSS is broken

__Fix__
Adjust the regex that detects `@import` to take this into account.