### PR TITLE
[IMP] core: warn compute related fields

### DIFF
--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -76,7 +76,7 @@ class CrmIapLeadMiningRequest(models.Model):
     lead_contacts_credits = fields.Char(compute='_compute_tooltip', readonly=True)
     lead_total_credits = fields.Char(compute='_compute_tooltip', readonly=True)
 
-    @api.onchange('lead_number', 'contact_number')
+    @api.depends('lead_number', 'contact_number')
     def _compute_tooltip(self):
         for record in self:
             company_credits = CREDIT_PER_COMPANY * record.lead_number

--- a/addons/l10n_ch/models/account_payment.py
+++ b/addons/l10n_ch/models/account_payment.py
@@ -10,7 +10,7 @@ class AccountPayment(models.Model):
 
     l10n_ch_reference_warning_msg = fields.Char(compute='_compute_l10n_ch_reference_warning_msg')
 
-    @api.onchange('partner_id', 'memo', 'payment_type')
+    @api.depends('partner_id', 'memo', 'payment_type')
     def _compute_l10n_ch_reference_warning_msg(self):
         for payment in self:
             if payment.payment_type == 'outbound' and\

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -453,7 +453,16 @@ class Field[T]:
                 warnings.warn(f"compute_sql attribute makes sense only if {self} is a computed field")
             if 'compute_sudo' not in attrs:
                 warnings.warn(f"compute_sql requires an explicit compute_sudo parameter on {self}")
-        if attrs.get('compute'):
+        if attrs.get('related'):
+            if attrs.pop('compute', None):
+                warnings.warn(f"Field {self} is both compute and related. Set one of them to None.")
+            # by default, related fields are not stored, computed in superuser
+            # mode, not copied and readonly
+            attrs['store'] = store = attrs.get('store', False)
+            attrs['compute_sudo'] = attrs.get('compute_sudo', attrs.get('related_sudo', True))
+            attrs['copy'] = attrs.get('copy', False)
+            attrs['readonly'] = attrs.get('readonly', True)
+        elif attrs.get('compute'):
             # by default, computed fields are not stored, computed in superuser
             # mode if stored, not copied (unless stored and explicitly not
             # readonly), and readonly (unless inversible)
@@ -462,13 +471,6 @@ class Field[T]:
             if not (attrs['store'] and not attrs.get('readonly', True)):
                 attrs['copy'] = attrs.get('copy', False)
             attrs['readonly'] = attrs.get('readonly', not attrs.get('inverse'))
-        if attrs.get('related'):
-            # by default, related fields are not stored, computed in superuser
-            # mode, not copied and readonly
-            attrs['store'] = store = attrs.get('store', False)
-            attrs['compute_sudo'] = attrs.get('compute_sudo', attrs.get('related_sudo', True))
-            attrs['copy'] = attrs.get('copy', False)
-            attrs['readonly'] = attrs.get('readonly', True)
         if attrs.get('precompute'):
             if not attrs.get('compute') and not attrs.get('related'):
                 warnings.warn(f"precompute attribute doesn't make any sense on non computed field {self}", stacklevel=1)

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -98,7 +98,7 @@ class Properties(Field):
             assert self.definition.count(".") == 1
             self.definition_record, self.definition_record_field = self.definition.rsplit('.', 1)
 
-            if not self.inherited_field:
+            if not self.related:
                 # make the field computed, and set its dependencies
                 self._depends = (self.definition_record, )
                 self.compute = self._compute


### PR DESCRIPTION
Warn developers when a field ends up with both `compute` and `related`.  Keep the existing behavior that `related` overrides `compute`.

https://github.com/odoo/enterprise/pull/113076