### PR TITLE
[IMP] l10n_jo_edi: Create column l10n_jo_edi_uuid in auto_init

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -406,6 +406,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         customer = invoice.partner_id
         is_refund = invoice.move_type == 'out_refund'
 
+        invoice._compute_l10n_jo_edi_uuid()
         vals['vals'].update({
             'ubl_version_id': '',
             'order_reference': '',

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -5,6 +5,7 @@ from werkzeug.urls import url_encode
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.sql import column_exists, create_column
 
 JOFOTARA_URL = "https://backend.jofotara.gov.jo/core/invoices/"
 
@@ -51,6 +52,11 @@ class AccountMove(models.Model):
         help="Jordan: e-invoice XML.",
     )
     reversed_entry_id = fields.Many2one(tracking=True)
+
+    def _auto_init(self):
+        if not column_exists(self.env.cr, 'account_move', 'l10n_jo_edi_uuid'):
+            create_column(self.env.cr, 'account_move', 'l10n_jo_edi_uuid', 'char')
+        return super()._auto_init()
 
     @api.depends("country_code", "move_type")
     def _compute_l10n_jo_edi_is_needed(self):


### PR DESCRIPTION
This commit ensures that the computed and stored field `l10n_jo_edi_uuid` of account_move model gets column created at l10n_jo_edi module installation. This ensures that the computation of the field does not trigger on module installation, potentially leading to too slow installation if the DB has many account_move records.

task-6095204

