### PR TITLE
[IMP] account_payment: Add access_token to overdue invoices route

### DIFF
--- a/addons/account_payment/controllers/payment.py
+++ b/addons/account_payment/controllers/payment.py
@@ -36,25 +36,25 @@ class PaymentPortal(payment_portal.PaymentPortal):
         return self._process_transaction(partner_sudo.id, invoice_sudo.currency_id.id, [invoice_id], False, **kwargs)
 
     @route('/invoice/transaction/overdue', type='jsonrpc', auth='public')
-    def overdue_invoices_transaction(self, payment_reference, **kwargs):
+    def overdue_invoices_transaction(self, payment_reference, partner_id=None, overdue_invoice_ids='', **kwargs):
         """ Create a draft transaction for overdue invoices and return its processing values.
 
         :param str payment_reference: The reference to the current payment
+        :param str partner_id: The id of the partner
+        :param str overdue_invoice_ids: coma-separated ids of the target overdue invoices
         :param dict kwargs: Locally unused data passed to `_create_transaction`
         :return: The mandatory values for the processing of the transaction
         :rtype: dict
         :raise: ValidationError if the user is not logged in, or all the overdue invoices don't share the same currency.
         """
-        logged_in = not request.env.user._is_public()
-        if not logged_in:
-            raise ValidationError(_("Please log in to pay your overdue invoices"))
-        partner = request.env.user.partner_id
-        overdue_invoices = request.env['account.move'].search(self._get_overdue_invoices_domain())
+        partner_id = (partner_id and int(partner_id)) or request.env.user.partner_id.id
+        overdue_invoice_ids = tuple(int(overdue_invoice_id) for overdue_invoice_id in overdue_invoice_ids.split(','))
+        overdue_invoices = request.env['account.move'].sudo().browse(overdue_invoice_ids)
         currencies = overdue_invoices.mapped('currency_id')
         if not all(currency == currencies[0] for currency in currencies):
             raise ValidationError(_("Impossible to pay all the overdue invoices if they don't share the same currency."))
         self._validate_transaction_kwargs(kwargs)
-        return self._process_transaction(partner.id, currencies[0].id, overdue_invoices.ids, payment_reference, **kwargs)
+        return self._process_transaction(partner_id, currencies[0].id, overdue_invoice_ids, payment_reference, **kwargs)
 
     def _process_transaction(self, partner_id, currency_id, invoice_ids, payment_reference, **kwargs):
         kwargs.update({

--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -51,13 +51,27 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
         return values
 
     @http.route(['/my/invoices/overdue'], type='http', auth='public', methods=['GET'], website=True, sitemap=False)
-    def portal_my_overdue_invoices(self, access_token=None, **kw):
-        try:
-            request.env['account.move'].check_access('read')
-        except (AccessError, MissingError):
-            return request.redirect('/my')
+    def portal_my_overdue_invoices(self, access_token=None, partner_id=None, company_ids=None, **kw):
+        if access_token:
+            if (
+                partner_id and (partner_id := request.env['res.partner'].sudo().browse(int(partner_id)))
+                and company_ids and (company_ids := tuple(int(company_id) for company_id in company_ids.split(',')))
+                and access_token == partner_id.with_context(allowed_company_ids=company_ids)._get_overdue_invoices_token()
+            ):
+                current_partner_id = partner_id.id
+            else:
+                return request.render("account_payment.portal_overdue_invoices_invalid_token", {'page_name': 'overdue_invoices'})
+        else:
+            try:
+                request.env['account.move'].check_access('read')
+                current_partner_id = request.env.user.partner_id.id
+            except (AccessError, MissingError):
+                return request.redirect('/my')
 
-        overdue_invoices = request.env['account.move'].search(self._get_overdue_invoices_domain())
+        overdue_invoices_domain = self._get_overdue_invoices_domain(current_partner_id)
+        if company_ids:
+            overdue_invoices_domain.append(('company_id', 'in', company_ids))
+        overdue_invoices = request.env['account.move'].sudo().search(overdue_invoices_domain)
 
         values = self._overdue_invoices_get_page_view_values(overdue_invoices, **kw)
         return request.render("account_payment.portal_overdue_invoices_page", values) if 'payment' in values else request.redirect('/my/invoices')
@@ -75,8 +89,6 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
 
         if any(invoice.partner_id != partner for invoice in overdue_invoices):
             raise ValidationError(_("Overdue invoices should share the same partner."))
-        if any(invoice.company_id != company for invoice in overdue_invoices):
-            raise ValidationError(_("Overdue invoices should share the same company."))
         if any(invoice.currency_id != currency for invoice in overdue_invoices):
             raise ValidationError(_("Overdue invoices should share the same currency."))
 
@@ -91,6 +103,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
                 'currency': currency,
             },
             'amount': total_amount,
+            'overdue_invoice_ids': ','.join(map(str, overdue_invoices.ids)),
         })
 
         common_view_values = self._get_common_page_view_values(

--- a/addons/account_payment/models/__init__.py
+++ b/addons/account_payment/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_payment_method
 from . import account_payment_method_line
 from . import payment_provider
 from . import payment_transaction
+from . import res_partner

--- a/addons/account_payment/models/res_partner.py
+++ b/addons/account_payment/models/res_partner.py
@@ -1,0 +1,26 @@
+from odoo import fields, models
+from odoo.tools import hmac
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _get_overdue_invoices_token(self):
+        self.ensure_one()
+        overdue_amount = dict(self.env['account.move']._read_group(
+            domain=[
+                ('state', 'not in', ('cancel', 'draft')),
+                ('move_type', 'in', ('out_invoice', 'out_receipt')),
+                ('payment_state', 'not in', ('in_payment', 'paid', 'reversed', 'blocked', 'invoicing_legacy')),
+                ('invoice_date_due', '<', fields.Date.today()),
+                ('partner_id', '=', self.id),
+                ('company_id', 'in', self.env.companies.ids),
+            ],
+            groupby=['partner_id'],
+            aggregates=['amount_total:sum'],
+        )).get(self, 0.0)
+        return hmac(self.env(su=True), 'account_payment.model_res_partner.overdue_invoices_token', {
+            'id': self.id,
+            'company_ids': self.env.companies.ids,
+            'overdue_amount': self.currency_id.format(overdue_amount),
+        })

--- a/addons/account_payment/static/src/interactions/payment_form.js
+++ b/addons/account_payment/static/src/interactions/payment_form.js
@@ -28,16 +28,18 @@ patch(PaymentForm.prototype, {
         await super.submitForm(...arguments);
     },
 
-        /**
+    /**
      * Prepare the params for the RPC to the transaction route.
      *
      * @override method from payment.payment_form
      * @private
      * @return {object} The transaction route params.
      */
-        _prepareTransactionRouteParams() {
-            const transactionRouteParams = super._prepareTransactionRouteParams(...arguments);
-            transactionRouteParams.payment_reference = this.paymentContext.paymentReference;
-            return transactionRouteParams;
-        },
+    _prepareTransactionRouteParams() {
+        const transactionRouteParams = super._prepareTransactionRouteParams(...arguments);
+        transactionRouteParams.payment_reference = this.paymentContext.paymentReference;
+        transactionRouteParams.overdue_invoice_ids = this.paymentContext.overdueInvoiceIds;
+        transactionRouteParams.partner_id = this.paymentContext.partnerId;
+        return transactionRouteParams;
+    },
 });

--- a/addons/account_payment/tests/test_payment_flows.py
+++ b/addons/account_payment/tests/test_payment_flows.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 from unittest.mock import patch
+from werkzeug.urls import url_encode
 
 from odoo import Command, fields
 from odoo.exceptions import AccessError
@@ -188,6 +189,8 @@ class TestFlows(AccountPaymentCommon, PaymentHttpCommon):
             'tokenization_requested': False,
             'landing_route': tx_context['landing_route'],
             'payment_reference': tx_context['payment_reference'],
+            'partner_id': tx_context['partner_id'],
+            'overdue_invoice_ids': tx_context['overdue_invoice_ids'],
         }
         with mute_logger('odoo.addons.payment.models.payment_transaction'):
             processing_values = self._get_processing_values(
@@ -261,3 +264,62 @@ class TestFlows(AccountPaymentCommon, PaymentHttpCommon):
         link = invoice._get_portal_payment_link()
         self.assertIsNotNone(link, "A payment link should be generated for the invoice.")
         self.assertIn('amount=300.0', link)  # 30% of 1000 first installment
+
+    def test_invoice_overdue_payment_no_user_flow(self):
+        """
+        Test the overdue payment of an invoice is correctly processed
+        with the invoice amount without user login
+        """
+        # Create a partner to create invoice
+        partner = self.env['res.partner'].create({'name': 'Alsh'})
+
+        # Create an invoice with invoice due date must be in past with payment status to be not paid
+        invoice = self.init_invoice(
+            "out_invoice", partner, amounts=[1000.0], currency=self.currency,
+        )
+        invoice.write({
+            'invoice_date_due': invoice.invoice_date - timedelta(days=10),
+        })
+        invoice.action_post()
+
+        url_params = url_encode({'access_token': partner._get_overdue_invoices_token(), 'partner_id': partner.id, 'company_ids': self.env.companies.ids})
+        overdue_url = self._build_url('/my/invoices/overdue?%s' % url_params)
+        resp = self._make_http_get_request(overdue_url, {})
+
+        self.assertEqual(resp.status_code, 200)
+
+        tx_context = self._get_payment_context(resp)
+
+        # Validate the transaction context amount and payment_reference
+        self.assertEqual(tx_context.get('amount'), invoice.amount_total)
+        self.assertEqual(tx_context['payment_reference'], invoice.payment_reference)
+
+        # Prepare the transaction route values
+        tx_route_values = {
+            'provider_id': self.provider.id,
+            'payment_method_id': self.payment_method_id,
+            'token_id': None,
+            'amount': tx_context.get('amount'),
+            'flow': 'direct',
+            'tokenization_requested': False,
+            'landing_route': tx_context['landing_route'],
+            'payment_reference': tx_context['payment_reference'],
+            'partner_id': tx_context['partner_id'],
+            'overdue_invoice_ids': tx_context['overdue_invoice_ids'],
+        }
+        with mute_logger('odoo.addons.payment.models.payment_transaction'):
+            processing_values = self._get_processing_values(
+                tx_route=tx_context['transaction_route'], **tx_route_values
+            )
+        tx_sudo = self._get_tx(processing_values['reference'])
+        tx_sudo._set_done()
+
+        # Validate the transaction amount is equal to the invoice amount
+        self.assertEqual(tx_sudo.amount, invoice.amount_total)
+
+        url = self._build_url('/payment/status/poll')
+        resp = self.make_jsonrpc_request(url, {})
+        self.assertTrue(tx_sudo.is_post_processed)
+
+        self.assertEqual(resp['state'], 'done')
+        self.assertTrue(invoice.payment_state == invoice._get_invoice_in_payment_state())

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -5,8 +5,11 @@
                 <li t-attf-class="breadcrumb-item active">
                     <a t-attf-href="/my/invoices?{{ keep_query() }}">Invoices &amp; Bills</a>
                 </li>
-                <li class="breadcrumb-item active">
+                <li t-if="payment" class="breadcrumb-item active">
                     <t t-out="payment['reference']"/>
+                </li>
+                <li t-else="" class="breadcrumb-item active">
+                    Not Found
                 </li>
             </t>
         </xpath>
@@ -29,6 +32,25 @@
                 Pay Now
             </button>
         </xpath>
+    </template>
+
+    <template id="portal_overdue_invoices_invalid_token" name="Invalid or Expired Token">
+        <t t-call="portal.portal_layout">
+            <div class="row justify-content-center my-5">
+                <div class="col-lg-6 text-center">
+                    <div class="alert alert-warning" role="alert">
+                        <h4 class="alert-heading mb-3">
+                            <i class="fa fa-exclamation-triangle"/> Invalid or Expired Link
+                        </h4>
+                        <p>This overdue invoices payment link is no longer valid.</p>
+                        <hr/>
+                        <p class="mb-0">
+                            Reach out to us for an updated link.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </t>
     </template>
 
     <template id="portal_overdue_invoices_page" name="Overdue payments">

--- a/addons/account_payment/views/payment_form_templates.xml
+++ b/addons/account_payment/views/payment_form_templates.xml
@@ -6,6 +6,7 @@
             <attribute name="t-att-data-invoice-next-amount-to-pay">next_amount_to_pay</attribute>
             <attribute name="t-att-data-invoice-amount-due">amount_due</attribute>
             <attribute name="t-att-data-payment-reference">payment_reference</attribute>
+            <attribute name="t-att-data-overdue-invoice-ids">overdue_invoice_ids</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
Allow partners without a system user to pay overdue invoices by adding an access_token to the overdue invoices route. The token is derived from the hashed overdue partner amount, and is used in followup modules.

task-6075621

