### PR TITLE
[FIX] hr_livechat: update My Team filter in Live Chat agent reports

### DIFF
--- a/addons/hr_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/hr_livechat/views/im_livechat_channel_member_history_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="im_livechat.im_livechat_agent_history_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//*[@name='my_session']" position="after">
-                <filter name="my_team" domain="[('partner_id.user_ids.employee_id.member_of_department', '=', True)]" string="My Team"/>
+                <filter name="my_team" domain="['|', ('partner_id.user_ids', '=', uid), ('partner_id.employee_ids.parent_id.user_id', '=', uid)]" string="My Team"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Replace the department-based domain with a hierarchy-based domain. The new filter includes the current user's records and the records of employees whose manager is the current user.

follow-up of https://github.com/odoo/odoo/pull/253567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
