### PR TITLE
[FIX] point_of_sale: correctly convert prices in multi-currency PoS

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -16,7 +16,7 @@ class ProductProduct(models.Model):
         taxes = self.env['account.tax'].search(self.env['account.tax']._check_company_domain(config.company_id.id))
         product_fields = taxes._eval_taxes_computation_prepare_product_fields()
         return list(product_fields.union({
-            'id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids',
+            'id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'currency_id',
             'product_template_attribute_value_ids', 'barcode', 'product_tag_ids', 'default_code', 'standard_price'
         }))
 
@@ -37,13 +37,20 @@ class ProductProduct(models.Model):
     @api.model
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
-        different_currency = config.currency_id != self.env.company.currency_id
-        if different_currency:
-            for product in read_records:
-                product['lst_price'] = self.env.company.currency_id._convert(
+
+        different_currency = {}
+        for product in read_records:
+            currency_id = product['currency_id']
+            if currency_id != config.currency_id.id:
+                different_currency.setdefault(currency_id, []).append(product)
+
+        for currency_id, products in different_currency.items():
+            currency = self.env['res.currency'].browse(currency_id)
+            for product in products:
+                product['lst_price'] = currency._convert(
                     product['lst_price'], config.currency_id, self.env.company, fields.Date.today()
                 )
-                product['standard_price'] = self.env.company.currency_id._convert(
+                product['standard_price'] = currency._convert(
                     product['standard_price'], config.currency_id, self.env.company, fields.Date.today()
                 )
         return read_records

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -166,7 +166,7 @@ class ProductTemplate(models.Model):
             'id', 'display_name', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name', 'list_price', 'is_favorite',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'tracking', 'type', 'service_tracking', 'is_storable',
             'write_date', 'color', 'pos_sequence', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_variant_ids', 'public_description',
-            'pos_optional_product_ids', 'sequence', 'product_tag_ids'
+            'pos_optional_product_ids', 'sequence', 'product_tag_ids', 'currency_id',
         ]
 
     @api.model
@@ -266,14 +266,20 @@ class ProductTemplate(models.Model):
             for tax in taxes:
                 taxes_by_company[tax.company_id.id].add(tax.id)
 
-        different_currency = config_id.currency_id != self.env.company.currency_id
+        different_currency = {}
+        for product in products:
+            currency_id = product['currency_id']
+            if currency_id != config_id.currency_id.id:
+                different_currency.setdefault(currency_id, []).append(product)
 
         self._add_archived_combinations(products)
-        for product in products:
-            if different_currency:
-                product['list_price'] = self.env.company.currency_id._convert(product['list_price'], config_id.currency_id, self.env.company, fields.Date.today())
-                product['standard_price'] = self.env.company.currency_id._convert(product['standard_price'], config_id.currency_id, self.env.company, fields.Date.today())
+        for currency_id, product_templates in different_currency.items():
+            currency = self.env['res.currency'].browse(currency_id)
+            for product in product_templates:
+                product['list_price'] = currency._convert(product['list_price'], config_id.currency_id, self.env.company, fields.Date.today())
+                product['standard_price'] = currency._convert(product['standard_price'], config_id.currency_id, self.env.company, fields.Date.today())
 
+        for product in products:
             product['image_128'] = bool(product['image_128'])
 
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3819,6 +3819,7 @@ class TestTaxCommonPOS(TestPointOfSaleHttpCommon, TestTaxCommon):
             'list_price': base_line['price_unit'],
             'taxes_id': [Command.set(base_line['tax_ids'].ids)],
             'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+            'company_id': self.env.company.id,
         })
 
     def ensure_products_on_document(self, document, product_prefix):


### PR DESCRIPTION
Before this commit, in a multi-currency environment, the company currency was used to convert the prices, while it was a wrong assumption that the product prices were in the company currency. The products have a currency_id field, and the price should be converted from that currency to the PoS config currency.

opw-6065969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
