### PR TITLE
[FIX] web: load display names of archived records

### DIFF
--- a/addons/web/static/src/core/name_service.js
+++ b/addons/web/static/src/core/name_service.js
@@ -76,7 +76,10 @@ export const nameService = {
 
                     const specification = { display_name: {} };
                     orm.silent
-                        .webSearchRead(resModel, [["id", "in", idsInBatch]], { specification })
+                        .webSearchRead(resModel, [["id", "in", idsInBatch]], {
+                            specification,
+                            context: { active_test: false },
+                        })
                         .then(({ records }) => {
                             const displayNames = Object.fromEntries(
                                 records.map((rec) => [rec.id, rec.display_name])

--- a/addons/web/static/tests/core/name_service_tests.js
+++ b/addons/web/static/tests/core/name_service_tests.js
@@ -12,10 +12,13 @@ QUnit.module("Name Service", {
         serverData = {
             models: {
                 dev: {
-                    fields: {},
+                    fields: {
+                        active: { string: "Active", type: "boolean", default: true },
+                    },
                     records: [
                         { id: 1, display_name: "Julien" },
                         { id: 2, display_name: "Pierre" },
+                        { id: 5, display_name: "Paul", active: false },
                     ],
                 },
             },
@@ -121,6 +124,21 @@ QUnit.test("inaccessible or missing id", async (assert) => {
     const env = await makeTestEnv({ serverData, mockRPC });
     const displayNames = await env.services.name.loadDisplayNames("dev", [3]);
     assert.deepEqual(displayNames, { 3: ERROR_INACCESSIBLE_OR_MISSING });
+    assert.verifySteps(["web_search_read"]);
+});
+
+QUnit.test("loadDisplayNames fetches archived records", async (assert) => {
+    const mockRPC = (_, { method, model, kwargs }) => {
+        if (method === "web_search_read") {
+            assert.step(method);
+            assert.strictEqual(model, "dev");
+            assert.deepEqual(kwargs.domain, [["id", "in", [5]]]);
+            assert.strictEqual(kwargs.context.active_test, false);
+        }
+    };
+    const env = await makeTestEnv({ serverData, mockRPC });
+    const displayNames = await env.services.name.loadDisplayNames("dev", [5]);
+    assert.deepEqual(displayNames, { 5: "Paul" });
     assert.verifySteps(["web_search_read"]);
 });
 


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Open Dashboard > Sales > Sales.
- Search for an item to filter.
- Click the "Product" filter.
- Click "Search more".
- Search for an archived product.
- Select it to add it to the filter.

Issue:
The filter needs `nameService.loadDisplayNames()` to resolve the label of the selected record ids. In 17.0, that service calls `webSearchRead()` without `active_test=False`, so archived records are filtered out and treated as missing. This makes spreadsheet global filters fail on archived records.

Fix:
Fetch display names with `active_test=False` in the shared web `nameService`, so already-known archived record ids can still be resolved.

Task: [6094596](https://www.odoo.com/odoo/project/2328/tasks/6094596)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
