### PR TITLE
[FIX] im_livechat: missing variable in transcript template

### DIFF
--- a/addons/im_livechat/data/mail_templates.xml
+++ b/addons/im_livechat/data/mail_templates.xml
@@ -43,6 +43,7 @@
                                 </div>
                                 <t t-if="is_html_empty" t-set="is_body_empty" t-value="is_html_empty(message.body)"/>
                                 <t t-else="" t-set="is_body_empty" t-value="not message.body"/>
+                                <t t-set="is_deleted_message" t-value="message in deleted_messages"/>
                                 <div t-if="not is_body_empty or is_deleted_message" style="background-color: #E2F3F6; padding: 12px; border-radius: 0 0.46875rem 0.46875rem 0.46875rem; display: inline-block; max-width: 100%;">
                                     <span class="o-LivechatReport-bodyContent" style="font-size: 13px; word-break: break-word;">
                                         <p t-if="is_deleted_message" style="color: #6c757d; font-style: italic;">This message has been removed</p>


### PR DESCRIPTION
Follow up of [1], the `is_deleted_message` template variable is not defined which lead to empty bubbles for deleted messages.

[1]: https://github.com/odoo/odoo/pull/255325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
