### PR TITLE
[IMP] html_editor: applying format on collapsed selection without changing DOM

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -254,6 +254,7 @@ export class DomPlugin extends Plugin {
 
         const block = closestBlock(selection.anchorNode);
         container = this.processThrough("before_insert_processors", container, block);
+        this.trigger("before_insert_handlers");
         if (!container.hasChildNodes()) {
             return [];
         }

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -7,29 +7,20 @@ import { closestBlock, isBlock } from "../utils/blocks";
 import { cleanTextNode, fillEmpty, removeClass, splitTextNode, unwrapContents } from "../utils/dom";
 import {
     areSimilarElements,
-    hasVisibleContent,
     isContentEditable,
     isElement,
-    isEmptyBlock,
     isEmptyTextNode,
     isPhrasingContent,
     isSelfClosingElement,
     isStylable,
     isTextNode,
-    isVisible,
     isVisibleTextNode,
     isZwnbsp,
     isZWS,
     previousLeaf,
 } from "../utils/dom_info";
 import { isFakeLineBreak } from "../utils/dom_state";
-import {
-    childNodes,
-    closestElement,
-    descendants,
-    findFurthest,
-    selectElements,
-} from "../utils/dom_traversal";
+import { childNodes, closestElement, descendants, selectElements } from "../utils/dom_traversal";
 import { formatsSpecs, FORMATTABLE_TAGS } from "../utils/formatting";
 import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../utils/position";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -45,7 +36,7 @@ function isFormatted(formatPlugin, format) {
  * @property { FormatPlugin['isSelectionFormat'] } isSelectionFormat
  * @property { FormatPlugin['insertAndSelectZws'] } insertAndSelectZws
  * @property { FormatPlugin['mergeAdjacentInlines'] } mergeAdjacentInlines
- * @property { FormatPlugin['formatSelection'] } formatSelection
+ * @property { FormatPlugin['requestFormat'] } requestFormat
  */
 
 /**
@@ -67,7 +58,7 @@ export class FormatPlugin extends Plugin {
         "isSelectionFormat",
         "insertAndSelectZws",
         "mergeAdjacentInlines",
-        "formatSelection",
+        "requestFormat",
         "removeFormats",
     ];
     /** @type {import("plugins").EditorResources} */
@@ -77,34 +68,34 @@ export class FormatPlugin extends Plugin {
                 id: "formatBold",
                 description: _t("Toggle bold"),
                 icon: "fa-bold",
-                run: this.formatSelection.bind(this, "bold"),
+                run: this.requestFormat.bind(this, "bold"),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
                 id: "formatItalic",
                 description: _t("Toggle italic"),
                 icon: "fa-italic",
-                run: this.formatSelection.bind(this, "italic"),
+                run: this.requestFormat.bind(this, "italic"),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
                 id: "formatUnderline",
                 description: _t("Toggle underline"),
                 icon: "fa-underline",
-                run: this.formatSelection.bind(this, "underline"),
+                run: this.requestFormat.bind(this, "underline"),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
                 id: "formatStrikethrough",
                 description: _t("Toggle strikethrough"),
                 icon: "fa-strikethrough",
-                run: this.formatSelection.bind(this, "strikeThrough"),
+                run: this.requestFormat.bind(this, "strikeThrough"),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
                 id: "formatFontSize",
                 run: ({ size }) =>
-                    this.formatSelection("fontSize", {
+                    this.requestFormat("fontSize", {
                         applyStyle: true,
                         formatProps: { size },
                     }),
@@ -113,7 +104,7 @@ export class FormatPlugin extends Plugin {
             {
                 id: "formatFontSizeClassName",
                 run: ({ className }) =>
-                    this.formatSelection("setFontSizeClassName", {
+                    this.requestFormat("setFontSizeClassName", {
                         applyStyle: true,
                         formatProps: { className },
                     }),
@@ -145,7 +136,7 @@ export class FormatPlugin extends Plugin {
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatBold",
-                isActive: isFormatted(this, "bold"),
+                isActive: () => isFormatted(this, "bold")() || this.activeFormats["bold"],
                 isDisabled: (sel, nodes) => nodes.some((node) => !isStylable(node)),
             },
             {
@@ -154,7 +145,7 @@ export class FormatPlugin extends Plugin {
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatItalic",
-                isActive: isFormatted(this, "italic"),
+                isActive: () => isFormatted(this, "italic")() || this.activeFormats["italic"],
                 isDisabled: (sel, nodes) => nodes.some((node) => !isStylable(node)),
             },
             {
@@ -163,7 +154,8 @@ export class FormatPlugin extends Plugin {
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatUnderline",
-                isActive: isFormatted(this, "underline"),
+                isActive: () =>
+                    isFormatted(this, "underline")() || this.activeFormats["formatUnderline"],
                 isDisabled: (sel, nodes) => nodes.some((node) => !isStylable(node)),
             },
             {
@@ -171,7 +163,8 @@ export class FormatPlugin extends Plugin {
                 description: _t("Strikethrough (Ctrl + 5)"),
                 groupId: "decoration",
                 commandId: "formatStrikethrough",
-                isActive: isFormatted(this, "strikeThrough"),
+                isActive: () =>
+                    isFormatted(this, "strikeThrough")() || this.activeFormats["strikeThrough"],
                 isDisabled: (sel, nodes) => nodes.some((node) => !isStylable(node)),
             },
             withSequence(20, {
@@ -184,9 +177,10 @@ export class FormatPlugin extends Plugin {
         ],
         /** Handlers */
         on_beforeinput_handlers: withSequence(20, this.onBeforeInput.bind(this)),
-        on_selectionchange_handlers: this.removeEmptyInlineElement.bind(this),
+        on_selectionchange_handlers: () => (this.activeFormats = {}),
         on_will_set_tag_handlers: this.removeFontSizeFormat.bind(this),
-        before_insert_processors: this.unwrapEmptyFormat.bind(this),
+        before_insert_handlers: this.beforeInsert.bind(this),
+        on_deleted_handlers: this.checkEmptyElementAndFormat.bind(this),
 
         /** Processors */
         clean_for_save_processors: this.cleanForSave.bind(this),
@@ -216,24 +210,30 @@ export class FormatPlugin extends Plugin {
         }
     }
 
-    unwrapEmptyFormat(insertedNode) {
-        const anchorNode = this.dependencies.selection.getEditableSelection().anchorNode;
-        if (!allWhitespaceRegex.test(insertedNode.textContent)) {
-            return insertedNode;
+    checkEmptyElementAndFormat() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        const element = closestElement(selection.anchorNode);
+        if (!isZWS(element) || !isPhrasingContent(element)) {
+            return;
         }
-        const emptyZWS = closestElement(anchorNode, "[data-oe-zws-empty-inline]");
+        // to think: can one node have multiple formats?
+        const format = Object.keys(formatsSpecs).find((format) =>
+            formatsSpecs[format].isFormatted(selection.anchorNode, { editable: this.editable })
+        );
+
         if (
-            !emptyZWS ||
-            !emptyZWS.parentElement.isContentEditable ||
-            this.dependencies.delete.isUnremovable(emptyZWS)
+            format &&
+            !this.dependencies.delete.isUnremovable(element) &&
+            element.getAttributeNames().length === 1
         ) {
-            return insertedNode;
+            const restoreSpaces = prepareUpdate(...leftPos(element), ...rightPos(element));
+            removeFormat(selection.anchorNode, formatsSpecs[format]);
+            restoreSpaces();
+            // let selectionchange event settle
+            setTimeout(() => {
+                this.activeFormats[format] = true;
+            });
         }
-        const cursors = this.dependencies.selection.preserveSelection();
-        cursors.update(callbacksForCursorUpdate.remove(emptyZWS));
-        emptyZWS.remove();
-        cursors.restore();
-        return insertedNode;
     }
 
     removeAllFormats() {
@@ -295,6 +295,30 @@ export class FormatPlugin extends Plugin {
         return targetedNodes.some(
             (node) => this.checkPredicates("has_format_predicates", node) ?? false
         );
+    }
+
+    requestFormat(formatName, options) {
+        const sel = this.dependencies.selection.getEditableSelection();
+        if (sel.isCollapsed && this.activeFormats[formatName] === true) {
+            this.activeFormats[formatName] = false;
+            return;
+        } else if (
+            sel.isCollapsed &&
+            !this.activeFormats[formatName] &&
+            !this.isSelectionFormat(formatName)
+        ) {
+            this.activeFormats[formatName] = true;
+            this.trigger("on_format_requested_handlers");
+            return;
+        } else if (
+            sel.isCollapsed &&
+            this.activeFormats[formatName] !== false &&
+            this.isSelectionFormat(formatName)
+        ) {
+            this.activeFormats[formatName] = false;
+            return;
+        }
+        this.formatSelection(formatName, options);
     }
 
     formatSelection(formatName, options) {
@@ -451,6 +475,7 @@ export class FormatPlugin extends Plugin {
                 } else if (formatName !== "fontSize" || formatProps.size !== undefined) {
                     formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                 }
+                delete this.activeFormats[formatName];
             }
         }
 
@@ -483,7 +508,14 @@ export class FormatPlugin extends Plugin {
             unformattedTextNodes[0] &&
             unformattedTextNodes[0].textContent === "\u200B"
         ) {
-            this.dependencies.selection.setCursorStart(unformattedTextNodes[0]);
+            const parentNode = unformattedTextNodes[0].parentElement;
+            const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesIn(parentNode);
+            this.dependencies.selection.setSelection({
+                anchorNode,
+                anchorOffset,
+                focusNode,
+                focusOffset,
+            });
         } else if (selectedTextNodes.length) {
             const firstNode = selectedTextNodes[0];
             const lastNode = selectedTextNodes[selectedTextNodes.length - 1];
@@ -548,32 +580,6 @@ export class FormatPlugin extends Plugin {
             }
         }
         this.mergeAdjacentInlines(root, { preserveSelection });
-    }
-
-    removeEmptyInlineElement(selectionData) {
-        const { anchorNode } = selectionData.editableSelection;
-        const blockEl = closestBlock(anchorNode);
-        if (!blockEl) {
-            return;
-        }
-        const inlineElement = findFurthest(
-            closestElement(anchorNode),
-            blockEl,
-            (e) => isPhrasingContent(e) && !isVisible(e) && !hasVisibleContent(e)
-        );
-        if (
-            this.lastEmptyInlineElement?.isConnected &&
-            this.lastEmptyInlineElement !== inlineElement
-        ) {
-            // Remove last empty inline element.
-            this.cleanElement(this.lastEmptyInlineElement, { preserveSelection: true });
-        }
-        // Skip if current block is empty.
-        if (inlineElement && !isEmptyBlock(blockEl)) {
-            this.lastEmptyInlineElement = inlineElement;
-        } else {
-            this.lastEmptyInlineElement = null;
-        }
     }
 
     cleanElement(element, { preserveSelection }) {
@@ -651,6 +657,22 @@ export class FormatPlugin extends Plugin {
         return zws;
     }
 
+    beforeInsert() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        if (!selection.isCollapsed) {
+            return;
+        }
+        if (this.activeFormats) {
+            Object.entries(this.activeFormats).forEach(([formatName, isActive]) => {
+                if (isActive) {
+                    this.formatSelection(formatName, { applyStyle: true });
+                } else {
+                    this.formatSelection(formatName, { applyStyle: false });
+                }
+            });
+        }
+    }
+
     onBeforeInput(ev) {
         if (
             ev.inputType.startsWith("format") &&
@@ -659,9 +681,20 @@ export class FormatPlugin extends Plugin {
             ev.preventDefault();
         }
         if (ev.inputType === "insertText") {
-            const selection = this.dependencies.selection.getEditableSelection();
+            let selection = this.dependencies.selection.getEditableSelection();
             if (!selection.isCollapsed) {
                 return;
+            }
+            if (this.activeFormats) {
+                Object.entries(this.activeFormats).forEach(([formatName, isActive]) => {
+                    if (isActive) {
+                        this.formatSelection(formatName, { applyStyle: true });
+                    } else {
+                        this.formatSelection(formatName, { applyStyle: false });
+                    }
+                    this.dependencies.delete.deleteSelection();
+                    selection = this.dependencies.selection.getEditableSelection();
+                });
             }
             // Links are a special case here. When typing, link
             // element gets removed automatically whereas
@@ -785,6 +818,11 @@ function removeFormat(node, formatSpec) {
                 newNode.attributes.setNamedItem(node.attributes[index].cloneNode());
             }
             node.parentNode.replaceChild(newNode, node);
+        } else if (
+            node.getAttributeNames().length === 1 &&
+            node.hasAttribute("data-oe-zws-empty-inline")
+        ) {
+            node.remove();
         } else {
             unwrapContents(node);
         }

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -50,7 +50,8 @@ export class ColorPlugin extends Plugin {
         "removeAllColor",
         "getElementColors",
         "getColorCombination",
-        "applyColor",
+        "applyColor", //check
+        "requestColor",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -58,7 +59,7 @@ export class ColorPlugin extends Plugin {
             {
                 id: "applyColor",
                 run: ({ color, mode }) => {
-                    this.applyColor(color, mode);
+                    this.requestColor(color, mode);
                     this.dependencies.history.addStep();
                 },
                 isAvailable: isHtmlContentSupported,
@@ -67,6 +68,7 @@ export class ColorPlugin extends Plugin {
         /** Handlers */
         on_all_formats_removed_handlers: this.removeAllColor.bind(this),
         color_combination_providers: getColorCombinationFromClass,
+        on_beforeinput_handlers: this.onBeforeInput.bind(this),
 
         /** Predicates */
         has_format_predicates: (node) => {
@@ -89,6 +91,18 @@ export class ColorPlugin extends Plugin {
         for (const el of selectElements(root, "font")) {
             if (isRedundantElement(el)) {
                 unwrapContents(el);
+            }
+        }
+    }
+
+    onBeforeInput(ev) {
+        if (ev.inputType === "insertText") {
+            const selection = this.dependencies.selection.getEditableSelection();
+            if (!selection.isCollapsed) {
+                return;
+            }
+            if (this.activeColorInfo && Object.keys(this.activeColorInfo).length) {
+                this.applyColor(this.activeColorInfo.color, this.activeColorInfo.mode);
             }
         }
     }
@@ -141,6 +155,15 @@ export class ColorPlugin extends Plugin {
                 }
             }
         }
+    }
+
+    requestColor(color, mode, previewMode = false) {
+        const sel = this.dependencies.selection.getEditableSelection();
+        if (sel.isCollapsed) {
+            this.activeColorInfo = { color, mode };
+            return;
+        }
+        this.applyColor(color, mode, previewMode);
     }
 
     /**
@@ -345,6 +368,14 @@ export class ColorPlugin extends Plugin {
             fonts = getFonts(selectedNodes);
         }
 
+        if (
+            fonts.length === 1 &&
+            fonts[0].childNodes.length === 1 &&
+            isTextNode(fonts[0].firstChild) &&
+            isZWS(fonts[0].firstChild)
+        ) {
+            fonts[0].setAttribute("data-oe-zws-empty-inline", "");
+        }
         // Color the selected <font>s and remove uncolored fonts.
         const fontsSet = new Set(fonts);
         for (const font of fontsSet) {
@@ -353,7 +384,8 @@ export class ColorPlugin extends Plugin {
                 !hasColor(font, "color") &&
                 !hasColor(font, "backgroundColor") &&
                 ["FONT", "SPAN"].includes(font.nodeName) &&
-                (!font.hasAttribute("style") || !color)
+                (!font.hasAttribute("style") || !color) &&
+                (!this.activeColorInfo || !Object.keys(this.activeColorInfo).length)
             ) {
                 cursors.update(callbacksForCursorUpdate.unwrap(font));
                 unwrapContents(font);
@@ -361,6 +393,7 @@ export class ColorPlugin extends Plugin {
             }
         }
         cursors.restore();
+        this.activeColorInfo = {};
     }
 
     /**

--- a/addons/html_editor/static/src/main/font/color_ui_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_ui_plugin.js
@@ -51,7 +51,7 @@ export class ColorUIPlugin extends Plugin {
         this.selectedColors = reactive({ color: "", backgroundColor: "" });
         this.previewableApplyColor = this.dependencies.history.makePreviewableOperation(
             (color, mode, previewMode) =>
-                this.dependencies.color.applyColor(color, mode, previewMode)
+                this.dependencies.color.requestColor(color, mode, previewMode)
         );
     }
 

--- a/addons/html_editor/static/src/main/font/font_family_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_family_plugin.js
@@ -45,7 +45,7 @@ export class FontFamilyPlugin extends Plugin {
                     fontFamilyItems: fontFamilyItems,
                     currentFontFamily: this.fontFamily,
                     onSelected: (item) => {
-                        this.dependencies.format.formatSelection("fontFamily", {
+                        this.dependencies.format.requestFormat("fontFamily", {
                             applyStyle: item.fontFamily !== false,
                             formatProps: item,
                         });

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -180,14 +180,14 @@ export class FontPlugin extends Plugin {
                     getItems: () => this.fontSizeItems,
                     getDisplay: () => this.fontSize,
                     onFontSizeInput: (size) => {
-                        this.dependencies.format.formatSelection("fontSize", {
+                        this.dependencies.format.requestFormat("fontSize", {
                             formatProps: { size },
                             applyStyle: true,
                         });
                         this.updateFontSizeSelectorParams();
                     },
                     onSelected: (item) => {
-                        this.dependencies.format.formatSelection("setFontSizeClassName", {
+                        this.dependencies.format.requestFormat("setFontSizeClassName", {
                             formatProps: { className: item.className },
                             applyStyle: true,
                         });

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -162,6 +162,7 @@ export class ToolbarPlugin extends Plugin {
         on_selection_leave_handlers: () => this.closeToolbar(),
         on_selection_enter_handlers: () => this.updateToolbar(),
         on_step_added_handlers: () => this.updateToolbar(),
+        on_format_requested_handlers: () => this.updateToolbar(),
         user_commands: {
             id: "expandToolbar",
             run: () => {

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -288,7 +288,7 @@ export function setFontSizeClassName(className) {
 }
 export function setFontFamily(fontFamily) {
     return (editor) => {
-        editor.shared.format.formatSelection("fontFamily", {
+        editor.shared.format.requestFormat("fontFamily", {
             applyStyle: fontFamily !== false,
             formatProps: {
                 name: fontFamily + "_name",

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -1,7 +1,7 @@
 import { after, before, describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
-import { setColor } from "./_helpers/user_actions";
+import { insertText, setColor } from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { animationFrame, press } from "@odoo/hoot-dom";
 
@@ -43,19 +43,21 @@ test("should apply a background color to a slice of text in a span in a font", a
 });
 
 test("should get ready to type with a different color", async () => {
-    await testEditor({
-        contentBefore: "<p>ab[]cd</p>",
-        stepFunction: setColor("rgb(255, 0, 0)", "color"),
-        contentAfter: '<p>ab<font style="color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
-    });
+    const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+    await setColor("rgb(255, 0, 0)", "color")(editor);
+    expect(getContent(el)).toBe("<p>ab[]cd</p>");
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe('<p>ab<font style="color: rgb(255, 0, 0);">x[]</font>cd</p>');
 });
 
 test("should get ready to type with a different background color", async () => {
-    await testEditor({
-        contentBefore: "<p>ab[]cd</p>",
-        stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
-        contentAfter: '<p>ab<font style="background-color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
-    });
+    const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+    await setColor("rgb(255, 0, 0)", "backgroundColor")(editor);
+    expect(getContent(el)).toBe("<p>ab[]cd</p>");
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe(
+        '<p>ab<font style="background-color: rgb(255, 0, 0);">x[]</font>cd</p>'
+    );
 });
 
 test("should apply a color on empty selection", async () => {

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -133,12 +133,13 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteBackward,
                 contentAfterEdit:
                     '<p data-selection-placeholder=""><br></p>' +
-                    '<div><p>ab</p><br><i data-oe-zws-empty-inline="">[]\u200B</i></div>' +
+                    "<div><p>ab</p><br><br>[]</div>" +
                     '<p data-selection-placeholder=""><br></p>',
                 contentAfter: "<div><p>ab</p><br><br>[]</div>",
             });
         });
 
+        // Same.
         test("should keep inline block (2)", async () => {
             await testEditor({
                 contentBefore: '<div><p>uv</p><br><span class="style">w[]</span></div>',
@@ -175,7 +176,7 @@ describe("Selection collapsed", () => {
                     await insertText(editor, "x");
                     undo(editor);
                 },
-                contentAfterEdit: '<p>ab<b data-oe-zws-empty-inline="">[]\u200B</b>de</p>',
+                contentAfterEdit: "<p>ab[]de</p>",
                 contentAfter: "<p>ab[]de</p>",
             });
         });
@@ -576,24 +577,6 @@ describe("Selection collapsed", () => {
                 contentBefore: `<p>a<a class="btn" href="http://test.test/">[]</a></p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>a[]</p>`,
-            });
-        });
-
-        test("should delete empty styled paragraph(s) and move cursor to previous styled inline (1)", async () => {
-            await testEditor({
-                contentBefore: `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
-                stepFunction: deleteBackward,
-                contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong><br></p>`,
-                contentAfter: `<p>[]<br></p>`,
-            });
-        });
-
-        test("should delete empty styled paragraph(s) and move cursor to previous styled inline (2)", async () => {
-            await testEditor({
-                contentBefore: `<p><strong>abc</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
-                stepFunction: deleteBackward,
-                contentAfterEdit: `<p><strong>abc</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong><br></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong><br></p>`,
-                contentAfter: `<p><strong>abc</strong></p><p><br></p><p>[]<br></p>`,
             });
         });
     });
@@ -1702,6 +1685,9 @@ describe("Selection collapsed", () => {
 
 describe("Selection not collapsed", () => {
     test("ZWS : should keep inline block (1)", async () => {
+        // why data-oe-zws-empty-inline my cursor is alreay within it....
+        // and if i move my cursor the span should be removed!
+        // To remove?
         await testEditor({
             contentBefore: '<div><p>ab <span class="style">[c]</span> d</p></div>',
             stepFunction: async (editor) => {

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -4,7 +4,7 @@ import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { deleteForward, insertText, tripleClick } from "../_helpers/user_actions";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
-import { animationFrame } from "@odoo/hoot-dom";
+import { animationFrame, tick } from "@odoo/hoot-dom";
 import {
     compareHighlightedContent,
     highlightedPre,
@@ -1325,21 +1325,6 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should not delete single remaining empty inline", async () => {
-        // Forward selection
-        await testEditor({
-            contentBefore: "<h1><i>[abcdef]</i></h1>",
-            stepFunction: deleteForward,
-            // The flagged 200B is there to preserve the font so if we
-            // write now, we still write in the font element's style.
-            contentAfterEdit:
-                '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><i data-oe-zws-empty-inline="">[]\u200B</i><br></h1>',
-            // The flagged 200B is removed by the sanitizer if its
-            // parent remains empty.
-            contentAfter: "<h1>[]<br></h1>",
-        });
-    });
-
     test("should not delete styling nodes if not selected", async () => {
         await testEditor({
             contentBefore: '<p>a<span class="style-class">[bcde]</span>f</p>',
@@ -1466,23 +1451,25 @@ describe("Selection not collapsed", () => {
     });
 
     test("should delete a selection from the beginning of a heading1 with a format to the end of a paragraph (1)", async () => {
-        await testEditor({
-            contentBefore: "<h1><u>[abcd</u></h1><p>ef]</p><h2>1</h2>",
-            stepFunction: deleteForward,
-            contentAfterEdit:
-                '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><u data-oe-zws-empty-inline="">[]\u200B</u><br></h1><h2>1</h2>',
-            contentAfter: "<h1>[]<br></h1><h2>1</h2>",
-        });
+        const { editor, el } = await setupEditor("<h1><u>[abcd</u></h1><p>ef]</p><h2>1</h2>");
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            `<h1 o-we-hint-text="Heading 1" class="o-we-hint">[]<br></h1><h2>1</h2>`
+        );
+        await tick();
+        await insertText(editor, "x");
+        expect(getContent(el)).toBe("<h1><u>x[]</u><br></h1><h2>1</h2>");
     });
 
     test("should delete a selection from the beginning of a heading1 with a format to the end of a paragraph (2)", async () => {
-        await testEditor({
-            contentBefore: "<h1>[<u>abcd</u></h1><p>ef]</p><h2>2</h2>",
-            stepFunction: deleteForward,
-            contentAfterEdit:
-                '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><u data-oe-zws-empty-inline="">[]\u200B</u><br></h1><h2>2</h2>',
-            contentAfter: "<h1>[]<br></h1><h2>2</h2>",
-        });
+        const { editor, el } = await setupEditor("<h1>[<u>abcd</u></h1><p>ef]</p><h2>2</h2>");
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            `<h1 o-we-hint-text="Heading 1" class="o-we-hint">[]<br></h1><h2>2</h2>`
+        );
+        await tick();
+        await insertText(editor, "x");
+        expect(getContent(el)).toBe("<h1><u>x[]</u><br></h1><h2>2</h2>");
     });
 
     test.tags("desktop");

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -133,24 +133,6 @@ test("should make a selection ending with bold text fully bold", async () => {
     });
 });
 
-test("should get ready to type in bold", async () => {
-    await testEditor({
-        contentBefore: "<p>ab[]cd</p>",
-        stepFunction: bold,
-        contentAfterEdit: `<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`,
-        contentAfter: `<p>ab[]cd</p>`,
-    });
-});
-
-test("should get ready to type in not bold", async () => {
-    await testEditor({
-        contentBefore: `<p><strong>ab[]cd</strong></p>`,
-        stepFunction: bold,
-        contentAfterEdit: `<p><strong>ab</strong><span data-oe-zws-empty-inline="">[]\u200B</span><strong>cd</strong></p>`,
-        contentAfter: `<p><strong>ab[]cd</strong></p>`,
-    });
-});
-
 describe("Redundant bold tags", () => {
     test(`should remove a strong tag that was redundant while performing the command.`, async () => {
         await testEditor({
@@ -311,10 +293,7 @@ test("should insert a span zws when toggling a formatting command twice", () =>
             bold(editor);
             bold(editor);
         },
-        // todo: It would be better to remove the zws entirely so that
-        // the P could have the "/" hint but that behavior might be
-        // complex with the current implementation.
-        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span data-oe-zws-empty-inline="">[]\u200B</span></p>`,
+        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
     }));
 
 // This test uses execCommand to reproduce as closely as possible the browser's
@@ -339,7 +318,7 @@ test("should type in bold", async () => {
 
     // Toggle bold on.
     bold(editor);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
     // Simulate text insertion as done by the contenteditable.
     await typeChar(editor, "x");
@@ -353,7 +332,7 @@ test("should type in bold", async () => {
     // Toggle bold off and type more.
     bold(editor);
     expect(getContent(el)).toBe(
-        `<p>ab<strong>xy</strong><span data-oe-zws-empty-inline="">[]\u200B</span>cd</p>`
+        `<p>ab<strong>xy[]</strong>cd</p>`
     );
     await typeChar(editor, "z");
     expect(getContent(el)).toBe(`<p>ab<strong>xy</strong>z[]cd</p>`);
@@ -363,19 +342,19 @@ test.tags("desktop");
 test("create bold with shortcut + selected with arrow", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
     await press(["control", "b"]);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
     await simulateArrowKeyPress(editor, ["Shift", "ArrowRight"]);
     await tick(); // await selectionchange
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 1);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[\u200B</strong>c]d</p>`);
+    expect(getContent(el)).toBe(`<p>ab[c]d</p>`);
 
     await simulateArrowKeyPress(editor, ["Shift", "ArrowLeft"]);
     await tick(); // await selectionchange
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 0);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[\u200B]</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 });
 
 const styleContentBold = `.boldClass { font-weight: bold; }`;
@@ -437,46 +416,51 @@ describe("inside container font-weight: 500 and strong being strong-weight: 500"
     });
 });
 
-test("should remove empty bold tag when changing selection", async () => {
+test("should remove bold state when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
 
     bold(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe(`<p>ax[]bcd</p>`);
 });
 
-test("should remove multiple formatted empty bold tag when changing selection", async () => {
+test("should remove multiple formatted state when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
 
     bold(editor);
     italic(editor);
     await tick();
     expect(getContent(el)).toBe(
-        `<p>ab<strong data-oe-zws-empty-inline=""><em data-oe-zws-empty-inline="">[]\u200B</em></strong>cd</p>`
+        `<p>ab[]cd</p>`
     );
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe(`<p>ax[]bcd</p>`);
 });
 
+// Shall be fixed by one of my other task!
 test("should not remove empty bold tag in an empty block when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>abcd</p><p>[]<br></p>");
 
     bold(editor);
     await tick();
     expect(getContent(el)).toBe(
-        `<p>abcd</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`
+        `<p>abcd</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 
     await simulateArrowKeyPress(editor, "ArrowUp");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(
-        `<p>[]abcd</p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p>`
+        `<p>[]abcd</p><p><br></p>`
     );
 });
 
@@ -489,7 +473,7 @@ test("should not add history step for bold on collapsed selection", async () => 
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "b"]);
-    expect(getContent(el)).toBe(`<p>abcd<strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<strong>A[]</strong></p>`);

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -4,7 +4,6 @@ import { unformat } from "../_helpers/format";
 import { setFontSize, setFontSizeClassName, tripleClick } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
-import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
 import { press } from "@odoo/hoot-dom";
 import { getContent } from "../_helpers/selection";
@@ -35,14 +34,6 @@ test("should change the font size of a whole heading after a triple click", asyn
         },
         contentAfter: '<h1><span style="font-size: 36px;">[ab]</span></h1><p>cd</p>',
     });
-});
-
-test("should get ready to type with a different font size", async () => {
-    const { editor } = await setupEditor('<p class="p">ab[]cd</p>');
-    execCommand(editor, "formatFontSize", { size: "36px" });
-    await animationFrame();
-    expect(".p span").toHaveStyle({ "font-size": "36px" });
-    expect(".p span").toHaveAttribute("data-oe-zws-empty-inline", "");
 });
 
 test("should change the font-size for a character in an inline that has a font-size", async () => {

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -150,24 +150,6 @@ test("should make two paragraphs (separated with whitespace) italic, then not it
     });
 });
 
-test("should get ready to type in italic", async () => {
-    await testEditor({
-        contentBefore: `<p>ab[]cd</p>`,
-        stepFunction: italic,
-        contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
-        contentAfter: `<p>ab[]cd</p>`,
-    });
-});
-
-test("should get ready to type in not italic", async () => {
-    await testEditor({
-        contentBefore: `<p><em>ab[]cd</em></p>`,
-        stepFunction: italic,
-        contentAfterEdit: `<p><em>ab</em><span data-oe-zws-empty-inline="">[]\u200B</span><em>cd</em></p>`,
-        contentAfter: `<p><em>ab[]cd</em></p>`,
-    });
-});
-
 test("should not format non-editable text (italic)", async () => {
     await testEditor({
         contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
@@ -176,16 +158,18 @@ test("should not format non-editable text (italic)", async () => {
     });
 });
 
-test("should remove empty italic tag when changing selection", async () => {
+test("should change italic active state when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
 
     italic(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe(`<p>ax[]bcd</p>`);
 });
 
 test("should make a few characters italic inside table (italic)", async () => {
@@ -245,7 +229,7 @@ test("should not add history step for italic on collapsed selection", async () =
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "i"]);
-    expect(getContent(el)).toBe(`<p>abcd<em data-oe-zws-empty-inline="">[]\u200B</em></p>`);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<em>A[]</em></p>`);

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -156,24 +156,6 @@ test("should make a selection ending with strikeThrough text fully strikeThrough
     });
 });
 
-test("should get ready to type in strikeThrough", async () => {
-    await testEditor({
-        contentBefore: `<p>ab[]cd</p>`,
-        stepFunction: strikeThrough,
-        contentAfterEdit: `<p>ab<s data-oe-zws-empty-inline="">[]\u200B</s>cd</p>`,
-        contentAfter: `<p>ab[]cd</p>`,
-    });
-});
-
-test("should get ready to type in not underline", async () => {
-    await testEditor({
-        contentBefore: `<p><s>ab[]cd</s></p>`,
-        stepFunction: strikeThrough,
-        contentAfterEdit: `<p><s>ab</s><span data-oe-zws-empty-inline="">[]\u200B</span><s>cd</s></p>`,
-        contentAfter: `<p><s>ab[]cd</s></p>`,
-    });
-});
-
 test("should do nothing when a block already has a line-through decoration", async () => {
     await testEditor({
         contentBefore: `<p style="text-decoration: line-through;">a[b]c</p>`,
@@ -257,16 +239,18 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
     });
 });
 
-test("should remove empty strikeThrough when changing selection", async () => {
+test("should change italic active state when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
 
     strikeThrough(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<s data-oe-zws-empty-inline="">[]\u200B</s>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+    await insertText(editor, "x");
+    expect(getContent(el)).toBe(`<p>ax[]bcd</p>`);
 });
 
 test("should not add history step for strikethrough on collapsed selection", async () => {
@@ -278,7 +262,7 @@ test("should not add history step for strikethrough on collapsed selection", asy
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "5"]);
-    expect(getContent(el)).toBe(`<p>abcd<s data-oe-zws-empty-inline="">[]\u200B</s></p>`);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<s>A[]</s></p>`);

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -148,24 +148,6 @@ test("should make two paragraphs (separated with whitespace) underline, then not
     });
 });
 
-test("should get ready to type in underline", async () => {
-    await testEditor({
-        contentBefore: `<p>ab[]cd</p>`,
-        stepFunction: underline,
-        contentAfterEdit: `<p>ab<u data-oe-zws-empty-inline="">[]\u200B</u>cd</p>`,
-        contentAfter: `<p>ab[]cd</p>`,
-    });
-});
-
-test("should get ready to type in not underline", async () => {
-    await testEditor({
-        contentBefore: `<p><u>ab[]cd</u></p>`,
-        stepFunction: underline,
-        contentAfterEdit: `<p><u>ab</u><span data-oe-zws-empty-inline="">[]\u200B</span><u>cd</u></p>`,
-        contentAfter: `<p><u>ab[]cd</u></p>`,
-    });
-});
-
 test("should not format non-editable text (underline)", async () => {
     await testEditor({
         contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
@@ -226,37 +208,48 @@ describe("with strikeThrough", () => {
     test("should get ready to write in strikeThrough without underline (underline was first)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd[]ef</s></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
-            contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "x");
+            },
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s>x[]</s><u><s>ef</s></u></p>`,
+            contentAfter: `<p>ab<u><s>cd</s></u><s>x[]</s><u><s>ef</s></u></p>`,
         });
     });
 
     test("should restore underline after removing it (collapsed, strikeThrough)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">\u200b[]</s><u><s>ef</s></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">[]\u200b</u></s><u><s>ef</s></u></p>`,
-            contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "x");
+            },
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s><u>x[]</u></s><u><s>ef</s></u></p>`,
+            contentAfter: `<p>ab<u><s>cd</s></u><s><u>x[]</u></s><u><s>ef</s></u></p>`,
         });
     });
 
     test("should remove underline after restoring it after removing it (collapsed, strikeThrough)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd</s></u><s><u>[]\u200b</u></s><u><s>ef</s></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
-            contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "x");
+            },
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s>x[]</s><u><s>ef</s></u></p>`,
+            contentAfter: `<p>ab<u><s>cd</s></u><s>x[]</s><u><s>ef</s></u></p>`,
         });
     });
 
     test("should remove underline after restoring it and writing after removing it (collapsed, strikeThrough)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd</s></u><s><u>ghi[]</u></s><u><s>ef</s></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s><u>ghi</u></s><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
-            // The reason the cursor is after the tag <s> is because when the editor get's cleaned, the zws tag gets deleted.
-            contentAfter: `<p>ab<u><s>cd</s></u><s><u>ghi</u></s>[]<u><s>ef</s></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "x");
+            },
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s><u>ghi</u>x[]</s><u><s>ef</s></u></p>`,
+            contentAfter: `<p>ab<u><s>cd</s></u><s><u>ghi</u>x[]</s><u><s>ef</s></u></p>`,
         });
     });
 
@@ -294,9 +287,10 @@ describe("with italic", () => {
             stepFunction: async (editor) => {
                 italic(editor);
                 underline(editor);
+                await insertText(editor, "A");
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">[]\u200b</u></em>cd</p>`,
-            contentAfter: `<p>ab[]cd</p>`,
+            contentAfterEdit: `<p>ab<em><u>A[]</u></em>cd</p>`,
+            contentAfter: `<p>ab<em><u>A[]</u></em>cd</p>`,
         });
     });
 
@@ -307,23 +301,22 @@ describe("with italic", () => {
                 italic(editor);
                 underline(editor);
                 underline(editor);
+                await insertText(editor, "A");
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
-            contentAfter: `<p>ab[]cd</p>`,
+            contentAfterEdit: `<p>ab<em>A[]</em>cd</p>`,
+            contentAfter: `<p>ab<em>A[]</em>cd</p>`,
         });
     });
 
     test("should get ready to write in italic, after changing one's mind about underline (separated by italic)", async () => {
-        await testEditor({
-            contentBefore: `<p>ab[]cd</p>`,
-            stepFunction: async (editor) => {
-                underline(editor);
-                italic(editor);
-                underline(editor);
-            },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
-            contentAfter: `<p>ab[]cd</p>`,
-        });
+        const { editor, el } = await setupEditor("<p>ab[]cd</p>");
+
+        underline(editor);
+        italic(editor);
+        underline(editor);
+        await insertText(editor, "A");
+        await tick();
+        expect(getContent(el)).toBe(`<p>ab<em>A[]</em>cd</p>`);
     });
 
     test("should get ready to write in italic, after changing one's mind about underline (two consecutive at the beginning)", async () => {
@@ -333,46 +326,46 @@ describe("with italic", () => {
                 underline(editor);
                 underline(editor);
                 italic(editor);
+                await insertText(editor, "A");
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
-            contentAfter: `<p>ab[]cd</p>`,
+            contentAfterEdit: `<p>ab<em>A[]</em>cd</p>`,
+            contentAfter: `<p>ab<em>A[]</em>cd</p>`,
         });
     });
 
     test("should get ready to write in italic without underline (underline was first)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><em>cd[]ef</em></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
-            contentAfter: `<p>ab<u><em>cd[]ef</em></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "A");
+            },
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em>A[]</em><u><em>ef</em></u></p>`,
+            contentAfter: `<p>ab<u><em>cd</em></u><em>A[]</em><u><em>ef</em></u></p>`,
         });
     });
 
     test("should restore underline after removing it (collapsed, italic)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><em>cd</em></u><em>[]\u200b</em><u><em>ef</em></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u data-oe-zws-empty-inline="">[]\u200b</u></em><u><em>ef</em></u></p>`,
-            contentAfter: `<p>ab<u><em>cd[]ef</em></u></p>`,
-        });
-    });
-
-    test("should remove underline after restoring it after removing it (collapsed, italic)", async () => {
-        await testEditor({
-            contentBefore: `<p>ab<u><em>cd</em></u><em><u>[]\u200b</u></em><u><em>ef</em></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
-            contentAfter: `<p>ab<u><em>cd[]ef</em></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "A");
+            },
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u>A[]</u></em><u><em>ef</em></u></p>`,
+            contentAfter: `<p>ab<u><em>cd</em></u><em><u>A[]</u></em><u><em>ef</em></u></p>`,
         });
     });
 
     test("should remove underline after restoring it and writing after removing it (collapsed, italic)", async () => {
         await testEditor({
             contentBefore: `<p>ab<u><em>cd</em></u><em><u>ghi[]</u></em><u><em>ef</em></u></p>`,
-            stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u>ghi</u></em><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
-            // The reason the cursor is after the tag <s> is because when the editor get's cleaned, the zws tag gets deleted.
-            contentAfter: `<p>ab<u><em>cd</em></u><em><u>ghi</u></em>[]<u><em>ef</em></u></p>`,
+            stepFunction: async (editor) => {
+                underline(editor);
+                await insertText(editor, "A");
+            },
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u>ghi</u>A[]</em><u><em>ef</em></u></p>`,
+            contentAfter: `<p>ab<u><em>cd</em></u><em><u>ghi</u>A[]</em><u><em>ef</em></u></p>`,
         });
     });
 
@@ -394,16 +387,18 @@ describe("with italic", () => {
         });
     });
 
-    test("should remove empty underline tag when changing selection", async () => {
+    test("should discard underline request when changing selection", async () => {
         const { editor, el } = await setupEditor("<p>ab[]cd</p>");
 
         underline(editor);
         await tick();
-        expect(getContent(el)).toBe(`<p>ab<u data-oe-zws-empty-inline="">[]\u200B</u>cd</p>`);
+        expect(getContent(el)).toBe(`<p>ab[]cd</p>`);
 
         await simulateArrowKeyPress(editor, "ArrowLeft");
         await tick(); // await selectionchange
         expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+        await insertText(editor, "A");
+        expect(getContent(el)).toBe(`<p>aA[]bcd</p>`);
     });
 });
 
@@ -416,7 +411,7 @@ test("should not add history step for underline on collapsed selection", async (
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "u"]);
-    expect(getContent(el)).toBe(`<p>abcd<u data-oe-zws-empty-inline="">[]\u200B</u></p>`);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<u>A[]</u></p>`);

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1496,10 +1496,9 @@ test("Image should not be inserted in a formatted empty node", async () => {
     Partner._records = [
         {
             id: 1,
-            txt: `<div class="o-paragraph"><strong>test</strong></div>
-                    <div class="o-paragraph">
-                        <strong data-oe-zws-empty-inline="">\u200b</strong><br />
-                    </div>`,
+            txt: `<div class="o-paragraph">
+                    <strong>a</strong>
+                  </div>`,
         },
     ];
 
@@ -1513,9 +1512,11 @@ test("Image should not be inserted in a formatted empty node", async () => {
             </form>`,
     });
     setSelection({
-        anchorNode: queryOne("div.o-paragraph strong[data-oe-zws-empty-inline]"),
-        anchorOffset: 0,
+        anchorNode: queryOne("div.o-paragraph strong"),
+        anchorOffset: 1,
     });
+    await press("Backspace");
+    await animationFrame();
     await insertText(htmlEditor, "/media");
     await waitFor(".o-we-powerbox");
     expect(queryAllTexts(".o-we-command-name")[0]).toBe("Media");

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -91,7 +91,7 @@ describe("button style", () => {
                 </div>
             `),
             stepFunction: (editor) => {
-                editor.shared.format.formatSelection("setFontSizeClassName", {
+                editor.shared.format.requestFormat("setFontSizeClassName", {
                     formatProps: { className: "h1-fs" },
                     applyStyle: true,
                 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
