### PR TITLE
[IMP] hr_recruitment: no auto create partner on incoming emails

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -251,7 +251,7 @@ class HrApplicant(models.Model):
                 if not applicant.partner_name:
                     raise UserError(_("You must define a Contact Name for this applicant."))
                 applicant.partner_id = applicant._partner_find_from_emails_single(
-                    [applicant.email_from], no_create=False,
+                    [applicant.email_from], no_create=True,
                     additional_values={
                         email_normalized: {'lang': self.env.lang}
                     },


### PR DESCRIPTION
Based on feedback : task-4729698

Purpose
=======
Don't create the res.partner when not needed when creating or "playing with" applicant.

Specifications
==============

When email is set on the applicant (at creation or afterwards), remove the partner auto-create.
A partner will only be created when going further in the recruitment process, basically, when a job position is set on the applicant.

Removing the auto-create on the inverse_email method allows the following process:
- you are an employee that forward the CV of a friend.
- an applicant is created with your own name and email address.
- It will not created a contact at applicant creation.
- the recruiter can adapt the name and email address of the applicant to use your friend's info
- The recruiter can link the applicant to a job position or directly send an mail to the applicant.
-> A partner will only be created at this point as an email is send and needs a res.partner to do so.

Task-4735867