### PR TITLE
[FIX] purchase_stock: prevent error when removing the promised date on a pol

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -54,7 +54,9 @@ class ResPartner(models.Model):
         # Fetch fields from db and put them in cache.
         order_lines.read(['date_promised', 'partner_id', 'product_uom_qty'], load='')
         moves.read(['purchase_line_id', 'date'], load='')
-        moves = moves.filtered(lambda m: m.date.date() <= m.purchase_line_id.date_promised.date())
+        moves = moves.filtered(
+            lambda m: (dp := m.purchase_line_id.date_promised) and m.date.date() <= dp.date()
+        )
         for move, quantity in zip(moves, moves.mapped('quantity')):
             lines_quantity[move.purchase_line_id.id] += quantity
         partner_dict = {}

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -864,3 +864,17 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 'debit': 0.0,
             },
         ])
+
+    def test_partner_on_time_rate_without_pol_promised_date(self):
+        """
+        Test that removing the promised date on a purchase order line
+        correctly computes the partner's on-time rate.
+        """
+        po = self.env['purchase.order'].create(self.po_vals)
+        po.button_confirm()
+
+        picking = po.picking_ids
+        picking.button_validate()
+
+        po.order_line.write({'date_promised': False})
+        self.assertEqual(self.partner_a.on_time_rate, 0)


### PR DESCRIPTION
Currently, an error occurs when the user removes the promised date on a purchase order line.

**Steps to Reproduce:**

 - Install the `purchase_stock` module.
 - Create a `purchase order` with an order line.
 - `Confirm` the purchase order.
 - `Validate` the receipt using the smart button on the purchase order.
 - In the order line, make the `Promised Date` (optional, hidden) field visible.
 - Remove the value of the `Promised Date` and save.

`AttributeError: 'bool' object has no attribute 'date'`

After [this commit], the partner on-time rate depends on the promised date. When the user 
removes the Promised Date from the purchase order line, it tries to compute partner on-time 
rate. When it filters the move records based on the comparison between the PO line promised 
date and the move date and accesses the date from promised date [1], it raises an error.

This commit ensures that the comparison between the move date and the promised date is 
performed only when the promised date exists.

[this commit]: https://github.com/odoo/odoo/commit/2ce0107c914f5eab3b724119ef6c812c347cdc8d#diff-c3231f0c5829f511c10589fc2c2298fe1c03d59f59a04a1ba8a60c85383ffa42

[1]- https://github.com/odoo/odoo/blob/2936763b700fcf31e3fd126a7c412c274783f342/addons/purchase_stock/models/res_partner.py#L57

sentry-7384699891


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
