### PR TITLE
[FIX] hr: avatar crash on recruiter assignment in kanban view

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -8,7 +8,7 @@
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128?unique={{autoCompleteItemScope.record.data.write_date.ts}}"/>
+                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                     <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open Recruitments
2. Find a job position without a recruiter in the kanban view
3. Clicking on the assign recruiter widget produces a traceback

**Bug Cause:**
The `?unique=` cache related parameter was added to the avatar image URL in the `autoCompleteItem` slot of `KanbanMany2OneAvatarEmployeeField`. This parameter relies on `write_date` being available on the autocomplete suggestion record. However, `web_name_search` only returns `id` and `display_name`, so `write_date` is undefined on
autocomplete suggestion records, causing a crash when accessing `autoCompleteItemScope.record.data.write_date.ts`.

**Bug Solution:**
Remove the `?unique=` parameter from the avatar image URL in the `autoCompleteItem` slot, reverting it to its original form. Cache is unnecessary for autocomplete suggestion avatars as they are only visible for the duration of the dropdown interaction.

**Task:** 6092768
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
