### PR TITLE
[FIX] point_of_sale: do not block scale if hw_proxy is not connected

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
@@ -59,7 +59,6 @@ export class PosScaleService extends Reactive {
     async readWeight() {
         this.loading = true;
         try {
-            this._checkScaleIsConnected();
             this.weight = await this._getWeightFromScale();
             this._clearLastWeightIfValid();
         } catch (error) {
@@ -153,15 +152,6 @@ export class PosScaleService extends Reactive {
 
     get _roundingDecimalPlaces() {
         return Math.ceil(Math.log(1.0 / this.product.rounding) / Math.log(10));
-    }
-
-    _checkScaleIsConnected() {
-        if (this.hardwareProxy.connectionInfo.status !== "connected") {
-            throw new Error(_t("Cannot weigh product - IoT Box is disconnected"));
-        }
-        if (this.hardwareProxy.connectionInfo.drivers.scale?.status !== "connected") {
-            throw new Error(_t("Cannot weigh product - Scale is not connected to IoT Box"));
-        }
     }
 }
 


### PR DESCRIPTION
The new IoT image removes the `hw_proxy/status_json` endpoint, which results in the hardware proxy service thinking there are no devices connected to the IoT. We now remove this check from the scale service so that the new image works correctly with a scale.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
