### PR TITLE
[IMP] mail, *: use self_member_id when possible

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -594,10 +594,9 @@ class DiscussChannel(models.Model):
         """ Set deactivate the livechat channel and notify (the operator) the reason of closing the session."""
         self.ensure_one()
         if not self.livechat_end_dt:
-            member = self.channel_member_ids.filtered(lambda m: m.is_self)
-            if member:
+            if self.self_member_id:
                 # sudo: discuss.channel.rtc.session - member of current user can leave call
-                member.sudo()._rtc_leave_call()
+                self.self_member_id.sudo()._rtc_leave_call()
             # sudo: discuss.channel - visitor left the conversation, state must be updated
             self.sudo().livechat_end_dt = fields.Datetime.now()
             # avoid useless notification if the channel is empty

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -138,13 +138,12 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 self.chatbot_script.operator_partner_id,
             )
             discuss_channel._add_members(users=self.env.user)
-            self_member = discuss_channel.channel_member_ids.filtered(lambda m: m.is_self)
             bot_member = discuss_channel.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.chatbot_script.operator_partner_id
             )
             guest_member = discuss_channel.channel_member_ids.filtered(lambda m: bool(m.guest_id))
             self.env["mail.presence"]._update_presence(guest_member.guest_id)
-            self_member._rtc_join_call()
+            discuss_channel.self_member_id._rtc_join_call()
             self.assertTrue(guest_member.rtc_inviting_session_id)
             self.assertFalse(bot_member.rtc_inviting_session_id)
 

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -175,19 +175,11 @@ class ChannelController(http.Controller):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise request.not_found()
+        # Do not create member automatically when setting typing to `False`
+        # as it could be resulting from the user leaving.
         if is_typing:
-            member = channel._find_or_create_member_for_self()
-        else:
-            # Do not create member automatically when setting typing to `False`
-            # as it could be resulting from the user leaving.
-            member = request.env["discuss.channel.member"].search(
-                [
-                    ("channel_id", "=", channel_id),
-                    ("is_self", "=", True),
-                ]
-            )
-        if member:
-            member._notify_typing(is_typing)
+            channel._find_or_create_member_for_self()
+        channel.self_member_id._notify_typing(is_typing)
 
     @mail_route("/discuss/channel/attachments", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     def load_attachments(self, channel_id, limit=30, before=None):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -714,11 +714,10 @@ class DiscussChannel(models.Model):
         stores.bus_send()
         if invite_to_rtc_call:
             for channel in self:
-                current_channel_member = self.env['discuss.channel.member'].search([('channel_id', '=', channel.id), ('is_self', '=', True)])
                 # sudo: discuss.channel.rtc.session - reading rtc sessions of current user
-                if current_channel_member and current_channel_member.sudo().rtc_session_ids:
+                if channel.self_member_id.sudo().rtc_session_ids:
                     # sudo: discuss.channel.rtc.session - current user can invite new members in call
-                    current_channel_member.sudo()._rtc_invite_members(member_ids=new_members.ids)
+                    channel.self_member_id.sudo()._rtc_invite_members(member_ids=new_members.ids)
         return all_new_members
 
     def _get_member_join_notification(self, member):
@@ -1196,10 +1195,8 @@ class DiscussChannel(models.Model):
 
     def _find_or_create_member_for_self(self):
         self.ensure_one()
-        domain = [("channel_id", "=", self.id), ("is_self", "=", True)]
-        member = self.env["discuss.channel.member"].search(domain)
-        if member:
-            return member
+        if self.self_member_id:
+            return self.self_member_id
         if not self.env.user._is_public():
             return self._add_members(users=self.env.user)
         guest = self.env["mail.guest"]._get_guest_from_context()
@@ -1227,8 +1224,7 @@ class DiscussChannel(models.Model):
         """
         self.ensure_one()
         guest = self.env["mail.guest"]
-        member = self.env["discuss.channel.member"].search([("channel_id", "=", self.id), ("is_self", "=", True)])
-        if member:
+        if member := self.self_member_id:
             return member.partner_id, member.guest_id
         if not self.env.user._is_public():
             self._add_members(users=self.env.user, post_joined_message=post_joined_message)
@@ -1629,7 +1625,7 @@ class DiscussChannel(models.Model):
                 channel_name=self.name,
             )
         else:
-            if members := self.channel_member_ids.filtered(lambda m: not m.is_self):
+            if members := self.channel_member_ids - self.self_member_id:
                 member_names = html_escape(format_list(self.env, [f"%(member_{member.id})s" for member in members])) % {
                     f"member_{member.id}": member._get_member_html_link()
                     for member in members
@@ -1659,7 +1655,7 @@ class DiscussChannel(models.Model):
         return msg
 
     def execute_command_who(self, **kwargs):
-        if all_other_members := self.channel_member_ids.filtered(lambda m: not m.is_self):
+        if all_other_members := self.channel_member_ids - self.self_member_id:
             members = all_other_members[:30]
             list_params = [f"%(member_{member.id})s" for member in members]
             if len(all_other_members) != len(members):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -441,21 +441,20 @@ class TestChannelInternals(MailCommon, HttpCase):
         chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat(pids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
-        self_member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
-        self_member._mark_as_read(msg_2.id)
+        chat.self_member_id._mark_as_read(msg_2.id)
         init_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
-            filter(lambda d: d["id"] == self_member.id, init_data["discuss.channel.member"])
+            filter(lambda d: d["id"] == chat.self_member_id.id, init_data["discuss.channel.member"])
         )
         self.assertEqual(
             self_member_info["seen_message_id"],
             msg_2.id,
             "Last message id should have been updated",
         )
-        self_member._mark_as_read(msg_1.id)
+        chat.self_member_id._mark_as_read(msg_1.id)
         final_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
-            filter(lambda d: d["id"] == self_member.id, final_data["discuss.channel.member"])
+            filter(lambda d: d["id"] == chat.self_member_id.id, final_data["discuss.channel.member"])
         )
         self.assertEqual(
             self_member_info["seen_message_id"],

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -17,7 +17,7 @@ class TestDiscussSubChannels(HttpCase):
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
         sub_channel._add_members(users=self.env.user)
-        self_member = sub_channel.channel_member_ids.filtered(lambda m: m.is_self)
+        self_member = sub_channel.self_member_id
         self.assertTrue(self_member.is_pinned)
         # Last interrest of the member is older than 2 days, no activity on the
         # channel: should be unpinned.
@@ -48,28 +48,28 @@ class TestDiscussSubChannels(HttpCase):
         channel = self.env["discuss.channel"].create({"name": "General"})
         with freeze_time(two_days_later_dt):
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
-            self.assertTrue(channel.channel_member_ids.filtered("is_self").is_pinned)
+            self.assertTrue(channel.self_member_id.is_pinned)
 
     def test_02_sub_channel_members_sync_with_parent(self):
         parent = self.env["discuss.channel"].create({"name": "General"})
         parent.action_unfollow()
-        self.assertFalse(any(m.is_self for m in parent.channel_member_ids))
+        self.assertFalse(parent.self_member_id)
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
         # Member created for sub channel (_create_sub_channel): should also be
         # created for the parent channel.
-        self.assertTrue(any(m.is_self for m in parent.channel_member_ids))
-        self.assertTrue(any(m.is_self for m in sub_channel.channel_member_ids))
+        self.assertTrue(parent.self_member_id)
+        self.assertTrue(sub_channel.self_member_id)
         # Member removed from parent channel: should also be removed from the sub
         # channel.
         parent.action_unfollow()
-        self.assertFalse(any(m.is_self for m in parent.channel_member_ids))
-        self.assertFalse(any(m.is_self for m in sub_channel.channel_member_ids))
+        self.assertFalse(parent.self_member_id)
+        self.assertFalse(sub_channel.self_member_id)
         # Member created for sub channel (add_members): should also be created
         # for parent.
         sub_channel._add_members(users=self.env.user)
-        self.assertTrue(any(m.is_self for m in parent.channel_member_ids))
-        self.assertTrue(any(m.is_self for m in sub_channel.channel_member_ids))
+        self.assertTrue(parent.self_member_id)
+        self.assertTrue(sub_channel.self_member_id)
 
     def test_03_cannot_create_recursive_sub_channel(self):
         parent = self.env["discuss.channel"].create({"name": "General"})

--- a/addons/mail/tests/discuss/test_load_messages.py
+++ b/addons/mail/tests/discuss/test_load_messages.py
@@ -1,26 +1,21 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
-from odoo import Command
+
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
 class TestLoadMessages(HttpCaseWithUserDemo):
     def test_01_mail_message_load_order_tour(self):
-        partner_admin = self.env.ref('base.partner_admin')
-        channel_id = self.env["discuss.channel"].create({
-            "name": "MyTestChannel",
-            "channel_member_ids": [Command.create({"partner_id": partner_admin.id})],
-        })
+        admin = self.env.ref("base.user_admin")
+        channel = self.env["discuss.channel"].with_user(admin).create({"name": "MyTestChannel"})
         self.env["mail.message"].create([{
             "body": str(n),
             "model": "discuss.channel",
             "pinned_at": odoo.fields.Datetime.now() if n == 1 else None,
-            "res_id": channel_id.id,
-            "author_id": partner_admin.id,
+            "res_id": channel.id,
+            "author_id": admin.partner_id.id,
             "message_type": "comment",
         } for n in range(1, 61)])
-        channel_id.channel_member_ids.filtered(
-            lambda m: m.partner_id == partner_admin
-        )._mark_as_read(channel_id.message_ids[0].id)
+        channel.self_member_id._mark_as_read(channel.message_ids[0].id)
         self.start_tour("/odoo/action-mail.action_discuss", "mail_message_load_order_tour", login="admin")

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -271,9 +271,6 @@ class TestDiscussTools(MailCase):
             },
         )
         odoobot_partner = self.env.ref("base.partner_root")
-        odoobot_member = public_channel.channel_member_ids.filtered(
-            lambda m: m.partner_id == odoobot_partner,
-        )
         bob_user = new_test_user(self.env, "bob_user", name="Bob", email="bob@secret.com")
         bob_member = public_channel._add_members(users=bob_user)
         portal_user = new_test_user(self.env, login="portal_user", groups="base.group_portal")
@@ -316,7 +313,7 @@ class TestDiscussTools(MailCase):
             ],
             "discuss.channel.member": [
                 {
-                    "id": odoobot_member.id,
+                    "id": public_channel.self_member_id.id,
                     "partner_id": odoobot_partner.id,
                     "seen_message_id": test_message.id,
                 },

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -300,9 +300,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             author_id=self.users[2].partner_id.id,
             partner_ids=self.users[0].partner_id.ids,
         )
-        members = self.channel_channel_public_1.channel_member_ids
-        member = members.filtered(lambda m: m.partner_id == self.users[0].partner_id).with_user(self.users[0])
-        member._mark_as_read(message_0.id)
+        self.channel_channel_public_1.with_user(self.users[0]).self_member_id._mark_as_read(
+            message_0.id,
+        )
         # add bookmark
         message_0.bookmarked_partner_ids = [Command.link(self.users[0].partner_id.id)]
         self.env.company.sudo().name = 'YourCompany'
@@ -317,13 +317,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             message_type="comment",
             author_id=self.users[2].partner_id.id,
         )
-        # add folded channel
-        members = self.channel_chat_1.channel_member_ids
-        member = members.with_user(self.users[0]).filtered(lambda m: m.is_self)
         # add call invitation
-        members = self.channel_channel_group_1.channel_member_ids
-        member_0 = members.with_user(self.users[0]).filtered(lambda m: m.is_self)
-        member_2 = members.with_user(self.users[2]).filtered(lambda m: m.is_self)
+        member_0 = self.channel_channel_group_1.with_user(self.users[0]).self_member_id
+        member_2 = self.channel_channel_group_1.with_user(self.users[2]).self_member_id
         self.channel_channel_group_1_invited_member = member_0
         # sudo: discuss.channel.rtc.session - creating a session in a test file
         data = {"channel_id": self.channel_channel_group_1.id, "channel_member_id": member_2.id}
@@ -344,8 +340,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         self._add_reactions(message_1, ["😊", "😁", "👍"])
         # add archive / muted on channels
         self.channel_channel_group_3.active = False
-        channel_group_4_member = self.channel_channel_group_4.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id)
-        channel_group_4_member.mute_until_dt = datetime.max
+        self.channel_channel_group_4.with_user(
+            self.users[0],
+        ).self_member_id.mute_until_dt = datetime.max
         self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
     def _add_reactions(self, message, reactions):
@@ -694,10 +691,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     def _expected_result_for_channel(self, channel):
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
-        members = channel.channel_member_ids
-        member_0 = members.filtered(lambda m: m.partner_id == self.users[0].partner_id)
-        member_2 = members.filtered(lambda m: m.partner_id == self.users[2].partner_id)
-        member_12 = members.filtered(lambda m: m.partner_id == self.users[12].partner_id)
+        member_0 = channel.with_user(self.users[0]).self_member_id
+        member_2 = channel.with_user(self.users[2]).self_member_id
+        member_12 = channel.with_user(self.users[12]).self_member_id
         last_interest_dt = fields.Datetime.to_string(channel.last_interest_dt)
         if channel == self.channel_general:
             return {
@@ -988,17 +984,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {}
 
     def _res_for_member(self, channel, partner=None, guest=None):
-        members = channel.channel_member_ids
-        member_0 = members.filtered(lambda m: m.partner_id == self.users[0].partner_id)
+        member_0 = channel.with_user(self.users[0]).self_member_id
         member_0_last_interest_dt = fields.Datetime.to_string(member_0.last_interest_dt)
         member_0_last_seen_dt = fields.Datetime.to_string(member_0.last_seen_dt)
         member_0_create_date = fields.Datetime.to_string(member_0.create_date)
-        member_1 = members.filtered(lambda m: m.partner_id == self.users[1].partner_id)
-        member_2 = members.filtered(lambda m: m.partner_id == self.users[2].partner_id)
-        member_3 = members.filtered(lambda m: m.partner_id == self.users[3].partner_id)
-        member_12 = members.filtered(lambda m: m.partner_id == self.users[12].partner_id)
-        member_14 = members.filtered(lambda m: m.partner_id == self.users[14].partner_id)
-        member_15 = members.filtered(lambda m: m.partner_id == self.users[15].partner_id)
+        member_1 = channel.with_user(self.users[1]).self_member_id
+        member_2 = channel.with_user(self.users[2]).self_member_id
+        member_3 = channel.with_user(self.users[3]).self_member_id
+        member_12 = channel.with_user(self.users[12]).self_member_id
+        member_14 = channel.with_user(self.users[14]).self_member_id
+        member_15 = channel.with_user(self.users[15]).self_member_id
         first_message = channel.message_ids.sorted(lambda message: message.id)[:1]
         last_message = channel._get_last_messages()
         last_message_of_partner_0 = self.env["mail.message"].search(
@@ -1008,7 +1003,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             order="id desc",
             limit=1,
         )
-        member_g = members.filtered(lambda m: m.guest_id)
+        member_g = channel.channel_member_ids.filtered(lambda m: m.guest_id)
         guest = member_g.guest_id
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
@@ -1366,6 +1361,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {"id": self.im_livechat_channel.id, "name": "support"}
 
     def _expected_result_for_livechat_member_history(self, channel):
+        member_0 = channel.with_user(self.users[0]).self_member_id
+        member_1 = channel.with_user(self.users[1]).self_member_id
+        member_g = channel.channel_member_ids.filtered(lambda m: m.guest_id == self.guest)
         histories = channel.livechat_channel_member_history_ids
         if channel == self.channel_livechat_1:
             return [
@@ -1374,18 +1372,14 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": histories.filtered(lambda h: h.livechat_member_type == "agent").id,
                     "livechat_member_type": "agent",
                     "partner_id": self.users[0].partner_id.id,
-                    "member_id": channel.channel_member_ids.filtered(
-                        lambda m: m.partner_id == self.users[0].partner_id
-                    ).id,
+                    "member_id": member_0.id,
                 },
                 {
                     "channel_id": channel.id,
                     "id": histories.filtered(lambda h: h.livechat_member_type == "visitor").id,
                     "livechat_member_type": "visitor",
                     "partner_id": self.users[1].partner_id.id,
-                    "member_id": channel.channel_member_ids.filtered(
-                        lambda m: m.partner_id == self.users[1].partner_id
-                    ).id,
+                    "member_id": member_1.id,
                 },
             ]
         if channel == self.channel_livechat_2:
@@ -1395,18 +1389,14 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": histories.filtered(lambda h: h.livechat_member_type == "agent").id,
                     "livechat_member_type": "agent",
                     "partner_id": self.users[0].partner_id.id,
-                    "member_id": channel.channel_member_ids.filtered(
-                        lambda m: m.partner_id == self.users[0].partner_id
-                    ).id,
+                    "member_id": member_0.id,
                 },
                 {
                     "channel_id": channel.id,
                     "guest_id": self.guest.id,
                     "id": histories.filtered(lambda h: h.livechat_member_type == "visitor").id,
                     "livechat_member_type": "visitor",
-                    "member_id": channel.channel_member_ids.filtered(
-                        lambda m: m.guest_id == self.guest
-                    ).id,
+                    "member_id": member_g.id,
                 },
             ]
         return []
@@ -1419,8 +1409,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         user_0 = self.users[0]
         user_1 = self.users[1]
         user_2 = self.users[2]
-        members = channel.channel_member_ids
-        member_g = members.filtered(lambda m: m.guest_id)
+        member_g = channel.channel_member_ids.filtered(lambda m: m.guest_id)
         guest = member_g.guest_id
         if channel == self.channel_general:
             return {
@@ -1956,8 +1945,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {}
 
     def _expected_result_for_rtc_session(self, channel, user):
-        members = channel.channel_member_ids
-        member_2 = members.filtered(lambda m: m.partner_id == self.users[2].partner_id)
+        member_2 = channel.with_user(self.users[2]).self_member_id
         if channel == self.channel_channel_group_1 and user == self.users[2]:
             return {
                 # sudo: discuss.channel.rtc.session - reading a session in a test file

--- a/addons/test_mail/tests/test_mail_push.py
+++ b/addons/test_mail/tests/test_mail_push.py
@@ -348,10 +348,8 @@ class TestWebPushNotification(SMSCommon):
         inviting_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(
             partners_to=[self.user_email.partner_id.id])
-        inviting_channel_member = channel.sudo().channel_member_ids.filtered(
-            lambda channel_member: channel_member.partner_id == inviting_user.partner_id)
-
-        inviting_channel_member._rtc_join_call()
+        inviting_channel_member = channel.with_user(inviting_user).self_member_id
+        inviting_channel_member.sudo()._rtc_join_call()
         push_to_end_point.assert_called_once()
         payload_value = json.loads(push_to_end_point.call_args.kwargs['payload'])
         self.assertEqual(
@@ -378,8 +376,7 @@ class TestWebPushNotification(SMSCommon):
         self.assertEqual(data['res_id'], channel.id)
         self.assertEqual(data['model'], "discuss.channel")
         push_to_end_point.reset_mock()
-
-        inviting_channel_member._rtc_leave_call()
+        inviting_channel_member.sudo()._rtc_leave_call()
         push_to_end_point.assert_called_once()
         payload_value = json.loads(push_to_end_point.call_args.kwargs['payload'])
         self.assertEqual(payload_value['options']['data']['type'], "CANCEL")

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -78,12 +78,8 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
         ])
         self.assertTrue(bool(livechat_discuss_channel))
         self.assertEqual(len(livechat_discuss_channel), 1)
-
         conversation_messages = livechat_discuss_channel.message_ids.sorted('id')
-        operator_member = livechat_discuss_channel.channel_member_ids.filtered(
-            lambda m: m.partner_id == self.operator.partner_id
-        )
-
+        operator_member = livechat_discuss_channel.with_user(self.operator).self_member_id
         expected_messages = [
             ("Hello! I'm a bot!", operator, False),
             ("I help lost visitors find their way.", operator, False),

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -160,7 +160,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         channel = self._common_basic_flow()
         self._reset_bus()
         guest = self.env["mail.guest"].search([], order="id desc", limit=1)
-        operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
+        operator_member = channel.with_user(self.operator).self_member_id
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
         self.assertEqual(
             Store().add(channel, "_store_channel_fields")._build_result(),
@@ -333,9 +333,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         with freeze_time(agent_left_dt):
             channel.with_user(self.operator).action_unfollow()
         self._reset_bus()
-        self.assertFalse(
-            channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
-        )
+        self.assertFalse(channel.with_user(self.operator).self_member_id)
         channel_w_user = channel.with_user(self.user_public).with_context(guest=guest)
         data = Store().add(channel_w_user, "_store_channel_fields")._build_result()
         self.assertEqual(

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -10,14 +10,14 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
 
         # Send first chat request - Open chat from operator side
         channel_1 = self._common_chat_request_flow()
-        guest = channel_1.channel_member_ids.filtered(lambda member: member.guest_id).guest_id
+        guest = channel_1.channel_member_ids.guest_id
         self.opener.cookies[guest._cookie_name] = guest._format_auth_cookie()
         # Visitor Rates the conversation (Good)
         self._send_rating(channel_1, self.visitor, 5)
 
         # Operator Re-Send a chat request
         channel_2 = self._common_chat_request_flow()
-        guest = channel_2.channel_member_ids.filtered(lambda member: member.guest_id).guest_id
+        guest = channel_2.channel_member_ids.guest_id
         self.opener.cookies[guest._cookie_name] = guest._format_auth_cookie()
         # Visitor Rates the conversation (Bad)
         self._send_rating(channel_2, self.visitor, 1, "Stop bothering me! I hate you </3 !")


### PR DESCRIPTION
\* = im_livechat, test_discuss_full, test_mail

The syntax is simpler, and the field might already be in cache which could avoid some queries.