### PR TITLE
[FIX] point_of_sale: deprecated Pillow Image getdata() call

### DIFF
--- a/addons/point_of_sale/receipt/pos_order_receipt.py
+++ b/addons/point_of_sale/receipt/pos_order_receipt.py
@@ -106,18 +106,7 @@ class PosOrderReceipt(models.AbstractModel):
         qr.add_data(qrcode_url)
         qr.make(fit=True)
 
-        img = qr.make_image(fill_color="black", back_color="white").convert("RGBA")
-        datas = img.getdata()
-        newData = []
-
-        # Make white background fully transparent
-        for item in datas:
-            if item[0] > 240 and item[1] > 240 and item[2] > 240:
-                newData.append((255, 255, 255, 0))
-                continue
-            newData.append(item)
-
-        img.putdata(newData)
+        img = qr.make_image(fill_color="black", back_color="transparent")
 
         # Convert to base64
         buffer = BytesIO()


### PR DESCRIPTION
This commit simplifies the qrcode generation and background color handling while removing reliance on deprecated (since v12.1.0) Pillow Image getdata() function.

Reference:
- https://pillow.readthedocs.io/en/stable/deprecations.html#image-getdata
