### PR TITLE
[REF] mail, im_livechat: call _add_members with users when possible

### DIFF
--- a/addons/im_livechat/tests/test_digest.py
+++ b/addons/im_livechat/tests/test_digest.py
@@ -1,12 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import datetime
 from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from odoo.addons.digest.tests.common import TestDigestCommon
-from odoo.tools import mute_logger
 from odoo import fields
+from odoo.tests.common import new_test_user
+from odoo.tools import mute_logger
+
+from odoo.addons.digest.tests.common import TestDigestCommon
 
 
 class TestLiveChatDigest(TestDigestCommon):
@@ -15,8 +18,7 @@ class TestLiveChatDigest(TestDigestCommon):
     @mute_logger('odoo.models.unlink')
     def setUpClass(cls):
         super().setUpClass()
-
-        other_partner = cls.env["res.partner"].create({"name": "Other Partner"})
+        other_user = new_test_user(cls.env, "Other User")
         cls.env["discuss.channel"].search([("channel_type", "=", "livechat")]).unlink()
         with (
             freeze_time(fields.Datetime.now() - datetime.timedelta(days=10)),
@@ -57,7 +59,7 @@ class TestLiveChatDigest(TestDigestCommon):
         )
         cls.channels = old_channel | new_channels
         cls.channels[0:5]._add_members(users=cls.env.user)
-        cls.channels[2]._add_members(partners=other_partner)
+        cls.channels[2]._add_members(users=other_user)
 
     def test_kpi_livechat_rating_value(self):
         self.assertEqual(round(self.digest_1.kpi_livechat_rating_value, 2), 50.00)

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -200,9 +200,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         # Add the operator to both channels in a batch, which should switch their status to 'in_progress'
         self.assertEqual(channel_1.livechat_agent_partner_ids, self.operators[0].partner_id)
         agent_user = channel_1.livechat_agent_partner_ids.mapped("main_user_id")
-        (channel_1 | channel_2).with_user(agent_user).add_members(
-            partner_ids=bob_operator.partner_id.ids
-        )
+        (channel_1 | channel_2).with_user(agent_user)._add_members(users=bob_operator)
         self.assertEqual(channel_1.livechat_status, "in_progress")
         self.assertEqual(channel_2.livechat_status, "in_progress")
 
@@ -210,9 +208,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         channel_1.livechat_status = "need_help"
         self.assertEqual(channel_1.livechat_status, "need_help")
         self.assertEqual(channel_1.livechat_agent_partner_ids, bob_operator.partner_id | self.operators[0].partner_id)
-        channel_1.with_user(agent_user).add_members(
-            partner_ids=bob_operator.partner_id.ids
-        )
+        channel_1.with_user(agent_user)._add_members(users=bob_operator)
         self.assertEqual(channel_1.livechat_status, "need_help")
 
     def test_join_livechat_needing_help(self):

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -35,7 +35,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             ).livechat_member_type,
             "visitor",
         )
-        channel.add_members(partner_ids=john.partner_id.ids)
+        channel._add_members(users=john)
         self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
         self.assertEqual(
             channel.channel_member_ids.livechat_member_history_ids.filtered(
@@ -44,7 +44,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             "agent",
         )
         channel.livechat_end_dt = fields.Datetime.now()
-        channel.add_members(partner_ids=michel.partner_id.ids)
+        channel._add_members(users=michel)
         self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
 
     def test_get_session_create_history_with_bot(self):
@@ -70,7 +70,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             ).livechat_member_type,
             "visitor",
         )
-        channel.add_members(partner_ids=john.partner_id.ids)
+        channel._add_members(users=john)
         self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
         self.assertEqual(
             channel.channel_member_ids.livechat_member_history_ids.filtered(
@@ -124,7 +124,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
     def test_can_only_create_history_for_livechats(self):
         john = self._create_operator("fr_FR")
         channel = self.env["discuss.channel"]._create_channel(name="General", group_id=None)
-        member = channel.add_members(partner_ids=john.partner_id.ids)
+        member = channel._add_members(users=john)
         with self.assertRaises(ValidationError):
             self.env["im_livechat.channel.member.history"].create({"member_id": member.id}).channel_id
 
@@ -146,7 +146,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
         self.assertEqual(og_history.livechat_member_type, "agent")
         self.assertEqual(og_history.member_id, john_member)
         # Add another agent so the channel stays active and the history can be updated.
-        channel.add_members(partner_ids=bob.partner_id.ids)
+        channel._add_members(users=bob)
         channel.with_user(john).action_unfollow()
         john_history = channel.channel_member_ids.livechat_member_history_ids.filtered(
             lambda m: m.partner_id == john.partner_id

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -632,9 +632,14 @@ class DiscussChannel(models.Model):
         member.unlink()
 
     def add_members(
-        self, partner_ids=None, guest_ids=None, invite_to_rtc_call=False, post_joined_message=True
+        self,
+        partner_ids=None,
+        guest_ids=None,
+        invite_to_rtc_call=False,
+        post_joined_message=True,
     ):
-        """ Adds the given partner_ids and guest_ids as member of self channels. """
+        """Adds the given partner_ids and guest_ids as member of self channels.
+        Prefer calling _add_members with recordsets directly when possible."""
         return self._add_members(
             partners=self.env["res.partner"].browse(partner_ids or []).exists(),
             guests=self.env["mail.guest"].browse(guest_ids or []).exists(),
@@ -653,6 +658,8 @@ class DiscussChannel(models.Model):
         post_joined_message=True,
         inviting_partner=None,
     ):
+        """Adds the given users, partners and guests as member of self channels.
+        Prefer giving users rather than partners when possible."""
         stores = Store.Stores()
         inviting_partner = inviting_partner or self.env["res.partner"]
         partners = partners or self.env["res.partner"]
@@ -1455,12 +1462,9 @@ class DiscussChannel(models.Model):
 
     def channel_join(self):
         """Shortcut to add the current user as member of self channels.
-        Prefer calling add_members() directly when possible.
-        """
-        if not self.self_member_id:
-            self._add_members(users=self.env.user)
-        else:
-            self.self_member_id.last_interest_dt = fields.Datetime.now()
+        If the user is already a member, updates the last_interest_dt."""
+        self.self_member_id.last_interest_dt = fields.Datetime.now()
+        (self - self.self_member_id.channel_id)._add_members(users=self.env.user)
 
     def open_chat_window_action(self):
         """Return an action the web client can use to open this channel."""
@@ -1539,7 +1543,11 @@ class DiscussChannel(models.Model):
                 "parent_channel_id": self.id,
             }
         )
-        sub_channel.add_members(partner_ids=(self.env.user.partner_id | message.author_id).ids, post_joined_message=False)
+        sub_channel._add_members(
+            users=self.env.user,
+            partners=message.author_id,
+            post_joined_message=False,
+        )
         notification = (
             Markup('<div class="o_mail_notification">%s</div>')
             % _(

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -57,9 +57,9 @@ class TestDiscussChannelMember(MailCommon):
 
     def test_group_subchannel_join(self):
         """Test join subchannel."""
-        self.group.add_members((self.user_1 | self.user_2).partner_id.ids)
+        self.group._add_members(users=self.user_1 | self.user_2)
         group_subchannel = self.group.with_user(self.user_1)._create_sub_channel()
-        group_subchannel.with_user(self.user_2).add_members(self.user_2.partner_id.id)
+        group_subchannel.with_user(self.user_2)._add_members(users=self.user_2)
         self.assertEqual(group_subchannel.channel_member_ids.partner_id, (self.user_1 | self.user_2).partner_id)
 
     # ------------------------------------------------------------

--- a/addons/mail/tests/discuss/test_discuss_res_role.py
+++ b/addons/mail/tests/discuss/test_discuss_res_role.py
@@ -36,7 +36,7 @@ class TestDiscussResRole(TestResRole):
                     self.env, login=f"user_{user_grp}_{idx}", role_ids=role.ids, groups=user_grp
                 )
                 if is_member:
-                    channel.add_members(partner_ids=user.partner_id.ids)
+                    channel._add_members(users=user)
                 data = self.make_jsonrpc_request(
                     "/mail/message/post",
                     {

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -65,7 +65,7 @@ class TestDiscussSubChannels(HttpCase):
         parent.action_unfollow()
         self.assertFalse(parent.self_member_id)
         self.assertFalse(sub_channel.self_member_id)
-        # Member created for sub channel (add_members): should also be created
+        # Member created for sub channel (_add_members): should also be created
         # for parent.
         sub_channel._add_members(users=self.env.user)
         self.assertTrue(parent.self_member_id)


### PR DESCRIPTION
It's always better to pass users rather than partners when possible.
`add_members` also does extra useless `exists()` queries.