### PR TITLE
[IMP] web: refine badge selection overflow behavior

### DIFF
--- a/addons/web/static/src/views/fields/badges_many2one/badges_many2one_field.js
+++ b/addons/web/static/src/views/fields/badges_many2one/badges_many2one_field.js
@@ -1,5 +1,5 @@
 import { getFieldDomain } from "@web/model/relational_model/utils";
-import { useSpecialData } from "@web/views/fields/relational_utils";
+import { useSelectCreate, useSpecialData } from "@web/views/fields/relational_utils";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { BaseBadgesField, extractStandardFieldProps } from "../badges_selection/base_badges_field";
 import { _t } from "@web/core/l10n/translation";
@@ -14,48 +14,49 @@ export class BadgesMany2oneField extends Component {
         domain: { type: [Array, Function], optional: true },
         relatedIconField: { type: String, optional: true },
         badgeLimit: { type: Number, optional: true },
-        placeholder: { type: String, optional: true },
         defaultIcon: { type: String, optional: true },
         canDeselect: { type: Boolean, optional: true },
     };
-    static components = {
-        BaseBadgesField,
-    };
+    static components = { BaseBadgesField };
 
     setup() {
         const { record, name, domain: propDomain, relatedIconField, defaultIcon } = this.props;
         const field = record.fields[name];
+
         this.specialData = useSpecialData(async (orm) => {
             const domain = getFieldDomain(record, name, propDomain);
             const { relation } = field;
-
             try {
                 if (relatedIconField) {
                     const records = await orm.call(relation, "search_read", [], {
                         domain,
                         fields: ["display_name", relatedIconField],
                     });
-
                     return records.map((r) => [
                         r.id,
                         r.display_name,
                         r[relatedIconField] || defaultIcon,
                     ]);
                 }
-
                 return await orm.call(relation, "name_search", ["", domain]);
             } catch (error) {
                 if (error instanceof ConnectionLostError) {
                     const currentVal = record.data[name];
-
                     if (!currentVal) {
                         return [];
                     }
-
                     return [[currentVal.id, currentVal.display_name]];
                 }
                 throw error;
             }
+        });
+
+        this.selectCreate = useSelectCreate({
+            resModel: field.relation,
+            activeActions: { create: false },
+            onSelected: (resIds) => {
+                this.props.record.update({ [this.props.name]: { id: resIds[0] } });
+            },
         });
     }
 
@@ -77,19 +78,29 @@ export class BadgesMany2oneField extends Component {
         if (!value) {
             this.props.record.update({ [this.props.name]: false });
         } else {
-            const option = this.options.find((option) => option[0] === value);
+            const option = this.options.find((opt) => opt[0] === value);
             this.props.record.update({
                 [this.props.name]: { id: option[0], display_name: option[1] },
             });
         }
     }
 
+    async onSearchMore() {
+        const { record, name, domain: propDomain } = this.props;
+        const domain = getFieldDomain(record, name, propDomain);
+        const context = record.context;
+        const field = record.fields[name];
+        const title = field.string?.trim() ? _t("Search: %s", field.string) : _t("Search");
+
+        this.selectCreate({ domain, context, title });
+    }
+
     get baseBadgeProps() {
         return {
             ...extractStandardFieldProps(this.props),
             onChange: this.onChange.bind(this),
+            onSearchMore: this.onSearchMore.bind(this),
             badgeLimit: this.props.badgeLimit,
-            placeholder: this.props.placeholder,
             canDeselect: this.props.canDeselect,
             options: this.options,
             string: this.string,
@@ -124,8 +135,7 @@ export const badgesMany2oneField = {
             help: _t("Fallback icon if co-model's field doesn't contain an icon"),
         },
     ],
-    extractProps: ({ options, placeholder }, dynamicInfo) => ({
-        placeholder,
+    extractProps: ({ options }, dynamicInfo) => ({
         defaultIcon: options.default_icon,
         domain: dynamicInfo.domain,
         canDeselect: !dynamicInfo.required,

--- a/addons/web/static/src/views/fields/badges_selection/badges_selection_field.js
+++ b/addons/web/static/src/views/fields/badges_selection/badges_selection_field.js
@@ -11,7 +11,6 @@ export class BadgesSelectionField extends Component {
         iconMapping: { type: Object, optional: true },
         allowedSelectionField: { type: String, optional: true },
         badgeLimit: { type: Number, optional: true },
-        placeholder: { type: String, optional: true },
         defaultIcon: { type: String, optional: true },
         canDeselect: { type: Boolean, optional: true },
     };
@@ -65,7 +64,6 @@ export class BadgesSelectionField extends Component {
             ...extractStandardFieldProps(this.props),
             onChange: this.onChange.bind(this),
             badgeLimit: this.props.badgeLimit,
-            placeholder: this.props.placeholder,
             canDeselect: this.props.canDeselect,
             options: this.options,
             string: this.string,
@@ -88,8 +86,7 @@ export const badgesSelectionField = {
             help: _t("Displays a dropdown if the badge count is higher than this value."),
         },
     ],
-    extractProps: ({ options, placeholder }, dynamicInfo) => ({
-        placeholder,
+    extractProps: ({ options }, dynamicInfo) => ({
         defaultIcon: options.default_icon,
         badgeLimit: options.badge_limit,
         canDeselect: !dynamicInfo.required,

--- a/addons/web/static/src/views/fields/badges_selection/base_badges_field.js
+++ b/addons/web/static/src/views/fields/badges_selection/base_badges_field.js
@@ -1,30 +1,72 @@
 import { Component } from "@odoo/owl";
-import { SelectMenu } from "@web/core/select_menu/select_menu";
-import { hasTouch } from "@web/core/browser/feature_detection";
 import { standardFieldProps } from "../standard_field_props";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { hasTouch } from "@web/core/browser/feature_detection";
 
+const DROPDOWN_ITEM_LIMIT = 8;
 export class BaseBadgesField extends Component {
     static template = "web.BaseBadgesField";
     static props = {
         ...standardFieldProps,
         badgeLimit: { type: Number, optional: true },
-        placeholder: { type: String, optional: true },
         options: { type: Array },
         string: { type: String },
         value: [String, Number, Boolean, { value: null }],
         onChange: { type: Function },
         canDeselect: { type: Boolean, optional: true },
+        onSearchMore: { type: Function, optional: true },
     };
     static components = {
-        SelectMenu,
+        Dropdown,
+        DropdownItem,
     };
 
-    get options() {
-        return this.props.options;
+    /**
+     * Computes the ordered list of options. If the selected value is
+     * beyond the limit, it is moved into the visible "unfolded" range.
+     */
+    get optionsDict() {
+        const { options, badgeLimit, value } = this.props;
+        const displayOptions = [...options];
+
+        if (this.hasMoreThanMax) {
+            const index = displayOptions.findIndex((opt) => opt[0] === value);
+
+            // If selected value is in the "More" dropdown, move it to the visible limit
+            if (index >= badgeLimit) {
+                const [selectedOption] = displayOptions.splice(index, 1);
+                displayOptions.splice(badgeLimit - 1, 0, selectedOption);
+            }
+        }
+
+        return {
+            unfolded: badgeLimit ? displayOptions.slice(0, badgeLimit) : displayOptions,
+            folded: badgeLimit ? displayOptions.slice(badgeLimit) : [],
+        };
     }
 
-    get placeholder() {
-        return this.props.placeholder || this.props.record.fields[this.props.name].string;
+    get badgesOptions() {
+        return this.optionsDict.unfolded;
+    }
+
+    get dropdownOptions() {
+        if (!this.hasMoreThanMax) {
+            return [];
+        }
+
+        const { onSearchMore } = this.props;
+        const { folded } = this.optionsDict;
+        return onSearchMore ? folded.slice(0, DROPDOWN_ITEM_LIMIT) : folded;
+    }
+
+    get extraBadgeLabel() {
+        const hiddenCount = this.props.options.length - this.props.badgeLimit;
+        return `+${hiddenCount}`;
+    }
+
+    get hasMoreThanMax() {
+        return this.props.badgeLimit && this.props.options.length > this.props.badgeLimit;
     }
 
     get string() {
@@ -33,14 +75,6 @@ export class BaseBadgesField extends Component {
 
     get value() {
         return this.props.value;
-    }
-
-    get hasMoreThanMax() {
-        return this.props.badgeLimit && this.options.length > this.props.badgeLimit;
-    }
-
-    get selectOptions() {
-        return this.options.map(([value, label, icon]) => ({ value, label, icon }));
     }
 
     get isBottomSheet() {

--- a/addons/web/static/src/views/fields/badges_selection/base_badges_field.xml
+++ b/addons/web/static/src/views/fields/badges_selection/base_badges_field.xml
@@ -6,31 +6,40 @@
                 <span t-out="this.string" t-att-raw-value="this.value" class="o_selection_badge pe-none btn btn-sm btn-secondary mb-1" t-att-class="this.getBadgeClassNames()" />
             </t>
             <t t-else="">
-                <t t-if="this.hasMoreThanMax">
-                    <SelectMenu 
-                        id="this.props.id" 
-                        value="this.value" 
-                        choices="this.selectOptions" 
-                        onSelect.bind="this.onChange" 
-                        placeholder="this.placeholder"
-                        searchable="!this.isBottomSheet"
-                        required="!this.props.canDeselect"
-                    />
+                <t t-foreach="this.badgesOptions" t-as="option" t-key="option[0]">
+                    <span
+                        class="o_selection_badge btn btn-sm btn-secondary mb-1"
+                        t-att-class="this.getBadgeClassNames(option)"
+                        t-att-value="this.stringify(option[0])"
+                        t-on-click="() => this.onChange(option[0])"
+                    >
+                        <t t-if="option[2]">
+                            <span t-att-class="`fa ${option[2]} pe-1`"/>
+                        </t>
+                        <span t-out="option[1]" t-att-value="this.stringify(option[0])"/>
+                    </span>
                 </t>
-                <t t-else="">
-                    <t t-foreach="this.options" t-as="option" t-key="option[0]">
-                        <span
-                            class="o_selection_badge btn btn-sm btn-secondary mb-1"
-                            t-att-class="this.getBadgeClassNames(option)"
-                            t-att-value="this.stringify(option[0])"
-                            t-on-click="() => this.onChange(option[0])"
-                        >
-                            <t t-if="option[2]">
-                                <span t-att-class="`fa ${option[2]} pe-1`"/>
+                <t t-if="this.hasMoreThanMax">
+                    <Dropdown>
+                        <span class="o_selection_badge btn btn-sm btn-secondary mb-1 o-dropdown-caret" t-out="this.extraBadgeLabel"/>
+                        <t t-set-slot="content">
+                            <t t-foreach="this.dropdownOptions" t-as="option" t-key="option[0]">
+                                <DropdownItem onSelected="() => this.onChange(option[0])">
+                                    <t t-if="option[2]">
+                                        <span t-att-class="`fa ${option[2]} pe-1`"/>
+                                    </t>
+                                    <t t-out="option[1]"/>
+                                </DropdownItem>
                             </t>
-                            <span t-out="option[1]" t-att-value="this.stringify(option[0])"/>
-                        </span>
-                    </t>
+                            <div t-if="this.props.onSearchMore" class="o-autocomplete">
+                                <span class="ui-menu-item o_m2o_dropdown_option ">
+                                    <DropdownItem tag="'a'" onSelected="() => this.props.onSearchMore()">
+                                        <t t-out="'Search more...'"/>
+                                    </DropdownItem>
+                                </span>
+                            </div>
+                        </t>
+                    </Dropdown>
                 </t>
             </t>
         </div>

--- a/addons/web/static/tests/views/fields/badges_many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/badges_many2one_field.test.js
@@ -1,4 +1,4 @@
-import { expect, queryAllTexts, test } from "@odoo/hoot";
+import { expect, test } from "@odoo/hoot";
 import {
     clickSave,
     contains,
@@ -8,6 +8,7 @@ import {
     mountView,
     onRpc,
 } from "@web/../tests/web_test_helpers";
+import { animationFrame } from "@odoo/hoot-mock";
 
 class Partner extends models.Model {
     product_id = fields.Many2one({ relation: "product" });
@@ -137,14 +138,24 @@ test("BadgesMany2OneField: with domain and badge_limit option", async () => {
     });
 
     expect("span.o_selection_badge").toHaveCount(2);
-    expect(".o_select_menu").toHaveCount(0);
+    expect(".dropdown-menu").toHaveCount(0);
 
-    await contains(".o_field_widget[name=product_min_id] input").edit("0");
-    expect("span.o_selection_badge").toHaveCount(0);
-    expect(".o_select_menu").toHaveCount(1);
+    await contains(".o_field_widget[name=product_min_id] input").edit("0", { confirm: "enter" });
 
-    await contains(".o_select_menu_input").click();
-    expect(queryAllTexts(".o_select_menu_item")).toEqual(["xmac", "xpad", "xphone"]);
+    expect("span.o_selection_badge").toHaveCount(3);
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
+
+    await contains(".o_selection_badge.o-dropdown-caret").click();
+    await animationFrame();
+
+    expect(".dropdown-menu").toHaveCount(1);
+
+    expect(".dropdown-menu .dropdown-item:not(:contains(Search more...))").toHaveCount(1);
+
+    await contains(".dropdown-menu .dropdown-item").click();
+    await animationFrame();
+
+    expect(".o_selection_badge.active").toHaveCount(1);
 });
 
 test("BadgesMany2OneField: placeholder attribute is used when provided", async () => {
@@ -159,11 +170,8 @@ test("BadgesMany2OneField: placeholder attribute is used when provided", async (
             </form>`,
     });
 
-    expect(
-        ".o_select_menu .dropdown-toggle .o_select_menu_input[placeholder='Pick a product']"
-    ).toHaveCount(1, {
-        message: "should display the custom placeholder",
-    });
+    expect("span.o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
 });
 
 test("BadgesMany2OneField: placeholder falls back to field label when not provided", async () => {
@@ -177,11 +185,8 @@ test("BadgesMany2OneField: placeholder falls back to field label when not provid
             </form>`,
     });
 
-    expect(
-        ".o_select_menu .dropdown-toggle .o_select_menu_input[placeholder='Product']"
-    ).toHaveCount(1, {
-        message: "should fall back to the field label as placeholder",
-    });
+    expect("span.o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
 });
 
 test("[Offline] BadgesMany2OneField: verify badges are displayed in offline mode", async () => {

--- a/addons/web/static/tests/views/fields/badges_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/badges_selection_field.test.js
@@ -163,17 +163,14 @@ test("BadgesSelectionField: switching to SelectMenu when badge_limit is exceeded
             </form>`,
     });
 
-    expect(".o_select_menu").toHaveCount(1, {
-        message: "Should render SelectMenu instead of badges",
+    expect("span.o_selection_badge").toHaveCount(2, {
+        message: "Should render 1 badge and 1 overflow dropdown toggle",
     });
-    expect("span.o_selection_badge").toHaveCount(0, {
-        message: "Should not render individual badges",
-    });
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
 
-    // Open dropdown and check values
-    await contains(".o_select_menu input").click();
+    await contains(".o_selection_badge.o-dropdown-caret").click();
     await animationFrame();
-    expect(".o-dropdown-item").toHaveCount(2);
+    expect(".dropdown-menu").toHaveCount(1);
 });
 
 test("BadgesSelectionField: verify options are filtered via the allowed_selection_field option", async () => {
@@ -208,11 +205,9 @@ test("BadgesSelectionField: placeholder attribute is used when provided", async 
             </form>`,
     });
 
-    expect(
-        ".o_select_menu .dropdown-toggle .o_select_menu_input[placeholder='Pick a color']"
-    ).toHaveCount(1, {
-        message: "should display the custom placeholder",
-    });
+    // With 2 options and badge_limit 1: 1 visible badge + "+1" overflow dropdown toggle
+    expect("span.o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
 });
 
 test("BadgesSelectionField: placeholder falls back to field label when not provided", async () => {
@@ -227,10 +222,7 @@ test("BadgesSelectionField: placeholder falls back to field label when not provi
             </form>`,
     });
 
-    expect(".o_select_menu .dropdown-toggle .o_select_menu_input[placeholder='Color']").toHaveCount(
-        1,
-        {
-            message: "should fall back to the field label as placeholder",
-        }
-    );
+    // With 2 options and badge_limit 1: 1 visible badge + "+1" overflow dropdown toggle
+    expect("span.o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge.o-dropdown-caret").toHaveText("+1");
 });


### PR DESCRIPTION
This PR refines the "overflow" behavior of the badge selection widget to keep it easier when dealing with many options. Instead of the widget completely turning into a dropdown when a limit is reached, it now uses a hybrid approach.

* Hybrid Display: The widget now shows a fixed number of badges (defined by `badgeLimit`) and puts the rest into a **"More" (+N)** dropdown. This keeps the most important options visible at all times.
* Reordering: If you select an option from the "More" dropdown, it automatically swaps into the visible badge area. This ensures your active choice is always front and center, not hidden in a menu.
* Search More: For Many2one fields, we've added a "Search more..." option inside the dropdown to help find specific records in large datasets.

**Task-6068373**