### PR TITLE
[PERF] stock_account: reduce search calls in _get_value_data()

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -446,6 +446,11 @@ class ProductProduct(models.Model):
             field_names=['id'],
             order='product_id, date, id'
         )
+
+        dropship_moves = moves.filtered(lambda m: m.is_dropship)
+        if len(dropship_moves) > 1:
+            self._get_moves_with_manual_value(product_ids=self.ids)
+
         # PERF avoid memoryerror
         move_fields = ['date', 'is_dropship', 'is_in', 'is_out', 'location_dest_id', 'location_id', 'move_line_ids', 'picked', 'value', 'product_id']
         move_line_fields = ['company_id', 'location_id', 'location_dest_id', 'lot_id', 'owner_id', 'picked', 'quantity_product_uom']
@@ -486,7 +491,10 @@ class ProductProduct(models.Model):
                         in_qty = move._get_valued_qty()
                         in_value = move.value
                         if move.is_dropship:
-                            in_value = move._get_value(forced_std_price=average_cost)
+                            ignore_manual_update = False
+                            if self.env.cr.cache.get('moves_with_manual_value', {}).get((at_date, move.product_id)):
+                                ignore_manual_update = move.id not in self.env.cr.cache['moves_with_manual_value'][at_date, move.product_id]
+                            in_value = move._get_value(at_date=at_date, forced_std_price=average_cost, ignore_manual_update=ignore_manual_update)
                         if lot:
                             lot_qty = move._get_valued_qty(lot)
                             in_value = (in_value * lot_qty / in_qty) if in_qty else 0
@@ -517,6 +525,7 @@ class ProductProduct(models.Model):
             std_price_by_product_id[product.id] = average_cost
             value_by_product_id[product.id] = value
 
+        self.env.cr.cache.pop('moves_with_manual_value', None)
         return std_price_by_product_id, value_by_product_id
 
     def _run_fifo_batch(self, at_date=None, lot=None, location=None):
@@ -679,6 +688,27 @@ class ProductProduct(models.Model):
                 for product in products:
                     if product.id in new_standard_price_by_product:
                         product.with_context(disable_auto_revaluation=True).sudo().standard_price = new_standard_price_by_product[product.id]
+
+    def _get_moves_with_manual_value(self, product_ids, at_date=False):
+        """Get the move IDs with manual product.value to populate the cursor cache."""
+        if not product_ids:
+            return
+        if not self.env.cr.cache.get('moves_with_manual_value'):
+            self.env.cr.cache['moves_with_manual_value'] = {}
+        query = """
+            SELECT sm.product_id, array_agg(DISTINCT pv.move_id)
+            FROM product_value pv
+            JOIN stock_move sm ON pv.move_id = sm.id
+            WHERE pv.move_id IS NOT NULL
+            AND sm.product_id IN %s
+        """
+        params = [tuple(product_ids)]
+        if at_date:
+            query += " AND sm.date <= %s"
+            params.append(at_date)
+        query += " GROUP BY sm.product_id"
+        for product, moves in self.env.execute_query(SQL(query, *params)):
+            self.env.cr.cache['moves_with_manual_value'][at_date, product] = set(moves)
 
     # -------------------------------------------------------------------------
     # Old to remove

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -191,6 +191,8 @@ class ProductProduct(models.Model):
         if at_date:
             products = products.with_context(at_date=at_date, to_date=at_date)
 
+        self._get_moves_with_manual_value(product_ids=products.ids, at_date=at_date)
+
         # PERF: Pre-compute:the sum of 'total_value' of lots per product in go
         std_price_by_company_id = {}
         total_value_by_company_id = {}
@@ -474,7 +476,10 @@ class ProductProduct(models.Model):
                         in_qty = move._get_valued_qty()
                         in_value = move.value
                         if at_date or move.is_dropship:
-                            in_value = move._get_value(at_date=at_date, forced_std_price=average_cost)
+                            ignore_manual_update = False
+                            if self.env.cr.cache.get('moves_with_manual_value', {}).get((at_date, move.product_id)):
+                                ignore_manual_update = move.id not in self.env.cr.cache.get('moves_with_manual_value').get((at_date, move.product_id))
+                            in_value = move._get_value(at_date=at_date, forced_std_price=average_cost, ignore_manual_update=ignore_manual_update)
                         if lot:
                             lot_qty = move._get_valued_qty(lot)
                             in_value = (in_value * lot_qty / in_qty) if in_qty else 0
@@ -540,7 +545,10 @@ class ProductProduct(models.Model):
             last_move = move
             move_value = move.value
             if at_date:
-                move_value = move._get_value(at_date=at_date)
+                ignore_manual_update = False
+                if self.env.cr.cache.get('moves_with_manual_value', {}).get((at_date, move.product_id)):
+                    ignore_manual_update = move.id not in self.env.cr.cache.get('moves_with_manual_value').get((at_date, move.product_id))
+                move_value = move._get_value(at_date=at_date, ignore_manual_update=ignore_manual_update)
             if qty_on_first_move:
                 valued_qty = move._get_valued_qty()
                 in_qty = qty_on_first_move
@@ -641,6 +649,26 @@ class ProductProduct(models.Model):
                 for product in products:
                     if product.id in new_standard_price_by_product:
                         product.with_context(disable_auto_revaluation=True).sudo().standard_price = new_standard_price_by_product[product.id]
+
+    def _get_moves_with_manual_value(self, product_ids, at_date):
+        """Get the move IDs with manual product.value to populate the cursor cache."""
+        if not self.env.cr.cache.get('moves_with_manual_value'):
+            self.env.cr.cache['moves_with_manual_value'] = {}
+        query = """
+            SELECT sm.product_id, array_agg(DISTINCT pv.move_id)
+            FROM product_value pv
+            JOIN stock_move sm ON pv.move_id = sm.id
+            WHERE pv.move_id IS NOT NULL
+            AND sm.product_id IN %s
+        """
+        params = [tuple(product_ids)]
+        if at_date:
+            query += " AND sm.date <= %s"
+            params.append(at_date)
+        query += " GROUP BY sm.product_id"
+        self.env.cr.execute(query, params)
+        for product, moves in self.env.cr.fetchall():
+            self.env.cr.cache['moves_with_manual_value'][at_date, product] = set(moves)
 
     # -------------------------------------------------------------------------
     # Old to remove


### PR DESCRIPTION
During the _run_average_batch(), we call _get_value() on each dropship move on which an AVCO product is used. In this function, if the following condition is met, we call the function _get_manual_value():

https://github.com/odoo/odoo/blob/12dd03fb678870ddd3f1f8dca66aa3f934aa7985/addons/stock_account/models/stock_move.py#L359-L361

This method's goal is to search product.value records related to the current move.

https://github.com/odoo/odoo/blob/12dd03fb678870ddd3f1f8dca66aa3f934aa7985/addons/stock_account/models/stock_move.py#L431-L447

This search is performed once per move selected previously even if they are not related to any product.value.

We propose to cache the id of every move that is linked to at least one product.value to ensure the search method is only performed for those and potentially reduce the number of calls to the search method.

Benchmark
------------

Reducing the execution time with this modification supposes that the majority of stock.move records are not linked to any product.value, which is usually the case.
The following benchmark shows the execution times of _run_average_batch() depending on that.

| No stock.move | No of moves linked to product.value | Before PR | After PR |
|---------------|-------------------------------------|-----------|----------|
|           100 |                                  10 |    1.03 s |   421 ms |
|          1000 |                                 100 |    7.13 s |   1.14 s |
|         10000 |                                 100 |   57.21 s |   1.55 s |
|         10000 |                                1000 |   60.42 s |   8.98 s |

When every stock.move is linked to a product.value, the modification will introduce more operations than needed and slow down the execution. The following benchmark illustrates that.

| No stock.move | Before PR | After PR |
|---------------|-----------|----------|
|           100 |    1.14 s |   1.15 s |
|          1000 |    8.21 s |   8.37 s |
|         10000 |   80.64 s |  81.51 s |

opw-6050007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
