### PR TITLE
[PERF] report: batch the export_data calls during data exports

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -11,11 +11,11 @@ from collections import OrderedDict
 
 from werkzeug.exceptions import InternalServerError
 
-from odoo import http
+from odoo import http, models
 from odoo.exceptions import UserError
 from odoo.http import content_disposition, request
 from odoo.tools import lazy_property, osutil
-from odoo.tools.misc import xlsxwriter
+from odoo.tools.misc import xlsxwriter, split_every
 
 
 _logger = logging.getLogger(__name__)
@@ -582,8 +582,13 @@ class ExportFormat(object):
         else:
             records = Model.browse(ids) if ids else Model.search(domain, offset=0, limit=False, order=False)
 
-            export_data = records.export_data(field_names).get('datas', [])
-            response_data = self.from_data(fields, columns_headers, export_data)
+            all_rows = []
+            for batch in split_every(models.PREFETCH_MAX, records.ids, Model.browse):
+                export_data = batch.export_data(field_names).get('datas', [])
+                all_rows.extend(export_data)
+                batch.invalidate_recordset()
+
+            response_data = self.from_data(fields, columns_headers, all_rows)
 
         _logger.info(
             "User %d exported %d %r records from %s. Fields: %s. %s: %s",


### PR DESCRIPTION
When exporting a number N of records as XLSX or CSV file, we call the export_data() method for the N records at the same time.
This method prefetches the selected fields for all the records which can lead to memory limit errors when N is too large.

We propose to batch this call and invalidate the recordsets between batches.

Benchmarks
-----------

Execution time:

| No records | Before PR | After PR |
|------------|-----------|----------|
|     70 260 |    3.82 s |   3.94 s |
|    228 116 |   18.71 s |  19.36 s |
|    394 381 |   31.02 s |  32.67 s |

Memory usage:

| No records | Before PR | After PR |
|------------|-----------|----------|
|     70 260 |  316.0 MB | 273.5 MB |
|    228 116 |  796.9 MB | 620.8 MB |
|    394 381 |    1.3 GB | 947.7 MB |

opw-5881026

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
