### PR TITLE
[FIX] website_sale: fix confirmation message styling in Treehouse theme

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -2052,3 +2052,12 @@ body.modal-open:has(.js_sale.o_wsale_product_page) {
 .o_wsale_alternative_products:not(:has(.s_dynamic_snippet_row)) {
     display: none;
 }
+
+div[name="order_confirmation"] {
+    .alert {
+        padding: #{$alert-padding-y} #{$alert-padding-x} !important; // TODO remove in master
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/addons/website_sale/templates/checkout/confirmation_templates.xml
+++ b/addons/website_sale/templates/checkout/confirmation_templates.xml
@@ -114,7 +114,7 @@
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
             <div
                 t-if="tx_sudo"
-                t-attf-class="alert px-3 pb-0 pt-3 #{
+                t-attf-class="alert px-3 pb-1 pt-3 #{
                     (tx_sudo.state == 'pending' and 'alert-info') or
                     (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or
                     (tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount and 'alert-warning') or


### PR DESCRIPTION
Steps to reproduce:
1) Select the Treehouse theme from the website editor 
2) Add a product to the cart and proceed to payment 
3) Complete the payment and reach the confirmation page

Issue:
- The payment success alert message is not displayed properly and appears slightly below the alignment.
- Also this particular issue is coming in this Treehouse theme only in rest of the themes the alert message is coming correctly.

opw-5976602