### PR TITLE
[FIX] account: round_tax_details_base_lines consider only not zero ta…

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1785,7 +1785,14 @@ class AccountTax(models.Model):
             if mode == 'mixed':
                 current_mode = 'included'
                 for base_line, taxes_data in values['base_line_x_taxes_data']:
-                    if any(not tax_data['price_include'] for tax_data in taxes_data):
+                    if any(
+                        not tax_data['price_include']
+                        for tax_data in taxes_data
+                        if (
+                            not base_line['currency_id'].is_zero(tax_data['tax_amount_currency'])
+                            or not company.currency_id.is_zero(tax_data['tax_amount'])
+                        )
+                    ):
                         current_mode = 'excluded'
                         break
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -860,9 +860,16 @@ export const accountTaxHelpers = {
             let current_mode = mode;
             if (current_mode === "mixed") {
                 current_mode = "included";
-                for (const base_line_taxes_data of values.base_line_x_taxes_data) {
-                    const taxes_data = base_line_taxes_data[1];
-                    if (taxes_data.some((tax_data) => !tax_data.price_include)) {
+                for (const [base_line, taxes_data] of values.base_line_x_taxes_data) {
+                    const not_zero_taxes_data = taxes_data.filter(
+                        (tax_data) =>
+                            !floatIsZero(
+                                tax_data.tax_amount_currency,
+                                base_line.currency_id.decimal_places
+                            ) &&
+                            !floatIsZero(tax_data.tax_amount, company.currency_id.decimal_places)
+                    );
+                    if (not_zero_taxes_data.some((tax_data) => !tax_data.price_include)) {
                         current_mode = "excluded";
                         break;
                     }

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -2438,3 +2438,52 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         tax_10.active = False
         invoice.env.invalidate_all()
         self._assert_tax_totals_summary(invoice.tax_totals, expected_values)
+
+    def _test_price_included_taxes_with_0_price_excluded_tax(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        tax_21 = self.percent_tax(21.0, price_include_override='tax_included')
+        tax_6 = self.percent_tax(6.0, price_include_override='tax_included')
+        tax_0 = self.percent_tax(0.0, price_include_override='tax_excluded')
+
+        document_params = self.init_document([
+            {'price_unit': 27.80, 'tax_ids': tax_21},
+            {'price_unit': 97.25, 'tax_ids': tax_6},
+            {'price_unit': 9.0, 'tax_ids': tax_0},
+        ])
+
+        document = self.populate_document(document_params)
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 123.73,
+            'tax_amount_currency': 10.32,
+            'total_amount_currency': 134.05,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 123.73,
+                    'tax_amount_currency': 10.32,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 123.73,
+                            'tax_amount_currency': 10.32,
+                            'display_base_amount_currency': 123.73,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 1, document, expected_values
+
+    def test_price_included_taxes_with_0_price_excluded_tax_generic_helpers(self):
+        for test_index, document, expected_values in self._test_price_included_taxes_with_0_price_excluded_tax():
+            with self.subTest(test_index=test_index):
+                self.assert_tax_totals_summary(document, expected_values)
+        self._run_js_tests()
+
+    def test_price_included_taxes_with_0_price_excluded_tax_invoices(self):
+        for test_index, document, expected_values in self._test_price_included_taxes_with_0_price_excluded_tax():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_tax_totals_summary(invoice, expected_values)


### PR DESCRIPTION
…xes_data

Suppose an invoice with price-included taxes but with a zero price excluded one. We don't want to fallback on the excluded mode just for that.

opw-6060486

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
