### PR TITLE
[FIX] mail: fix avatar name width

### DIFF
--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -7,7 +7,7 @@
                 t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"
                 t-on-click.stop.prevent="onClickAvatar"
             />
-            <span t-if="props.displayName" class="text-truncate w-0 flex-grow-1" t-esc="props.displayName"/>
+            <span t-if="props.displayName" class="text-truncate flex-grow-1" t-esc="props.displayName"/>
         </div>
     </t>
 

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -5,7 +5,7 @@
         <t t-set="relation" t-value="props.record.fields[props.name].relation"/>
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="true" displayName="displayName"/>
+                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="!displayName?.length" displayName="displayName"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">


### PR DESCRIPTION
This commit fix the width of the displayName option of the Avatar component which was fixed to zero (bootstrap class 'w-0')

Task-5122979
