### PR TITLE
[FIX] account: prevent column shrink in payment term lines

### DIFF
--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -63,7 +63,7 @@
                         </group>
                         <group>
                             <group string="Due Terms">
-                                <field name="line_ids" widget="payment_term_line_ids" nolabel="1">
+                                <field name="line_ids" widget="payment_term_line_ids" nolabel="1" colspan="2">
                                     <list string="Payment Terms" editable="bottom" no_open="True">
                                         <field name="value_amount"/>
                                         <field name="value" nolabel="1"/>


### PR DESCRIPTION
Previously, after a language switch, text gets longer 
inside cell. On clicking/focusing `o_cell_custom` the 
widths were recomputed and the list shrinks/flickers.

In this commit `colspan='2'` is set on `line_ids` to 
give the x2many list more horizontal space.
This avoids column shrinking/flickering.

Task-5189713

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
