### PR TITLE
[IMP] web: `o_touch_device` reflect the real state of the device.

### DIFF
--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -211,6 +211,18 @@ export const uiService = {
             }
         }
 
+        const pointerQuery = window.matchMedia("(pointer: coarse)");
+
+        // Update the class on the body element when touch capability changes
+        const handlePointerChange = (event) => {
+            if (event.matches) {
+                document.body.classList.add("o_touch_device");
+            } else {
+                document.body.classList.remove("o_touch_device");
+            }
+        };
+        pointerQuery.addEventListener("change", handlePointerChange);
+
         const ui = reactive({
             bus,
             size: utils.getSize(),


### PR DESCRIPTION
Before this commit, the class `o_touch_device` was only add at the start of the WebClient if the device had touch capacities.

After this commit, we also add/remove this class when the browser detect a change for the touch capability[1].

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries/Testing#receiving_query_notifications

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
