### PR TITLE
[IMP] orm: _access_domain().is_false() indicates inaccessible models

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1335,7 +1335,7 @@ class HrEmployee(models.Model):
         if operation == 'read' and self.env.context.get('_allow_read_hr_employee') is _ALLOW_READ_HR_EMPLOYEE:
             return Domain.TRUE
 
-        if not self.env['ir.model.access'].check(self._name, operation, raise_exception=False):
+        if self._name not in self.env['ir.model.access']._get_allowed_models(operation):
             return Domain.FALSE
 
         return self.env['ir.rule']._compute_domain(self._name, operation, include_inherits=False)

--- a/addons/hr_calendar/models/hr_employee.py
+++ b/addons/hr_calendar/models/hr_employee.py
@@ -23,26 +23,28 @@ class HrEmployee(models.Model):
 
             for day in DAYS:
                 work_locations_by_employee[employee.id][day] = {
-                    'location_type': employee[day]["location_type"],
-                    'location_name': employee[day]["name"],
+                    'location_type': employee[day].location_type,
+                    'location_name': employee[day].name,
                     'work_location_id': employee[day].id,
                 }
 
-        exceptions_for_period = self.env['hr.employee.location'].search_read([
-            ('employee_id', 'in', self.ids),
-            ('date', '>=', start_date),
-            ('date', '<=', end_date)
-        ], ['employee_id', 'date', 'work_location_name', 'work_location_id', 'work_location_type'])
+        exceptions_for_period = self.env['hr.employee.location']
+        if exceptions_for_period.has_access('read'):
+            exceptions_for_period = self.env['hr.employee.location'].search_fetch([
+                ('employee_id', 'in', self.ids),
+                ('date', '>=', start_date),
+                ('date', '<=', end_date)
+            ], ['employee_id', 'date', 'work_location_name', 'work_location_id', 'work_location_type'])
 
         for exception in exceptions_for_period:
-            date = exception["date"].strftime(DEFAULT_SERVER_DATE_FORMAT)
+            date = exception.date.strftime(DEFAULT_SERVER_DATE_FORMAT)
             exception_value = {
-                'hr_employee_location_id': exception["id"],
-                'location_type': exception['work_location_type'],
-                'location_name': exception['work_location_name'],
-                'work_location_id': exception['work_location_id'][0],
+                'hr_employee_location_id': exception.id,
+                'location_type': exception.work_location_type,
+                'location_name': exception.work_location_name,
+                'work_location_id': exception.work_location_id.id,
             }
-            employee_id = exception["employee_id"][0]
+            employee_id = exception.employee_id.id
             if "exceptions" not in work_locations_by_employee[employee_id]:
                 work_locations_by_employee[employee_id]["exceptions"] = {}
             work_locations_by_employee[employee_id]["exceptions"][date] = exception_value

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -2,7 +2,7 @@
 import json
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.tools import float_compare
 from odoo.tools.misc import clean_context, OrderedSet
@@ -397,13 +397,16 @@ class MrpBom(models.Model):
         domain = self._bom_find_domain(products, picking_type=picking_type, company_id=company_id, bom_type=bom_type)
 
         # Performance optimization, allow usage of limit and avoid the for loop `bom.product_tmpl_id.product_variant_ids`
-        if len(products) == 1:
-            bom = self.search(domain, order='sequence, product_id, id', limit=1)
-            if bom:
-                bom_by_product[products] = bom
+        try:
+            if len(products) == 1:
+                bom = self.search(domain, order='sequence, product_id, id', limit=1)
+                if bom:
+                    bom_by_product[products] = bom
+                return bom_by_product
+            else:
+                boms = self.search(domain, order='sequence, product_id, id')
+        except AccessError:
             return bom_by_product
-
-        boms = self.search(domain, order='sequence, product_id, id')
 
         products_ids = set(products.ids)
         for bom in boms:

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -365,7 +365,7 @@ class ProductProduct(models.Model):
 
     @api.depends_context('partner_id')
     def _compute_product_code(self):
-        read_access = self.env['ir.model.access'].check('product.supplierinfo', 'read', False)
+        read_access = self.env['product.supplierinfo'].has_access('read')
         for product in self:
             product.code = product.default_code
             if read_access:

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -675,8 +675,9 @@ class TestSaleMrpKitBom(BaseCommon):
 
     def test_sale_kit_qty_change(self):
 
-        # Create record rule
+        # Create record rule (remove access from all)
         mrp_bom_model = self.env['ir.model']._get('mrp.bom')
+        self.env['ir.rule'].search([('model_id', '=', mrp_bom_model.id)]).unlink()
         self.env['ir.rule'].create({
             'name': "No one allowed to access BoMs",
             'model_id': mrp_bom_model.id,

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -32,7 +32,7 @@ class TestPerfSessionInfo(common.HttpCase):
 
         self.env.registry.clear_all_caches()
         # cold ormcache:
-        # - Only web: 43
+        # - Only web: 35
         # - All modules: 122
         with self.assertQueryCount(122):
             self.url_open(
@@ -42,7 +42,7 @@ class TestPerfSessionInfo(common.HttpCase):
             )
 
         # cold fields cache - warm ormcache:
-        # - Only web: 5
+        # - Only web: 6
         # - All modules: 32
         with self.assertQueryCount(32):
             self.url_open(
@@ -55,41 +55,45 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
         # cold orm/fields cache:
-        # - Web only: 14
-        # - All modules 64
-        with self.assertQueryCount(64):
+        # - Web only: 17
+        # - All modules 60
+        with self.assertQueryCount(60):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache:
         # - Web only: 0
         # - All modules: 1 (web_studio + 1)
+        has_studio = self.env['ir.module.module'].sudo().search_count(
+            [('name', '=', 'web_studio'), ('state', '=', 'installed')])
         self.env.invalidate_all()
-        with self.assertQueryCount(1):
+        with self.assertQueryCount(has_studio):
             self.env['ir.ui.menu'].load_web_menus(False)
 
     def test_load_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
         # cold orm/fields cache:
-        # - Web only: 14
-        # - All modules 64
-        with self.assertQueryCount(64):
+        # - Web only: 17
+        # - All modules 60
+        with self.assertQueryCount(60):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache:
         # - Web only: 0
         # - All modules: 1 (web_studio + 1)
+        has_studio = self.env['ir.module.module'].sudo().search_count(
+            [('name', '=', 'web_studio'), ('state', '=', 'installed')])
         self.env.invalidate_all()
-        with self.assertQueryCount(1):
+        with self.assertQueryCount(has_studio):
             self.env['ir.ui.menu'].load_menus(False)
 
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
         # cold ormcache:
-        # - Only web 13
-        # - All modules: 21
-        with self.assertQueryCount(21):
+        # - Only web 16
+        # - All modules: 27
+        with self.assertQueryCount(27):
             self.env['ir.ui.menu']._visible_menu_ids()
 
         # cold fields cache - warm orm cache (only web: 0, all module: 0)

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -155,11 +155,7 @@ class IrActionsActions(models.Model):
                     # the user may not perform this action
                     continue
                 res_model = action.pop('res_model', None)
-                if res_model and not self.env['ir.model.access'].check(
-                    res_model,
-                    mode='read',
-                    raise_exception=False
-                ):
+                if res_model and not ((model := self.env.get(res_model)) is not None and model.has_access('read')):
                     # the user won't be able to read records
                     continue
                 actions.append(action)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -17,6 +17,7 @@ from odoo import api, fields, models, tools
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.tools import BinaryBytes, frozendict, reset_cached_properties, split_every, sql, unique, OrderedSet, SQL
+from odoo.tools.func import deprecated
 from odoo.tools.safe_eval import expr_eval, safe_eval, datetime, dateutil, time
 from odoo.tools.translate import FIELD_TRANSLATE, LazyTranslate, _
 
@@ -2183,6 +2184,7 @@ class IrModelAccess(models.Model):
         )
 
     @api.model
+    @deprecated("Since 20.0, use Model.has_access")
     def check(self, model, mode='read', raise_exception=True):
         if self.env.su:
             # User root have all accesses

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -111,7 +111,6 @@ class IrUiMenu(models.Model):
         }
         menu_ids = set(menus._ids)
         visible_ids = set()
-        access = self.env['ir.model.access']
         # process action menus, check whether their action is allowed
         for menu in menus:
             action = menu.action
@@ -119,7 +118,7 @@ class IrUiMenu(models.Model):
                 continue
             model_fname = MODEL_BY_TYPE.get(action._name)
             # action[model_fname] has been fetched in batch in `exists_actions`
-            if model_fname and not access.check(action[model_fname], 'read', False):
+            if model_fname and not ((model := self.env.get(action[model_fname])) is not None and model.has_access('read')):
                 continue
             # make menu visible, and its folder ancestors, too
             menu_id = menu.id

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3418,9 +3418,15 @@ class BaseModel(metaclass=MetaModel):
             return all(map(access.__getitem__, origin._ids))
 
         domain = self._access_domain(operation)
+        # resolve the 'access' operator if just checking model access
+        # so that a rule `('order_id', 'access', 'read')` may become false
+        if not origin:
+            domain = domain.map_conditions(
+                lambda cond: cond.optimize_dynamic(self.sudo()) if cond.operator == 'access' else cond)
+            return not domain.is_false()
         if domain.is_false():
             return False
-        if not origin or domain.is_true():
+        if domain.is_true():
             return True
         return origin == origin.sudo().with_context(active_test=False).filtered_domain(domain)
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3409,28 +3409,20 @@ class BaseModel(metaclass=MetaModel):
             return True
 
         origin = self._origin
-        if not origin:  # only new ids or empty
-            return (
-                self.env['ir.model.access'].check(self._name, operation, raise_exception=False)
-                or not self._access_domain(operation).is_false()  # check for overrides
-            )
-
-        if operation != 'read':
-            domain = self._access_domain(operation)
-            if domain.is_true():
+        if operation == 'read' and origin:
+            access = self.env._access_cache[self._name]
+            if all(map(access.get, origin._ids)):
                 return True
-            if domain.is_false():
-                return False
-            return origin == origin.sudo().with_context(active_test=False).filtered_domain(domain)
+            domain = self._access_domain(operation)
+            origin.__check_access_fill_cache(access, domain)
+            return all(map(access.__getitem__, origin._ids))
 
-        # check the cache
-        access = self.env._access_cache[self._name]
-        ids = origin._ids
-        if all(map(access.get, ids)):
-            return True
         domain = self._access_domain(operation)
-        origin.__check_access_fill_cache(access, domain)
-        return all(map(access.__getitem__, ids))
+        if domain.is_false():
+            return False
+        if not origin or domain.is_true():
+            return True
+        return origin == origin.sudo().with_context(active_test=False).filtered_domain(domain)
 
     @typing.final
     def _filtered_access(self, operation: str) -> typing.Self:
@@ -3444,32 +3436,30 @@ class BaseModel(metaclass=MetaModel):
             return self
 
         origin = self._origin
-        if not origin:  # only new ids
-            if (
-                self.env['ir.model.access'].check(self._name, operation, raise_exception=False)
-                or not self._access_domain(operation).is_false()  # check for overrides
-            ):
+        if operation == 'read' and origin:
+            access = self.env._access_cache[self._name]
+            if all(map(access.get, origin._ids)):
                 return self
-            return self.browse()
-        if origin is not self:  # we have some new ids
-            accessible_ids = {False, *origin._filtered_access(operation)._ids}
-            return self.filtered(lambda rec: rec._origin.id in accessible_ids)
-
-        if operation != 'read':
             domain = self._access_domain(operation)
+            origin.__check_access_fill_cache(access, domain)
             if domain.is_true():
                 return self
             if domain.is_false():
                 return self.browse()
-            return self.sudo().with_context(active_test=False).filtered_domain(domain).with_env(self.env)
+            if origin is not self:  # we have some new ids
+                return self.filtered(lambda rec: not (id_ := rec._origin.id) or access.get(id_))
+            return self.filtered(lambda rec: access[rec._ids[0]])
 
-        # filter using the cache
-        access = self.env._access_cache[self._name]
-        if all(map(access.get, self._ids)):
-            return self
         domain = self._access_domain(operation)
-        self.__check_access_fill_cache(access, domain)
-        return self.filtered(lambda rec: access[rec._ids[0]])
+        if domain.is_false():
+            return self.browse()
+        if not origin or domain.is_true():
+            return self
+        accessible = origin.sudo().with_context(active_test=False).filtered_domain(domain).with_env(self.env)
+        if origin is not self:  # we have some new ids
+            accessible_ids = {False, *accessible._ids}
+            return self.filtered(lambda rec: rec._origin.id in accessible_ids)
+        return accessible
 
     def __check_access_fill_cache(self, access: dict[IdType, bool], domain: Domain) -> None:
         """ Fill the access cache for records in self. """
@@ -3523,7 +3513,7 @@ class BaseModel(metaclass=MetaModel):
         restrict the access to ``self``.
         """
         domain = self._access_domain(operation)
-        if domain.is_false() and not self.env['ir.model.access'].check(self._name, operation, raise_exception=False):
+        if domain.is_false():
             return self, functools.partial(self._make_access_error_message, operation, domain)
 
         origin = self._origin
@@ -3543,7 +3533,7 @@ class BaseModel(metaclass=MetaModel):
         If the user has no model access, return the false domain.
         Otherwise, the default implementation returns the access rule domain.
         """
-        if not self.env['ir.model.access'].check(self._name, operation, raise_exception=False):
+        if self._name not in self.env['ir.model.access']._get_allowed_models(operation):
             return Domain.FALSE
 
         return self.env['ir.rule']._compute_domain(self._name, operation)
@@ -3554,7 +3544,7 @@ class BaseModel(metaclass=MetaModel):
         :param domain: security domain from :meth:`_access_domain`
         """
         Access = self.env['ir.model.access']
-        if domain.is_false() and not Access.check(self._name, operation, raise_exception=False):
+        if domain.is_false() and self._name not in Access._get_allowed_models(operation):
             return Access._make_access_error(self._name, operation)
 
         return self.env['ir.rule']._make_access_error(operation, self)
@@ -4754,8 +4744,7 @@ class BaseModel(metaclass=MetaModel):
         else:
             sec_domain = self._access_domain('read')
             if sec_domain.is_false():
-                # raise here if we don't have any access
-                self.browse().check_access('read')
+                raise self._make_access_error_message('read', sec_domain)
 
         domain = Domain(domain)
         # inactive records unless they were explicitly asked for


### PR DESCRIPTION
Make `Model._access_domain` the single point for access checks:
model access and record access.

An inaccessible model is now defined by `_access_domain` returning
`Domain.FALSE`. This allows all access checks to rely on `has_access`.

This aligns with the current behavior where record rules define the
access domain when model access is granted, and simplifies permission
management ahead of merging ir.model.access and record rules.

Given a record rule such as `[('order_id', 'access', 'read')]`, we want
the user to have access to the model if they have access to orders.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
