### PR TITLE
[FIX] html_editor: convert email address to link on space

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -936,11 +936,17 @@ export class LinkPlugin extends Plugin {
             // In case of multiple matches, only the last one will be converted.
             const match = [...potentialUrl.matchAll(new RegExp(URL_REGEX, "g"))].pop();
 
-            if (match && !EMAIL_REGEX.test(match[0])) {
+            if (match) {
                 const nodeForSelectionRestore = selection.anchorNode.splitText(
                     selection.anchorOffset
                 );
-                const url = match[2] ? match[0] : "http://" + match[0];
+                let url;
+                if (!EMAIL_REGEX.test(match[0])) {
+                    url = match[2] ? match[0] : "http://" + match[0];
+                } else {
+                    url = "mailto:" + match[0];
+                }
+
                 const startOffset = selection.anchorOffset - potentialUrl.length + match.index;
                 const text = selection.anchorNode.textContent.slice(
                     startOffset,

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -111,11 +111,11 @@ test("should transform url after shift+enter", async () => {
     });
 });
 
-test("should not transform an email url after space", async () => {
+test("should transform an email to url after space", async () => {
     await testEditor({
         contentBefore: "<p>user@domain.com[]</p>",
         stepFunction: (editor) => insertSpace(editor),
-        contentAfter: "<p>user@domain.com&nbsp;[]</p>",
+        contentAfter: '<p><a href="mailto:user@domain.com">user@domain.com</a>&nbsp;[]</p>',
     });
 });
 


### PR DESCRIPTION
Before this commit: when typing an email address, it's not converted to a mailto link after spacing.

After this commit: the mailto link is created after spacing.

task- 6053993

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
