### PR TITLE
[FIX] api_doc: docutils 0.22.4 deprecation warning

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -11,6 +11,7 @@ import typing
 from http import HTTPStatus
 
 import docutils.core
+from docutils.writers.html4css1 import Writer as HtmlWriter
 from werkzeug.exceptions import NotFound
 from werkzeug.http import is_resource_modified, parse_cache_control_header
 
@@ -651,7 +652,7 @@ class _DocUtils:
         root.append(tree)
         html = docutils.core.publish_from_doctree(
             root,
-            writer_name='html',
+            writer=HtmlWriter(),
             settings=cls._settings_html,
         )
         head = b'\n</head>\n<body>\n<div class="document">'


### PR DESCRIPTION
Argument "writer_name" will be removed in Docutils 2.0.  Specify writer name in the "writer" argument.

Reference:
- https://docutils.sourceforge.io/0.22/RELEASE-NOTES.html#writers
