### PR TITLE
[REF] orm: invalidate_access_cache

### DIFF
--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -55,7 +55,7 @@ class TestActivityRights(TestActivityCommon):
 
         # If user has no access to the record, should return activity view instead
         with patch.object(MailTestActivity, '_access_domain', autospec=True, side_effect=_employee_no_access):
-            self.env.transaction.clear_access_cache()
+            self.env.transaction.invalidate_access_cache()
             self.assertFalse(self.test_record.with_user(self.user_employee).has_access('read'))
 
             action = test_activity.with_user(self.user_employee).action_open_document()
@@ -139,13 +139,13 @@ class TestActivityRights(TestActivityCommon):
             )
 
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         # check read access correctly uses '_mail_get_operation_for_mail_message_operation'
         admin_activities[0].with_user(self.user_employee).read(['summary'])
         admin_activities[1].with_user(self.user_employee).read(['summary'])
 
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         # check search correctly uses '_mail_get_operation_for_mail_message_operation'
         found = self.env['mail.activity'].with_user(self.user_employee).search([('res_model', '=', 'mail.test.access.custo')])
         self.assertEqual(found, admin_activities[:2] + emp_new_1 + emp_new_2, 'Should respect _ge_mail_get_operation_for_mail_message_operationt_mail_message_access, reading non locked records')
@@ -565,7 +565,7 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
 
         # if not assigned -> should filter out
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         self.test_activities_removed.write({'user_id': self.user_admin.id})
         test_with_removed = self.env['mail.activity'].search([
             ('id', 'in', self.test_activities.ids),

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -88,7 +88,7 @@ class TestMailMail(MailCommon):
 
         with patch.object(self.env.registry['ir.attachment'], '_access_domain', _patched_check_access):
             # Sanity check
-            self.env.transaction.clear_access_cache()
+            self.env.transaction.invalidate_access_cache()
             self.assertEqual(mail.restricted_attachment_count, 2)
             self.assertEqual(len(mail.unrestricted_attachment_ids), 2)
             self.assertEqual(mail.unrestricted_attachment_ids.mapped('name'), ['file 1', 'file 3'])

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -568,7 +568,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                     msg.write(msg_vals)
 
                 self.env.invalidate_all()
-                self.env.transaction.clear_access_cache()
+                self.env.transaction.invalidate_access_cache()
                 if should_crash:
                     with self.assertRaises(AccessError):
                         msg.with_user(self.user_portal).read(['body'])
@@ -884,7 +884,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         # hence messages are out of search, symmetrical to reading therm
         records[2].write({'is_locked': True, 'name': 'Locked !'})
         records[2].flush_recordset()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         found_emp = self.env['mail.message'].with_user(self.user_employee).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1377,7 +1377,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # filter records: 3 (1 / model)
         # '_fetch_query': 1
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         profile = self.profile() if self.warm else nullcontext()
         with self.assertQueryCount(employee=5), profile:
             content = (self.activities - self.activities_emp_nope).with_env(self.env).read(['summary'])
@@ -1390,7 +1390,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # select mail.activity: 1
         # filter records: 4 (1 / model)
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         profile = self.profile() if self.warm else nullcontext()
         with self.assertQueryCount(employee=5), profile:
             found = self.activities.with_env(self.env).search([('summary', 'ilike', 'TestActivity')])
@@ -1405,7 +1405,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # _get_mail_message_access: 2 on custom implementation, no prefetching (one unreachable)
         # 'read': 1
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         profile = self.profile() if self.warm else nullcontext()
         with self.assertQueryCount(employee=5), profile:
             content = (self.messages - self.messages_emp_nope).with_env(self.env).read(['body'])
@@ -1415,7 +1415,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
     @warmup
     def test_message_search(self):
         self.env.invalidate_all()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         # queries
         # select mail.message: 1
         # filter records: 1 / model (access rules done in batch)

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -182,14 +182,14 @@ class IrRule(models.Model):
 
     def unlink(self):
         res = super().unlink()
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         return res
 
     @api.model_create_multi
     def create(self, vals_list):
         self.env.flush_all()
         res = super().create(vals_list)
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         return res
 
     def write(self, vals):
@@ -199,7 +199,7 @@ class IrRule(models.Model):
         # - odoo/addons/base/tests/test_orm.py (/home/dle/src/odoo/master-nochange-fp/odoo/addons/base/tests/test_orm.py)
         self.env.flush_all()
         res = super().write(vals)
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         return res
 
     def _make_access_error(self, operation, records):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -603,7 +603,7 @@ class ResUsers(models.Model):
 
         if 'company_id' in vals or 'company_ids' in vals:
             # Access cache depends on the company, clear it
-            self.env.transaction.clear_access_cache()
+            self.env.transaction.invalidate_access_cache()
             # Reset lazy properties `company` & `companies` on all envs,
             # This is unlikely in a business code to change the company of a user and then do business stuff
             # but in case it happens this is handled.

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -2082,7 +2082,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         existing.categories
 
         # invalidate 'categories' for the assertQueryCount
-        self.env.transaction.clear_access_cache()
+        self.env.transaction.invalidate_access_cache()
         records.invalidate_model(['categories'])
         with self.assertQueryCount(5):
             # <categories>.__get__(existing)

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -714,6 +714,18 @@ class Transaction:
             else:
                 context_dict.clear()
 
+    def invalidate_field_data(self) -> None:
+        """ Invalidate the cache of all the fields.
+
+        This operation is unsafe by default, and must be used with care.
+        Indeed, invalidating a dirty field on a record may lead to an error,
+        because doing so drops the value to be written in database.
+        """
+        self.field_data.clear()
+        # reset Field._get_cache()
+        for env in self.envs:
+            env.__dict__.pop('_field_cache_memo', None)
+
     def clear(self):
         """ Clear the caches and pending computations and updates in the transactions. """
         self.clear_access_cache()
@@ -788,18 +800,6 @@ class Transaction:
         self.clear()
         for env in self.envs:
             reset_cached_properties(env)
-
-    def invalidate_field_data(self) -> None:
-        """ Invalidate the cache of all the fields.
-
-        This operation is unsafe by default, and must be used with care.
-        Indeed, invalidating a dirty field on a record may lead to an error,
-        because doing so drops the value to be written in database.
-        """
-        self.field_data.clear()
-        # reset Field._get_cache()
-        for env in self.envs:
-            env.__dict__.pop('_field_cache_memo', None)
 
 
 class TransactionState(typing.NamedTuple):

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -705,7 +705,11 @@ class Transaction:
                 Environment(env.cr, public_user.id, {}).flush_all()
                 break
 
+    @deprecated("Since 20.0, renamed to invalidate_access_cache")
     def clear_access_cache(self, model_name: str = '') -> None:
+        self.invalidate_access_cache(model_name)
+
+    def invalidate_access_cache(self, model_name: str = '') -> None:
         """ Clear the access cache for record rule checks. """
         # clear each context separately because it is cached in Environment
         for context_dict in self.access_read.values():
@@ -728,7 +732,7 @@ class Transaction:
 
     def clear(self):
         """ Clear the caches and pending computations and updates in the transactions. """
-        self.clear_access_cache()
+        self.invalidate_access_cache()
         self.invalidate_field_data()
         self.field_data_patches.clear()
         self.field_dirty.clear()

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6190,7 +6190,7 @@ class BaseModel(metaclass=MetaModel):
             for invf in self.pool.field_inverses[field]:
                 self.env[invf.model_name].flush_model([invf.name])
                 invf._invalidate_cache(env)
-        self.env.transaction.clear_access_cache(self._name)
+        self.env.transaction.invalidate_access_cache(self._name)
 
     @api.private
     def modified(self, fnames: Collection[str], create: bool = False, before: bool = False) -> None:


### PR DESCRIPTION
The function `clear_access_cache` is named differently from other
invalidation methods: the name contains an implementation detail. Align
the name of the function introduced in 19.1 to other methods.

https://github.com/odoo/enterprise/pull/113089


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
