### PR TITLE
[FIX] point_of_sale: hide website on receipt when empty

### DIFF
--- a/addons/point_of_sale/receipt/pos_receipt_common.xml
+++ b/addons/point_of_sale/receipt/pos_receipt_common.xml
@@ -11,9 +11,11 @@
                         </td>
 
                         <td class="text-end top w-40" >
-                            <div>Tel: <t t-out="config['phone']"/></div>
-                            <div t-out="config['email']"/>
-                            <div t-out="config['website']"/>
+                            <div t-if="config['phone']">
+                                <div>Tel: <t t-out="config['phone']"/></div>
+                            </div>
+                            <div t-if="config['email']" t-out="config['email']"/>
+                            <div t-if="config['website']" t-out="config['website']"/>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Steps to reproduce:
1- Install Point of Sale
2- Open Company settings and make sure the website field is blank
3- Open a PoS session and cash out a customer
4- Print receipt

Description of issue:
Receipt prints "false" in the placeholder of the company website

Expected behavior:
Should not print anything in that space

Why this happens:
The commit aeaca09 introduces a refactor to the PoS receipts logic. In the newly created xml file, the company info fields are output without any conditional check which results in outputing "false" if they are empty.

opw-6085875