### PR TITLE
[FIX] payment: restrict branch companies to be set as provider company

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -43,8 +43,13 @@ class PaymentProvider(models.Model):
              "are only visible on manage forms.",
     )
     company_id = fields.Many2one(  # Indexed to speed-up ORM searches (from ir_rule or others)
-        string="Company", comodel_name='res.company', default=lambda self: self.env.company.id,
-        required=True, index=True)
+        string="Company",
+        comodel_name="res.company",
+        default=lambda self: self.env.company.id,
+        required=True,
+        index=True,
+        domain=[("parent_id", "=", False)],
+    )
     main_currency_id = fields.Many2one(
         related='company_id.currency_id',
         help="The main currency of the company, used to display monetary fields.",

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -574,6 +574,15 @@ class PaymentProvider(models.Model):
 
         # Search the providers matching the compatibility criteria.
         compatible_providers = self.env['payment.provider'].search(domain)
+
+        # In case of duplicate providers, keeping the one from the current company over parent.
+        current_company_providers = compatible_providers.filtered(lambda p: p.company_id.id == company_id)
+        parent_company_providers = compatible_providers - current_company_providers
+        existing_codes = current_company_providers.mapped('code')
+        compatible_providers = current_company_providers | parent_company_providers.filtered(
+            lambda p: p.code not in existing_codes
+        )
+
         return compatible_providers
 
     def _get_supported_currencies(self):

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -289,3 +289,20 @@ class TestPaymentProvider(PaymentCommon):
         )._get_validation_currency()
         self.assertIn(validation_currency, self.provider.available_currency_ids)
         self.assertIn(validation_currency, self.payment_method.supported_currency_ids)
+
+    def test_parent_provider_ignored_when_duplicated_in_branch(self):
+        """ Test that only the branch provider is available in the branch company if the provider
+        is duplicated in both branch and the parent company. """
+        branch_company = self.env['res.company'].create({
+            'name': "Provider Branch Company",
+            'parent_id': self.provider.company_id.id,
+        })
+        branch_provider = self.provider.copy({
+            'company_id': branch_company.id,
+            'state': 'enabled',
+        })
+        compatible_providers = self.provider._get_compatible_providers(
+            branch_company.id, self.partner.id, self.amount,
+        )
+        self.assertNotIn(self.provider, compatible_providers)
+        self.assertIn(branch_provider, compatible_providers)


### PR DESCRIPTION
Issue:
---
Branch companies can be selected as payment provider company, which
should be restricted due to the limitation on account jounral.

Steps to reproduce:
1- Create a branch company.
2- Add a website to the branch company.
3- Enable a payment provider in the parent company.
4- Duplicate the provider for the branch company and set branch as the company.
5- Navigate to the shop and add a product to cart.
6- Checkout and pay.

In the SO, you can check that the payment provider from parent is used.

Cause:
---
This is introduced after https://github.com/odoo/odoo/commit/b093786714e9e8567cf75abf78ac3d954a3d89b2.
That fix ensures providers from parent company to be returned as
the branch compatible provider.

However, that fix didn't restrict the branch companies to be selected as
provider company which we shouldn't allow.

#263869
opw-6013978
