### PR TITLE
[IMP] sale: control Services & Materials feature via sale settings

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -25,7 +25,7 @@ class ProductTemplate(models.Model):
     )
     sale_line_warn_msg = fields.Text(string="Sales Order Line Warning")
     reinvoice_policy = fields.Selection(
-        selection=[("no", "No"), ("cost", "At cost"), ("sales_price", "Sales price")],
+        selection=[("no", "No"), ("cost", "At cost"), ("sales_price", "At Sales price")],
         string="Re-Invoice Costs",
         default="no",
         compute="_compute_reinvoice_policy",
@@ -99,7 +99,9 @@ class ProductTemplate(models.Model):
     @api.depends("purchase_ok", "sale_ok")
     def _compute_visible_reinvoice_policy(self):
         self.visible_reinvoice_policy = False
-        if self.env.user.has_group("analytic.group_analytic_accounting"):
+        if self.env.user.has_group("analytic.group_analytic_accounting") or self.env.user.has_group(
+            "sale.group_services_and_material"
+        ):
             self.filtered(lambda pt: pt.purchase_ok or pt.sale_ok).visible_reinvoice_policy = True
 
     @api.depends("sale_ok")

--- a/addons/sale/security/res_groups.xml
+++ b/addons/sale/security/res_groups.xml
@@ -17,4 +17,7 @@
         <field name="name">Pro Forma Invoices</field>
     </record>
 
+    <record id="group_services_and_material" model="res.groups">
+        <field name="name">Enable Services and Materials in Sales</field>
+    </record>
 </odoo>

--- a/addons/sale/views/account_analytic_line_views.xml
+++ b/addons/sale/views/account_analytic_line_views.xml
@@ -40,7 +40,10 @@
                 <field
                     name="product_id"
                     domain="[('reinvoice_policy', '!=', 'no')]"
-                    context="{'default_reinvoice_policy' : 'sales_price'}"
+                    context="{
+                        'default_reinvoice_policy': 'sales_price',
+                        'default_invoice_policy': 'delivery'
+                    }"
                     required="True"
                     width="350px"
                 />

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -59,6 +59,7 @@
                     type="object"
                     class="oe_stat_button"
                     icon="fa-bars"
+                    groups="sale.group_services_and_material"
                     invisible="service_line_count == 0"
                 >
                     <field name="service_line_count" string="Services" widget="statinfo"/>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -30,7 +30,7 @@
                                nolabel="1" colspan="2"/>
                     </group>
                 </t>
-                <group name="expense_info" string="Expense" invisible="not visible_reinvoice_policy">
+                <group name="expense_info" string="Expenses, Services &amp; Materials" invisible="not visible_reinvoice_policy">
                     <field name="reinvoice_policy" widget="radio"/>
                 </group>
             </group>

--- a/addons/sale/views/sale_menus.xml
+++ b/addons/sale/views/sale_menus.xml
@@ -43,7 +43,7 @@
             <menuitem
                 id="menu_service_material"
                 action="action_service_material"
-                groups="analytic.group_analytic_accounting"
+                groups="sale.group_services_and_material"
                 sequence="10"
             />
 

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -29,6 +29,9 @@ class ResConfigSettings(models.TransientModel):
     group_warning_sale = fields.Boolean(
         string="Sale Order Warnings", implied_group="sale.group_warning_sale"
     )
+    group_services_and_material = fields.Boolean(
+        string="Services & Materials", implied_group="sale.group_services_and_material"
+    )
 
     # Config params
     automatic_invoice = fields.Boolean(

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -178,6 +178,12 @@
                         <setting id="setting_commission" help="Manage Sales &amp; teams targets and commissions">
                             <field name="module_sale_commission" widget="upgrade_boolean"/>
                         </setting>
+                        <setting
+                            id="setting_services_and_materials"
+                            help="Use fixed-price and cost-based services and materials for re-invoicing"
+                        >
+                            <field name="group_services_and_material"/>
+                        </setting>
                     </block>
                     <block title="Connectors" id="connectors_setting_container">
                         <setting id="amazon_connector" documentation="/applications/sales/sales/amazon_connector/setup.html" help="Import Amazon orders and sync deliveries">


### PR DESCRIPTION
Previously, the Services & Material feature depended on Analytic Accounting in Accounting settings.

Now it can be enabled or disabled directly from Sales settings.

Additionally, when a product is created from the Services & Materials view,
the invoicing policy is set to Delivered quantities by default.

task-6058770