### PR TITLE
[FIX] point_of_sale: prevent duplicate pickings

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1023,6 +1023,8 @@ class PosOrder(models.Model):
 
     def _create_order_picking(self):
         self.ensure_one()
+        if self.picking_ids:
+            return
         if self.shipping_date:
             self.sudo().lines._launch_stock_rule_from_pos_order_lines()
         else:

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -346,6 +346,50 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
 
         self.assertTrue(all(stock_output_amls.mapped('reconciled')))
 
+    def test_no_duplicate_picking_on_repeated_invoice_action(self):
+        """Calling action_pos_order_invoice multiple times (e.g. a backend user
+        clicking 'Customer Invoice' on an already-invoiced order) must not
+        create more than one stock picking for the same POS order.
+
+        Regression test for the guard added to _create_order_picking:
+        the condition at the top of action_pos_order_invoice (anglo_saxon +
+        update_stock_at_closing + session open) would previously call
+        _create_order_picking unconditionally, producing one extra picking on
+        every repeated click.
+        """
+        self.company.point_of_sale_update_stock_quantities = 'closing'
+
+        self.pos_config.open_ui()
+        order = self.PosOrder.create({
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'product_id': self.product.id,
+                'price_unit': 450,
+                'qty': 1.0,
+                'price_subtotal': 450,
+                'price_subtotal_incl': 450,
+            })],
+            'amount_total': 450,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+        })
+        context_make_payment = {'active_ids': [order.id], 'active_id': order.id}
+        self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 450.0,
+            'payment_method_id': self.cash_payment_method.id,
+        }).with_context({'active_id': order.id}).check()
+
+        # First legitimate call: invoice + picking created
+        order.action_pos_order_invoice()
+        self.assertEqual(len(order.picking_ids), 1, "First call should create exactly one picking")
+
+        # Second call: simulates a backend user clicking 'Customer Invoice' again
+        order.action_pos_order_invoice()
+        self.assertEqual(len(order.picking_ids), 1, "Repeated call must not create a duplicate picking")
+
     def test_action_pos_order_invoice_with_discount(self):
         """This test make sure that the line containing 'Discoun from' is correctly added to the invoice"""
 


### PR DESCRIPTION
Calling `action_pos_order_invoice` on an already-invoiced POS order (e.g. a backend user clicking "Invoice" more than once) would unconditionally invoke `_create_order_picking`, producing one extra `stock.picking` per click under anglo-saxon + update_stock_at_closing configurations.

opw-6092999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
