### PR TITLE
[IMP] account: improve reload chart of accounts error handling

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -12,7 +12,7 @@ import re
 
 from odoo import Command, api, models
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError, UserError, RedirectWarning
 from odoo.modules import get_resource_from_path
 from odoo.tools import file_open, float_compare, get_lang, groupby, SQL
 from odoo.tools.translate import _, code_translations, TranslationImporter
@@ -1216,11 +1216,26 @@ class AccountChartTemplate(models.AbstractModel):
                     if not mapped_tag:
                         country = self.env['res.country'].browse(country_id)
                         if not self._context.get('ignore_missing_tags'):
-                            raise UserError(self.env._(
-                                'Error while loading the localization: missing tax tag %(tag_name)s for country %(country_name)s.'
-                                ' You should probably update your localization app first.',
-                                tag_name=format_tag, country_name=country.name
-                            ))
+                            raise RedirectWarning(
+                                message=self.env._(
+                                    'Error while loading the localization: missing tax tag %(tag_name)s for country %(country_name)s.'
+                                    ' You should probably update your localization app first.',
+                                    tag_name=format_tag, country_name=country.name
+                                ),
+                                action={
+                                    'name': self.env._('Need to update'),
+                                    'res_model': 'ir.module.module',
+                                    'type': 'ir.actions.act_window',
+                                    'views': [(self.env.ref('base.module_view_kanban').id, 'kanban')],
+                                    'context': {
+                                        'search_default_name': country.name,
+                                        'search_default_category_id': self.env.ref(
+                                            'base.module_category_accounting_localizations_account_charts'
+                                        ).id,
+                                    },
+                                },
+                                button_text=self.env._("Update app"),
+                            )
                         else:
                             _logger.error(
                                 'Error while loading the localization: missing tax tag %s for country %s.'

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -4,7 +4,7 @@ from markupsafe import Markup
 from unittest.mock import patch
 
 from odoo import Command
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning
 from odoo.tests import tagged
 from odoo.addons.account.models.chart_template import code_translations, AccountChartTemplate, TEMPLATE_MODELS
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -824,7 +824,7 @@ class TestChartTemplate(AccountTestInvoicingCommon):
                 Command.create({'document_type': 'refund', 'factor_percent': 100, 'repartition_type': 'tax'}),
             ]
         }
-        with self.assertRaisesRegex(UserError, 'update your localization'):
+        with self.assertRaisesRegex(RedirectWarning, 'update your localization'):
             self.env['account.chart.template']._deref_account_tags('test', {'tax1': tax_to_load})
 
     def test_install_with_translations(self):

--- a/addons/l10n_in_withholding/models/account_chart_template.py
+++ b/addons/l10n_in_withholding/models/account_chart_template.py
@@ -1,6 +1,5 @@
 from odoo import models
 from odoo.addons.account.models.chart_template import template
-from odoo.exceptions import UserError, RedirectWarning
 
 
 class AccountChartTemplate(models.AbstractModel):
@@ -23,25 +22,3 @@ class AccountChartTemplate(models.AbstractModel):
                 'l10n_in_withholding_account_id': 'p100595',
             },
         }
-
-    def _get_tag_mapper(self, country_id):
-        original_mapper = super()._get_tag_mapper(country_id)
-        if country_id != self.env.ref('base.in').id:
-            return original_mapper
-
-        def wrapped_mapper(*args):
-            try:
-                return original_mapper(*args)
-            except UserError as e:
-                raise RedirectWarning(
-                    message=e.args[0],
-                    action={
-                        'name': self.env._('App need to update'),
-                        'res_model': 'ir.module.module',
-                        'type': 'ir.actions.act_window',
-                        'views': [(self.env.ref('base.module_form').id, 'form')],
-                        'res_id': self.env.ref('base.module_l10n_in').id,
-                    },
-                    button_text=self.env._("Update app"),
-                )
-        return wrapped_mapper


### PR DESCRIPTION
Previously, when new taxes with new tax tags were introduced, reloading the
chart of accounts would raise a generic UserError suggesting to update the
localization app. This could be confusing for users, as it did not indicate
which app needed to be updated.

With this commit, the UserError is replaced by a RedirectWarning that guides
users directly to the Apps menu with the relevant localization modules,
making the resolution clearer and more user-friendly.