### PR TITLE
[FIX] web: prevent colibri crash on null elements in applyTOut

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -171,6 +171,7 @@ export class Colibri {
     }
 
     applyTOut(el, value, initialValue) {
+        if (!el) return;
         if (value === INITIAL_VALUE) {
             value = initialValue;
         }
@@ -339,6 +340,7 @@ export class Colibri {
                 dynamicAttr.initialValues = initialValues;
             }
             for (const node of nodes) {
+                if (!node) continue;
                 try {
                     const value = definition.call(interaction, node);
                     if (!initialValues || !initialValues.has(node)) {
@@ -379,6 +381,7 @@ export class Colibri {
                 tOut.initialValue = initialValue;
             }
             for (const node of nodes) {
+                if (!node) continue;
                 if (!initialValue || !initialValue.has(node)) {
                     if (!owl) {
                         owl = odoo.loader.modules.get("@odoo/owl");


### PR DESCRIPTION
**Bug:**
Colibri.applyTOut crashes with `TypeError: Cannot set properties of null (setting 'textContent')` when visiting `/my/home` (portal homepage) because dynamicContent can resolve to nodes that become null by the time updateContent runs.

**Fix:**
This adds a strict null guard inside `applyTOut` (`if (!el) return;`) and filters out null nodes during iterations within `updateContent` to prevent crashes when evaluating elements like `node.children.length`.

**Steps to Reproduce:**
1. Log in as a portal user
2. Navigate to /my/home
3. Check browser console for TypeError
