### PR TITLE
[FIX] website: start countdown interaction in snippet preview dialog

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/countdown.edit.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.edit.js
@@ -19,3 +19,8 @@ registry
         Interaction: Countdown,
         mixin: CountdownEdit,
     });
+registry
+    .category("public.interactions.preview")
+    .add("website.countdown", {
+        Interaction: Countdown,
+    });


### PR DESCRIPTION
The content of the countdown snippet did not appear in snippets preview dialog, because the interaction that fills it was not loaded for preview.

This commit adds the interaction in the registry for loading it inside the iframe of the snippets preview dialog.

Steps to reproduce:
- Open website builder
- Drop a `s_text_image` snippet
- Drop a `s_countdown` snippet inside
- Save the first one as a custom snippet
- Click on "Custom" snippets category
- Bug: the countdown does not appear

task-6088029
