### PR TITLE
 [FIX] web, mail: prevent bottom sheet dropdown overflow 

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -8,7 +8,7 @@
         >
             <button
                 t-if="isPermissionGranted(props.kind)"
-                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary o-dropdown-caret {{ env.inDialog ? 'w-50' : 'w-100' }}"
+                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary o-dropdown-caret min-w-0 {{ env.inDialog ? 'w-50' : 'w-100' }}"
                 t-att-data-kind="props.kind"
              >
                 <i t-if="props.icon" t-att-class="props.icon"/>

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -240,6 +240,7 @@
         font-size: $h5-font-size;
         font-weight: $o-font-weight-medium;
         text-align: start !important;
+        white-space: normal;
     }
 
     .dropdown-item .o_stat_value {
@@ -247,6 +248,11 @@
     }
 
     .o_bottom_sheet_body:not(.o_custom_bottom_sheet) {
+        // Leave space for the active checkmark icon
+        &:has(.dropdown-item.active, .dropdown-item.selected) .dropdown-item {
+            padding-right: $spacer * 2.5;
+        }
+
         // Dropdown
         .dropdown-item {
             &.active, &.selected {


### PR DESCRIPTION
**Purpose of this PR:**

Before this commit, in the bottom sheet, dropdown labels could overflow their active container or overlap with the checkmark icon when selected. In voice/video settings, long selected device names could cause horizontal
scrolling on small screens.

This commit:
- Allows dropdown labels in bottom sheets to wrap on small screens.
- Reserves space for the checkmark icon in all bottom sheet dropdowns if any item is selected, ensuring consistent alignment.
- Constrains the selected device label within the available space voice/video settings to prevent layout overflow.

<table>
  <tr>
    <td><b>Before</b></td>
    <td><b>After</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8f347abc-fe26-427a-95ec-97ace3a0c5a2" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/6d6104b5-46c3-404b-be09-1cfa55209a96" width="300"/></td>
  </tr>
</table>

task-[6095602](https://www.odoo.com/odoo/project/1519/tasks/6095602)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
