### PR TITLE
[FIX] hr_holidays: respect partial work days in time off allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -602,7 +602,7 @@ class HrLeave(models.Model):
             for (date_from, date_to, include_public_holidays_in_duration, calendar), employees in employees_by_dates_calendar.items()
         }
         work_days_data_mapped = {
-            (date_from, date_to, include_public_holidays_in_duration, calendar): employees._get_work_days_data_batch(date_from, date_to, compute_leaves=not include_public_holidays_in_duration, domain=domain, calendar=calendar)
+            (date_from, date_to, include_public_holidays_in_duration, calendar): employees._get_work_days_data_batch(date_from, date_to, compute_leaves=not include_public_holidays_in_duration, domain=domain, calendar=calendar, is_half_day=leave.work_entry_type_request_unit == 'half_day')
             for (date_from, date_to, include_public_holidays_in_duration, calendar), employees in employees_by_dates_calendar.items()
         }
         for leave in self:

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -560,7 +560,7 @@ class ResourceCalendar(models.Model):
         if len(Intervals(result)) != len(result):
             raise ValidationError(self.env._("Attendances can't overlap."))
 
-    def _get_attendance_intervals_days_data(self, attendance_intervals):
+    def _get_attendance_intervals_days_data(self, attendance_intervals, is_half_day=False):
         """
         helper function to compute duration of `intervals` that have
         'resource.calendar.attendance' records as payload (3rd element in tuple).
@@ -579,7 +579,7 @@ class ResourceCalendar(models.Model):
             day_hours[start.date()] += interval_hours
 
         for day, hours in day_hours.items():
-            if len(self) == 1 and self._is_duration_based_on_date(day):
+            if len(self) == 1 and self._is_duration_based_on_date(day) and not is_half_day:
                 hours_per_day = self._get_duration_based_work_hours_on_date(day)
                 day_days[start.date()] += hours / hours_per_day if hours_per_day else 0
             else:

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -90,7 +90,7 @@ class ResourceMixin(models.AbstractModel):
     def _get_hours_per_day_batch(self, date_from=None):
         return {resource.id: resource.hours_per_day for resource in self}
 
-    def _get_work_days_data_batch(self, from_datetime, to_datetime, compute_leaves=True, calendar=None, domain=None):
+    def _get_work_days_data_batch(self, from_datetime, to_datetime, compute_leaves=True, calendar=None, domain=None, is_half_day=False):
         """
             By default the resource calendar is used, but it can be
             changed using the `calendar` argument.
@@ -126,7 +126,7 @@ class ResourceMixin(models.AbstractModel):
                 intervals = calendar._attendance_intervals_batch(from_datetime, to_datetime, resources_per_tz)
 
             for calendar_resource in calendar_resources:
-                result[calendar_resource.id] = calendar._get_attendance_intervals_days_data(intervals[calendar_resource.id])
+                result[calendar_resource.id] = calendar._get_attendance_intervals_days_data(intervals[calendar_resource.id], is_half_day)
 
         # convert "resource: result" into "employee: result"
         return {mapped_employees[r.id]: result[r.id] for r in resources}


### PR DESCRIPTION
This commit will ensure that time off requests correctly calculate half-day durations for employees with irregular weekly working schedules.
**Why**:
Previously, the time off system incorrectly treated all work days as full days (8 hours) even when the employee's contract specified a partial day (e.g., a 4-hour Wednesday). When an employee on a 36-week contract with a 4-hour Wednesday tried to apply for leave on that day, the system deducted a full day's worth of entitlement. This led to incorrect leave balances and miscalculations in the payroll work entries, as the system failed to align the leave duration with the resource calendar's specific daily working hours.

**What**:
- Refined the leave duration calculation to fetch the specific hours from the resource calendar for the requested date.
- Ensured that if the calendar specifies a half-day slot (4-hour slot), the leave is processed as a half-day (0.5) instead of a full day (1.0).

task-5909431