### PR TITLE
[FIX] mrp,stock: prevent losing lots on the moves after producing a product

### DIFF
--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -1,5 +1,6 @@
 import copy
 
+from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests import common, tagged, Form
 
@@ -487,4 +488,29 @@ class TestConsumeComponent(TestConsumeComponentCommon):
             {'quantity': 0.0, 'picked': False},
             {'quantity': 0.0, 'picked': False},
             {'quantity': 0.0, 'picked': False},
+        ])
+
+    def test_consumed_lots_after_production(self):
+        """
+        Test that manually added move lines with selected lots are preserved after
+        producing the product from a Manufacturing Order.
+        """
+        quant = self.create_quant(self.raw_lot, 10)
+        quant |= self.create_quant(self.raw_lot, 10, offset=1)
+        quant |= self.create_quant(self.raw_serial, 1)
+        quant.action_apply_inventory()
+        mo = self.create_mo(self.mo_lot_tmpl, self.DEFAULT_TRIGGERS_COUNT)
+        mo.action_confirm()
+        mo.action_generate_serial()
+        lot_move = mo.move_raw_ids[1]
+        lot_move.move_line_ids.quantity = 1
+        lot_move.move_line_ids = [Command.create({
+            'product_id': self.raw_lot.id,
+            'quantity': 1,
+            'lot_id': quant[1].lot_id.id
+        })]
+        mo.button_mark_done()
+        self.assertRecordValues(lot_move.move_line_ids, [
+            {'quantity': 1, 'picked': True, 'lot_id': quant[0].lot_id.id},
+            {'quantity': 1, 'picked': True, 'lot_id': quant[1].lot_id.id},
         ])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2312,9 +2312,17 @@ Please change the quantity done or the rounding precision of your unit of measur
                                                                       owner_id=ml.owner_id,
                                                                       strict=True)
             avail_qty = sum(q[1] for q in ml_quants)
+            total_quants = self.env['stock.quant']._get_available_quantity(self.product_id,
+                                                                      ml.location_id,
+                                                                      lot_id=ml.lot_id,
+                                                                      package_id=ml.package_id,
+                                                                      owner_id=ml.owner_id,
+                                                                      strict=True)
             # the quant did not add the quantity reserved on this specific move line
             consumed_quant |= {q[0].id for q in ml_quants}
-            if float_compare(avail_qty, qty, precision_rounding=self.product_uom.rounding) <= 0:
+            if float_compare(
+                avail_qty, qty, precision_rounding=self.product_uom.rounding
+            ) <= 0 and not (ml.lot_id and float_compare(total_quants, avail_qty, precision_rounding=self.product_uom.rounding) > 0):
                 qty -= avail_qty  # decrease the target quantity for the next move lines
                 avail_qty += ml_qty  # add the actual move line quantity as we will update it and not `+=` it
                 if ml.product_uom_id != self.product_id.uom_id:


### PR DESCRIPTION
Currently, when the user takes a component product from different lots for manufacturing, after producing the product, the stock moves are modified in such a way that only the first lot is used for consumption, ignoring the intended selection across multiple lots.

## Steps to replicate:
- Install mrp without demo data
- Enable Lots and Serial Numbers
- Create two products: Car and Bolt, and set Bolt to be tracked by lots
- Update the on-hand quantity of Bolt by creating two lots with 10 units each
- Create a BoM for Car with Bolt as a component and quantity set to 4
- Create and confirm a Manufacturing Order for Car, see Components and open More Details
- Assign Lot 1 with quantity 2 and Lot 2 with quantity 2, then save the MO
- Click on Produce All

## Observed Behavior:
Even though the user manually selected 2 units from lot 2 and 2 units from lot 1 , after producing the product, all 4 units are taken from lot 1 instead of being split evenly. This can also be verified in the traceability report.

## Root cause:
This issue was introduced after commit [1], which added support for considering physical inventory (stock quants) when updating quantities on stock moves and automatically creating or adjusting stock move lines.

When the `Produce All` button is pressed, the `button_mark_done` method is triggered This calls `pre_button_mark_done`, which in turn invokes `_set_quantities` [2]. That method calls `_set_qty_producing`, eventually leading to `_set_quantity_done`  [3], which marks the move as done. During this process, `_set_quantity_done_prepare_vals` is executed.

Inside `_set_quantity_done_prepare_vals` [4], the system assigns quantities to move lines based on the move and its reservations. In this scenario, the stock move has a total quantity of 4. The first move line has a quantity of 2, which is subtracted as the consumed (taken) quantity.

At this point, the reserved (available) quantity is also 2, so the final condition is satisfied. This condition subtracts the available quantity from the remaining required quantity for the move, which is 2 for the next move line. As a result, the remaining required quantity becomes 0.

Because of this, the next move line ends up with a required quantity of 0 and is removed at [5], effectively prioritizing the first move line.

[1]:
https://github.com/odoo/odoo/commit/eed96007f9032d1a9e30211c8bdcf53f8ce96a49 
[2]:
https://github.com/odoo/odoo/blob/a9a63976372d3b5411fd798a48cc5302c2de8af0/addons/mrp/models/mrp_production.py#L2821-L2830 [3]:
https://github.com/odoo/odoo/blob/a9a63976372d3b5411fd798a48cc5302c2de8af0/addons/mrp/models/mrp_production.py#L1342-L1343 [4]:
https://github.com/odoo/odoo/blob/a9a63976372d3b5411fd798a48cc5302c2de8af0/addons/stock/models/stock_move.py#L2301-L2322 [5]:
https://github.com/odoo/odoo/blob/a9a63976372d3b5411fd798a48cc5302c2de8af0/addons/stock/models/stock_move.py#L2286-L2288
## Solution:
Since manual selection of lots is possible, the total available quantity across all lots should be checked before prioritizing any specific move line for updates.

Updates should only occur when lots are not being used and the maximum possible quantity has already been reserved from the total available inventory.

This prevents all quantities from being assigned to the first stock move line associated with a lot and ensures manually added lots remain on the move lines.



opw-6058908