### PR TITLE
[FIX] l10n_it_edi: Set filename when importing from SDI

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -411,7 +411,7 @@ class AccountMove(models.Model):
         # EXTENDS 'account'
         self.ensure_one()
         if filetype == 'fatturapa':
-            if fatturapa_attachment := self.l10n_it_edi_attachment_file:
+            if (fatturapa_attachment := self.l10n_it_edi_attachment_file) and self.l10n_it_edi_attachment_name:
                 return {
                     'filename': self.l10n_it_edi_attachment_name,
                     'filetype': 'xml',
@@ -1303,6 +1303,7 @@ class AccountMove(models.Model):
             # TODO: write to l10n_it_edi_attachment_file directly
             attachment = file_data['attachment']
             attachment.write({'res_model': 'account.move', 'res_id': move.id, 'res_field': 'l10n_it_edi_attachment_file'})
+            move.l10n_it_edi_attachment_name = file_data['name']
 
             # Post the attachment in the chatter
             move.message_post(

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -668,6 +668,7 @@ class TestItEdiImport(TestItEdi):
             ('res_field', '=', 'l10n_it_edi_attachment_file'),
         ])
         self.assertEqual(len(it_edi_attachment), 1)
+        self.assertEqual(move.l10n_it_edi_attachment_name, 'IT01234567890_FPR02.xml')
         self.assertEqual(move.l10n_it_edi_attachment_file, b64encode(import_content))
 
         # ensure that the embedded files are imported correctly


### PR DESCRIPTION
PR #212726 removed a Many2One field and replaced it with an existing binary field (`l10n_it_edi_attachment_file`) and a new Char field (`l10n_it_edi_attachment_name`) to store E-invoice files as XMLs. This change was made for security reasons.

This pre-existing binary field was already used for importing SDI documents, which caused errors resolved in PR #252806.

The new char field was not set during the SDI import process in PR #212726. This can cause errors when exporting invoice documents, as our code sees content in the binary field and expects the name to also be present. See [`_get_invoice_legal_documents()`](https://github.com/odoo/odoo/blob/f48f221c91b8d123bcaf1c4d8ed6c7dfba763ae6/addons/l10n_it_edi/models/account_move.py#L411).

This commit ensures that the name of an imported SDI document is set in the move's `l10n_it_edi_attachment_name` field.

opw-6023263
[link](https://www.odoo.com/odoo/my-tasks/6023263)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
