### PR TITLE
[FIX] calendar: Avoid user confusion by not reusing field labels.

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -78,8 +78,8 @@
                             string="Send Mail"/>
                 </header>
                 <field name="name" string="Subject" decoration-bf="1" readonly="recurrency"/>
-                <field name="start" string="Start Date" readonly="1"/>
-                <field name="stop" string="End Date" readonly="1"/>
+                <field name="start" readonly="1"/>
+                <field name="stop" readonly="1"/>
                 <field name="user_id" widget="many2one_avatar_user" readonly="recurrency" optional="hide"/>
                 <field name="partner_ids" widget="many2many_tags" readonly="recurrency" optional="show"/>
                 <field name="alarm_ids" widget="many2many_tags" optional="hide" readonly="recurrency"/>


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:

In the calendar view, the start/stop fields were using the same labels as the start_date/stop_date fields.

<img width="731" height="160" alt="Screenshot 2026-04-03 at 8 59 17 AM" src="https://github.com/user-attachments/assets/13e96e5f-4b8f-4fa5-aa17-42ffd28800cc" />

#### Current behavior before PR:

Users applying custom filters mistakenly select the wrong field.

<img width="352" height="629" alt="Screenshot 2026-04-03 at 8 59 32 AM" src="https://github.com/user-attachments/assets/04ba5f3a-61ed-410d-aa67-6fa045cce8a4" />

#### Desired behavior after PR is merged:

Users filter on the field they intend.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
