### PR TITLE
[FIX] pos_self_order: squished product image on combo screen

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -26,7 +26,7 @@
                         <div class="d-flex flex-column align-items-center">
                             <h1 class="mt-kiosk-p-3 mb-3 text-reset" t-esc="currentCombo.name" t-ref="productName"/>
                             <div class="o_self_combo_image ratio ratio-1x1 rounded-4 w-70 w-m-50 ">
-                                <img class="rounded-4" t-attf-src="/web/image/product.template/{{ props.productTemplate.id }}/image_512?unique=#{props.productTemplate.write_date}" loading="lazy"/>
+                                <img class="rounded-4 object-fit-cover" t-attf-src="/web/image/product.template/{{ props.productTemplate.id }}/image_512?unique=#{props.productTemplate.write_date}" loading="lazy"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Before this commit, the product image shown in the header of the combo screen in the self order interface was squished to fit the container, resulting in distortion for non-square images.

After this commit, we add the `object-fit: cover` style to match the how the images are displayed elsewhere in self order.

Before the change:
<img width="595" height="536" alt="image" src="https://github.com/user-attachments/assets/fb90167c-8c28-46c9-9ab5-3ac472299c67" />

After the change:
<img width="597" height="538" alt="image" src="https://github.com/user-attachments/assets/44d5c5a6-037b-46e2-8a28-5ef9df4d5e58" />

Product screen for reference (no change):
<img width="561" height="143" alt="image" src="https://github.com/user-attachments/assets/4ee20d8c-9cde-4cc8-bcf1-8179f878a517" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
