### PR TITLE
[FIX] base: test model used from testing utilities

### DIFF
--- a/odoo/addons/base/tests/test_res_config.py
+++ b/odoo/addons/base/tests/test_res_config.py
@@ -162,24 +162,6 @@ class TestResConfigExecute(TransactionCase):
             _logger.info("Testing %s" % (config_settings.name))
             self.env[config_settings.name].create({}).execute()
 
-    def test_boolean_config_parameter(self):
-        ICP = self.env['ir.config_parameter'].sudo()
-        ResConfigTest = self.env['res.config.test']
-
-        # If no `ir.config_parameter` record exists yet for the config, value
-        # should be `False`
-        ICP.search([('key', '=', 'resConfigTest.parameterBool')]).unlink()
-        defaults = ResConfigTest.default_get(['param_bool'])
-        self.assertFalse(defaults['param_bool'])
-
-        ICP.set_param('resConfigTest.parameterBool', 'False')
-        defaults = ResConfigTest.default_get(['param_bool'])
-        self.assertFalse(defaults['param_bool'])
-
-        ICP.set_param('resConfigTest.parameterBool', 'True')
-        defaults = ResConfigTest.default_get(['param_bool'])
-        self.assertTrue(defaults['param_bool'])
-
     def test_settings_access(self):
         """Check that settings user are able to open & save settings
 

--- a/odoo/addons/test_testing_utilities/tests/test_res_config.py
+++ b/odoo/addons/test_testing_utilities/tests/test_res_config.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from unittest.mock import patch
 from odoo.tests.common import TransactionCase
+
 
 class TestResConfig(TransactionCase):
 
@@ -16,3 +16,21 @@ class TestResConfig(TransactionCase):
             self.env['res.config.test'].create({}).execute()
 
         set_param_mock.assert_not_called()
+
+    def test_boolean_config_parameter(self):
+        ICP = self.env['ir.config_parameter'].sudo()
+        ResConfigTest = self.env['res.config.test']
+
+        # If no `ir.config_parameter` record exists yet for the config, value
+        # should be `False`
+        ICP.search([('key', '=', 'resConfigTest.parameterBool')]).unlink()
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertFalse(defaults['param_bool'])
+
+        ICP.set_param('resConfigTest.parameterBool', 'False')
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertFalse(defaults['param_bool'])
+
+        ICP.set_param('resConfigTest.parameterBool', 'True')
+        defaults = ResConfigTest.default_get(['param_bool'])
+        self.assertTrue(defaults['param_bool'])


### PR DESCRIPTION
Move the test to test_testing_utilities where the model res.config.test is defined.

Move test introduced in odoo/odoo#257033.

runbot-242309


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
