### PR TITLE
[FIX] microsoft_calendar: fix events missed

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -78,7 +78,6 @@ class ResUsers(models.Model):
 
     def _sync_microsoft_calendar(self):
         self.ensure_one()
-        self.sudo().microsoft_last_sync_date = datetime.now()
         if self._get_microsoft_sync_status() != "sync_active":
             return False
 

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -385,22 +385,24 @@ class TestCreateEvents(TestCommon):
             self.assertEqual(event.ms_universal_event_id, False,
                             "Event should not be synchronized while sync is paused.")
 
-        # Update local event information.
-        event.write({
-            "name": "New event name"
-        })
-        self.call_post_commit_hooks()
+        twenty_minutes_after_creation = event.write_date + timedelta(minutes=20)
+        with self.mock_datetime_and_now(twenty_minutes_after_creation):
+            # Update local event information.
+            event.write({
+                "name": "New event name"
+            })
+            self.call_post_commit_hooks()
 
-        # Prepare mock for new synchronization.
-        event_id = "123"
-        event_iCalUId = "456"
-        mock_insert.return_value = (event_id, event_iCalUId)
-        mock_get_events.return_value = ([], None)
+            # Prepare mock for new synchronization.
+            event_id = "123"
+            event_iCalUId = "456"
+            mock_insert.return_value = (event_id, event_iCalUId)
+            mock_get_events.return_value = ([], None)
 
-        # Synchronize local event with Outlook after updating it locally.
-        self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
-        self.call_post_commit_hooks()
-        event.invalidate_recordset()
+            # Synchronize local event with Outlook after updating it locally.
+            self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
+            self.call_post_commit_hooks()
+            event.invalidate_recordset()
 
         # Assert that the event got synchronized with Microsoft (through mock).
         self.assertEqual(event.microsoft_id, "123")


### PR DESCRIPTION
The `microsoft_last_sync_date` field was being set to the current time at the top of `_sync_microsoft_calendar` before fetching the events. The domain filters events by `write_date >= microsoft_last_sync_date - 5min` so setting this field prematurely caused any event whose `write_date` fell between the previous sync time and `(current_time - 5min)` to be silently skipped.

opw-6060118

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
