### PR TITLE
[FIX] l10n_hr_edi: Typo fix align for move sending constraints

### DIFF
--- a/addons/l10n_hr_edi/models/account_move_send.py
+++ b/addons/l10n_hr_edi/models/account_move_send.py
@@ -13,7 +13,7 @@ class AccountMoveSend(models.AbstractModel):
     _inherit = 'account.move.send'
 
     @api.model
-    def _check_move_constrains(self, moves):
+    def _check_move_constraints(self, moves):
         # HR-BR-37: Invoice must contain HR-BT-4: Operator code in accordance with the Fiscalization Act.
         if any((move.country_code == 'HR' and not move.l10n_hr_operator_name) for move in moves):
             raise UserError(self.env._("Operator label is required for sending invoices in Croatia."))
@@ -33,7 +33,7 @@ class AccountMoveSend(models.AbstractModel):
             any(any((tax.tax_exigibility == 'on_payment' and not tax.invoice_legal_notes) for tax in line.tax_ids
              ) for line in move.line_ids if line.display_type == 'product') for move in moves):
             raise ValidationError(self.env._('For Croatia, Legal Notes should be provided for all cash basis taxes.'))
-        super()._check_move_constrains(moves)
+        super()._check_move_constraints(moves)
 
     # -------------------------------------------------------------------------
     # SENDING METHODS


### PR DESCRIPTION
In 18.0, the `_check_move_constraints()` method contained a typo - `_check_move_constrains()` - and the module was developed with this in mind. The typo was fixed in 19.0, but this was missed during the forward port of this module, leading to additional constraints not triggering properly.
ticket-6036500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
