### PR TITLE
[IMP] web: enable inline creation in offline list views

### DIFF
--- a/addons/stock/static/tests/inventory_report_list.test.js
+++ b/addons/stock/static/tests/inventory_report_list.test.js
@@ -179,6 +179,7 @@ test("Work in grouped list", async function () {
     // Edit the freshly created record...
     await contains(".o_data_row:eq(3) .o_field_cell").click();
     await contains("[name=age] input").edit("66");
+    await contains(".o_list_renderer").click();
 
     // Check both records have been updated...
     expect(queryOne('.o_data_row:eq(0) [name="age"]').textContent).toBe(

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -224,7 +224,7 @@ class OfflineManager extends Reactive {
      * Mark an action, view type and optionally record as available offline.
      *
      * @param {number} actionId
-     * @param {"kanban"|"list"|"form"} viewType
+     * @param {"kanban"|"list"|"form"|"kanban_quick_create"|"list_quick_create"} viewType
      * @param {Object} params
      * @param {number} [params.resId] the record id, when viewType is "form"
      * @param {Object} [params.search] the current search view state
@@ -233,7 +233,7 @@ class OfflineManager extends Reactive {
         if (!this.offline) {
             const key = this._generateKey(actionId, viewType, resId);
             let value;
-            if (["form", "kanban_quick_create"].includes(viewType)) {
+            if (["form", "kanban_quick_create", "list_quick_create"].includes(viewType)) {
                 value = true;
             } else {
                 value = (await this._idb.read(this._visitedUITable, key)) || {};

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -104,14 +104,22 @@ export class DynamicRecordList extends DynamicList {
     // -------------------------------------------------------------------------
 
     async _addNewRecord(atFirstPosition) {
-        const values = await this.model._loadNewRecord({
-            resModel: this.resModel,
-            activeFields: this.activeFields,
-            fields: this.fields,
-            context: this.context,
-        });
+        const { promise, resolve } = Promise.withResolvers();
+        const values = await this.model._loadNewRecord(
+            {
+                resModel: this.resModel,
+                activeFields: this.activeFields,
+                fields: this.fields,
+                context: this.context,
+                isMonoRecord: true,
+            },
+            {
+                cache: this.model._getCacheParams({ ...this.config, isMonoRecord: true }, promise),
+            }
+        );
         const record = this._createRecordDatapoint(values, "edit");
         this._addRecord(record, atFirstPosition ? 0 : this.records.length);
+        resolve({ root: record, loadId: this.config.loadId });
         return record;
     }
 

--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -66,7 +66,7 @@ export class Group extends DataPoint {
         return record;
     }
 
-    async addNewRecord(_unused, atFirstPosition = false) {
+    async addNewRecord(atFirstPosition = false) {
         const canProceed = await this.model.root.leaveEditMode();
         if (canProceed) {
             const record = await this.list.addNewRecord(atFirstPosition);

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -718,8 +718,13 @@ export class RelationalModel extends Model {
      * @param {Object} result the data loaded with the given config (rpc result)
      */
     _setAvailableOffline(config, result) {
-        const { actionId, viewType } = this.env.config;
+        let { actionId, viewType } = this.env.config;
+        let resId = config.resId;
         let markAsAvailableOffline = actionId;
+        if (config.isMonoRecord && ["list", "kanban"].includes(viewType)) {
+            viewType = viewType + "_quick_create"; // list_quick_create or kanban_quick_create
+            resId = false;
+        }
         if (!config.isMonoRecord) {
             const hasRecords = config.groupBy.length
                 ? result.groups.some((group) => group.__count > 0)
@@ -728,7 +733,7 @@ export class RelationalModel extends Model {
         }
         if (markAsAvailableOffline) {
             const params = config.isMonoRecord
-                ? { resId: config.resId }
+                ? { resId }
                 : { search: this.env.searchModel.getCurrentSearch() };
             this.offline.setAvailableOffline(actionId, viewType, params);
         }

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -315,7 +315,7 @@ export class KanbanRecordQuickCreate extends Component {
                 ...getDefaultConfig(),
                 actionId: this.env.config.actionId,
                 actionName: this.env.config.actionName,
-                viewType: "kanban_quick_create",
+                viewType: "kanban",
                 resId: false,
             },
         });

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -271,13 +271,14 @@ export class ListController extends Component {
     }
 
     get isNewButtonAvailableOffline() {
-        if (
-            !this.archInfo.editable &&
-            this.offlineService.isAvailableOffline(this.env.config.actionId, "form", false)
-        ) {
-            return true;
+        if (this.archInfo.editable && !this.model.root.isGrouped) {
+            return this.offlineService.isAvailableOffline(
+                this.env.config.actionId,
+                "list_quick_create",
+                false
+            );
         }
-        return false;
+        return this.offlineService.isAvailableOffline(this.env.config.actionId, "form", false);
     }
 
     getExportableFields() {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -379,7 +379,7 @@ export class ListRenderer extends Component {
     async addInGroup(group) {
         const left = await this.props.list.leaveEditMode({ canAbandon: false });
         if (left) {
-            group.addNewRecord({}, this.props.editable === "top");
+            group.addNewRecord(this.props.editable === "top");
         }
     }
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -16059,6 +16059,27 @@ test(`quickcreate in a many2one in a list`, async () => {
     expect(`.o_data_cell:eq(0)`).toHaveText("aaa");
 });
 
+test.tags("desktop");
+test(`quickcreate (grouped) multiple records`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list editable="top"><field name="foo"/></list>`,
+        groupBy: ["bar"],
+    });
+
+    await contains(".o_group_header:eq(1)").click();
+
+    expect(queryAllTexts(`.o_data_cell`)).toEqual(["yop", "blip", "gnap"]);
+
+    await contains(".o_group_field_row_add a").click();
+    await contains(`.o_data_row .o_data_cell input`).edit("aaa");
+    await contains(`.o_data_row .o_data_cell input`).edit("ooo");
+    await contains(`.o_data_row .o_data_cell input`).edit("ttt");
+
+    expect(queryAllTexts(`.o_data_cell`)).toEqual(["", "ttt", "ooo", "aaa", "yop", "blip", "gnap"]);
+});
+
 test(`float field render with digits attribute on listview`, async () => {
     await mountView({
         resModel: "foo",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -560,7 +560,68 @@ test(`editable list with edit="0"`, async () => {
 });
 
 test.tags("desktop");
-test(`[Offline] editable list`, async () => {
+test(`[Offline] editable list (create)`, async () => {
+    expect.errors(2); // 2x ConnectionLostError
+    onRpc("web_save", () => expect.step(`web_save`));
+    Foo._views = {
+        "list,false": `<list editable="top"><field name="foo"/></list>`,
+        "search,false": `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "foo",
+            views: [[false, "list"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(`tbody tr.o_data_row[data-id]`).toHaveCount(4);
+    expect(queryAllTexts(".o_data_cell")).toEqual(["yop", "blip", "gnap", "blip"]);
+
+    await contains(`.o_list_button_add`).click();
+    expect(`tbody tr.o_selected_row`).toHaveCount(1, { message: "should have editable row" });
+    await contains(`.o_list_renderer`).click();
+
+    await setOffline(true);
+
+    expect("button.o_list_button_add").not.toHaveClass("o_disabled_offline");
+    await contains(`.o_list_button_add`).click();
+
+    expect(`tbody tr.o_selected_row`).toHaveCount(1, { message: "should have editable row" });
+    await contains(`.o_field_widget[name=foo] input`).edit("Offline");
+
+    await contains(`.o_control_panel`).click();
+    expect(queryAllTexts(".o_data_cell")).toEqual(["Offline", "yop", "blip", "gnap", "blip"]);
+
+    // The edited record will be save the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts(`.o-dropdown--menu .o_offline_systray_content div`)).toEqual([
+        "ACTION 1",
+        "Record",
+        "Created",
+        "",
+    ]);
+
+    expect.verifyErrors([
+        `Error: Connection to "/web/dataset/call_kw/foo/onchange" couldn't be established or was interrupted`,
+        `Error: Connection to "/web/dataset/call_kw/foo/onchange" couldn't be established or was interrupted`,
+    ]);
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["web_save"]);
+});
+
+test.tags("desktop");
+test(`[Offline] editable list (edit)`, async () => {
     onRpc("web_save", () => expect.step(`web_save`));
     Foo._views = {
         "list,false": `<list editable="top"><field name="foo"/></list>`,


### PR DESCRIPTION
[IMP] web: enable inline creation in offline list views

This commit enables the creation of new lines in editable list views while
offline. Following the same logic as the Kanban quick-create and the form
view, the user must have performed a similar creation while online to
ensure the necessary onchange results are stored in the cache.

---

[REF] web: align Group.addNewRecord signature with DynamicRecordList

This commit refactors the addNewRecord function signature in the Group
class to match the signature used in the DynamicRecordList class.

Aligning these signatures ensures consistency across record-handling
utilities and simplifies future maintenance.