### PR TITLE
[FIX] pos_self_order: fix combo price with free combo with 0 price

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -320,6 +320,7 @@ class PosOrder(models.Model):
 
             if index == len(child_line_free) - 1:
                 price_unit += remaining_total
+                remaining_total = 0
 
             selected_attributes = child.attribute_value_ids
             price_extra = sum(attr.price_extra for attr in selected_attributes)

--- a/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
@@ -145,6 +145,26 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Purple 3", attributes: [] },
         ]),
         ...commonSteps,
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Small Combo"),
+        ...ProductPage.setupCombo([{ product: "No Price 1", attributes: [] }], false), //Only one free and max so no need to click on add to cart
+        ...ProductPage.setupCombo([
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+        ]),
+        ...commonSteps,
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("No Free Combo"),
+        ...ProductPage.setupCombo([
+            { product: "First no Free 1", attributes: [] },
+            { product: "First no Free 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Second no Free 1", attributes: [] },
+            { product: "Second no Free 1", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([{ product: "Third no Free 2", attributes: [] }]),
+        ...commonSteps,
     ],
 });
 

--- a/addons/pos_self_order/tests/test_self_order_prices.py
+++ b/addons/pos_self_order/tests/test_self_order_prices.py
@@ -31,6 +31,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         })
 
         self.combo_category = self.env['pos.category'].create({'name': 'Combo Category'})
+        self.combo_no_price = self.combo_generator('No Price', [20.0, 30.0, 40.0], [0.0, 0.0, 0.0], 1, 1)
         self.combo1 = self.combo_generator('Green', [0.0, 5.0, 10.0], [50.0, 70.0, 90.0], 2, 1)
         self.combo2 = self.combo_generator('Red', [0.0, 0.0, 0.0], [40.0, 60.0, 80.0], 5, 0)
         self.combo3 = self.combo_generator('Purple', [10.0, 20.0, 30.0], [0, 0, 0], 10, 0)
@@ -39,6 +40,26 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'type': 'combo',
             'uom_id': self.env.ref('uom.product_uom_unit').id,
             'combo_ids': [(6, 0, [self.combo1.id, self.combo2.id, self.combo3.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
+        })
+        self.small_combo = self.env['product.product'].create({
+            'name': 'Small Combo',
+            'type': 'combo',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'combo_ids': [(6, 0, [self.combo_no_price.id, self.combo3.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
+        })
+
+        self.combo_no_free1 = self.combo_generator('First no Free', [20.0, 30.0, 40.0], [0.0, 5.0, 10.0], 2, 0)
+        self.combo_no_free2 = self.combo_generator('Second no Free', [10.0, 15.0, 3.0], [1.0, 3.0, 2.3], 3, 0)
+        self.combo_no_free3 = self.combo_generator('Third no Free', [1.3, 2.88, 9.43], [10.0, 20.0, 30.0], 4, 0)
+        self.no_free_combo = self.env['product.product'].create({
+            'name': 'No Free Combo',
+            'type': 'combo',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'combo_ids': [(6, 0, [self.combo_no_free1.id, self.combo_no_free2.id, self.combo_no_free3.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
             'available_in_pos': True,
         })


### PR DESCRIPTION
In a specific scenario where a combo had combo choice with free quaitites and combo choice with only extra quantities and the price of the combo choice with free quantities was 0, the price of the combo product was distributed on the "free" lines and on the "extra" lines, which was causing the price to be wrong.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
