### PR TITLE
[FIX] website: s_chart adapt chart colors to the block's color preset

### DIFF
--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -10,12 +10,20 @@ import { registry } from "@web/core/registry";
 
 export class ChartOptionPlugin extends Plugin {
     static id = "chartOptionPlugin";
-    static dependencies = ["history"];
+    static dependencies = ["history", "edit_interaction"];
     static shared = ["isPieChart"];
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         so_content_addition_selectors: [".s_chart"],
+        on_bg_color_updated_handlers: (element) => {
+            const chartEl = element.matches(".s_chart")
+                ? element
+                : element.querySelector(".s_chart");
+            if (chartEl) {
+                this.dependencies.edit_interaction.restartInteractions(chartEl);
+            }
+        },
         builder_actions: {
             SetChartTypeAction,
             AddColumnAction,

--- a/addons/website/static/src/snippets/s_chart/chart.edit.js
+++ b/addons/website/static/src/snippets/s_chart/chart.edit.js
@@ -13,6 +13,14 @@ const ChartEdit = (I) =>
             this.websiteEditService = this.services.website_edit;
             this.websiteEditService.callShared("builderOverlay", "refreshOverlays");
         }
+
+        getConfigurationSnapshot() {
+            let snapshot = super.getConfigurationSnapshot();
+            snapshot = JSON.parse(snapshot || "{}");
+            snapshot.bgColor = getComputedStyle(this.el).backgroundColor;
+            snapshot = JSON.stringify(snapshot);
+            return snapshot;
+        }
     };
 
 registry.category("public.interactions.edit").add("website.chart", {

--- a/addons/website/static/src/snippets/s_chart/chart.js
+++ b/addons/website/static/src/snippets/s_chart/chart.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { loadBundle } from "@web/core/assets";
+import { convertCSSColorToRgba } from "@web/core/utils/colors";
 
 export class Chart extends Interaction {
     static selector = ".s_chart";
@@ -11,6 +12,7 @@ export class Chart extends Interaction {
         this.chart = null;
         this.noAnimation = false;
         this.style = window.getComputedStyle(document.documentElement);
+        this.chartBlockStyle = window.getComputedStyle(this.el);
     }
 
     async willStart() {
@@ -23,7 +25,12 @@ export class Chart extends Interaction {
             el.backgroundColor = this.convertToCSS(el.backgroundColor);
             el.borderColor = this.convertToCSS(el.borderColor);
             el.borderWidth = this.el.dataset.borderWidth;
+            el.color = this.convertToCSS(el.color);
         });
+
+        const colorRgba = convertCSSColorToRgba(this.chartBlockStyle.color);
+        const textColor = `rgba(${colorRgba.red}, ${colorRgba.green}, ${colorRgba.blue}, ${colorRgba.opacity})`;
+        const cartesianColor = `rgba(${colorRgba.red}, ${colorRgba.green}, ${colorRgba.blue}, 0.25)`;
 
         const radialAxis = {
             beginAtZero: true,
@@ -35,11 +42,23 @@ export class Chart extends Interaction {
             beginAtZero: true,
             min: parseInt(this.el.dataset.ticksMin),
             max: parseInt(this.el.dataset.ticksMax),
+            grid: {
+                color: cartesianColor,
+            },
+            ticks: {
+                color: textColor,
+            },
         };
 
         const categoryAxis = {
             type: "category",
             stacked: this.el.dataset.stacked === "true",
+            grid: {
+                color: cartesianColor,
+            },
+            ticks: {
+                color: textColor,
+            },
         };
 
         const chartData = {
@@ -50,6 +69,9 @@ export class Chart extends Interaction {
                     legend: {
                         display: this.el.dataset.legendPosition !== "none",
                         position: this.el.dataset.legendPosition,
+                        labels: {
+                            color: textColor,
+                        },
                     },
                     tooltip: {
                         enabled: this.el.dataset.tooltipDisplay === "true",
@@ -58,6 +80,7 @@ export class Chart extends Interaction {
                     title: {
                         display: !!this.el.dataset.title,
                         text: this.el.dataset.title,
+                        color: textColor,
                     },
                 },
                 scales: {

--- a/addons/website/static/src/snippets/s_chart/chart.js
+++ b/addons/website/static/src/snippets/s_chart/chart.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { loadBundle } from "@web/core/assets";
+import { convertCSSColorToRgba } from "@web/core/utils/colors";
 
 export class Chart extends Interaction {
     static selector = ".s_chart";
@@ -11,6 +12,7 @@ export class Chart extends Interaction {
         this.chart = null;
         this.noAnimation = false;
         this.style = window.getComputedStyle(document.documentElement);
+        this.chartBlockStyle = window.getComputedStyle(this.el);
     }
 
     async willStart() {
@@ -23,7 +25,12 @@ export class Chart extends Interaction {
             el.backgroundColor = this.convertToCSS(el.backgroundColor);
             el.borderColor = this.convertToCSS(el.borderColor);
             el.borderWidth = this.el.dataset.borderWidth;
+            el.color = this.convertToCSS(el.color);
         });
+
+        const colorRgba = convertCSSColorToRgba(this.chartBlockStyle.color);
+        const textColor = `rgba(${colorRgba.red}, ${colorRgba.green}, ${colorRgba.blue}, ${colorRgba.opacity})`;
+        const cartesianColor = `rgba(${colorRgba.red}, ${colorRgba.green}, ${colorRgba.blue}, 0.25)`;
 
         const radialAxis = {
             beginAtZero: true,
@@ -35,11 +42,23 @@ export class Chart extends Interaction {
             beginAtZero: true,
             min: parseInt(this.el.dataset.ticksMin),
             max: parseInt(this.el.dataset.ticksMax),
+            grid: {
+                color: cartesianColor,
+            },
+            ticks: {
+                color: textColor,
+            }
         };
 
         const categoryAxis = {
             type: "category",
             stacked: this.el.dataset.stacked === "true",
+            grid: {
+                color: cartesianColor,
+            },
+            ticks: {
+                color: textColor,
+            }
         };
 
         const chartData = {
@@ -50,6 +69,9 @@ export class Chart extends Interaction {
                     legend: {
                         display: this.el.dataset.legendPosition !== "none",
                         position: this.el.dataset.legendPosition,
+                        labels: {
+                            color: textColor
+                        }
                     },
                     tooltip: {
                         enabled: this.el.dataset.tooltipDisplay === "true",
@@ -58,6 +80,7 @@ export class Chart extends Interaction {
                     title: {
                         display: !!this.el.dataset.title,
                         text: this.el.dataset.title,
+                        color: textColor
                     },
                 },
                 scales: {


### PR DESCRIPTION
Before this PR, the chart's label and cartesian grid line colors
were hard-coded. This made them unreadable when the containing block
used a dark background preset, as the colors did not adapt to the
current text color.

After this commit, label colors (legend, axes ticks, title) are derived
from the block's computed CSS `color` property, which follows the active
color preset. Cartesian grid lines use the same color at reduced
opacity (0.25) to remain subtle but visible on any background.

A re-render is also triggered whenever the background color changes by
overriding `getConfigurationSnapshot` in the `ChartEdit` interaction
mixin (chart.edit.js). The snapshot now includes the block's computed
`backgroundColor`, so the framework detects the change and restarts the
interaction automatically, including on preview revert.

task-6095137

| master |
|--------|
| <img width="958" height="476" alt="image" src="https://github.com/user-attachments/assets/82e87451-b9d3-4ce9-9376-c46f293f51f9" /> |

| this pr |
|--------|
| <img width="1510" height="756" alt="image" src="https://github.com/user-attachments/assets/8224274e-51a1-458c-85ce-3bd1b35b1143" /> <img width="1044" height="518" alt="image" src="https://github.com/user-attachments/assets/92555b60-8a3e-4e69-8ea6-d7a051ab2e3f" /> | 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
