### PR TITLE
[FIX] stock_dropshipping,purchase: display shipping address on PO report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -10,20 +10,16 @@
         <t t-if="o.state == 'purchase'">Purchase Order #<span t-field="o.name"/></t>
         <t t-if="o.state == 'cancel'">Cancelled Purchase Order #<span t-field="o.name"/></t>
     </t>
+    <t t-set="information_block" t-if="o.dest_address_id">
+        <strong class="d-block mt-3">Shipping address</strong>
+        <div t-field="o.dest_address_id"
+            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>
+    </t>
     <t t-call="web.external_layout"
         address="address"
-        layout_document_title="layout_document_title">
+        layout_document_title="layout_document_title"
+        information_block="information_block">
         <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
-        <t t-if="o.dest_address_id">
-            <t t-set="information_block">
-                <strong class="d-block mt-3">Shipping address</strong>
-                <div t-if="o.dest_address_id">
-                    <div t-field="o.dest_address_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>
-                </div>
-
-            </t>
-        </t>
         <div class="page">
             <div class="oe_structure"/>
 

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -8,22 +8,21 @@
     <t t-set="layout_document_title">
         <span>Request for Quotation <span t-field="o.name"/></span>
     </t>
+    <t t-set="information_block" t-if="o.dest_address_id">
+        <strong class="d-block mt-3">Shipping address</strong>
+        <div t-field="o.dest_address_id"
+            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>
+        <div>
+            <strong>Requested Ship Date:</strong>
+            <span t-field="o.date_planned" t-options="{'date_only': 'true'}"/>
+        </div>
+    </t>
     <t t-call="web.external_layout"
         forced_vat="o.fiscal_position_id.foreign_vat"
         address="address"
-        layout_document_title="layout_document_title">
+        layout_document_title="layout_document_title"
+        information_block="information_block">
         <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
-        <t t-if="o.dest_address_id">
-            <t t-set="information_block">
-                <strong class="d-block mt-3">Shipping address</strong>
-                <div t-field="o.dest_address_id"
-                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>
-                <div>
-                    <strong>Requested Ship Date:</strong>
-                    <span t-field="o.date_planned" t-options="{'date_only': 'true'}"/>
-                </div>
-            </t>
-        </t>
         <div class="page">
             <div class="oe_structure"/>
 


### PR DESCRIPTION
Version:
----------
- saas-19.2+

Steps to reproduce:
----------------------

1. Install `stock_dropshipping` and `sale_management` modules.
2. Create a Customer (res.partner) with a proper address block.
3. Create a dropship product (route: Dropship).
4. Create a Sales Order for the created customer.
5. Add the dropship product.
6. Confirm the Sales Order to generate a Purchase Order.
7. Open the generated PO/RFQ and print the report.

Issue:
------
The shipping address is missing in the printed PO/RFQ report.

Cause:
--------

The `t-call` syntax is updated to use the new semantic, which passes
values *as attributes/parameters* on the `<t>` (with `t-call`) tag itself,
instead of relying on nested `t-set` directive.

- Old (Deprecated): Used nested `<t t-set='var_name' t-value='x'/>` tags
inside the calling element to define variables.
- New: Variables are passed as attributes directly on the element where
the `t-call` is located (e.g., `<t t-call='module.template' var_name='x'/>`).

A warning is added to alert developers when using the old deprecated
syntax.

see Reference: https://github.com/odoo/odoo/pull/197296

<details>
  <summary>Click here to see the results:</summary>

  <p><strong>Before:</strong></p>
  <div class="image-row">
    <img src="https://github.com/user-attachments/assets/c6892b30-10d6-4fb4-881c-1433d4fe07a0" />
  </div>
  <p><strong>After:</strong></p>
  <div class="image-row">
    <img src="https://github.com/user-attachments/assets/6109fcc3-5773-44a8-b07b-6566ed855d3f" />
  </div>
</details>


> NOTE: We can also move test into `purchase_stock`

----

opw-6075017

---

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
