### PR TITLE
[FIX] web : Clear error message when no error occurs

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1213,6 +1213,9 @@ export class SearchModel extends EventBus {
             category.errorMsg = error_msg;
             values = [];
         }
+        else {
+            category.errorMsg = null;
+        }
         if (category.hierarchize) {
             category.parentField = parentField;
         }
@@ -1255,6 +1258,9 @@ export class SearchModel extends EventBus {
         if (error_msg) {
             filter.errorMsg = error_msg;
             values = [];
+        }
+        else {
+            filter.errorMsg = null;
         }
 
         // restore checked property


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Create view with search, for exemple add partner_id on search panel of sale.order. Add a limit. 
```
<searchpanel>
                    <field name="partner_id" icon="fa-filter" groupby="parent_id" limit="80" enable_counters="True"/>
                </searchpanel>
```

On database with lot of data, On the categorie partner of search panel there is an error 'Too many items to display.'.

Now filter order to get only 50 (exemple order of the daus). --> Issues the error is not removed

ping @Whenrow 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
