### PR TITLE
[REF] html_editor: mixed node origins

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -241,7 +241,7 @@ export class BaseContainerPlugin extends Plugin {
                 div.classList.add(BASE_CONTAINER_CLASS);
                 newBaseContainers.push(div);
                 if (!div.hasChildNodes()) {
-                    const br = document.createElement("br");
+                    const br = this.document.createElement("br");
                     div.appendChild(br);
                 }
             }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -481,7 +481,7 @@ export class DomPlugin extends Plugin {
                     isBlock(nodeToInsert) &&
                     this.dependencies.split.isUnsplittable(nodeToInsert)
                 ) {
-                    const br = document.createElement("br");
+                    const br = this.document.createElement("br");
                     currentNode[
                         isEmptyBlock(currentNode) || !isTangible(currentNode) ? "before" : "after"
                     ](br);

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -487,7 +487,7 @@ export class DomPlugin extends Plugin {
                     isBlock(nodeToInsert) &&
                     this.dependencies.split.isUnsplittable(nodeToInsert)
                 ) {
-                    const br = document.createElement("br");
+                    const br = this.document.createElement("br");
                     currentNode[
                         isEmptyBlock(currentNode) || !isTangible(currentNode) ? "before" : "after"
                     ](br);
@@ -672,7 +672,7 @@ export class DomPlugin extends Plugin {
     // --------------------------------------------------------------------------
 
     insertFontAwesome({ faClass = "fa fa-star" } = {}) {
-        const fontAwesomeNode = document.createElement("i");
+        const fontAwesomeNode = this.document.createElement("i");
         fontAwesomeNode.className = faClass;
         this.insert(fontAwesomeNode);
         this.dependencies.history.addStep();

--- a/addons/html_editor/static/src/main/local_overlay_plugin.js
+++ b/addons/html_editor/static/src/main/local_overlay_plugin.js
@@ -3,6 +3,7 @@ import { Plugin } from "../plugin";
 /**
  * @typedef { Object } LocalOverlayShared
  * @property { LocalOverlayPlugin['makeLocalOverlay'] } makeLocalOverlay
+ * @property { LocalOverlayPlugin['createElement'] } createElement
  */
 
 /**
@@ -11,7 +12,7 @@ import { Plugin } from "../plugin";
  */
 export class LocalOverlayPlugin extends Plugin {
     static id = "localOverlay";
-    static shared = ["makeLocalOverlay"];
+    static shared = ["makeLocalOverlay", "createElement"];
 
     setup() {
         this.localOverlayContainer = this.config.localOverlayContainers?.ref.el;
@@ -35,6 +36,11 @@ export class LocalOverlayPlugin extends Plugin {
             this.localOverlays.add(container);
         }
         return container;
+    }
+
+    createElement(tagName, options) {
+        const document = this.localOverlayContainer?.ownerDocument ?? window.document;
+        return document.createElement(tagName, options);
     }
 
     destroy() {

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -208,7 +208,7 @@ export class FilePlugin extends Plugin {
             accessToken: true,
         });
         const { name: filename, mimetype, id } = attachment;
-        return renderStaticFileBox(filename, mimetype, url, id);
+        return renderStaticFileBox(filename, mimetype, url, id, this.document);
     }
 
     onClickFileImage(fileImage) {

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -196,6 +196,6 @@ export class FilePlugin extends Plugin {
             accessToken: true,
         });
         const { name: filename, mimetype, id } = attachment;
-        return renderStaticFileBox(filename, mimetype, url, id);
+        return renderStaticFileBox(filename, mimetype, url, id, this.document);
     }
 }

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -221,6 +221,7 @@ export class IconPlugin extends Plugin {
             visibleTabs: ["ICONS"],
             media: selectedIcon,
             save: (el) => this.onSaveIcon(el, selectedIcon),
+            document: this.document,
         });
     }
 

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -203,6 +203,7 @@ export class IconPlugin extends Plugin {
             visibleTabs: ["ICONS"],
             media: selectedIcon,
             save: (el) => this.onSaveIcon(el, selectedIcon),
+            document: this.document,
         });
     }
 

--- a/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
@@ -60,7 +60,7 @@ export class DocumentSelector extends FileSelector {
     /**
      * Utility method used by the MediaDialog component.
      */
-    static async createElements(selectedMedia, { orm }) {
+    static async createElements(selectedMedia, { orm, document = window.document } = {}) {
         return Promise.all(
             selectedMedia.map(async (attachment) => {
                 let url = `/web/content/${encodeURIComponent(
@@ -75,22 +75,29 @@ export class DocumentSelector extends FileSelector {
                     }
                     url += `&access_token=${encodeURIComponent(accessToken)}`;
                 }
-                return this.renderFileElement(attachment, url);
+                return this.renderFileElement(attachment, url, document);
             })
         );
     }
 
-    static renderFileElement(attachment, downloadUrl) {
+    static renderFileElement(attachment, downloadUrl, document) {
         return renderStaticFileBox(
             attachment.name,
             attachment.mimetype,
             downloadUrl,
-            attachment.id
+            attachment.id,
+            document
         );
     }
 }
 
-export function renderStaticFileBox(filename, mimetype, downloadUrl, id) {
+export function renderStaticFileBox(
+    filename,
+    mimetype,
+    downloadUrl,
+    id,
+    document = window.document
+) {
     const rootSpan = document.createElement("span");
     rootSpan.classList.add("o_file_box", "o-contenteditable-false");
     rootSpan.contentEditable = false;
@@ -98,6 +105,6 @@ export function renderStaticFileBox(filename, mimetype, downloadUrl, id) {
     const bannerElement = renderToElement("html_editor.StaticFileBox", {
         fileModel: { filename, mimetype, downloadUrl },
     });
-    rootSpan.append(bannerElement);
+    rootSpan.append(document.importNode(bannerElement, true));
     return rootSpan;
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
@@ -56,7 +56,7 @@ export class IconSelector extends Component {
     /**
      * Utility methods, used by the MediaDialog component.
      */
-    static createElements(selectedMedia) {
+    static createElements(selectedMedia, { document = window.document } = {}) {
         return selectedMedia.map((icon) => {
             const iconEl = document.createElement("span");
             iconEl.classList.add(icon.fontBase, icon.names[0]);

--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
@@ -65,7 +65,7 @@ export class IconSelector extends Component {
     /**
      * Utility methods, used by the MediaDialog component.
      */
-    static createElements(selectedMedia) {
+    static createElements(selectedMedia, { document = window.document } = {}) {
         return selectedMedia.map((icon) => {
             const iconEl = document.createElement("span");
             iconEl.classList.add(icon.fontBase, icon.names[0]);

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -383,7 +383,7 @@ export class ImageSelector extends FileSelector {
     /**
      * Utility method used by the MediaDialog component.
      */
-    static async createElements(selectedMedia, { orm }) {
+    static async createElements(selectedMedia, { orm, document = window.document } = {}) {
         // Create all media-library attachments.
         const toSave = Object.fromEntries(
             selectedMedia

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -372,7 +372,7 @@ export class ImageSelector extends FileSelector {
     /**
      * Utility method used by the MediaDialog component.
      */
-    static async createElements(selectedMedia, { orm }) {
+    static async createElements(selectedMedia, { orm, document = window.document } = {}) {
         // Create all media-library attachments.
         const toSave = Object.fromEntries(
             selectedMedia

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -26,6 +26,7 @@ export const mediaDialogProps = {
     pendingAttachments: t.array().optional([]),
     save: t.function(),
     close: t.function(),
+    document: t.customValidator(t.any(), (p) => p.nodeType === Node.DOCUMENT_NODE),
 };
 
 export class MediaDialog extends Component {
@@ -219,6 +220,7 @@ export class MediaDialog extends Component {
                 selectedMedia: selectedMedia,
                 extraClassesToAdd: this.extraClassesToAdd(),
                 extraClassesToRemove: this.initialIconClasses,
+                document: this.props.document,
             });
             elements = this.props.multiImages ? elements : elements[0];
             await this.props.save(elements, selectedMedia, this.activeTab(), this.props.media);

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -16,6 +16,7 @@ export class MediaDialog extends Component {
     static defaultProps = {
         useMediaLibrary: true,
         extraTabs: [],
+        document: window.document,
     };
     static components = {
         Dialog,
@@ -25,6 +26,7 @@ export class MediaDialog extends Component {
         extraTabs: { type: Array, optional: true, element: Object },
         visibleTabs: { type: Array, optional: true, element: String },
         activeTab: { type: String, optional: true },
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE, optional: true },
         "*": true,
     };
 
@@ -214,6 +216,7 @@ export class MediaDialog extends Component {
                 extraClassesToRemove: this.initialIconClasses,
                 multiImages: this.props.multiImages,
                 saveFunction: this.props.save,
+                document: this.props.document,
             });
         }
         this.close({ closeReason: "save" });

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
@@ -32,6 +32,7 @@ export async function renderMedia({
     orm,
     activeTab,
     availableTabs,
+    document,
     oldMediaNode,
     selectedMedia,
     extraClassesToAdd,
@@ -39,6 +40,7 @@ export async function renderMedia({
 }) {
     const elements = await availableTabs[activeTab].Component.createElements(selectedMedia, {
         orm: orm,
+        document,
     });
     elements.forEach((element) => {
         if (oldMediaNode) {

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
@@ -27,6 +27,7 @@ export async function renderAndSaveMedia({
     extraClassesToAdd,
     extraClassesToRemove,
     multiImages,
+    document,
     saveFunction,
     aiChannelId = null,
 }) {
@@ -39,6 +40,7 @@ export async function renderAndSaveMedia({
         extraClassesToAdd,
         extraClassesToRemove,
         aiChannelId,
+        document,
     });
     if (multiImages) {
         await saveFunction(elements, selectedMedia, activeTab, oldMediaNode);
@@ -62,6 +64,7 @@ export async function renderMedia({
     orm,
     activeTab,
     availableTabs,
+    document,
     oldMediaNode,
     selectedMedia,
     extraClassesToAdd,
@@ -70,6 +73,7 @@ export async function renderMedia({
 }) {
     const elements = await availableTabs[activeTab].Component.createElements(selectedMedia, {
         orm: orm,
+        document,
     });
     elements.forEach((element) => {
         if (oldMediaNode) {

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -343,7 +343,7 @@ export class VideoSelector extends Component {
      * @param   {Object} selectedVideos.options
      * @returns {Element[]}
      */
-    static createElements(selectedVideos) {
+    static createElements(selectedVideos, { document = window.document } = {}) {
         return selectedVideos.map((videoData) => {
             const div = document.createElement("div");
             div.dataset.baseUrl = videoData.baseUrl;

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -311,7 +311,7 @@ export class VideoSelector extends Component {
     /**
      * Utility method, called by the MediaDialog component.
      */
-    static createElements(selectedMedia) {
+    static createElements(selectedMedia, { document = window.document } = {}) {
         return selectedMedia.map((video) => {
             const div = document.createElement("div");
             div.dataset.oeExpression = video.src;

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -264,6 +264,7 @@ export class MediaPlugin extends Plugin {
             resModel,
             resId,
             field,
+            document: this.document,
             useMediaLibrary: !!(
                 field &&
                 ((resModel === "ir.ui.view" && field === "arch") || type === "html")

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -244,6 +244,7 @@ export class MediaPlugin extends Plugin {
             resModel,
             resId,
             field,
+            document: this.document,
             useMediaLibrary: !!(
                 field &&
                 ((resModel === "ir.ui.view" && field === "arch") || type === "html")

--- a/addons/html_editor/static/src/main/media/signature_plugin.js
+++ b/addons/html_editor/static/src/main/media/signature_plugin.js
@@ -34,7 +34,7 @@ export class SignaturePlugin extends Plugin {
                 displaySignatureRatio: 3,
             },
             uploadSignature: (signature) => {
-                const img = document.createElement("img");
+                const img = this.document.createElement("img");
                 img.classList.add("img", "img-fluid", "o_we_custom_image");
                 img.style = "width: 50%";
                 img.src = signature.signatureImage;

--- a/addons/html_editor/static/src/main/media/video/video_plugin.js
+++ b/addons/html_editor/static/src/main/media/video/video_plugin.js
@@ -66,6 +66,8 @@ export class VideoPlugin extends Plugin {
     }
 
     createVideoElement(videoData) {
-        return this.componentForMediaDialog.createElements([videoData])[0];
+        return this.componentForMediaDialog.createElements([videoData], {
+            document: this.document,
+        })[0];
     }
 }

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -136,7 +136,7 @@ export class MoveNodePlugin extends Plugin {
             elementsToGarbageCollect.delete(element);
             let hookElement = this.elementHookMap.get(element);
             if (!hookElement) {
-                hookElement = document.createElement("div");
+                hookElement = this.dependencies.localOverlay.createElement("div");
                 this.elementHookMap.set(element, hookElement);
                 hookElement.classList.add("oe-dropzone-hook");
                 hookElement.addEventListener("mouseenter", () => {
@@ -266,7 +266,7 @@ export class MoveNodePlugin extends Plugin {
             anchorY += (anchorBlockRect.height - WIDGET_MOVE_SIZE) / 2;
         }
 
-        this.moveWidget = this.document.createElement("div");
+        this.moveWidget = this.dependencies.localOverlay.createElement("div");
         this.moveWidget.className = "oe-sidewidget-move oi oi-draggable";
         const formSheet = this.widgetContainer.closest(".o_form_sheet");
         // Calculate moveWidget's left pos in advance to avoid layout trashing
@@ -340,7 +340,7 @@ export class MoveNodePlugin extends Plugin {
                     const container =
                         movableElement.tagName === "LI"
                             ? movableElement.parentElement.cloneNode(false)
-                            : document.createElement("div");
+                            : this.dependencies.localOverlay.createElement("div");
                     if (container.tagName === "OL") {
                         const originalIndex = childNodeIndex(movableElement) + 1;
                         container.setAttribute("start", originalIndex);
@@ -391,7 +391,7 @@ export class MoveNodePlugin extends Plugin {
                 originalRect.height + marginTop + marginBottom
             );
 
-            const dropzoneBox = document.createElement("div");
+            const dropzoneBox = this.dependencies.localOverlay.createElement("div");
             dropzoneBox.className = `oe-dropzone-box`;
             dropzoneBox.style.top = `${dropzoneRect.top - containerRect.top}px`;
             dropzoneBox.style.left =
@@ -401,7 +401,7 @@ export class MoveNodePlugin extends Plugin {
             dropzoneBox.style.width = `${dropzoneRect.width}px`;
             dropzoneBox.style.height = `${dropzoneRect.height}px`;
 
-            const dropzoneHintBox = document.createElement("div");
+            const dropzoneHintBox = this.dependencies.localOverlay.createElement("div");
             dropzoneHintBox.className = `oe-dropzone-box`;
             dropzoneHintBox.style.top = `${dropzoneHintRect.top - containerRect.top}px`;
             dropzoneHintBox.style.left = `${dropzoneHintRect.left - containerRect.left}px`;
@@ -410,7 +410,7 @@ export class MoveNodePlugin extends Plugin {
 
             const sideElements = {};
             for (const direction of directions) {
-                const sideElement = document.createElement("div");
+                const sideElement = this.dependencies.localOverlay.createElement("div");
                 sideElement.className = `oe-dropzone-box-side oe-dropzone-box-side-${direction}`;
                 sideElements[direction] = sideElement;
                 dropzoneBox.append(sideElement);
@@ -418,7 +418,7 @@ export class MoveNodePlugin extends Plugin {
                     this._currentZone = [direction];
 
                     removeDropHint();
-                    this._currentDropHint = document.createElement("div");
+                    this._currentDropHint = this.dependencies.localOverlay.createElement("div");
                     this._currentDropHint.className = `oe-current-drop-hint`;
                     const currentDropHintSize = 4;
                     const currentDropHintSizeHalf = currentDropHintSize / 2;

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -136,7 +136,7 @@ export class MoveNodePlugin extends Plugin {
             elementsToGarbageCollect.delete(element);
             let hookElement = this.elementHookMap.get(element);
             if (!hookElement) {
-                hookElement = document.createElement("div");
+                hookElement = this.document.createElement("div");
                 this.elementHookMap.set(element, hookElement);
                 hookElement.classList.add("oe-dropzone-hook");
                 hookElement.addEventListener("mouseenter", () => {
@@ -320,7 +320,7 @@ export class MoveNodePlugin extends Plugin {
                     const container =
                         movableElement.tagName === "LI"
                             ? movableElement.parentElement.cloneNode(false)
-                            : document.createElement("div");
+                            : this.document.createElement("div");
                     if (container.tagName === "OL") {
                         const originalIndex = childNodeIndex(movableElement) + 1;
                         container.setAttribute("start", originalIndex);
@@ -371,7 +371,7 @@ export class MoveNodePlugin extends Plugin {
                 originalRect.height + marginTop + marginBottom
             );
 
-            const dropzoneBox = document.createElement("div");
+            const dropzoneBox = this.document.createElement("div");
             dropzoneBox.className = `oe-dropzone-box`;
             dropzoneBox.style.top = `${dropzoneRect.top - containerRect.top}px`;
             dropzoneBox.style.left =
@@ -381,7 +381,7 @@ export class MoveNodePlugin extends Plugin {
             dropzoneBox.style.width = `${dropzoneRect.width}px`;
             dropzoneBox.style.height = `${dropzoneRect.height}px`;
 
-            const dropzoneHintBox = document.createElement("div");
+            const dropzoneHintBox = this.document.createElement("div");
             dropzoneHintBox.className = `oe-dropzone-box`;
             dropzoneHintBox.style.top = `${dropzoneHintRect.top - containerRect.top}px`;
             dropzoneHintBox.style.left = `${dropzoneHintRect.left - containerRect.left}px`;
@@ -478,7 +478,7 @@ export class MoveNodePlugin extends Plugin {
                     previousParent.remove();
                 } else {
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    const br = document.createElement("br");
+                    const br = this.document.createElement("br");
                     baseContainer.append(br);
                     previousParent.append(baseContainer);
                 }

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -101,7 +101,7 @@ export class PowerButtonsPlugin extends Plugin {
             };
         };
         const renderButton = ({ description, icon, text, run }) => {
-            const btn = this.document.createElement("button");
+            const btn = this.dependencies.localOverlay.createElement("button");
             let className = "power_button btn px-2 py-1 cursor-pointer";
             if (icon) {
                 const iconLibrary = icon.includes("fa-") ? "fa" : "oi";
@@ -127,7 +127,7 @@ export class PowerButtonsPlugin extends Plugin {
         // Render HTML buttons.
         this.descriptionToElementMap = new Map(powerButtons.map((pb) => [pb, renderButton(pb)]));
 
-        this.powerButtonsContainer = this.document.createElement("div");
+        this.powerButtonsContainer = this.dependencies.localOverlay.createElement("div");
         this.powerButtonsContainer.className = `o_we_power_buttons d-flex justify-content-center invisible position-absolute`;
         this.powerButtonsContainer.append(...this.descriptionToElementMap.values());
         this.powerButtonsOverlay.append(this.powerButtonsContainer);

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -533,7 +533,7 @@ export class TablePlugin extends Plugin {
                 }
             }
             if (colgroup) {
-                const newcol = document.createElement("col");
+                const newcol = this.document.createElement("col");
                 const children = colgroup.children;
                 const currentCol = children[gridCellIndex];
                 newcol.style.width = currentCol.style.width;

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -486,7 +486,7 @@ export class TablePlugin extends Plugin {
                 }
             }
             if (colgroup) {
-                const newcol = document.createElement("col");
+                const newcol = this.document.createElement("col");
                 const children = colgroup.children;
                 const currentCol = children[gridCellIndex];
                 newcol.style.width = currentCol.style.width;

--- a/addons/html_editor/static/src/main/table/table_resize_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_resize_plugin.js
@@ -99,11 +99,11 @@ export class TableResizePlugin extends Plugin {
 
             if (!colgroup) {
                 const cells = tableGrid[0];
-                colgroup = document.createElement("colgroup");
+                colgroup = this.document.createElement("colgroup");
                 for (const cell of cells) {
                     const rect = cell.getBoundingClientRect();
                     const width = rect.width / (cell.colSpan || 1);
-                    const col = document.createElement("col");
+                    const col = this.document.createElement("col");
                     col.style.width = `${width}px`;
                     colgroup.appendChild(col);
                 }

--- a/addons/html_editor/static/src/main/translate/translate_dialog.js
+++ b/addons/html_editor/static/src/main/translate/translate_dialog.js
@@ -8,7 +8,7 @@ import { GoogleTranslator, ChatGPTTranslator } from "./translator";
 
 const RTL_LANGUAGES = new Set(["ar", "he", "fa", "ur", "yi", "ps", "ku", "sd", "ug", "dv", "ha"]);
 
-const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer) => {
+const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer, document) => {
     let lines = content.split("\n");
     if (baseContainer.toUpperCase() === "P") {
         // P has a margin bottom which is used as an interline, no need to
@@ -68,6 +68,7 @@ export class TranslateDialog extends Component {
             languageCode: t.string(),
             languageName: t.string(),
         }),
+        document: t.customValidator(t.any(), (p) => p.nodeType === Node.DOCUMENT_NODE),
     });
 
     setup() {
@@ -103,7 +104,11 @@ export class TranslateDialog extends Component {
     }
 
     formatContent(content) {
-        const fragment = POSTPROCESS_GENERATED_CONTENT(content, this.props.baseContainer);
+        const fragment = POSTPROCESS_GENERATED_CONTENT(
+            content,
+            this.props.baseContainer,
+            this.props.document
+        );
         let result = "";
         for (const child of fragment.children) {
             this.props.sanitize(child, { IN_PLACE: true });
@@ -171,7 +176,8 @@ export class TranslateDialog extends Component {
             });
             const fragment = POSTPROCESS_GENERATED_CONTENT(
                 translatedText || "",
-                this.props.baseContainer
+                this.props.baseContainer,
+                this.props.document
             );
             this.props.sanitize(fragment, { IN_PLACE: true });
             this.props.insert(fragment);

--- a/addons/html_editor/static/src/main/translate/translate_dialog.js
+++ b/addons/html_editor/static/src/main/translate/translate_dialog.js
@@ -7,7 +7,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { GoogleTranslator, ChatGPTTranslator } from "./translator";
 
-const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer) => {
+const POSTPROCESS_GENERATED_CONTENT = (content, baseContainer, document) => {
     let lines = content.split("\n");
     if (baseContainer.toUpperCase() === "P") {
         // P has a margin bottom which is used as an interline, no need to
@@ -64,9 +64,11 @@ export class TranslateDialog extends Component {
         baseContainer: { type: String, optional: true },
         originalText: String,
         targetLang: { type: Object, shape: { languageCode: String, languageName: String } },
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE, optional: true },
     };
     static defaultProps = {
         baseContainer: "DIV",
+        document: window.document,
     };
 
     setup() {
@@ -97,7 +99,11 @@ export class TranslateDialog extends Component {
     }
 
     formatContent(content) {
-        const fragment = POSTPROCESS_GENERATED_CONTENT(content, this.props.baseContainer);
+        const fragment = POSTPROCESS_GENERATED_CONTENT(
+            content,
+            this.props.baseContainer,
+            this.props.document
+        );
         let result = "";
         for (const child of fragment.children) {
             this.props.sanitize(child, { IN_PLACE: true });
@@ -165,7 +171,8 @@ export class TranslateDialog extends Component {
             });
             const fragment = POSTPROCESS_GENERATED_CONTENT(
                 translatedText || "",
-                this.props.baseContainer
+                this.props.baseContainer,
+                this.props.document
             );
             this.props.sanitize(fragment, { IN_PLACE: true });
             this.props.insert(fragment);

--- a/addons/html_editor/static/src/main/translate/translate_plugin.js
+++ b/addons/html_editor/static/src/main/translate/translate_plugin.js
@@ -75,7 +75,7 @@ export class TranslatePlugin extends Plugin {
                         endTop += endParent.offsetTop - endParent.scrollTop;
                         endParent = endParent.offsetParent;
                     }
-                    const div = document.createElement("div");
+                    const div = this.document.createElement("div");
                     div.classList.add("o-translator-content");
                     const FRAME_PADDING = 3;
                     div.style.left = `${left - FRAME_PADDING}px`;
@@ -98,6 +98,7 @@ export class TranslatePlugin extends Plugin {
             ...dialogParams,
             originalText,
             sanitize,
+            document: this.document,
         });
         if (this.services.ui.isSmall) {
             // TODO: Find a better way and avoid modifying range

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -70,6 +70,8 @@ export class YoutubePlugin extends Plugin {
     }
 
     createVideoElement(videoData) {
-        return VideoSelector.createElements([{ src: videoData.embed_url }])[0];
+        return VideoSelector.createElements([{ src: videoData.embed_url }], {
+            document: this.document,
+        })[0];
     }
 }

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -100,10 +100,10 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         // Draw user avatar.
         let avatarElement = selectionInfo.avatarElement;
         if (!avatarElement) {
-            avatarElement = this.document.createElement("div");
+            avatarElement = this.dependencies.localOverlay.createElement("div");
             avatarElement.className = "oe-collaboration-caret-avatar";
             avatarElement.style.display = "none";
-            const image = this.document.createElement("img");
+            const image = this.dependencies.localOverlay.createElement("img");
             avatarElement.append(image);
             image.onload = () => avatarElement.style.removeProperty("display");
             image.setAttribute("src", avatarUrl);
@@ -142,7 +142,7 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
             const size = infos.size;
             if (size > 1) {
                 const [left, top] = overlapKey.split("|").map((n) => parseInt(n, 10));
-                const div = document.createElement("div");
+                const div = this.dependencies.localOverlay.createElement("div");
                 div.className = "oe-overlapping-counter";
                 div.style.left = left + 10 + "px";
                 div.style.top = top + 10 + "px";

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -142,7 +142,7 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
             const size = infos.size;
             if (size > 1) {
                 const [left, top] = overlapKey.split("|").map((n) => parseInt(n, 10));
-                const div = document.createElement("div");
+                const div = this.document.createElement("div");
                 div.className = "oe-overlapping-counter";
                 div.style.left = left + 10 + "px";
                 div.style.top = top + 10 + "px";

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -113,7 +113,7 @@ export class CollaborationSelectionPlugin extends Plugin {
         // Draw rects (in case the selection is not collapsed).
         const containerRect = this.selectionOverlay.getBoundingClientRect();
         const indicators = clientRects.map(({ x, y, width, height }) => {
-            const rectElement = this.document.createElement("div");
+            const rectElement = this.dependencies.localOverlay.createElement("div");
             rectElement.style = `
                 position: absolute;
                 top: ${y - containerRect.y}px;
@@ -129,13 +129,13 @@ export class CollaborationSelectionPlugin extends Plugin {
         });
 
         // Draw carret.
-        const caretElement = this.document.createElement("div");
+        const caretElement = this.dependencies.localOverlay.createElement("div");
         caretElement.style = `border-left: 2px solid ${selectionColor}; position: absolute;`;
         caretElement.setAttribute("data-selection-peer-id", peerId);
         caretElement.className = "oe-collaboration-caret";
 
         // Draw carret top square.
-        const caretTopSquare = this.document.createElement("div");
+        const caretTopSquare = this.dependencies.localOverlay.createElement("div");
         caretTopSquare.className = "oe-collaboration-caret-top-square";
         caretTopSquare.style["background-color"] = selectionColor;
         caretTopSquare.setAttribute("data-peer-name", peerName);

--- a/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_documents_selector.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_documents_selector.js
@@ -9,8 +9,8 @@ export class EmbeddedFileDocumentsSelector extends DocumentSelector {
     static mediaSpecificClasses = [];
 
     /** @override */
-    static async renderFileElement(attachment) {
-        return renderEmbeddedFileBox(attachment);
+    static async renderFileElement(attachment, _, document) {
+        return renderEmbeddedFileBox(attachment, document);
     }
 }
 
@@ -18,7 +18,7 @@ export class EmbeddedFileDocumentsSelector extends DocumentSelector {
  * @param {Object} attachment
  * @returns {Element}
  */
-export function renderEmbeddedFileBox(attachment) {
+export function renderEmbeddedFileBox(attachment, document = window.document) {
     const dotSplit = attachment.name.split(".");
     const extension = dotSplit.length > 1 ? dotSplit.pop() : undefined;
     const fileData = {
@@ -32,7 +32,8 @@ export function renderEmbeddedFileBox(attachment) {
         type: attachment.type,
         url: attachment.url || "",
     };
-    return renderToElement("html_editor.EmbeddedFileBlueprint", {
+    const fileEl = renderToElement("html_editor.EmbeddedFileBlueprint", {
         embeddedProps: JSON.stringify({ fileData }),
     });
+    return document.importNode(fileEl, true);
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
@@ -23,7 +23,7 @@ export class EmbeddedFilePlugin extends FilePlugin {
 
     /** @override */
     renderDownloadBox(attachment) {
-        return renderEmbeddedFileBox(attachment);
+        return renderEmbeddedFileBox(attachment, this.document);
     }
 
     /** @override */

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_youtube_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_youtube_plugin.js
@@ -11,6 +11,8 @@ export class EmbeddedYoutubePlugin extends YoutubePlugin {
     /** @override */
     createVideoElement(videoData) {
         const { video_id: videoId, platform, params } = videoData;
-        return EmbeddedVideoSelector.createElements([{ videoId, platform, params }])[0];
+        return EmbeddedVideoSelector.createElements([{ videoId, platform, params }], {
+            document: this.document,
+        })[0];
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
@@ -6,9 +6,9 @@ export class EmbeddedVideoSelector extends VideoSelector {
     static mediaSpecificClasses = [];
 
     /** @override */
-    static createElements(selectedVideos) {
-        return selectedVideos.map((videoData) =>
-            renderToElement("html_editor.EmbeddedVideoBlueprint", {
+    static createElements(selectedVideos, { document = window.document } = {}) {
+        return selectedVideos.map((videoData) => {
+            const videoElement = renderToElement("html_editor.EmbeddedVideoBlueprint", {
                 embeddedProps: JSON.stringify({
                     baseUrl: videoData.baseUrl || "",
                     videoId: videoData.videoId,
@@ -16,7 +16,8 @@ export class EmbeddedVideoSelector extends VideoSelector {
                     params: videoData.options || {},
                 }),
                 isVertical: videoData.options?.isVertical || false,
-            })
-        );
+            });
+            return document.importNode(videoElement, true);
+        });
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
@@ -6,16 +6,17 @@ export class EmbeddedVideoSelector extends VideoSelector {
     static mediaSpecificClasses = [];
 
     /** @override */
-    static createElements(selectedMedia) {
-        return selectedMedia.map((media) =>
-            renderToElement("html_editor.EmbeddedVideoBlueprint", {
+    static createElements(selectedMedia, { document = window.document } = {}) {
+        return selectedMedia.map((media) => {
+            const el = renderToElement("html_editor.EmbeddedVideoBlueprint", {
                 embeddedProps: JSON.stringify({
                     videoId: media.videoId,
                     platform: media.platform,
                     params: media.params || {},
                 }),
                 isVertical: media.params?.isVertical,
-            })
-        );
+            });
+            return document.importNode(el, true);
+        });
     }
 }


### PR DESCRIPTION
Currently in html_editor, nodes are in some places created via `document.createElement(...)` and in some other places via `this.document.createElement(...)`. When this.document is the iframe's one, this.document !== document. Mixing nodes from different document origins should not be done. This PR replaces `document.createElement` by `this.document.createElement` to ensures that node origins are not mixed.

task-3603248





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
