### PR TITLE
[FIX] l10n_de, base: fix display name for child contact

### DIFF
--- a/addons/l10n_de/__init__.py
+++ b/addons/l10n_de/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import report

--- a/addons/l10n_de/report/__init__.py
+++ b/addons/l10n_de/report/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_report

--- a/addons/l10n_de/report/account_invoice_report.py
+++ b/addons/l10n_de/report/account_invoice_report.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class ReportInvoiceWithoutPayment(models.AbstractModel):
+    _name = 'report.account.report_invoice'
+    _inherit = 'report.account.report_invoice'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        rslt = super()._get_report_values(docids, data)
+        rslt['docs'] = rslt['docs'].with_context(partner_display_name_hide_company=True)
+        return rslt

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -358,7 +358,7 @@ class Partner(models.Model):
         if self.company_name or self.parent_id:
             if not name and self.type in displayed_types:
                 name = type_description[self.type]
-            if not self.is_company:
+            if not self.is_company and not self.env.context.get('partner_display_name_hide_company'):
                 name = f"{self.commercial_company_name or self.sudo().parent_id.name}, {name}"
         return name.strip()
 
@@ -890,7 +890,10 @@ class Partner(models.Model):
                 }
 
     @api.depends('complete_name', 'email', 'vat', 'state_id', 'country_id', 'commercial_company_name')
-    @api.depends_context('show_address', 'partner_show_db_id', 'address_inline', 'show_email', 'show_vat', 'lang')
+    @api.depends_context(
+        'show_address', 'partner_display_name_hide_company', 'partner_show_db_id', 'address_inline',
+        'show_email', 'show_vat', 'lang',
+    )
     def _compute_display_name(self):
         for partner in self:
             name = partner.with_context(lang=self.env.lang)._get_complete_name()


### PR DESCRIPTION
If two GmbH (Ltd.) names appear in the invoice address field (e.g., "Proveco GmbH, Test GmbH"),
the invoice is problematic from a tax perspective, as two GmbH are considered separate
legal entities, and it is not clearly identifiable who the actual recipient of the service is.
Consequently, the tax office can refuse the input tax deduction if the invoice recipient
is not clearly identifiable.

Steps:

- Create a company contact (X) and a delivery address (Y)
- Create an invoice for X, delivery address will be Y
- Open preview
-> The delivery partner's display name is 'X, Y', it should be only 'Y'

Fix:

Adding a context key to the invoice document to conditionally display
the parent contact name in the display_name

Ticket [link](https://www.odoo.com/odoo/project.task/5900567)
opw-5900567
