### PR TITLE
[FIX] website_sale_stock: limit number of combo product

### DIFF
--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -54,7 +54,9 @@ VariantMixin._onChangeCombinationStock = async function (ev, parent, combination
             ctaWrapper.classList.replace('d-flex', 'd-none');
             ctaWrapper.classList.add('out_of_stock');
         }
-    } else if (has_max_combo_quantity) {
+    }
+
+    if (has_max_combo_quantity) {
         if (addQtyInput) {
             addQtyInput.dataset.max = combination.max_combo_quantity || 1;
             if (qty > combination.max_combo_quantity) {

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_combo_configurator.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_combo_configurator.js
@@ -39,3 +39,36 @@ registry
             },
         ],
    });
+
+registry.category("web_tour.tours").add("test_website_sale_stock_max_combo", {
+    steps: () => [
+        {
+            content: "Select ComboProduct",
+            trigger: ".oe_product_cart:first a:contains('ComboProduct')",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "VariantMixin has set the maximum",
+            trigger: "input[name=add_qty][data-max='2']",
+        },
+        {
+            content: "Add one quantity",
+            trigger: ".css_quantity_plus",
+            run: "click",
+        },
+        {
+            content: "One quantity should be added",
+            trigger: "input[name=add_qty]:value(2)",
+        },
+        {
+            content: "Try to add one quantity",
+            trigger: ".css_quantity_plus",
+            run: "click",
+        },
+        {
+            content: "No quantity should be added",
+            trigger: "input[name=add_qty]:value(2)",
+        },
+    ],
+});

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_combo.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_combo.py
@@ -54,3 +54,25 @@ class TestWebsiteSaleStockProductCombo(HttpCase, WebsiteSaleStockCommon):
         })
 
         self.assertIsNone(combo._get_max_quantity(self.website, self.cart))
+
+    def test_website_sale_stock_max_combo(self):
+        """
+        Ensure we cannot add to the cart more units of a combo product than what is available in
+        stock (the maximum quantity of its combo items).
+        """
+        product1 = self._create_product(name='Test product1')
+        self.env['stock.quant']._update_available_quantity(product1, self.warehouse.lot_stock_id, 2)
+        product2 = self._create_product(name='Test product2')
+        self.env['stock.quant']._update_available_quantity(product2, self.warehouse.lot_stock_id, 1)
+        self._create_product(
+            name='ComboProduct',
+            type='combo',
+            combo_ids=[Command.create({
+                'name': 'Test combo',
+                'combo_item_ids': [
+                    Command.create({'product_id': product1.id}),
+                    Command.create({'product_id': product2.id}),
+                ],
+            })],
+        )
+        self.start_tour('/shop?search=ComboProduct', 'test_website_sale_stock_max_combo')


### PR DESCRIPTION
You cannot increase the quantity of a combo product that has options with Sell when Out-of-Stock disabled

Steps to reproduce:
1. Install Inventory and eCommerce
2. Go to Website > eCommerce > Products and create a new product "Combo"
3. Set the Product Type to Combo, create and edit a Combo Choice "test" with two options "test 1" and "test 2". Both have Track Inventory enabled, 5 Quantity On Hand and Sell when Out-of-Stock disabled
4. Publish product "Combo" to the website
5. Click on smart button "Go to Website" to open the shop page of product "Combo"
6. Try to increase the quantity
7. The quantity is limited to 1

Solution:
Always set the quantity input's maximum when `has_max_combo_quantity` is true

Issue:
We only set the quantity input's maximum if `allow_out_of_stock_order` is false
This error was introduced in https://github.com/odoo/odoo/commit/0247538efe788a9ff9a4d58f64470325348a4eaa

opw-6050876