### PR TITLE
[FIX] sale_mrp: compute delivered kit qty with multiple routes

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import Form
+from odoo.fields import Command
 
 from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCommon
 
@@ -15,58 +16,72 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
         cls.customer = cls.env["res.partner"].create({"name": "Customer"})
         cls.dropship_route = cls.env.ref('stock_dropshipping.route_drop_shipping')
 
-    def test_dropship_with_different_suppliers(self):
+    def test_kit_delivered_quantity_with_mixed_dropshipped_pick_shipped_components(self):
         """
-        Suppose a kit with 3 components supplied by 3 vendors
-        When dropshipping this kit, if 2 components are delivered and if the last
-        picking is cancelled, we should consider the kit as fully delivered.
+        Test the kit delivered quantity in complex setups.
+
+        Consider a kit with 2 components: one dropshipped and another MTO buy
+        delivered in 2-steps, process partial deliveries and returns.
         """
-        partners = self.env['res.partner'].create([{'name': 'Vendor %s' % i} for i in range(4)])
-        compo01, compo02, compo03, kit = self.env['product.product'].create([{
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_ship'
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        mto_route.active = True
+        routes = [self.dropship_route.ids, mto_route.ids, []]
+        compo01, compo02, kit = self.env['product.product'].create([{
             'name': name,
             'type': 'consu',
-            'route_ids': [(6, 0, [self.dropship_route.id])],
-            'seller_ids': [(0, 0, {'partner_id': seller.id})],
-        } for name, seller in zip(['Compo01', 'Compo02', 'Compo03', 'Kit'], partners)])
+            'route_ids': [Command.set(route_ids)],
+            'seller_ids': [Command.create({'partner_id': self.supplier.id})],
+        } for name, route_ids in zip(['Compo01', 'Compo02', 'Compo03', 'Kit'], routes)])
 
         self.env['mrp.bom'].create({
             'product_tmpl_id': kit.product_tmpl_id.id,
             'product_qty': 1,
             'type': 'phantom',
             'bom_line_ids': [
-                (0, 0, {'product_id': compo01.id, 'product_qty': 1}),
-                (0, 0, {'product_id': compo02.id, 'product_qty': 1}),
-                (0, 0, {'product_id': compo03.id, 'product_qty': 1}),
+                Command.create({'product_id': compo01.id, 'product_qty': 1}),
+                Command.create({'product_id': compo02.id, 'product_qty': 1}),
             ],
         })
-
         sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [
-                (0, 0, {'name': kit.name, 'product_id': kit.id, 'product_uom_qty': 1}),
+                Command.create({'name': kit.name, 'product_id': kit.id, 'product_uom_qty': 5}),
             ],
         })
         sale_order.action_confirm()
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
 
-        purchase_orders = self.env['purchase.order'].search([('partner_id', 'in', partners.ids)])
+        purchase_orders = sale_order.stock_reference_ids.purchase_ids
         purchase_orders.button_confirm()
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
 
-        # Deliver the first one
-        picking = sale_order.picking_ids.filtered(lambda p: p.partner_id == partners[0])
-        picking.button_validate()
+        # Deliver 5 units of the dropshipped Compo01
+        dropship = sale_order.picking_ids.filtered(lambda p: p.partner_id == self.supplier)
+        pick = sale_order.picking_ids - dropship
+        dropship.move_ids.quantity = 5.0
+        dropship.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
 
-        # Deliver the third one
-        picking = sale_order.picking_ids.filtered(lambda p: p.partner_id == partners[2])
-        picking.button_validate()
+        # Deliver 3 units of Compo02 in two steps
+        pick.move_ids.quantity = 4.0
+        Form.from_action(self.env, pick.button_validate()).save().process()
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
+        ship = pick.move_ids.move_dest_ids.picking_id
+        ship.move_ids.quantity = 3.0
+        Form.from_action(self.env, ship.button_validate()).save().process()
+        self.assertEqual(sale_order.order_line.qty_delivered, 3.0)
 
-        # Cancel the second one
-        sale_order.picking_ids[1].action_cancel()
-        self.assertEqual(sale_order.order_line.qty_delivered, 1)
+        # Return 3 units of the dropshipped Compo01
+        return_form = Form(self.env['stock.return.picking'].with_context(active_ids=dropship.ids, active_id=dropship.id, active_model='stock.picking'))
+        with return_form.product_return_moves.edit(0) as line_form:
+            line_form.quantity = 3.0
+        return_wiz = return_form.save()
+        dropship_return = Form.from_action(self.env, return_wiz.action_create_returns()).save()
+        dropship_return.button_validate()
+        self.assertEqual(sale_order.order_line.qty_delivered, 2.0)
 
     def test_return_kit_and_delivered_qty(self):
         """

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -35,7 +35,6 @@ class SaleOrderLine(models.Model):
         for order_line in self:
             if order_line.qty_delivered_method == 'stock_move':
                 boms = order_line.move_ids.filtered(lambda m: m.state != 'cancel').bom_line_id.bom_id
-                dropship = any(m._is_dropshipped() for m in order_line.move_ids)
                 # We fetch the BoMs of type kits linked to the order_line,
                 # the we keep only the one related to the finished produst.
                 # This bom should be the only one since bom_line_id was written on the moves
@@ -45,25 +44,6 @@ class SaleOrderLine(models.Model):
                 if not relevant_bom:
                     relevant_bom = boms._bom_find(order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')[order_line.product_id]
                 if relevant_bom:
-                    # not written on a move coming from a PO: all moves (to customer) must be done
-                    # and the returns must be delivered back to the customer
-                    # FIXME: if the components of a kit have different suppliers, multiple PO
-                    # are generated. If one PO is confirmed and all the others are in draft, receiving
-                    # the products for this PO will set the qty_delivered. We might need to check the
-                    # state of all PO as well... but sale_mrp doesn't depend on purchase.
-                    if dropship:
-                        moves = order_line.move_ids.filtered(lambda m: m.state != 'cancel')
-                        if any((m.location_dest_id.usage == 'customer' and m.state != 'done')
-                               or (m.location_dest_id.usage != 'customer'
-                               and m.state == 'done'
-                               and float_compare(m.quantity,
-                                                 sum(sub_m.product_uom._compute_quantity(sub_m.quantity, m.product_uom) for sub_m in m.returned_move_ids if sub_m.state == 'done'),
-                                                 precision_rounding=m.product_uom.rounding) > 0)
-                               for m in moves) or not moves:
-                            delivered_qties[order_line] = 0
-                        else:
-                            delivered_qties[order_line] = order_line.product_uom_qty
-                        continue
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and m.location_dest_usage != 'inventory')
                     filters = {
                         # in/out perspective w/ respect to moves is flipped for sale order document

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -570,6 +570,12 @@ class StockMove(models.Model):
         return (self.location_id.usage == 'customer' or (self.location_id.usage == 'transit' and not self.location_id.company_id)) \
            and (self.location_dest_id.usage == 'supplier' or (self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id))
 
+    def _is_incoming(self):
+        return super()._is_incoming() and not self._is_dropshipped()
+
+    def _is_outgoing(self):
+        return super()._is_outgoing() and not self._is_dropshipped_returned()
+
     def _prepare_analytic_lines(self):
         self.ensure_one()
         if not self._get_analytic_distribution() and not self.analytic_account_line_ids:


### PR DESCRIPTION
### Steps to reproduce:

- In the settings Dropshipping
- Put you warehouse in 2 steps delivery
- Create a kit product with 2 components: COMP1, COMP2
- Set a vendor on COMP2 and the dropship route
- Create and confirm an SO for 1 unit of your kit
- Validate the ship and pick for COMP1
- Confirm the PO for COMP2 and validate the associated dropship
#### > The qty_delivered on the sol is still at 0

### Cause of the issue:

The `delivered_qty` is computed via the `_prepare_qty_delivered`: https://github.com/odoo/odoo/blob/9b9ff3ddcba6f0c9d37d08fb4fb900bed3b396a4/addons/sale/models/sale_order_line.py#L887-L902 However, since at least on of the component is dropshipped, the qty_delivered is computed by this condition: https://github.com/odoo/odoo/blob/9b9ff3ddcba6f0c9d37d08fb4fb900bed3b396a4/addons/sale_mrp/models/sale_order_line.py#L54-L63 Which is 0 since the pick `location_dest_id.usage` is not `customer`.

### Additional issue:

The delivered quantity of a Kit with at least one dropshipped component can only be 0 or the full demand.

- In the settings enable Dropshipping
- Create a kit product with 2 components: COMP1, COMP2
- Set a vendor on COMP2 and the dropship route
- Create and confirm an SO for 3 unit of your kit
- Validate the delivery for COMP1 for 2 units and backorder
- Confirm the PO for COMP2 and validate the associated dropship for 1 unit and do not backorder
#### > The qty_delivered on the sol is 0 instead of 1
- Cancel the backorder for COMP1
### > The qty_delivered on the sol is 3 instead of 1

### Cause of the issue:

This is caused by the exact same dropship computation: https://github.com/odoo/odoo/blob/9b9ff3ddcba6f0c9d37d08fb4fb900bed3b396a4/addons/sale_mrp/models/sale_order_line.py#L63-L66

### Note:

The behavior should be consistent if the components are fully dropshipped or MTO buy and as such they should not be considered to be in all or nothing shipping policy.

opw-6040640

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
