### PR TITLE
[FIX] website_event_exhibitor: prevent invalid sponsor image srcset

### DIFF
--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -32,7 +32,7 @@
 <template id="event_sponsor_thumb_details">
     <div class="p-2">
         <span t-field="sponsor.image_128"
-            t-options='{"widget": "image", "class": "img img-fluid", "filename-field": "partner_name"}'/>
+            t-options='{"widget": "image", "class": "img img-fluid", "filename-field": "partner_name", "preview_image": "image_128"}'/>
     </div>
     <span t-if="sponsor.sudo().sponsor_type_id.display_ribbon_style and sponsor.sudo().sponsor_type_id.display_ribbon_style != 'no_ribbon'"
             t-field="sponsor.sudo().sponsor_type_id" t-attf-class="o_ribbon d-block w-100 ribbon_#{sponsor.sudo().sponsor_type_id.display_ribbon_style}"/>


### PR DESCRIPTION
Problem:
Sponsor logos were broken on the event sponsor footer cards after https://github.com/odoo/odoo/commit/36e680feca4884940e020119de6a13cd7f927516, even when `image_128` / `image_512` were set. The QWeb image widget generated a `srcset` including larger sizes (`image_1024`, `image_1920`) that do not exist on `event.sponsor`, allowing browsers to pick invalid URLs.

Cause:
The template renders `sponsor.image_128` with the generic image widget, which auto-generates a `srcset` from the image family. Without restricting it, larger nonexistent variants are included.

Solution:
Set `t-options` with `"preview_image": "image_128"` in the sponsor footer template to limit `srcset` to existing variant and ensure valid image URL is selected.

Task-6079695
