### PR TITLE
[FIX] html_builder: add overlap in Bold 10 shape

### DIFF
--- a/addons/html_builder/static/shapes/Bold/19.svg
+++ b/addons/html_builder/static/shapes/Bold/19.svg
@@ -1,5 +1,5 @@
 <svg fill="#383E45" xmlns="http://www.w3.org/2000/svg">
-    <rect width="calc(50% - 660px)" height="192px" x="0%"/>
+    <rect width="calc(51% - 660px)" height="192px" x="0%"/>
     <rect width="100%" height="64px" x="1320"/>
     <svg viewBox="0 0 1320 192" preserveAspectRatio="xMidYMin meet" height="192">
         <path d="M581.426 64H1320V0H0V192H428.574C436.53 192 444.161 188.839 449.787 183.213L560.213 72.7868C565.839 67.1607 573.47 64 581.426 64Z"/>


### PR DESCRIPTION
Steps to reproduce:
- Enter website edit mode
- Insert `s_banner_connected` snippet
- Add "Bold 10" shape (`19.svg`)
- Depending on padding, size, resolution etc. a thin line appears

This commit adds an overlap to fix the apparition of the line.
| Before | After |
|--------|--------|
| <img width="1919" height="861" alt="image" src="https://github.com/user-attachments/assets/06ecf9c4-f9d8-44bd-b48f-a3d8f559d973" /> | <img width="1918" height="847" alt="image" src="https://github.com/user-attachments/assets/1bda5da4-53f4-4105-9af2-06a57da67d0a" /> |
