### PR TITLE
[FIX] web: hoot suites: more accurate timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -196,7 +196,8 @@ class WebSuite(HootCommon, odoo.tests.CrossModule):
         filters = self._get_hoot_filters(addons_from_asset_bundle, modules)
         if not filters:
             return
-        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=desktop&timeout=15000{filters}', "", "", login='admin', timeout=3600, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+        timeout = 5400 if self.is_test_all else 1800
+        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=desktop&timeout=15000{filters}', "", "", login='admin', timeout=timeout, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
 
 
 @odoo.tests.tagged('hoot', 'post_install', '-at_install')
@@ -211,7 +212,8 @@ class MobileWebSuite(HootCommon, odoo.tests.CrossModule):
         filters = self._get_hoot_filters(addons_from_asset_bundle, modules)
         if not filters:
             return
-        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000{filters}', "", "", login='admin', timeout=2100, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+        timeout = 5400 if self.is_test_all else 1800
+        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000{filters}', "", "", login='admin', timeout=timeout, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
 
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -115,8 +115,10 @@ class TagsSelector(object):
                     test_filter_module = test_filter[1]
                     if test_filter_module:
                         included_modules.add(test_filter_module)
+                        test.is_test_all = False
                     else:
                         included_modules |= self.available_modules
+                        test.is_test_all = True
                 else:
                     break
 


### PR DESCRIPTION
Hoot suites (test_unit_desktop and test_unit_mobile) are now split and run in each sub builds on runbot [1]. As a consequence, the historical timeout isn't accurate anymore (we don't need a 1h timeout when only a part of the suite is run in a sub build). On the other hand, the whole suite is also run at once in nightly builds. There, the 1h timeout is sometimes not enough, as the suite keeps growing.

This commit makes the timeout more accurate by taking into account 2 different cases: if the suite is run for a subset of modules, or if it is run for the whole codebase. This allows it to timeout earlier on regular builds if it is deadlocked, and it doesn't timeout anymore on nightly builds.

[1] https://github.com/odoo/odoo/pull/234132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
