### PR TITLE
[FIX] project, portal: remove hardcoded top padding in portal chatter

### DIFF
--- a/addons/portal/static/src/chatter/core/portal_chatter.xml
+++ b/addons/portal/static/src/chatter/core/portal_chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="portal.Chatter">
-    <div t-if="state.thread" class="o-mail-Chatter o-portal-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
+    <div t-if="state.thread" class="o-mail-Chatter o-portal-Chatter w-100 h-100 flex-grow-1 d-flex" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top top-0" t-att-class="{ 'col-lg-5':props.twoColumns, 'position-sticky':props.composer }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter and !env.projectSharingId) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
             <Composer t-if="props.composer" composer="state.thread.composer" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId" type="'message'"/>
         </div>

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
@@ -23,7 +23,7 @@ function compileChatter(node, params) {
         displayFollowButton: params.displayFollowButton,
     });
     const chatterContainerHookXml = createElement("div");
-    chatterContainerHookXml.classList.add("o-mail-ChatterContainer", "o-mail-Form-chatter", "pt-2");
+    chatterContainerHookXml.classList.add("o-mail-ChatterContainer", "o-mail-Form-chatter");
     append(chatterContainerHookXml, chatterContainerXml);
     return chatterContainerHookXml;
 }


### PR DESCRIPTION
**Steps to reproduce:**
1. Log in as a portal user.
2. Open a shared project and then open any task within it.
3. Observe the vertical spacing above the Follow/Unfollow button and the chatter 
component.

**Issue:**
The chatter UI has incorrect vertical spacing, causing elements like the
Follow/Unfollow button to sit too far down and appear misaligned.

**Cause:**
The pt-2 padding class was hardcoded in two separate locations: 
1. The compileChatter wrapper in project_sharing_form_compiler.js.
2. The portal.Chatter XML template.
When combined this caused a double-padding effect forcing excessive space.

**Fix:**
Removed the hardcoded pt-2 class from both the JavaScript compiler wrapper and 
the core XML template. This eliminates the double-padding conflict. This resolves 
the alignment issue in Project Sharing and does not affect the layout or 
functionality of other portal components.

task-4203362

