### PR TITLE
[FIX] purchase_stock: set date_promised new purchase line

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -99,10 +99,10 @@ class PurchaseOrderLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
+        confirmed_lines = lines.filtered(lambda l: l.order_id.state == 'purchase' and not l.display_type)
         if not self.env.context.get('bypass_move_update'):
-            confirmed_lines = lines.filtered(lambda l: l.order_id.state == 'purchase' and not l.display_type)
             confirmed_lines._create_or_update_picking()
-            confirmed_lines._set_date_promised()
+        confirmed_lines._set_date_promised()
         return lines
 
     def write(self, vals):

--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -45,6 +45,7 @@ class ResPartner(models.Model):
             ('date_order', '>', fields.Date.today() - timedelta(date_order_days_delta)),
             ('qty_received', '!=', 0),
             ('order_id.state', '=', 'purchase'),
+            ('date_promised', '!=', False),
             ('product_id', 'in', self.env['product.product'].sudo()._search([('type', '!=', 'service')]))
         ])
         lines_quantity = defaultdict(lambda: 0)

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -94,6 +94,17 @@ class TestCreatePicking(ProductVariantsCommon):
         self.assertRecordValues(backorder.move_line_ids, [
             {'product_id': self.product_id_2.id, 'quantity': 4, 'picking_type_id': receipt_type_id}])
 
+        backorder.button_validate()
+
+        # Ensure that, after all those operations, it is still possible to create a PO
+        # Need use of `Form` to ensure that all compute/onchange are working (cf commit)
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.po.partner_id
+        with po_form.order_line.new() as po_line:
+            po_line.product_id = self.product_id_2
+        po = po_form.save()
+        self.assertTrue(po)
+
     def test_01_check_double_validation(self):
 
         # make double validation two step


### PR DESCRIPTION
How to reproduce:
- Install both Purchase and Inventory application
- Create a PO with Vendor X (with a purchase line to be able to create a picking but the  purchase line in itself will not matter)
- Confirm Order > Receive
- Add a new move line with any product and atleast one quantity
- Validate
- Try to access or create any PO with the Vendor X

The problem:
A traceback is shown

Cause:
When accessing or creating a new PO with Vendor X, we compute his
`on_time_rate`. During this computation, we filter the moves using their
purchase line's `date_promised`
https://github.com/odoo/odoo/blob/7e60b3f3da2d7991220b164046a179b224384f9e/addons/purchase_stock/models/res_partner.py#L57

Commit [1] altered the behavior when creating new lines in a picking and a
slight oversight was made while forward-porting :
https://github.com/odoo/odoo/blob/7e60b3f3da2d7991220b164046a179b224384f9e/addons/purchase_stock/models/purchase_order_line.py#L102-L105
This makes it so `date_promised` is not set for these new lines and stays
`False`. Calling `.date()` on a bool creates a traceback

That said, the compute method should also be more robust since the field
`date_promised` is not required.

opw-6082456

[1] https://github.com/odoo/odoo/commit/52da6f77f7bf053b448f602196175b1354f70702