### PR TITLE
[IMP] tools: trust automatically wrapped modules (`safe_eval`)

### DIFF
--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import types
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ from odoo.tools.safe_eval import (
     const_eval,
     safe_checker,
     safe_eval,
+    wrap_module,
 )
 from odoo.tools.safe_eval.runtime import (
     _SafeGenerator,
@@ -814,6 +816,40 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaises(UnsafeFunctionError):
             safe_checker.check(__import__)
         safe_checker.check(safe_eval._import)
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_trust_wrapped_custom_modules(self):
+
+        def _add_to_module(module: types.ModuleType, name: str, obj: object):
+            setattr(module, name, obj)
+            if hasattr(obj, '__module__'):
+                obj.__module__ = module.__name__
+
+        class C: ...
+
+        class Z: ...
+
+        def foo(): ...
+
+        custom_module = types.ModuleType('custom_module')
+        _add_to_module(custom_module, 'C', C)
+        _add_to_module(custom_module, 'Z', Z)
+        _add_to_module(custom_module, 'foo', foo)
+
+        wrapped_custom_module = wrap_module(custom_module, ['C', 'foo'], top_level_=True)
+
+        expr = """
+            custom_module.C()
+            custom_module.foo()
+        """
+        safe_eval(dedent(expr), {'custom_module': wrapped_custom_module}, mode='exec')
+
+        expr = """
+            # `custom_module.Z()` raises an `AttributeError`
+            Z()
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), {'Z': custom_module.Z}, mode='exec')
 
     def test_prevent_bypass_module(self):
         from collections import deque  # noqa: PLC0415

--- a/odoo/tools/safe_eval/evaluation.py
+++ b/odoo/tools/safe_eval/evaluation.py
@@ -480,7 +480,7 @@ Pre-wrapped modules are provided as attributes of `odoo.tools.safe_eval`.
 
 
 class wrap_module:
-    def __init__(self, module, attributes):
+    def __init__(self, module, attributes, top_level_=False):
         """Helper for wrapping a package/module to expose selected attributes
 
         :param module: the actual package/module to wrap, as returned by ``import <module>``
@@ -489,13 +489,18 @@ class wrap_module:
                                     are used as an ``attributes`` in case the
                                     corresponding item is a submodule
         """
+        # Determine if top-level instanciation
+        is_top_level = top_level_ or sys._getframe(1).f_code.co_name == '<module>'
         # builtin modules don't have a __file__ at all
         modfile = getattr(module, '__file__', '(built-in)')
         self._repr = f"<wrapped {module.__name__!r} ({modfile})>"
         for attrib in attributes:
             target = getattr(module, attrib)
             if isinstance(target, types.ModuleType):
-                target = wrap_module(target, attributes[attrib])
+                target = wrap_module(target, attributes[attrib], is_top_level)
+            elif is_top_level:
+                # Only attributes of top-level instanciations are trusted automatically
+                safe_whitelist.add_generic(target)
             setattr(self, attrib, target)
 
     def __repr__(self):

--- a/odoo/tools/safe_eval/runtime.py
+++ b/odoo/tools/safe_eval/runtime.py
@@ -467,7 +467,10 @@ class _SafeWhitelist:
     A wildcard '*' at the end of a qualified name to trust all objects
     within subpath namespace.
 
+    The `add_generic` method allows to trust an object using its object reference.
+
     .. code-block:: python
+        safe_whitelist.add_generic(<object>)
         safe_whitelist.add_class('odoo.orm.models.*')
         safe_whitelist.add_instance('odoo.orm.environments.Environment')
         safe_whitelist.add_function('odoo.tools.float_utils.float_compare')
@@ -530,6 +533,22 @@ class _SafeWhitelist:
         self._classes = list()
         self._instances = list()
         self._functions = list()
+
+    def add_generic(self, obj: object) -> None:
+        if isinstance(obj, type):
+            if obj not in safe_whitelist.TRUSTED_CLASSES:
+                self.add_class(self.get_full_path(obj))
+        elif isinstance(obj, (
+            FunctionType, MethodType, BuiltinMethodType,
+            MethodDescriptorType, MemberDescriptorType, GetSetDescriptorType,
+            ClassMethodDescriptorType, WrapperDescriptorType,
+        )):
+            if obj not in safe_whitelist.TRUSTED_FUNCTIONS:
+                self.add_function(self.get_full_path(obj))
+        else:
+            t_obj = type(obj)
+            if t_obj not in safe_whitelist.TRUSTED_CLASSES:
+                self.add_instance(self.get_full_path(t_obj))
 
     def add_class(self, qualname: str) -> None:
         self._classes.append(qualname)
@@ -736,26 +755,6 @@ def _initialize_safe_whitelist():
     safe_whitelist.add_function('odoo.tools.safe_eval.evaluation.<evaluated_code>.*')
     # Generators wrapper
     safe_whitelist.add_function('odoo.tools.safe_eval.runtime.safe_gen_wrapper.<locals>._wrapper')
-    # Wrapped modules
-    safe_whitelist.add_class('datetime.date')
-    safe_whitelist.add_class('datetime.datetime')
-    safe_whitelist.add_class('datetime.time')
-    safe_whitelist.add_class('datetime.timedelta')
-    safe_whitelist.add_class('datetime.timezone')
-    safe_whitelist.add_class('datetime.tzinfo')
-    safe_whitelist.add_class('dateutil.tz.tz.tzutc')
-    safe_whitelist.add_function('dateutil.parser.isoparser.isoparser.isoparse')
-    safe_whitelist.add_function('dateutil.parser._parser.parse')
-    safe_whitelist.add_class('dateutil.relativedelta.relativedelta')
-    safe_whitelist.add_class('dateutil.rrule.rrule')
-    safe_whitelist.add_class('dateutil.rrule.rruleset')
-    safe_whitelist.add_instance('dateutil.rrule._rrulestr')
-    safe_whitelist.add_function('json.dumps')
-    safe_whitelist.add_function('json.loads')
-    safe_whitelist.add_function('time.time')
-    safe_whitelist.add_function('time.strptime')
-    safe_whitelist.add_function('time.strftime')
-    safe_whitelist.add_function('time.sleep')
     # Monkey patches
     safe_whitelist.add_class('odoo._monkeypatches.zoneinfo.ZoneInfo')
     safe_whitelist.add_function('odoo._monkeypatches.*')


### PR DESCRIPTION
An instance of `wrap_module` allows us to place a mock module within the context of arbitrary code. This mechanism is widely used. Therefore, the whitelist must adapt automatically. Indeed, it would be annoying to manually whitelist all attributes of wrapped modules.

The `add_object` method has been added to `_SafeWhitelist` to trust an object using its object reference.

/!\ The whitelist is shared across a process.
This means that if a wrapped module is defined, its attributes will be whitelisted for all logic executed within that process.

Task-6084493