### PR TITLE
[IMP] base_vat: avoid calling IAP if no cron to pull VIES updates

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -213,6 +213,10 @@ class ResPartner(models.Model):
         If they exist, we simply return them. If they don't, we create them in another cursor to
         avoid the current transaction to be rolled back after the record has been created on IAP.
         """
+        # No existing cron = no way for db to pull updates, thus no need to bother IAP
+        if not self.env.ref('base_vat.vies_iap_check_update', raise_if_not_found=False):
+            return "dummy_identifier", "dummy_token"  # ignored by IAP, same as neutralized
+
         IrConfigParam = self.env['ir.config_parameter'].sudo()
         identifier = IrConfigParam.get_param('iap_vies.client_identifier')
         token = IrConfigParam.get_param('iap_vies.client_token')


### PR DESCRIPTION
If the user contacts us from an unreachable db (localhost, firewall, .. .), we currently rely on a cron on the db to pull updates by calling `vies_check_update`.
Currently, all dbs, even those that don't have the cron (i.e. haven't yet upgraded the `iap` module) will send the `client_identifier/token` upon calling `vies_check_validity`. However, since they don't have the cron, they won't be able to pull updates from IAP.

Thus, if we detect that the crond does not exist, we will now send dummy `client_identifier/token` to avoid poluting IAP.

task-none