### PR TITLE
[FIX] web: fix some edge cases in the display of file sizes

### DIFF
--- a/addons/web/static/src/core/utils/binary.js
+++ b/addons/web/static/src/core/utils/binary.js
@@ -14,7 +14,7 @@ export function isBinarySize(value) {
  * @returns {number} number of char
  */
 export function toBase64Length(maxBytes) {
-    return Math.ceil(maxBytes * 4 / 3);
+    return Math.ceil((maxBytes * 4) / 3);
 }
 
 /**
@@ -22,11 +22,11 @@ export function toBase64Length(maxBytes) {
  * @param {string}
  */
 export function humanSize(size) {
-    const units = _t("Bytes|Kb|Mb|Gb|Tb|Pb|Eb|Zb|Yb").split("|");
+    const units = _t("Bytes|kB|MB|GB|TB|PB|EB|ZB|YB").split("|");
     let i = 0;
     while (size >= 1024) {
         size /= 1024;
         ++i;
     }
-    return `${size.toFixed(2)} ${units[i].trim()}`;
+    return `${i === 0 ? size : size.toFixed(2)} ${units[i].trim()}`;
 }

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -7,7 +7,7 @@ import {
 import { localization as l10n } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { isBinarySize } from "@web/core/utils/binary";
+import { humanSize, isBinarySize } from "@web/core/utils/binary";
 import {
     formatFloat as formatFloatNumber,
     humanNumber,
@@ -20,22 +20,6 @@ import { formatCurrency } from "@web/core/currency";
 import { normalizeTimeStr } from "@web/core/l10n/time";
 
 // -----------------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------------
-
-function humanSize(value) {
-    if (!value) {
-        return "";
-    }
-    const suffix = value < 1024 ? " " + _t("Bytes") : "b";
-    return (
-        humanNumber(value, {
-            decimals: 2,
-        }) + suffix
-    );
-}
-
-// -----------------------------------------------------------------------------
 // Exports
 // -----------------------------------------------------------------------------
 
@@ -46,8 +30,7 @@ function humanSize(value) {
 export function formatBinary(value) {
     if (!isBinarySize(value)) {
         // Computing approximate size out of base64 encoded string
-        // http://en.wikipedia.org/wiki/Base64#MIME
-        return humanSize(value.length / 1.37);
+        return humanSize(Math.round(value.length * 0.75));
     }
     // already bin_size
     return value;

--- a/addons/web/static/tests/core/utils/binary.test.js
+++ b/addons/web/static/tests/core/utils/binary.test.js
@@ -8,10 +8,10 @@ describe.current.tags("headless");
 
 test("humanSize", () => {
     allowTranslations();
-    expect(humanSize(0)).toBe("0.00 Bytes");
-    expect(humanSize(3)).toBe("3.00 Bytes");
-    expect(humanSize(2048)).toBe("2.00 Kb");
-    expect(humanSize(2645000)).toBe("2.52 Mb");
+    expect(humanSize(0)).toBe("0 Bytes");
+    expect(humanSize(3)).toBe("3 Bytes");
+    expect(humanSize(2048)).toBe("2.00 kB");
+    expect(humanSize(2645000)).toBe("2.52 MB");
 });
 
 test("resize image", async () => {

--- a/addons/web/static/tests/views/fields/binary_field.test.js
+++ b/addons/web/static/tests/views/fields/binary_field.test.js
@@ -330,7 +330,7 @@ test("BinaryField in list view (formatter)", async () => {
         type: "list",
         arch: `<list><field name="document"/></list>`,
     });
-    expect(`.o_data_row .o_data_cell`).toHaveText("93.43 Bytes");
+    expect(`.o_data_row .o_data_cell`).toHaveText("96 Bytes");
 });
 
 test("BinaryField in list view with filename", async () => {

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -19,6 +19,7 @@ import {
     formatX2many,
     formatDate,
     formatDateTime,
+    formatBinary,
 } from "@web/views/fields/formatters";
 
 const { DateTime } = luxon;
@@ -248,13 +249,17 @@ test("formatFloatTime special cases", () => {
 
     localization.locale = "ar-SY";
     expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("١س ١٥د ٤٥ث");
-    expect(formatFloatTime(1.25 + 45 / 3600, { ...options, numeric: true })).toBe(
-        "1:15:45"
-    );
+    expect(formatFloatTime(1.25 + 45 / 3600, { ...options, numeric: true })).toBe("1:15:45");
 
     localization.locale = "th-TH";
     expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1ชม. 15นาที 45วิ");
 
     localization.locale = "hi-IN";
     expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1घं 15मि 45से");
+});
+
+test("formatBinary", () => {
+    expect(formatBinary("1.5 MB")).toBe("1.5 MB", { message: "binary sizes are not modified" });
+    expect(formatBinary("aGVsbG8=")).toBe("6 Bytes");
+    expect(formatBinary("a".repeat(3000))).toBe("2.20 kB");
 });


### PR DESCRIPTION
The generally accepted symbol for bytes is an uppercase B, while a
lowercase b generally designates bits and is largely used when referring
to data transfer rates (kbps, Mbps, etc.). In a similar vein, the
commonly accepted prefix for kilo is a lowercase k.

This commit changes the humanNumber util used for formatting sizes to
use the generally accepted uppercase B and lowercase k.

It also makes it so that the binary field formatter calls this util
instead of reimplementing it on top of humanNumber. In this specific
case it also fixes a minor issue where the result of dividing the length
of the Base64 encoded string could result in fractional number of bytes,
which doesn't make sense for file sizes, and changes the division by
1.37 to a multiplication by .75, the 1.37 figure is specifically for
Base64 encoded files in email that have a max line length of 76, which
is irrelevant for this case. The size is still approximate because of
padding.

Lastly, we do not display .00 after numbers with a unit of "Bytes" as
these digits are not significant (because again, fractional bytes don't
make sense for file sizes)