### PR TITLE
[FIX] l10n_pe_pos: fix customer address creation for city

### DIFF
--- a/addons/l10n_pe_pos/static/src/overrides/components/partner_editor/partner_editor.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/partner_editor/partner_editor.js
@@ -20,11 +20,16 @@ patch(PartnerDetailsEdit.prototype, {
         return res;
     },
     saveChanges() {
-        if (this.pos.isPeruvianCompany() && (!this.props.partner.vat && !this.changes.vat)) {
-            return this.popup.add(ErrorPopup, {
-                title: _t("Missing Field"),
-                body: _t("A Identification Number Is Required"),
-            });
+        if (this.pos.isPeruvianCompany()) {
+            if (!this.props.partner.vat && !this.changes.vat) {
+                return this.popup.add(ErrorPopup, {
+                    title: _t("Missing Field"),
+                    body: _t("A Identification Number Is Required"),
+                });
+            }
+            const city_id = parseInt(this.changes.city_id);
+            const city = this.pos.cities.find((c) => c.id == city_id);
+            this.changes.city = city ? city.name : this.changes.city;
         }
         return super.saveChanges(...arguments);
     },

--- a/addons/l10n_pe_pos/static/src/overrides/components/partner_editor/partner_editor.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/partner_editor/partner_editor.js
@@ -20,11 +20,16 @@ patch(PartnerDetailsEdit.prototype, {
         return res;
     },
     saveChanges() {
-        if (this.pos.isPeruvianCompany() && (!this.props.partner.vat && !this.changes.vat)) {
-            return this.popup.add(ErrorPopup, {
-                title: _t("Missing Field"),
-                body: _t("A Identification Number Is Required"),
-            });
+        if (this.pos.isPeruvianCompany()) {
+            if (!this.props.partner.vat && !this.changes.vat) {
+                return this.popup.add(ErrorPopup, {
+                    title: _t("Missing Field"),
+                    body: _t("A Identification Number Is Required"),
+                });
+            }
+            const city_id = parseInt(this.changes?.city_id);
+            const city = this.pos.cities.find((c) => c.id == city_id);
+            this.changes.city = city ? city.name : this.changes.city;
         }
         return super.saveChanges(...arguments);
     },


### PR DESCRIPTION
Steps to reproduce:
-------------------
* Install l10n_pe_pos
* Switch to PE company
* Create a pos
* Enable shipping later for that pos
* Open the pos
* Make an order
* Create a new customer inside the pos, fill in all information
* Go to pay the order
* Select the ship later option
* valdiate
> Popup, incorrect address for shipping

Why the fix:
------------
The field city_id is a list containing the id of the city and the name string. For the PE loca we were only setting the city_id field when creating a customer and not city. Which is the required field when checking addresses.

opw-6070005