### PR TITLE
[FIX] mrp_account: set price_unit on byproduct moves for non-FIFO/AVCO costing

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -4,7 +4,7 @@ from ast import literal_eval
 from collections import defaultdict
 
 from odoo import api, fields, models, _
-from odoo.tools import float_round
+from odoo.tools import float_is_zero, float_round
 
 
 class MrpProduction(models.Model):
@@ -61,28 +61,35 @@ class MrpProduction(models.Model):
 
         work_center_cost = 0
         finished_move = self.move_finished_ids.filtered(
-            lambda x: x.product_id == self.product_id and x.state not in ('done', 'cancel') and x.quantity > 0)
+            lambda m: m.product_id == self.product_id and m.state not in ('done', 'cancel')
+            and m.product_uom.compare(m.quantity, 0) > 0)
         if finished_move:
-            if finished_move.product_id.cost_method not in ('fifo', 'average'):
-                finished_move.price_unit = finished_move.product_id.standard_price
-                return True
             finished_move.ensure_one()
             for work_order in self.workorder_ids:
                 work_center_cost += work_order._cal_cost()
             quantity = finished_move.product_uom._compute_quantity(
                 finished_move.quantity, finished_move.product_id.uom_id)
             extra_cost = self.extra_cost * quantity
-
             total_cost = sum(move.value for move in consumed_moves) + work_center_cost + extra_cost
-            byproduct_moves = self.move_byproduct_ids.filtered(lambda m: m.state not in ('done', 'cancel') and m.quantity > 0)
+
+            byproduct_moves = self.move_byproduct_ids.filtered(
+                lambda m: m.state not in ('done', 'cancel')
+                and m.product_uom.compare(m.quantity, 0) > 0)
             byproduct_cost_share = 0
             for byproduct in byproduct_moves:
-                if byproduct.cost_share == 0:
-                    continue
                 byproduct_cost_share += byproduct.cost_share
                 if byproduct.product_id.cost_method in ('fifo', 'average'):
-                    byproduct.price_unit = total_cost * byproduct.cost_share / 100 / byproduct.product_uom._compute_quantity(byproduct.quantity, byproduct.product_id.uom_id)
-            finished_move.price_unit = total_cost * float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001) / quantity
+                    if float_is_zero(byproduct.cost_share, precision_digits=2):
+                        continue
+                    byproduct_qty = byproduct.product_uom._compute_quantity(byproduct.quantity, byproduct.product_id.uom_id)
+                    byproduct.price_unit = total_cost * byproduct.cost_share / 100 / byproduct_qty if byproduct_qty else 0
+                else:
+                    byproduct.price_unit = byproduct.product_id.standard_price
+
+            if finished_move.product_id.cost_method not in ('fifo', 'average'):
+                finished_move.price_unit = finished_move.product_id.standard_price
+            else:
+                finished_move.price_unit = total_cost * float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001) / quantity
         return True
 
     def _get_backorder_mo_vals(self):

--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -4,7 +4,7 @@ from ast import literal_eval
 from collections import defaultdict
 
 from odoo import api, fields, models, _
-from odoo.tools import float_round
+from odoo.tools import float_compare, float_round
 
 
 class MrpProduction(models.Model):
@@ -65,6 +65,21 @@ class MrpProduction(models.Model):
         if finished_move:
             if finished_move.product_id.cost_method not in ('fifo', 'average'):
                 finished_move.price_unit = finished_move.product_id.standard_price
+                byproduct_moves = self.move_byproduct_ids.filtered(
+                    lambda m: m.state not in ('done', 'cancel') and float_compare(m.quantity, 0, precision_rounding=m.product_uom.rounding) > 0)
+                total_cost = None
+                for byproduct in byproduct_moves:
+                    if byproduct.product_id.cost_method not in ('fifo', 'average'):
+                        byproduct.price_unit = byproduct.product_id.standard_price
+                    elif byproduct.cost_share:
+                        if total_cost is None:
+                            for work_order in self.workorder_ids:
+                                work_center_cost += work_order._cal_cost()
+                            quantity = finished_move.product_uom._compute_quantity(
+                                finished_move.quantity, finished_move.product_id.uom_id)
+                            total_cost = sum(move.value for move in consumed_moves) + work_center_cost + self.extra_cost * quantity
+                        byproduct_qty = byproduct.product_uom._compute_quantity(byproduct.quantity, byproduct.product_id.uom_id)
+                        byproduct.price_unit = total_cost * byproduct.cost_share / 100 / byproduct_qty if byproduct_qty else 0
                 return True
             finished_move.ensure_one()
             for work_order in self.workorder_ids:
@@ -74,14 +89,17 @@ class MrpProduction(models.Model):
             extra_cost = self.extra_cost * quantity
 
             total_cost = sum(move.value for move in consumed_moves) + work_center_cost + extra_cost
-            byproduct_moves = self.move_byproduct_ids.filtered(lambda m: m.state not in ('done', 'cancel') and m.quantity > 0)
+            byproduct_moves = self.move_byproduct_ids.filtered(lambda m: m.state not in ('done', 'cancel') and float_compare(m.quantity, 0, precision_rounding=m.product_uom.rounding) > 0)
             byproduct_cost_share = 0
             for byproduct in byproduct_moves:
                 if byproduct.cost_share == 0:
                     continue
                 byproduct_cost_share += byproduct.cost_share
                 if byproduct.product_id.cost_method in ('fifo', 'average'):
-                    byproduct.price_unit = total_cost * byproduct.cost_share / 100 / byproduct.product_uom._compute_quantity(byproduct.quantity, byproduct.product_id.uom_id)
+                    byproduct_qty = byproduct.product_uom._compute_quantity(byproduct.quantity, byproduct.product_id.uom_id)
+                    byproduct.price_unit = total_cost * byproduct.cost_share / 100 / byproduct_qty if byproduct_qty else 0
+                else:
+                    byproduct.price_unit = byproduct.product_id.standard_price
             finished_move.price_unit = total_cost * float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001) / quantity
         return True
 

--- a/addons/mrp_account/tests/test_valuation_operation.py
+++ b/addons/mrp_account/tests/test_valuation_operation.py
@@ -36,11 +36,14 @@ class TestMrpValuationOperationStandard(TestBomPriceOperationCommon):
         moves = self.env['stock.move'].search([
             ('product_id', '=', self.scrap_wood.id),
         ])
+        # price_unit = total_cost * cost_share% / qty_in_product_uom
+        # line 1 (8 units, 1%):    (P+N) * 0.01 / 8  = (P+N) / 800
+        # line 2 (1 dozen, 12%):   (P+N) * 0.12 / 12 = (P+N) / 100
         self.assertRecordValues(moves, [
-            {'value': self.company.currency_id.round((PRICE + 10) * 0.01)},
-            {'value': self.company.currency_id.round((PRICE + 10) * 0.12)},
-            {'value': self.company.currency_id.round((PRICE + 20) * 0.01)},
-            {'value': self.company.currency_id.round((PRICE + 20) * 0.12)},
+            {'value': self.company.currency_id.round((PRICE + 10) * 0.01), 'price_unit': (PRICE + 10) / 800},
+            {'value': self.company.currency_id.round((PRICE + 10) * 0.12), 'price_unit': (PRICE + 10) / 100},
+            {'value': self.company.currency_id.round((PRICE + 20) * 0.01), 'price_unit': (PRICE + 20) / 800},
+            {'value': self.company.currency_id.round((PRICE + 20) * 0.12), 'price_unit': (PRICE + 20) / 100},
         ])
 
     # def test_average_cost_unbuild_with_byproducts(self):
@@ -76,6 +79,33 @@ class TestMrpValuationOperationStandard(TestBomPriceOperationCommon):
     #         {'product_id': self.scrap_wood.id, 'value': (PRICE + 10) * byproduct_cost_share},
     #         {'product_id': self.glass.id, 'value': 10},
     #     ])
+
+    def test_standard_finished_byproduct_price_unit(self):
+        """Standard-cost byproducts use their own standard_price when the
+        finished product is standard cost — the MO has no influence."""
+        (self.dining_table | self.scrap_wood).categ_id = self.category_standard
+        self._make_in_move(self.glass, 1, 10)
+        mo = self._create_mo(self.bom_1, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        self.assertEqual(mo.move_byproduct_ids.mapped('price_unit'), [30.0, 30.0])
+
+    def test_fifo_finished_standard_byproduct_price_unit(self):
+        """Standard-cost byproducts use their own standard_price even when the
+        finished product is FIFO. Their cost_share is still deducted from the
+        finished product so no value disappears from inventory."""
+        self.scrap_wood.categ_id = self.category_standard
+        self._make_in_move(self.glass, 1, 10)
+        mo = self._create_mo(self.bom_1, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        self.assertEqual(mo.move_byproduct_ids.mapped('price_unit'), [30.0, 30.0])
+        total_cost = PRICE + 10
+        byproduct_cost_share = sum(self.bom_1.byproduct_ids.mapped('cost_share')) / 100
+        self.assertEqual(
+            self.dining_table.total_value,
+            self.company.currency_id.round(total_cost * (1 - byproduct_cost_share)),
+        )
 
     def test_fifo_cost_scrap_kit_product(self):
         """Verify that scrapping a Kit correctly propagates FIFO valuation to the exploded component moves.

--- a/addons/mrp_account/tests/test_valuation_operation.py
+++ b/addons/mrp_account/tests/test_valuation_operation.py
@@ -77,6 +77,40 @@ class TestMrpValuationOperationStandard(TestBomPriceOperationCommon):
     #         {'product_id': self.glass.id, 'value': 10},
     #     ])
 
+    def test_standard_finished_byproduct_price_unit(self):
+        """Standard-cost byproducts use their own standard_price when the
+        finished product is standard cost — the MO has no influence."""
+        self.dining_table.categ_id = self.category_standard
+        self.scrap_wood.categ_id = self.category_standard
+        self.scrap_wood.standard_price = 30
+        self._make_in_move(self.glass, 1, 10)
+        mo = self._create_mo(self.bom_1, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        byproduct_moves = mo.move_byproduct_ids.filtered(lambda m: m.state == 'done')
+        for move in byproduct_moves:
+            self.assertAlmostEqual(move.price_unit, 30.0)
+
+    def test_fifo_finished_standard_byproduct_price_unit(self):
+        """Standard-cost byproducts use their own standard_price even when the
+        finished product is FIFO. Their cost_share is still deducted from the
+        finished product so no value disappears from inventory."""
+        self.scrap_wood.categ_id = self.category_standard
+        self.scrap_wood.standard_price = 30
+        self._make_in_move(self.glass, 1, 10)
+        mo = self._create_mo(self.bom_1, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        byproduct_moves = mo.move_byproduct_ids.filtered(lambda m: m.state == 'done')
+        for move in byproduct_moves:
+            self.assertAlmostEqual(move.price_unit, 30.0)
+        total_cost = PRICE + 10
+        byproduct_cost_share = 0.13
+        self.assertEqual(
+            self.dining_table.total_value,
+            self.company.currency_id.round(total_cost * (1 - byproduct_cost_share)),
+        )
+
     def test_fifo_cost_scrap_kit_product(self):
         """Verify that scrapping a Kit correctly propagates FIFO valuation to the exploded component moves.
         """


### PR DESCRIPTION
Steps to reproduce
1. Go to Manufacturing > Configuration > Settings and enable By-Products
2. Go to Inventory > Configuration > Locations, find the location with type
   Production and set the Cost of Production account
3. Go to Inventory > Configuration > Product Categories and set the costing
   method to Standard Price and Inventory Valuation to Perpetual (at invoicing)
4. Set the finished product and byproduct as Storable with a non-zero Cost
5. Create a BoM with a component and a byproduct with a Cost Share % assigned
6. Create and complete a manufacturing order
7. Check the journal entries of the MO: the byproduct entry shows $0

Issue
Standard-cost byproduct moves have no price_unit set in either code path
of _cal_price, so their journal entries always show $0.

When the finished product is standard cost, _cal_price returns early at
https://github.com/odoo/odoo/blob/55221db559cda1c61229eecf8493f5fbaee5cd50/addons/mrp_account/models/mrp_production.py#L66-L68
without iterating byproducts at all, so no price_unit is ever set on them.

When the finished product is FIFO/AVCO, the byproduct loop at
https://github.com/odoo/odoo/blob/55221db559cda1c61229eecf8493f5fbaee5cd50/addons/mrp_account/models/mrp_production.py#L83-L84
only sets price_unit for FIFO/AVCO byproducts. Standard byproducts are
skipped, giving them $0 even though their cost_share was already deducted
from the finished product, making value disappear from inventory entirely.

For standard-cost products the MO has no influence on their value — they
always use the standard_price from the product form, regardless of cost_share.

Solution
In the early-return branch, iterate byproducts: standard ones get
standard_price, FIFO/AVCO ones get total_cost * cost_share.
In the FIFO/AVCO branch, add the same standard_price fallback so standard
byproducts are no longer left at $0 when their cost_share is set.

opw-6020065