### PR TITLE
[FIX] survey: prevent crash when printing survey without answers

### DIFF
--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -52,7 +52,7 @@
                                             </t>
                                             <t t-if="not question.is_page and not answer or (question in answer.predefined_question_ids &amp; questions_to_display)" >
                                                 <t t-set="answer_lines" t-value="answer.user_input_line_ids.filtered(lambda line: line.question_id == question)"/>
-                                                <t t-set="answer_line" t-value="answer_lines[0]"/>
+                                                <t t-set="answer_line" t-value="answer_lines[:1]"/>
                                                 <div t-att-id="question.id" t-attf-class="o_survey_question px-4 px-md-5">
                                                     <div class="d-flex justify-content-between gap-4">
                                                         <h3 class="h5">


### PR DESCRIPTION
Printing a survey without any answers currently triggers a rendering error because the template attempts to access an element from an empty recordset. Since the recordset contains no entries, this results in an index exception, causing the template engine to fail and display an error page.

Steps to reproduce:
1. Open a survey in the "Surveys" app
2. Click on the cog menu of the control panel
3. Select "Print Survey" from the dropdown menu

=> An error page is displayed instead of the survey

To resolve the issue, we will update the `survey_page_print` template to safely retrieve the first answer line by applying a slice operation [:1] on the `answer_lines` recordset that is currently causing the error. After this change, the user should be able to print the survey without answers.

See: odoo/odoo#247409

Task-6093043

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
