### PR TITLE
[FIX] account: use move line company to resolve account_code

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -104,7 +104,10 @@ class AccountMoveLine(models.Model):
         tracking=True,
     )
     account_name = fields.Char(related='account_id.name') # Used for easy configuration of consolidation in the reports
-    account_code = fields.Char(related='account_id.code') # Used for easy configuration of consolidation in the reports
+    account_code = fields.Char(  # Used for easy configuration of consolidation in the reports
+        compute='_compute_account_code',
+        search='_search_account_code',
+    )
     name = fields.Char(
         string='Label',
         compute='_compute_name', store=True, readonly=False, precompute=True,
@@ -497,6 +500,15 @@ class AccountMoveLine(models.Model):
                 line.currency_id = line.move_id.currency_id
             else:
                 line.currency_id = line.currency_id or line.company_id.currency_id
+
+    @api.depends('account_id', 'company_id')
+    def _compute_account_code(self):
+        for line in self:
+            line.account_code = line.account_id.with_company(line.company_id).code
+
+    @api.model
+    def _search_account_code(self, operator, value):
+        return [('account_id.code', operator, value)]
 
     @api.depends('product_id', 'move_id.ref', 'move_id.payment_reference')
     def _compute_name(self):

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -1019,6 +1019,45 @@ class TestAccountAccount(TestAccountMergeCommon):
             "group_id computation should work if company_id is not in self.env.companies"
         )
 
+    def test_account_code_multicompany_move_line(self):
+        """account_code on move lines must reflect the line's own company, not the session company.
+
+        Regression test for: when viewing journal items across companies, lines from a
+        non-active company showed no account code because account.account.code is
+        depends_context('company') and evaluated against env.company (the session company).
+        """
+        company_1 = self.company_data['company']
+        company_2 = self.company_data_2['company']
+
+        # Create one shared account with distinct codes per company.
+        account = self.env['account.account'].with_company(company_1).create({
+            'name': 'Cross-company Account',
+            'code': 'TEST001',
+            'account_type': 'expense',
+        })
+        account.with_company(company_2).code = 'TEST002'
+
+        # Create a move line for company_2 while the session company is company_1.
+        move = self.env['account.move'].with_company(company_2).create({
+            'move_type': 'entry',
+            'line_ids': [
+                Command.create({
+                    'account_id': account.id,
+                    'debit': 100.0,
+                    'credit': 0.0,
+                }),
+                Command.create({
+                    'account_id': self.company_data_2['default_account_expense'].id,
+                    'debit': 0.0,
+                    'credit': 100.0,
+                }),
+            ],
+        })
+
+        line = move.line_ids.filtered(lambda l: l.account_id == account)
+        # account_code must use the line's company (company_2) → 'TEST002', not company_1's 'TEST001'
+        self.assertEqual(line.account_code, 'TEST002', "account_code should use the move line's company")
+
     def test_compute_account(self):
         account_sale = self.company_data['default_account_revenue'].copy()
 


### PR DESCRIPTION
## Problem

`account.move.line.account_code` was a `related` field delegating to `account_id.code`.
Because `account.account.code` is `@api.depends_context('company')`, it is evaluated against `env.company` — the **session's** primary company.

When journal items from multiple companies are shown together (e.g. the Journal Items list with multi-company enabled, or a multi-company spreadsheet using `ODOO.LIST`), lines belonging to a non-active company had no account code — the field returned `False` / empty.

Reported in: **Closes #226823**

## Root cause

`account.account._compute_code` was introduced in #171079 (the `code_store` architecture).
It is correctly context-dependent *for a single company*, but a `related` field on `account.move.line` does not override the company context with the line's own company before reading it.

## Fix

Replace the `related` field with a computed field that explicitly calls `account_id.with_company(line.company_id)` before reading `.code`.  This ensures the correct per-company code is returned regardless of which company is active in the session.

A `_search_account_code` helper preserves the existing search/filter behaviour by delegating to `account_id.code`.

## Test

Added `test_account_code_multicompany_move_line` to `test_account_account.py`:
creates an account with different codes in two companies, creates a journal entry in company 2 while the session is company 1, and asserts that `line.account_code` returns the company-2 code.