### PR TITLE
[IMP] sale_project_*: update timesheet report category

### DIFF
--- a/addons/mrp_account/models/analytic_account.py
+++ b/addons/mrp_account/models/analytic_account.py
@@ -76,7 +76,7 @@ class AccountAnalyticAccount(models.Model):
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
-    category = fields.Selection(selection_add=[('manufacturing_order', 'Manufacturing Order')])
+    category = fields.Selection(selection_add=[('manufacturing_order', 'Manufacturing Orders')])
 
 
 class AccountAnalyticApplicability(models.Model):

--- a/addons/project_mrp_sale/__init__.py
+++ b/addons/project_mrp_sale/__init__.py
@@ -1,1 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/project_mrp_sale/models/__init__.py
+++ b/addons/project_mrp_sale/models/__init__.py
@@ -1,5 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_analytic_line
-from . import account_move_line
-from . import hr_expense

--- a/addons/project_mrp_sale/models/account_analytic_line.py
+++ b/addons/project_mrp_sale/models/account_analytic_line.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    billable_type = fields.Selection(selection_add=[('14_manufacturing_order', 'Manufacturing Orders')])
+
+    def _set_billable_cost(self):
+        aals_mrp = self.filtered(lambda aal: aal.category == 'manufacturing_order')
+        aals_mrp.billable_type = '14_manufacturing_order'
+        super(AccountAnalyticLine, self - aals_mrp)._set_billable_cost()

--- a/addons/project_sale_expense/models/account_analytic_line.py
+++ b/addons/project_sale_expense/models/account_analytic_line.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    category = fields.Selection(selection_add=[('expense', 'Expense')])
+    billable_type = fields.Selection(selection_add=[('13_expense', 'Expenses')])
+
+    def _set_billable_cost(self):
+        aals_expense = self.filtered(lambda aal: aal.category == 'expense')
+        aals_expense.billable_type = '13_expense'
+        super(AccountAnalyticLine, self - aals_expense)._set_billable_cost()

--- a/addons/project_sale_expense/models/account_move_line.py
+++ b/addons/project_sale_expense/models/account_move_line.py
@@ -15,3 +15,9 @@ class AccountMoveLine(models.Model):
         mapping_from_expense = self._get_so_mapping_from_expense()
         mapping_from_project.update(mapping_from_expense)
         return mapping_from_project
+
+    def _prepare_analytic_distribution_line(self, distribution, account_ids, distribution_on_each_plan):
+        vals = super()._prepare_analytic_distribution_line(distribution, account_ids, distribution_on_each_plan)
+        if self.expense_id:
+            vals['category'] = 'expense'
+        return vals

--- a/addons/sale_project/models/account_analytic_line.py
+++ b/addons/sale_project/models/account_analytic_line.py
@@ -8,7 +8,8 @@ BILLABLE_TYPES = [
     ('07_revenues_manual', 'Revenues (Manual)'),
     ('10_service_revenues', 'Service Revenues'),
     ('11_other_revenues', 'Other Revenues'),
-    ('12_other_costs', 'Other Costs'),
+    ('12_vendor_bill', 'Vendor Bills'),
+    ('30_other_costs', 'Other Costs'),
 ]
 
 
@@ -18,7 +19,11 @@ class AccountAnalyticLine(models.Model):
     billable_type = fields.Selection(BILLABLE_TYPES, string="Billable Type",
         compute='_compute_project_billable_type', compute_sudo=True, store=True, readonly=True)
 
-    @api.depends('so_line.product_id', 'amount')
+    category_report = fields.Selection(
+        [('costs', 'Costs'), ('revenues', 'Revenues')],
+        compute='_compute_category_report', compute_sudo=True, store=True, readonly=True)
+
+    @api.depends('so_line.product_id', 'amount', 'category')
     def _compute_project_billable_type(self):
         for line in self:
             if line.amount >= 0 and line.unit_amount >= 0:
@@ -37,9 +42,27 @@ class AccountAnalyticLine(models.Model):
                         invoice_type = '01_revenues_fixed'
                     else:
                         invoice_type = '11_other_revenues'
-                    line.billable_type = invoice_type
+                    line.billable_type = line._get_invoice_type(invoice_type)
             else:
-                line.billable_type = '12_other_costs'
+                line._set_billable_cost()
+
+    def _set_billable_cost(self):
+        if self.category == 'vendor_bill':
+            self.billable_type = '12_vendor_bill'
+        else:
+            self.billable_type = '30_other_costs'
+
+    def _get_invoice_type(self, invoice_type):
+        return invoice_type
+
+    @api.depends('billable_type')
+    def _compute_category_report(self):
+        for line in self:
+            if line.billable_type in ['01_revenues_fixed', '05_revenues_milestones', '07_revenues_manual',
+                                      '10_service_revenues', '11_other_revenues']:
+                line.category_report = 'revenues'
+            else:
+                line.category_report = 'costs'
 
     def action_open_account_analytic_line_origine(self):
         self.ensure_one()

--- a/addons/sale_project/report/account_analytic_line_views.xml
+++ b/addons/sale_project/report/account_analytic_line_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='date']" position="after">
                 <field name="category" type="row"/>
+                <field name="category_report" type="col"/>
             </xpath>
             <xpath expr="//field[@name='date']" position="replace">
                 <field name="account_id" type="col"/>
@@ -42,11 +43,23 @@
         </field>
     </record>
 
+    <record id="sale_project_line_search" model="ir.ui.view">
+        <field name="name">sale_project.account.analytic.margins.search</field>
+        <field name="model">account.analytic.line</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="account.view_account_analytic_line_filter_inherit_account"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='category']" position="replace">
+                <filter string="Category" name='category' context="{'group_by': 'category_report'}"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_analytic_reporting_inherit_sale_project" model="ir.actions.act_window">
         <field name="name">Real Margins</field>
         <field name="res_model">account.analytic.line</field>
         <field name="path">project-actual-margins</field>
-        <field name="search_view_id" ref="account.view_account_analytic_line_filter_inherit_account"/>
+        <field name="search_view_id" ref="sale_project.sale_project_line_search"/>
         <field name="view_id" ref="view_account_analytic_line_inherit_sale_project_pivot"/>
         <field name="view_mode">pivot,list,kanban,graph</field>
         <field name="context">{

--- a/addons/sale_project_stock/models/__init__.py
+++ b/addons/sale_project_stock/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_analytic_line
 from . import project_project
 from . import stock_move
 from . import stock_picking

--- a/addons/sale_project_stock/models/account_analytic_line.py
+++ b/addons/sale_project_stock/models/account_analytic_line.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    billable_type = fields.Selection(selection_add=[('15_picking_entry_positive', 'Inventory Transfers (Revenues)'),
+                                                    ('16_picking_entry_negative', 'Inventory Transfers (Costs)')])
+
+    @api.depends('billable_type')
+    def _compute_category_report(self):
+        picking_revenues = self.filtered(lambda t: t.billable_type == '15_picking_entry_positive')
+        picking_revenues.category_report = 'revenues'
+        super(AccountAnalyticLine, self - picking_revenues)._compute_category_report()
+
+    def _set_billable_cost(self):
+        aals_delivery = self.filtered(lambda aal: aal.category == 'picking_entry')
+        aals_delivery.billable_type = '16_picking_entry_negative'
+        super(AccountAnalyticLine, self - aals_delivery)._set_billable_cost()
+
+    def _get_invoice_type(self, invoice_type):
+        if self.category == 'picking_entry':
+            return '15_picking_entry_positive'
+        return super()._get_invoice_type(invoice_type)

--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -23,7 +23,7 @@ def _sale_timesheet_post_init(env):
         product._compute_service_policy()
 
     lines = env['account.analytic.line'].search(['&', '|',
-        ('billable_type', '=', '12_other_costs'),
+        ('billable_type', '=', '30_other_costs'),
         ('billable_type', '=', '11_other_revenues'),
         ('project_id', '!=', False),
     ])

--- a/addons/sale_timesheet/models/account_analytic_line.py
+++ b/addons/sale_timesheet/models/account_analytic_line.py
@@ -9,7 +9,7 @@ from odoo.tools.misc import unquote
 from odoo.addons.sale_project.models.account_analytic_line import BILLABLE_TYPES
 
 TIMESHEET_BILLABLE_TYPES = [
-    ('02_billable_fixed', 'Timesheet (Fixed price)'),
+    ('02_billable_fixed', 'Timesheets (Fixed Price)'),
     ('03_timesheet_revenues', 'Revenues (Time & Material)'),
     ('04_billable_time', 'Timesheets (Time & Materials)'),
     ('06_billable_milestones', 'Timesheets (Milestones)'),
@@ -50,7 +50,7 @@ class AccountAnalyticLine(models.Model):
         for timesheet in self:
             timesheet.commercial_partner_id = timesheet.task_id.sudo().partner_id.commercial_partner_id or timesheet.project_id.sudo().partner_id.commercial_partner_id
 
-    @api.depends('so_line.product_id', 'project_id.billing_type', 'amount')
+    @api.depends('so_line.product_id', 'project_id.billing_type', 'amount', 'category')
     def _compute_project_billable_type(self):
         timesheets_with_project = self.filtered(lambda t: t.project_id)
         for timesheet in timesheets_with_project:
@@ -73,6 +73,16 @@ class AccountAnalyticLine(models.Model):
                     invoice_type = '02_billable_fixed'
             timesheet.billable_type = invoice_type
         super(AccountAnalyticLine, self - timesheets_with_project)._compute_project_billable_type()
+
+    @api.depends('billable_type')
+    def _compute_category_report(self):
+        timesheets = self.filtered(lambda t: t.project_id)
+        for timesheet in timesheets:
+            if timesheet.billable_type == '03_timesheet_revenues':
+                timesheet.category_report = 'revenues'
+            else:
+                timesheet.category_report = 'costs'
+        super(AccountAnalyticLine, self - timesheets)._compute_category_report()
 
     @api.depends('task_id.sale_line_id', 'project_id.sale_line_id', 'employee_id', 'project_id.allow_billable')
     def _compute_so_line(self):


### PR DESCRIPTION
This commit's purpose is to modify the default group by of the margin report of projects. Instead of grouping non-timesheets aal into the generic 'other costs' billable type, we now use 2 group bys. One more generic with the 'category' of the aal, then a more specific 'billable type' with specific column for the deliveries, manufacturing and expenses costs.

task - 6086087

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
