### PR TITLE
[IMP] website_sale: prevent full page reload when selecting filters

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -697,6 +697,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return request.render("website_sale.products", values)
 
+    @route(["/shop/reload"], type="jsonrpc", auth="public", website=True)
+    def shop_reload(self, *args, **kwargs):
+        response = self.shop(*args, **kwargs)
+        html_content = response.render()
+        product_count = response.qcontext.get("search_count", 0)
+
+        return {"product_count": product_count, "html": str(html_content)}
+
     @route(
         [
             f"{SHOP_PATH}/<model('product.template'):product>",
@@ -2056,7 +2064,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @staticmethod
     def _populate_currency_and_pricelist(kwargs):
-        kwargs.update({"currency_id": request.env.website.currency_id.id, "pricelist_id": request.pricelist.id})
+        kwargs.update({
+            "currency_id": request.env.website.currency_id.id,
+            "pricelist_id": request.pricelist.id,
+        })
 
     @staticmethod
     def _validate_and_get_category(category):

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -583,7 +583,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             )
         values.update(self._get_additional_shop_values(values, **post))
 
-        if post.get("is_ajax") == "true":
+        if request.httprequest.headers.get("X-Requested-With") == "XMLHttpRequest":
             html_content = request.env["ir.ui.view"]._render_template(
                 "website_sale.products", values
             )

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -394,6 +394,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             options, post, search, website
         )
 
+        if post.get("is_ajax_count") == "true":
+            return request.make_response(json.dumps({"count": product_count}))
+
         filter_by_price_enabled = website.is_view_active("website_sale.filter_products_price")
         if filter_by_price_enabled:
             # TODO Find an alternative way to obtain the domain through the search metadata.

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -394,9 +394,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             options, post, search, website
         )
 
-        if post.get("is_ajax_count") == "true":
-            return request.make_response(json.dumps({"count": product_count}))
-
         filter_by_price_enabled = website.is_view_active("website_sale.filter_products_price")
         if filter_by_price_enabled:
             # TODO Find an alternative way to obtain the domain through the search metadata.
@@ -585,6 +582,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 indent=2,
             )
         values.update(self._get_additional_shop_values(values, **post))
+
+        if post.get("is_ajax") == "true":
+            html_content = request.env["ir.ui.view"]._render_template(
+                "website_sale.products", values
+            )
+
+            return request.make_response(
+                json.dumps({"count": product_count, "html": str(html_content)}),
+                headers=[("Content-Type", "application/json")],
+            )
         return request.render("website_sale.products", values)
 
     @route(

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -1,6 +1,6 @@
 import { Interaction } from '@web/public/interaction';
-import { redirect } from '@web/core/utils/urls';
 import { registry } from '@web/core/registry';
+import wSaleUtils from '@website_sale/js/website_sale_utils';
 
 export class PriceRange extends Interaction {
     static selector = '#o_wsale_price_range_option';
@@ -11,7 +11,7 @@ export class PriceRange extends Interaction {
     /**
      * @param {Event} ev
      */
-    onPriceRangeSelected(ev) {
+    async onPriceRangeSelected(ev) {
         const range = ev.currentTarget;
         const url = new URL(range.dataset.url, window.location.origin);
         const searchParams = url.searchParams;
@@ -21,11 +21,10 @@ export class PriceRange extends Interaction {
         if (parseFloat(range.max) !== range.valueHigh) {
             searchParams.set("max_price", range.valueHigh);
         }
-        const product_list_div = document.querySelector('.o_wsale_products_grid_table_wrapper');
-        if (product_list_div) {
-            product_list_div.classList.add('opacity-50');
-        }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
+        await wSaleUtils.updateShopContent(this, {
+            url,
+            searchParams,
+        });
     }
 }
 

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -58,6 +58,15 @@ export class PriceRange extends Interaction {
             if (applyBtn) {
                 applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
+        }else {
+            const filters = document.querySelector('.o_wsale_products_grid_before_rail');
+            const newFilters = tempDiv.querySelector('.o_wsale_products_grid_before_rail');
+            if(filters && newFilters){
+                const shopPageEl = document.querySelector('.o_wsale_products_page');
+                this.services['public.interactions'].stopInteractions(shopPageEl);
+                filters.innerHTML = newFilters.innerHTML;
+                this.services['public.interactions'].startInteractions(shopPageEl);
+            }
         }
         searchParams.delete('is_ajax');
         window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -24,10 +24,11 @@ export class PriceRange extends Interaction {
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
         if (isOffcanvas) {
             const offcanvas = document.querySelector('.o_website_offcanvas');
-            const offcanvasResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const offcanvaData = await offcanvasResponse.text();
+            searchParams.set('is_ajax', 'true');
+            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            const data = await response.json();
             const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = offcanvaData;
+            tempDiv.innerHTML = data.html;
 
             const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
             const shopPageEl = document.querySelector('.o_wsale_products_page');
@@ -35,13 +36,9 @@ export class PriceRange extends Interaction {
             offcanvas.innerHTML = newOffcanvas;
             this.services['public.interactions'].startInteractions(shopPageEl);
 
-            searchParams.set('is_ajax_count', 'true');
-            const countResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const countData = await countResponse.json();
-
-            const applyBtn = document.querySelector('#o_wsale_offcanvas #o_wsale_apply_filters_btn');
+            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
             if (applyBtn) {
-                applyBtn.textContent = `Apply Filters (${countData.count})`;
+                applyBtn.textContent = `Apply Filters (${data.count})`;
             }
         } else {
             const product_list_div = document.querySelector('.o_wsale_products_grid_table_wrapper');

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -11,7 +11,7 @@ export class PriceRange extends Interaction {
     /**
      * @param {Event} ev
      */
-    onPriceRangeSelected(ev) {
+    async onPriceRangeSelected(ev) {
         const range = ev.currentTarget;
         const url = new URL(range.dataset.url, window.location.origin);
         const searchParams = url.searchParams;
@@ -21,11 +21,35 @@ export class PriceRange extends Interaction {
         if (parseFloat(range.max) !== range.valueHigh) {
             searchParams.set("max_price", range.valueHigh);
         }
-        const product_list_div = document.querySelector('.o_wsale_products_grid_table_wrapper');
-        if (product_list_div) {
-            product_list_div.classList.add('opacity-50');
+        const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
+        if (isOffcanvas) {
+            const offcanvas = document.querySelector('.o_website_offcanvas');
+            const offcanvasResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            const offcanvaData = await offcanvasResponse.text();
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = offcanvaData;
+
+            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
+            const shopPageEl = document.querySelector('.o_wsale_products_page');
+            this.services['public.interactions'].stopInteractions(shopPageEl);
+            offcanvas.innerHTML = newOffcanvas;
+            this.services['public.interactions'].startInteractions(shopPageEl);
+
+            searchParams.set('is_ajax_count', 'true');
+            const countResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            const countData = await countResponse.json();
+
+            const applyBtn = document.querySelector('#o_wsale_offcanvas #o_wsale_apply_filters_btn');
+            if (applyBtn) {
+                applyBtn.textContent = `Apply Filters (${countData.count})`;
+            }
+        } else {
+            const product_list_div = document.querySelector('.o_wsale_products_grid_table_wrapper');
+            if (product_list_div) {
+                product_list_div.classList.add('opacity-50');
+            }
+            redirect(`${url.pathname}?${searchParams.toString()}`);
         }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
     }
 }
 

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -1,6 +1,7 @@
 import { Interaction } from '@web/public/interaction';
 import { redirect } from '@web/core/utils/urls';
 import { registry } from '@web/core/registry';
+import { updateShopContent } from "./shop_ajax";
 
 export class PriceRange extends Interaction {
     static selector = '#o_wsale_price_range_option';
@@ -27,40 +28,11 @@ export class PriceRange extends Interaction {
         if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
 
         if (isOffcanvas) {
-            searchParams.set('is_ajax', 'true');
-            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            searchParams.delete('is_ajax');
-            const data = await response.json();
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = data.html;
-
-            const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
-            const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
-            if (currentProductsGrid && newProductsGrid) {
-                currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
-            }else{
-                redirect(`${url.pathname}?${searchParams.toString()}`);
-            }
-
-            const newPager = tempDiv.querySelector('.products_pager');
-            const currentPager = document.querySelector('.products_pager');
-            if (currentPager && newPager) {
-                currentPager.innerHTML = newPager.innerHTML;
-            }
-            const offcanvas = document.querySelector('.o_website_offcanvas');
-            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
-            if (offcanvas && newOffcanvas) {
-                const shopPageEl = document.querySelector('.o_wsale_products_page');
-                this.services['public.interactions'].stopInteractions(shopPageEl);
-                offcanvas.innerHTML = newOffcanvas.innerHTML;
-                this.services['public.interactions'].startInteractions(shopPageEl);
-            }
-            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
-            if (applyBtn) {
-                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
-            }
-            window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
-            if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
+            await updateShopContent({
+                url,
+                searchParams,
+                services: this.services,
+            });
         }else {
             redirect(`${url.pathname}?${searchParams.toString()}`);
         }

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -22,31 +22,46 @@ export class PriceRange extends Interaction {
             searchParams.set("max_price", range.valueHigh);
         }
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
+
+        const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
+        if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
+
+        searchParams.set('is_ajax', 'true');
+
+        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+        const data = await response.json();
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = data.html;
+
+        const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
+        const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
+        if (currentProductsGrid && newProductsGrid) {
+            currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
+        }
+
+        const newPager = tempDiv.querySelector('.products_pager');
+        const currentPager = document.querySelector('.products_pager');
+        if (currentPager && newPager) {
+            currentPager.innerHTML = newPager.innerHTML;
+        }
+
         if (isOffcanvas) {
             const offcanvas = document.querySelector('.o_website_offcanvas');
-            searchParams.set('is_ajax', 'true');
-            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const data = await response.json();
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = data.html;
-
-            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
-            const shopPageEl = document.querySelector('.o_wsale_products_page');
-            this.services['public.interactions'].stopInteractions(shopPageEl);
-            offcanvas.innerHTML = newOffcanvas;
-            this.services['public.interactions'].startInteractions(shopPageEl);
-
+            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
+            if (offcanvas && newOffcanvas) {
+                const shopPageEl = document.querySelector('.o_wsale_products_page');
+                this.services['public.interactions'].stopInteractions(shopPageEl);
+                offcanvas.innerHTML = newOffcanvas.innerHTML;
+                this.services['public.interactions'].startInteractions(shopPageEl);
+            }
             const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
             if (applyBtn) {
-                applyBtn.textContent = `Apply Filters (${data.count})`;
+                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
-        } else {
-            const product_list_div = document.querySelector('.o_wsale_products_grid_table_wrapper');
-            if (product_list_div) {
-                product_list_div.classList.add('opacity-50');
-            }
-            redirect(`${url.pathname}?${searchParams.toString()}`);
         }
+        searchParams.delete('is_ajax');
+        window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
+        if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
     }
 }
 

--- a/addons/website_sale/static/src/interactions/price_range.js
+++ b/addons/website_sale/static/src/interactions/price_range.js
@@ -26,26 +26,27 @@ export class PriceRange extends Interaction {
         const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
         if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
 
-        searchParams.set('is_ajax', 'true');
-
-        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-        const data = await response.json();
-        const tempDiv = document.createElement('div');
-        tempDiv.innerHTML = data.html;
-
-        const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
-        const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
-        if (currentProductsGrid && newProductsGrid) {
-            currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
-        }
-
-        const newPager = tempDiv.querySelector('.products_pager');
-        const currentPager = document.querySelector('.products_pager');
-        if (currentPager && newPager) {
-            currentPager.innerHTML = newPager.innerHTML;
-        }
-
         if (isOffcanvas) {
+            searchParams.set('is_ajax', 'true');
+            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            searchParams.delete('is_ajax');
+            const data = await response.json();
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = data.html;
+
+            const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
+            const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
+            if (currentProductsGrid && newProductsGrid) {
+                currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
+            }else{
+                redirect(`${url.pathname}?${searchParams.toString()}`);
+            }
+
+            const newPager = tempDiv.querySelector('.products_pager');
+            const currentPager = document.querySelector('.products_pager');
+            if (currentPager && newPager) {
+                currentPager.innerHTML = newPager.innerHTML;
+            }
             const offcanvas = document.querySelector('.o_website_offcanvas');
             const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
             if (offcanvas && newOffcanvas) {
@@ -58,19 +59,11 @@ export class PriceRange extends Interaction {
             if (applyBtn) {
                 applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
+            window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
+            if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
         }else {
-            const filters = document.querySelector('.o_wsale_products_grid_before_rail');
-            const newFilters = tempDiv.querySelector('.o_wsale_products_grid_before_rail');
-            if(filters && newFilters){
-                const shopPageEl = document.querySelector('.o_wsale_products_page');
-                this.services['public.interactions'].stopInteractions(shopPageEl);
-                filters.innerHTML = newFilters.innerHTML;
-                this.services['public.interactions'].startInteractions(shopPageEl);
-            }
+            redirect(`${url.pathname}?${searchParams.toString()}`);
         }
-        searchParams.delete('is_ajax');
-        window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
-        if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
     }
 }
 

--- a/addons/website_sale/static/src/interactions/shop_ajax.js
+++ b/addons/website_sale/static/src/interactions/shop_ajax.js
@@ -1,0 +1,79 @@
+import { redirect } from '@web/core/utils/urls';
+
+export async function updateShopContent({
+    url,
+    searchParams,
+    services,
+    options = {}
+}) {
+    const {
+        updateOffcanvas = true,
+        updateHistory = true,
+    } = options;
+
+    const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
+    productGridWrapper?.classList.add('opacity-50');
+
+    try {
+        const response = await fetch(`${url.pathname}?${searchParams.toString()}`, {
+            headers: {
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        });
+        const data = await response.json();
+
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = data.html;
+
+        const newGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
+        const currentGrid = document.querySelector('.o_wsale_products_grid_table');
+
+        if (currentGrid && newGrid) {
+            currentGrid.innerHTML = newGrid.innerHTML;
+        }else{
+            redirect(`${url.pathname}?${searchParams.toString()}`);
+        }
+
+        const newPager = tempDiv.querySelector('.products_pager');
+        const currentPager = document.querySelector('.products_pager');
+
+        if (currentPager && newPager) {
+            currentPager.innerHTML = newPager.innerHTML;
+        }
+
+        if (updateOffcanvas) {
+            const offcanvas = document.querySelector('.o_website_offcanvas');
+            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
+
+            if (offcanvas && newOffcanvas) {
+                const shopPageEl = document.querySelector('.o_wsale_products_page');
+                services?.['public.interactions']?.stopInteractions(shopPageEl);
+                offcanvas.innerHTML = newOffcanvas.innerHTML;
+                services?.['public.interactions']?.startInteractions(shopPageEl);
+            }
+        }
+
+        const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
+        if (applyBtn) {
+            applyBtn.innerHTML = `
+                Apply Filters
+                <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">
+                    ${data.count}
+                </span>`;
+        }
+
+        if (updateHistory) {
+            window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
+        }
+
+        return data;
+
+    } catch (error) {
+        console.warn('[shop_ajax] update failed:', error);
+
+        redirect(`${url.pathname}?${searchParams.toString()}`);
+
+    } finally {
+        productGridWrapper?.classList.remove('opacity-50');
+    }
+}

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -48,12 +48,17 @@ export class ShopPage extends Interaction {
      *
      * @param {Event} ev
      */
-    onChangeAttribute(ev) {
-        const productGrid = this.el.querySelector('.o_wsale_products_grid_table_wrapper');
-        if (productGrid) {
-            productGrid.classList.add('opacity-50');
-        }
+    async onChangeAttribute(ev) {
         const form = ev.currentTarget.closest('form');
+        const searchParams = this._getSearchParams(form);
+        const url = new URL(form.action);
+        await wSaleUtils.updateShopContent(this, {
+            url,
+            searchParams,
+        });
+    }
+
+    _getSearchParams(form) {
         const filters = form.querySelectorAll('input:checked, select');
         const attributeValueSlugs = Array.from(filters).filter(
             filter => filter.name === 'attribute_value' && filter.value
@@ -71,7 +76,7 @@ export class ShopPage extends Interaction {
         if (tagSlugs.length) {
             searchParams.set('tags', [...new Set(tagSlugs)].join(','));
         }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
+        return searchParams;
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -56,42 +56,31 @@ export class ShopPage extends Interaction {
         const searchParams = this._getSearchParams(form);
         const url = new URL(form.action);
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
-        const range = isOffcanvas ? document.querySelector('#o_wsale_offcanvas input[type="range"]') : document.querySelector('#o_wsale_price_range_option input[type="range"]');
-        if (range) {
-            if (range.valueLow !== undefined) {
-                searchParams.set("min_price", range.valueLow);
-            }
-            if (range.valueHigh !== undefined) {
-                searchParams.set("max_price", range.valueHigh);
-            }
-        }
 
         const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
         if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
 
-        searchParams.set('is_ajax', 'true');
-
-        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-        const data = await response.json();
-        const tempDiv = document.createElement('div');
-        tempDiv.innerHTML = data.html;
-
-        const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
-        const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
-        if (currentProductsGrid && newProductsGrid) {
-            currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
-        }else{
-            searchParams.delete('is_ajax');
-            redirect(`${url.pathname}?${searchParams.toString()}`);
-        }
-
-        const newPager = tempDiv.querySelector('.products_pager');
-        const currentPager = document.querySelector('.products_pager');
-        if (currentPager && newPager) {
-            currentPager.innerHTML = newPager.innerHTML;
-        }
-
         if (isOffcanvas) {
+            searchParams.set('is_ajax', 'true');
+            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            searchParams.delete('is_ajax');
+            const data = await response.json();
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = data.html;
+
+            const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
+            const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
+            if (currentProductsGrid && newProductsGrid) {
+                currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
+            }else{
+                redirect(`${url.pathname}?${searchParams.toString()}`);
+            }
+
+            const newPager = tempDiv.querySelector('.products_pager');
+            const currentPager = document.querySelector('.products_pager');
+            if (currentPager && newPager) {
+                currentPager.innerHTML = newPager.innerHTML;
+            }
             const offcanvas = document.querySelector('.o_website_offcanvas');
             const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
             if (offcanvas && newOffcanvas) {
@@ -103,18 +92,11 @@ export class ShopPage extends Interaction {
             if (applyBtn) {
                 applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
+            window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
+            if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
         }else {
-            const filters = document.querySelector('.o_wsale_products_grid_before_rail');
-            const newFilters = tempDiv.querySelector('.o_wsale_products_grid_before_rail');
-            if(filters && newFilters){
-                this.services['public.interactions'].stopInteractions(this.el);
-                filters.innerHTML = newFilters.innerHTML;
-                this.services['public.interactions'].startInteractions(this.el);
-            }
+            redirect(`${url.pathname}?${searchParams.toString()}`);
         }
-        searchParams.delete('is_ajax');
-        window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
-        if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
     }
 
     _getSearchParams(form) {
@@ -149,18 +131,15 @@ export class ShopPage extends Interaction {
     }
 
     async _fetchInitialCount(applyBtn) {
-        const form = document.querySelector('#o_wsale_offcanvas form.js_attributes');
-        if (!form) return;
-
-        const searchParams = this._getSearchParams(form);
-        const url = new URL(form.action);
-        searchParams.set('is_ajax', 'true');
-
-        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+        let response;
+        if (window.location.search){
+            response = await fetch(`${window.location.href}&is_ajax=true`);
+        }else{
+            response = await fetch(`${window.location.href}?is_ajax=true`);
+        }
         const data = await response.json();
 
         applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
-
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -21,6 +21,7 @@ export class ShopPage extends Interaction {
         },
         '.o_wsale_attribute_search_bar': { 't-on-input': this.searchAttributeValues },
         '.o_wsale_view_more_btn': { 't-on-click': this.onToggleViewMoreLabel },
+        '.o_wsale_apply_filters_btn': {'t-on-click': this._onApplyFiltersClick },
     };
 
     setup() {
@@ -47,12 +48,63 @@ export class ShopPage extends Interaction {
      *
      * @param {Event} ev
      */
-    onChangeAttribute(ev) {
-        const productGrid = this.el.querySelector('.o_wsale_products_grid_table_wrapper');
-        if (productGrid) {
-            productGrid.classList.add('opacity-50');
-        }
+    async onChangeAttribute(ev) {
         const form = ev.currentTarget.closest('form');
+        const searchParams = this._getSearchParams(form);
+        const url = new URL(form.action);
+
+        const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
+        if (isOffcanvas) {
+            const offcanvas = document.querySelector('.o_website_offcanvas');
+
+            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            const data = await response.text();
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = data;
+
+            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
+            this.services['public.interactions'].stopInteractions(this.el);
+            offcanvas.innerHTML = newOffcanvas;
+            this.services['public.interactions'].startInteractions(this.el);
+
+            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
+            searchParams.set('is_ajax_count', 'true');
+            const counResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
+            const countData = await counResponse.json();
+            if (applyBtn) {
+                applyBtn.textContent = `Apply Filters (${countData.count})`;
+            }
+        }
+        else {
+            const productGrid = this.el.querySelector('.o_wsale_products_grid_table_wrapper');
+            if (productGrid) {
+                productGrid.classList.add('opacity-50');
+            }
+
+            redirect(`${url.pathname}?${searchParams.toString()}`);
+        }
+    }
+
+    async _onApplyFiltersClick(ev) {
+        ev.preventDefault();
+        const form = document.querySelector('#o_wsale_offcanvas form.js_attributes');
+        const searchParams = this._getSearchParams(form);
+        const url = new URL(form.action);
+
+        const range = document.querySelector('#o_wsale_offcanvas input[type="range"]');
+
+        if (range) {
+            if (range.valueLow !== undefined) {
+                searchParams.set("min_price", range.valueLow);
+            }
+            if (range.valueHigh !== undefined) {
+                searchParams.set("max_price", range.valueHigh);
+            }
+        }
+        redirect(`${url.pathname}?${searchParams.toString()}`);
+    }
+
+    _getSearchParams(form) {
         const filters = form.querySelectorAll('input:checked, select');
         const attributeValues = new Map();
         const tags = new Set();
@@ -80,7 +132,7 @@ export class ShopPage extends Interaction {
         if (tags.size) {
             searchParams.set('tags', [...tags].join(','));
         }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
+        return searchParams;
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -3,6 +3,7 @@ import { registry } from '@web/core/registry';
 import { hasTouch, isBrowserFirefox } from '@web/core/browser/feature_detection';
 import { redirect } from '@web/core/utils/urls';
 import { setElementContent } from "@web/core/utils/html";
+import { updateShopContent } from "./shop_ajax";
 import { _t } from "@web/core/l10n/translation";
 
 export class ShopPage extends Interaction {
@@ -61,39 +62,11 @@ export class ShopPage extends Interaction {
         if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
 
         if (isOffcanvas) {
-            searchParams.set('is_ajax', 'true');
-            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            searchParams.delete('is_ajax');
-            const data = await response.json();
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = data.html;
-
-            const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
-            const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
-            if (currentProductsGrid && newProductsGrid) {
-                currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
-            }else{
-                redirect(`${url.pathname}?${searchParams.toString()}`);
-            }
-
-            const newPager = tempDiv.querySelector('.products_pager');
-            const currentPager = document.querySelector('.products_pager');
-            if (currentPager && newPager) {
-                currentPager.innerHTML = newPager.innerHTML;
-            }
-            const offcanvas = document.querySelector('.o_website_offcanvas');
-            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
-            if (offcanvas && newOffcanvas) {
-                this.services['public.interactions'].stopInteractions(offcanvas);
-                offcanvas.innerHTML = newOffcanvas.innerHTML;
-                this.services['public.interactions'].startInteractions(offcanvas);
-            }
-            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
-            if (applyBtn) {
-                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
-            }
-            window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
-            if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
+            await updateShopContent({
+                url,
+                searchParams,
+                services: this.services,
+            });
         }else {
             redirect(`${url.pathname}?${searchParams.toString()}`);
         }
@@ -131,12 +104,11 @@ export class ShopPage extends Interaction {
     }
 
     async _fetchInitialCount(applyBtn) {
-        let response;
-        if (window.location.search){
-            response = await fetch(`${window.location.href}&is_ajax=true`);
-        }else{
-            response = await fetch(`${window.location.href}?is_ajax=true`);
-        }
+        const response = await fetch(`${window.location.href}`, {
+            headers: {
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        });
         const data = await response.json();
 
         applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -21,7 +21,7 @@ export class ShopPage extends Interaction {
         },
         '.o_wsale_attribute_search_bar': { 't-on-input': this.searchAttributeValues },
         '.o_wsale_view_more_btn': { 't-on-click': this.onToggleViewMoreLabel },
-        '.o_wsale_apply_filters_btn': {'t-on-click': this._onApplyFiltersClick },
+        '#o_wsale_apply_filters_btn': {'t-on-click': this._onApplyFiltersClick },
     };
 
     setup() {
@@ -56,23 +56,20 @@ export class ShopPage extends Interaction {
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
         if (isOffcanvas) {
             const offcanvas = document.querySelector('.o_website_offcanvas');
-
+            searchParams.set('is_ajax', 'true');
             const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const data = await response.text();
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = data;
-
-            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
-            this.services['public.interactions'].stopInteractions(this.el);
-            offcanvas.innerHTML = newOffcanvas;
-            this.services['public.interactions'].startInteractions(this.el);
-
+            const data = await response.json();
+            if(data.count > 0){
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = data.html;
+                const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
+                this.services['public.interactions'].stopInteractions(this.el);
+                offcanvas.innerHTML = newOffcanvas;
+                this.services['public.interactions'].startInteractions(this.el);
+            }
             const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
-            searchParams.set('is_ajax_count', 'true');
-            const counResponse = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const countData = await counResponse.json();
             if (applyBtn) {
-                applyBtn.textContent = `Apply Filters (${countData.count})`;
+                applyBtn.textContent = `Apply Filters (${data.count})`;
             }
         }
         else {

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -41,6 +41,10 @@ export class ShopPage extends Interaction {
         if (isBrowserFirefox() || hasTouch() || !isFilmstripScrollable) {
             filmstripContainer?.classList.add('o_wsale_filmstrip_fancy_disabled');
         }
+        const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
+        if (applyBtn){
+            this._fetchInitialCount(applyBtn);
+        }
     }
 
     /**
@@ -56,6 +60,8 @@ export class ShopPage extends Interaction {
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
         if (isOffcanvas) {
             const offcanvas = document.querySelector('.o_website_offcanvas');
+            const productsGrid = document.querySelector('.o_wsale_products_grid_table');
+            const pager = document.querySelector('.products_pager');
             searchParams.set('is_ajax', 'true');
             const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
             const data = await response.json();
@@ -63,13 +69,17 @@ export class ShopPage extends Interaction {
                 const tempDiv = document.createElement('div');
                 tempDiv.innerHTML = data.html;
                 const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
+                const newProductGrid = tempDiv.querySelector('.o_wsale_products_grid_table').innerHTML;
+                const newPager = tempDiv.querySelector('.o_wsale_products_grid_table').innerHTML;
                 this.services['public.interactions'].stopInteractions(this.el);
                 offcanvas.innerHTML = newOffcanvas;
+                productsGrid.innerHTML = newProductGrid;
+                pager.innerHTML = newPager
                 this.services['public.interactions'].startInteractions(this.el);
             }
             const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
             if (applyBtn) {
-                applyBtn.textContent = `Apply Filters (${data.count})`;
+                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
         }
         else {
@@ -130,6 +140,21 @@ export class ShopPage extends Interaction {
             searchParams.set('tags', [...tags].join(','));
         }
         return searchParams;
+    }
+
+    async _fetchInitialCount(applyBtn) {
+        const form = document.querySelector('#o_wsale_offcanvas form.js_attributes');
+        if (!form) return;
+
+        const searchParams = this._getSearchParams(form);
+        const url = new URL(form.action);
+        searchParams.set('is_ajax', 'true');
+
+        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+        const data = await response.json();
+
+        applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
+
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -103,6 +103,14 @@ export class ShopPage extends Interaction {
             if (applyBtn) {
                 applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
             }
+        }else {
+            const filters = document.querySelector('.o_wsale_products_grid_before_rail');
+            const newFilters = tempDiv.querySelector('.o_wsale_products_grid_before_rail');
+            if(filters && newFilters){
+                this.services['public.interactions'].stopInteractions(this.el);
+                filters.innerHTML = newFilters.innerHTML;
+                this.services['public.interactions'].startInteractions(this.el);
+            }
         }
         searchParams.delete('is_ajax');
         window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -21,7 +21,6 @@ export class ShopPage extends Interaction {
         },
         '.o_wsale_attribute_search_bar': { 't-on-input': this.searchAttributeValues },
         '.o_wsale_view_more_btn': { 't-on-click': this.onToggleViewMoreLabel },
-        '#o_wsale_apply_filters_btn': {'t-on-click': this._onApplyFiltersClick },
     };
 
     setup() {
@@ -56,50 +55,8 @@ export class ShopPage extends Interaction {
         const form = ev.currentTarget.closest('form');
         const searchParams = this._getSearchParams(form);
         const url = new URL(form.action);
-
         const isOffcanvas = !!ev.currentTarget.closest('#o_wsale_offcanvas');
-        if (isOffcanvas) {
-            const offcanvas = document.querySelector('.o_website_offcanvas');
-            const productsGrid = document.querySelector('.o_wsale_products_grid_table');
-            const pager = document.querySelector('.products_pager');
-            searchParams.set('is_ajax', 'true');
-            const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
-            const data = await response.json();
-            if(data.count > 0){
-                const tempDiv = document.createElement('div');
-                tempDiv.innerHTML = data.html;
-                const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas').innerHTML;
-                const newProductGrid = tempDiv.querySelector('.o_wsale_products_grid_table').innerHTML;
-                const newPager = tempDiv.querySelector('.o_wsale_products_grid_table').innerHTML;
-                this.services['public.interactions'].stopInteractions(this.el);
-                offcanvas.innerHTML = newOffcanvas;
-                productsGrid.innerHTML = newProductGrid;
-                pager.innerHTML = newPager
-                this.services['public.interactions'].startInteractions(this.el);
-            }
-            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
-            if (applyBtn) {
-                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
-            }
-        }
-        else {
-            const productGrid = this.el.querySelector('.o_wsale_products_grid_table_wrapper');
-            if (productGrid) {
-                productGrid.classList.add('opacity-50');
-            }
-
-            redirect(`${url.pathname}?${searchParams.toString()}`);
-        }
-    }
-
-    async _onApplyFiltersClick(ev) {
-        ev.preventDefault();
-        const form = document.querySelector('#o_wsale_offcanvas form.js_attributes');
-        const searchParams = this._getSearchParams(form);
-        const url = new URL(form.action);
-
-        const range = document.querySelector('#o_wsale_offcanvas input[type="range"]');
-
+        const range = isOffcanvas ? document.querySelector('#o_wsale_offcanvas input[type="range"]') : document.querySelector('#o_wsale_price_range_option input[type="range"]');
         if (range) {
             if (range.valueLow !== undefined) {
                 searchParams.set("min_price", range.valueLow);
@@ -108,7 +65,48 @@ export class ShopPage extends Interaction {
                 searchParams.set("max_price", range.valueHigh);
             }
         }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
+
+        const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
+        if (productGridWrapper) productGridWrapper.classList.add('opacity-50');
+
+        searchParams.set('is_ajax', 'true');
+
+        const response = await fetch(`${url.pathname}?${searchParams.toString()}`);
+        const data = await response.json();
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = data.html;
+
+        const newProductsGrid = tempDiv.querySelector('.o_wsale_products_grid_table');
+        const currentProductsGrid = document.querySelector('.o_wsale_products_grid_table');
+        if (currentProductsGrid && newProductsGrid) {
+            currentProductsGrid.innerHTML = newProductsGrid.innerHTML;
+        }else{
+            searchParams.delete('is_ajax');
+            redirect(`${url.pathname}?${searchParams.toString()}`);
+        }
+
+        const newPager = tempDiv.querySelector('.products_pager');
+        const currentPager = document.querySelector('.products_pager');
+        if (currentPager && newPager) {
+            currentPager.innerHTML = newPager.innerHTML;
+        }
+
+        if (isOffcanvas) {
+            const offcanvas = document.querySelector('.o_website_offcanvas');
+            const newOffcanvas = tempDiv.querySelector('.o_website_offcanvas');
+            if (offcanvas && newOffcanvas) {
+                this.services['public.interactions'].stopInteractions(offcanvas);
+                offcanvas.innerHTML = newOffcanvas.innerHTML;
+                this.services['public.interactions'].startInteractions(offcanvas);
+            }
+            const applyBtn = document.querySelector('#o_wsale_apply_filters_btn');
+            if (applyBtn) {
+                applyBtn.innerHTML = `Apply Filters <span class="badge rounded-pill bg-o-color-3 text-o-color-1 ms-2">${data.count}</span>`;
+            }
+        }
+        searchParams.delete('is_ajax');
+        window.history.pushState({}, '', `${url.pathname}?${searchParams.toString()}`);
+        if (productGridWrapper) productGridWrapper.classList.remove('opacity-50');
     }
 
     _getSearchParams(form) {

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -1,6 +1,9 @@
 import { browser } from '@web/core/browser/browser';
 import { _t } from '@web/core/l10n/translation';
-import { createElementWithContent } from '@web/core/utils/html';
+import { rpc } from "@web/core/network/rpc";
+import { createElementWithContent, setElementContent } from '@web/core/utils/html';
+import { redirect } from '@web/core/utils/urls';
+import { markup } from "@odoo/owl";
 
 /**
  * Updates both navbar cart
@@ -82,6 +85,53 @@ function updateQuickReorderSidebar(data) {
     }
 }
 
+async function updateShopContent(interaction, {
+    url,
+    searchParams,
+}) {
+    const targetUrl = `${url.pathname}?${searchParams.toString()}`;
+
+    const productGridWrapper = document.querySelector('.o_wsale_products_grid_table_wrapper');
+    productGridWrapper?.classList?.add('opacity-50');
+
+    try {
+        const paramsObject = Object.fromEntries(searchParams.entries());
+        const data = await interaction.waitFor(rpc('/shop/reload', paramsObject));
+        const updatedShopPage = document.createElement('div');
+        setElementContent(updatedShopPage, markup(data.html))
+        const shopPageEl = document.querySelector('.o_wsale_products_page');
+        interaction.services['public.interactions'].stopInteractions(shopPageEl);
+
+        const newSidebar = updatedShopPage.querySelector('#products_grid_before');
+        const currentSidebar = document.querySelector('#products_grid_before');
+        if (newSidebar && currentSidebar) {
+            setElementContent(currentSidebar, markup(newSidebar.innerHTML))
+        }
+
+        const newGrid = updatedShopPage.querySelector('.o_wsale_products_grid_table');
+        const currentGrid = document.querySelector('.o_wsale_products_grid_table');
+        setElementContent(currentGrid, markup(newGrid.innerHTML))
+
+        const newPager = updatedShopPage.querySelector('.products_pager');
+        const currentPager = document.querySelector('.products_pager');
+        setElementContent(currentPager, markup(newPager.innerHTML))
+
+        const newOffcanvas = updatedShopPage.querySelector('.o_website_offcanvas');
+        const currentOffcanvas = document.querySelector('.o_website_offcanvas');
+        setElementContent(currentOffcanvas, markup(newOffcanvas.innerHTML))
+
+        const applyBtn = document.querySelector('#o_wsale_offcanvas_product_count');
+        if (applyBtn) {
+            setElementContent(applyBtn, data.product_count)
+        }
+        history.pushState({}, '', targetUrl);
+        interaction.services['public.interactions'].startInteractions(shopPageEl);
+        productGridWrapper?.classList.remove('opacity-50');
+    } catch {
+        redirect(targetUrl);
+    }
+}
+
 /**
  * Return the selected attribute values from the given container.
  *
@@ -144,4 +194,5 @@ export default {
     unslug: unslug,
     getAttributeValueParams: getAttributeValueParams,
     clearAttributeValueParams: clearAttributeValueParams,
+    updateShopContent: updateShopContent,
 };

--- a/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
@@ -6,13 +6,19 @@ registry.category("web_tour.tours").add("shop_attribute_filters_remain_when_chan
             content: "Select first attribute value",
             trigger: ".products_attributes_filters form.js_attributes input:eq(0)",
             run: "click",
-            expectUnloadPage: true,
+        },
+        {
+            content: "Check that the first filter is applied",
+            trigger: "li.active a.page-link[href*='size']",
         },
         {
             content: "Select last attribute value",
             trigger: ".products_attributes_filters form.js_attributes input:eq(3)",
             run: "click",
-            expectUnloadPage: true,
+        },
+        {
+            content: "Check that the second filter is applied",
+            trigger: "li.active a.page-link[href*='color']",
         },
         {
             content: "Select page 2",

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -862,7 +862,7 @@
                         t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}_header"
                     >
                         <button
-                            t-attf-class="o_wsale_offcanvas_title accordion-button rounded-0 {{'' if _expand_attributes else 'collapsed'}}"
+                            t-attf-class="o_wsale_offcanvas_title accordion-button px-4 bg-transparent shadow-none {{'' if _expand_attributes else 'collapsed'}}"
                             type="button"
                             data-bs-toggle="collapse"
                             t-attf-data-bs-target="#o_wsale_offcanvas_attribute_{{a.id}}"
@@ -963,9 +963,6 @@
     <template id="website_sale.o_wsale_offcanvas" name="Offcanvas">
         <aside id="o_wsale_offcanvas"
                class="o_website_offcanvas offcanvas offcanvas-end p-0">
-            <div class="offcanvas-header justify-content-end">
-                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
-            </div>
             <div id="o_wsale_offcanvas_content" class="accordion accordion-flush flex-grow-1 overflow-auto">
                 <!-- Show sorting only if it's not avavailbe in the topbar already -->
                 <div t-if="not is_view_active('website_sale.sort')" class="accordion-item">
@@ -1048,7 +1045,7 @@
                     <t t-call="website_sale.ribbon_filter_pills"/>
                 </div>
             </div>
-            <div class="offcanvas-body d-flex justify-content-between flex-grow-0 flex-shrink-0 border-top overflow-hidden">
+            <div class="offcanvas-body d-flex flex-column flex-grow-0 overflow-hidden">
                 <t
                     t-set="has_active_filters"
                     t-value="(
@@ -1060,7 +1057,7 @@
                     )"
                 />
                 <a
-                    t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{not has_active_filters and 'disabled'}}"
+                    t-attf-class="btn btn-link w-100 py-1 mb-2 {{not has_active_filters and 'disabled'}}"
                     t-att-aria-disabled="'true' if not has_active_filters else 'false'"
                     t-att-href="keep(
                         **reset_attribute_value_params, tags=0,
@@ -1071,6 +1068,20 @@
                 >
                     Clear Filters
                 </a>
+                <button
+                    id="o_wsale_apply_filters_btn"
+                    class="btn btn-primary w-100"
+                    type="button"
+                    data-bs-dismiss="offcanvas"
+                >
+                    Apply Filters
+                    <span
+                        id="o_wsale_offcanvas_product_count"
+                        class="badge rounded-pill bg-o-color-3 text-o-color-1"
+                    >
+                        <t t-out="search_count"/>
+                    </span>
+                </button>
             </div>
         </aside>
     </template>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -954,7 +954,7 @@
     <template id="website_sale.o_wsale_offcanvas" name="Offcanvas">
         <aside id="o_wsale_offcanvas"
                class="o_website_offcanvas offcanvas offcanvas-end p-0">
-            <div id="o_wsale_offcanvas_content" class="o_wsale_offcanvas_content accordion accordion-flush flex-grow-1 overflow-auto">
+            <div id="o_wsale_offcanvas_content" class="accordion accordion-flush flex-grow-1 overflow-auto">
                 <!-- Show sorting only if it's not avavailbe in the topbar already -->
                 <div t-if="not is_view_active('website_sale.sort')" class="accordion-item">
                     <t t-if="isSortingBy" t-set="isSortingBy" t-value="isSortingBy[0][1]"/>
@@ -1039,7 +1039,7 @@
                 </a>
                 <button
                     id="o_wsale_apply_filters_btn"
-                    class="o_wsale_apply_filters_btn btn btn-primary w-100"
+                    class="btn btn-primary w-100"
                     type="button"
                     data-bs-dismiss="offcanvas"
                 >

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -410,63 +410,7 @@
                             </header>
 
                             <div t-if="products" class="o_wsale_products_grid_table_wrapper">
-                                <t t-set="grid_md_allow_custom_cols" t-value="hasLeftColumn"/>
-                                <t
-                                    t-set="grid_md_use_3col"
-                                    t-value="(not hasLeftColumn and ppr == 4) or (opt_wsale_fullwidth and ppr > 3)"
-                                />
-
-                                <section
-                                    id="o_wsale_products_grid"
-                                    t-attf-class="o_wsale_products_grid_table grid
-                                        {{grid_md_allow_custom_cols and 'o_wsale_products_grid_table_md'}}
-                                        {{website.shop_opt_products_design_classes}}"
-                                    t-attf-style="--o-wsale-ppr: {{ppr}}; --o-wsale-ppg: {{ppg}}; --o-wsale-products-grid-gap: {{gap}};"
-                                    t-att-data-name="grid_block_name"
-                                >
-                                    <t t-foreach="bins" t-as="tr_product">
-                                        <t t-foreach="tr_product" t-as="td_product">
-                                            <t t-if="td_product">
-                                                <t t-set="col_height" t-value="td_product['y']"/>
-                                                <t t-set="col_width"
-                                                   t-value="12 // ppr * td_product['x']"/>
-                                                <t t-set="col_class" t-valuef="g-col-6"/>
-                                                <t t-set="col_class_lg"
-                                                   t-value="'g-col-lg-' + str(col_width)"/>
-                                                <t t-set="col_class_md"
-                                                   t-value="grid_md_allow_custom_cols and ('g-col-md-' + str(col_width)) or grid_md_use_3col and 'g-col-md-4' or 'g-col-md-6'"/>
-                                                <t t-set="col_is_stretched"
-                                                   t-value="(td_product['x'] &gt;= td_product['y'] * 2)"/>
-                                                <t t-set="col_is_custom_portrait"
-                                                   t-value="not col_is_stretched and (col_height &gt; td_product['x'])"/>
-                                                <t t-set="product" t-value="td_product['product']"/>
-                                                <t t-set="product_variant" t-value="product_variants[product]"/>
-                                                <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                                                <t
-                                                    t-set="ribbon"
-                                                    t-value="product._get_ribbon(
-                                                        price_vals=template_price_vals,
-                                                        auto_assign_ribbons=auto_assign_ribbons,
-                                                        variant=product_variants[product],
-                                                    )"
-                                                />
-                                                <div
-                                                    t-attf-class="oe_product {{col_is_custom_portrait and 'oe_product_custom_portrait'}} {{col_class}} {{col_class_md}} {{col_class_lg}} {{col_is_stretched and 'oe_product_size_stretch'}}"
-                                                    t-attf-style="--o-wsale-products-grid-product-col-height: {{col_height}};"
-                                                    t-att-data-colspan="td_product['x'] != 1 and td_product['x']"
-                                                    t-att-data-rowspan="td_product['y'] != 1 and td_product['y']"
-                                                    t-att-data-name="product_block_name"
-                                                >
-                                                    <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
-                                                        <t t-call="website_sale.products_item"
-                                                            design_field="website.shop_opt_products_design_classes"
-                                                            product_href="product._get_product_url(category, product_query_params, grouped_attributes_values)"/>
-                                                    </div>
-                                                </div>
-                                            </t>
-                                        </t>
-                                    </t>
-                                </section>
+                                <t t-call="website_sale.products_grid"/>
                             </div>
                             <div t-else="" class="text-center mt128 mb256">
                                 <t groups="base.group_public">
@@ -526,9 +470,6 @@
                                     </div>
                                 </t>
                             </div>
-                            <div id="o_wsale_pager" t-attf-class="products_pager d-flex justify-content-center {{opt_wsale_design_grid and 'py-4' or 'py-5 pb-4'}}">
-                                <t t-call="website.pager"/>
-                            </div>
                             <t t-if="category">
                                 <t t-set='footer_editor_message'>
                                     Drag blocks here to customize the footer of
@@ -572,6 +513,69 @@
             >
                 <p/>
             </section>
+        </div>
+    </template>
+
+    <template id="website_sale.products_grid">
+        <t t-set="grid_md_allow_custom_cols" t-value="hasLeftColumn"/>
+        <t
+            t-set="grid_md_use_3col"
+            t-value="(not hasLeftColumn and ppr == 4) or (opt_wsale_fullwidth and ppr > 3)"
+        />
+
+        <section
+            id="o_wsale_products_grid"
+            t-attf-class="o_wsale_products_grid_table grid
+                {{grid_md_allow_custom_cols and 'o_wsale_products_grid_table_md'}}
+                {{website.shop_opt_products_design_classes}}"
+            t-attf-style="--o-wsale-ppr: {{ppr}}; --o-wsale-ppg: {{ppg}}; --o-wsale-products-grid-gap: {{gap}};"
+            t-att-data-name="grid_block_name"
+        >
+            <t t-foreach="bins" t-as="tr_product">
+                <t t-foreach="tr_product" t-as="td_product">
+                    <t t-if="td_product">
+                        <t t-set="col_height" t-value="td_product['y']"/>
+                        <t t-set="col_width"
+                            t-value="12 // ppr * td_product['x']"/>
+                        <t t-set="col_class" t-valuef="g-col-6"/>
+                        <t t-set="col_class_lg"
+                            t-value="'g-col-lg-' + str(col_width)"/>
+                        <t t-set="col_class_md"
+                            t-value="grid_md_allow_custom_cols and ('g-col-md-' + str(col_width)) or grid_md_use_3col and 'g-col-md-4' or 'g-col-md-6'"/>
+                        <t t-set="col_is_stretched"
+                            t-value="(td_product['x'] &gt;= td_product['y'] * 2)"/>
+                        <t t-set="col_is_custom_portrait"
+                           t-value="not col_is_stretched and (col_height &gt; td_product['x'])"/>
+                        <t t-set="product" t-value="td_product['product']"/>
+                        <t t-set="product_variant" t-value="product_variants[product]"/>
+                        <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
+                        <t
+                            t-set="ribbon"
+                            t-value="product._get_ribbon(
+                                price_vals=template_price_vals,
+                                auto_assign_ribbons=auto_assign_ribbons,
+                                variant=product_variants[product],
+                            )"
+                        />
+                        <div
+                            t-attf-class="oe_product {{col_is_custom_portrait and 'oe_product_custom_portrait'}} {{col_class}} {{col_class_md}} {{col_class_lg}} {{col_is_stretched and 'oe_product_size_stretch'}}"
+                            t-attf-style="--o-wsale-products-grid-product-col-height: {{col_height}};"
+                            t-att-data-colspan="td_product['x'] != 1 and td_product['x']"
+                            t-att-data-rowspan="td_product['y'] != 1 and td_product['y']"
+                            t-att-data-name="product_block_name"
+                        >
+                           <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
+                                <t t-call="website_sale.products_item"
+                                    design_field="website.shop_opt_products_design_classes"
+                                    product_href="product._get_product_url(category, product_query_params, grouped_attributes_values)"/>
+                            </div>
+                        </div>
+                    </t>
+                </t>
+            </t>
+        </section>
+        <div id="o_wsale_pager" t-attf-class="products_pager d-flex justify-content-center {{opt_wsale_design_grid and 'py-4' or 'py-5 pb-4'}}">
+            <t t-call="website.pager"/>
         </div>
     </template>
 
@@ -852,7 +856,8 @@
                         t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}_header"
                     >
                         <button
-                            t-attf-class="o_wsale_offcanvas_title accordion-button rounded-0 {{'' if _expand_attributes else 'collapsed'}}"
+                            t-attf-class="o_wsale_offcanvas_title accordion-button bg-transparent shadow-none {{'' if _expand_attributes else 'collapsed'}}"
+                            style="padding-left: 20px;"
                             type="button"
                             t-att-data-status="_status"
                             data-bs-toggle="collapse"

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -824,7 +824,7 @@
         name="Product Attribute Filters Form"
     >
         <form
-            t-attf-class="js_attributes {{('accordion accordion-flush d-flex flex-column ' + ('border-bottom' if attributes else '')) if isMobile else 'position-relative mb-2'}}"
+            t-attf-class="product_attribute_filters_form js_attributes {{('accordion accordion-flush d-flex flex-column ' + ('border-bottom' if attributes else '')) if isMobile else 'position-relative mb-2'}}"
             method="get"
             t-att-action="keep(attribute_values=0, tags=0)"
         >
@@ -954,20 +954,7 @@
     <template id="website_sale.o_wsale_offcanvas" name="Offcanvas">
         <aside id="o_wsale_offcanvas"
                class="o_website_offcanvas offcanvas offcanvas-end p-0">
-            <div class="offcanvas-header justify-content-end">
-                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
-            </div>
-            <div
-                t-if="is_view_active('website_sale.search') and (opt_wsale_attributes or opt_wsale_attributes_top)"
-                class="offcanvas-body flex-grow-0 overflow-visible"
-            >
-                <t t-if="category" t-set="placeholder" t-valuef.translate="Search in {{category.name}}"/>
-                <t t-call="website_sale.search"
-                    placeholder="placeholder"
-                    search="original_search or search"
-                    _s_searchbar_autocomplete_classes.f="bg-primary"/>
-            </div>
-            <div id="o_wsale_offcanvas_content" class="accordion accordion-flush flex-grow-1 overflow-auto">
+            <div id="o_wsale_offcanvas_content" class="o_wsale_offcanvas_content accordion accordion-flush flex-grow-1 overflow-auto">
                 <!-- Show sorting only if it's not avavailbe in the topbar already -->
                 <div t-if="not is_view_active('website_sale.sort')" class="accordion-item">
                     <t t-if="isSortingBy" t-set="isSortingBy" t-value="isSortingBy[0][1]"/>
@@ -1043,13 +1030,21 @@
                    _classes_title.f="ms-n1 pt-3 pb-2"
                    isOffcanvas="True"/>
             </div>
-            <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
-                <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
+            <div class="offcanvas-body d-flex flex-column flex-grow-0 overflow-hidden">
+                <a t-attf-class="btn btn-link w-100 py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled text-muted' or 'text-dark'}}"
                    t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
                    t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
                    title="Clear Filters">
                     Clear Filters
                 </a>
+                <button
+                    id="o_wsale_apply_filters_btn"
+                    class="o_wsale_apply_filters_btn btn btn-primary w-100"
+                    type="button"
+                    data-bs-dismiss="offcanvas"
+                >
+                    Apply Filters
+                </button>
             </div>
         </aside>
     </template>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -856,8 +856,7 @@
                         t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}_header"
                     >
                         <button
-                            t-attf-class="o_wsale_offcanvas_title accordion-button bg-transparent shadow-none {{'' if _expand_attributes else 'collapsed'}}"
-                            style="padding-left: 20px;"
+                            t-attf-class="o_wsale_offcanvas_title accordion-button px-4 bg-transparent shadow-none {{'' if _expand_attributes else 'collapsed'}}"
                             type="button"
                             t-att-data-status="_status"
                             data-bs-toggle="collapse"


### PR DESCRIPTION
Before this PR, applying filters on the shop page triggered a full page
reload through URL redirection. This resulted in a less fluid user
experience, especially on mobile devices where the offcanvas filter
panel closed after every interaction.

This PR introduces asynchronous shop filtering:

- The product grid and pager have been extracted into a
dedicated template and are now updated dynamically through
AJAX after each filter change.
- The browser URL is updated using the History API without
reloading the page.
- Product counts and filter sections are refreshed in place to
remain consistent with the currently selected criteria.
- Price range and attribute filters now share the same
dynamic update flow.

For the mobile/offcanvas filtering experience:

The offcanvas header close button has been removed to
simplify the layout. Filter accordion headers have been
visually simplified for better readability. A new “View Products”
button has been added at the bottom of the panel. The filters
button is now hidden when no filter section is available.

task-6030829