### PR TITLE
[FIX] l10n_in:  correct sign for TDS report amounts

### DIFF
--- a/addons/l10n_in/data/account_tax_report_tcs_it_act_25_data.xml
+++ b/addons/l10n_in/data/account_tax_report_tcs_it_act_25_data.xml
@@ -19,7 +19,7 @@
                     <record id="tcs_report_line_section_394_1_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)1 LIQ</field>
+                        <field name="formula">-TCS 394(1)1 LIQ</field>
                     </record>
                 </field>
             </record>
@@ -29,7 +29,7 @@
                     <record id="tcs_report_line_section_394_1_2_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)2 TENDU</field>
+                        <field name="formula">-TCS 394(1)2 TENDU</field>
                     </record>
                 </field>
             </record>
@@ -39,7 +39,7 @@
                     <record id="tcs_report_line_section_394_1_3_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)3 TIMBER</field>
+                        <field name="formula">-TCS 394(1)3 TIMBER</field>
                     </record>
                 </field>
             </record>
@@ -49,7 +49,7 @@
                     <record id="tcs_report_line_section_394_1_4_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)4 SCRAP</field>
+                        <field name="formula">-TCS 394(1)4 SCRAP</field>
                     </record>
                 </field>
             </record>
@@ -59,7 +59,7 @@
                     <record id="tcs_report_line_section_394_1_5_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)5 MINERALS</field>
+                        <field name="formula">-TCS 394(1)5 MINERALS</field>
                     </record>
                 </field>
             </record>
@@ -69,7 +69,7 @@
                     <record id="tcs_report_line_section_394_1_6_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)6(a) MOTOR VEH</field>
+                        <field name="formula">-TCS 394(1)6(a) MOTOR VEH</field>
                     </record>
                 </field>
             </record>
@@ -79,7 +79,7 @@
                     <record id="tcs_report_line_section_394_1_6_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)6(b) NOTIF GOOD</field>
+                        <field name="formula">-TCS 394(1)6(b) NOTIF GOOD</field>
                     </record>
                 </field>
             </record>
@@ -89,7 +89,7 @@
                     <record id="tcs_report_line_section_394_1_7_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)7(a) LRS EDU</field>
+                        <field name="formula">-TCS 394(1)7(a) LRS EDU</field>
                     </record>
                 </field>
             </record>
@@ -99,7 +99,7 @@
                     <record id="tcs_report_line_section_394_1_7_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)7(b) LRS OTH</field>
+                        <field name="formula">-TCS 394(1)7(b) LRS OTH</field>
                     </record>
                 </field>
             </record>
@@ -109,7 +109,7 @@
                     <record id="tcs_report_line_section_394_1_9_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TCS 394(1)9 PARKING</field>
+                        <field name="formula">-TCS 394(1)9 PARKING</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_in/data/account_tax_report_tds_it_act_25_data.xml
+++ b/addons/l10n_in/data/account_tax_report_tds_it_act_25_data.xml
@@ -19,7 +19,7 @@
                     <record id="tds_report_line_section_392_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 392(1) SALARY</field>
+                        <field name="formula">-TDS 392(1) SALARY</field>
                     </record>
                 </field>
             </record>
@@ -29,7 +29,7 @@
                     <record id="tds_report_line_section_393_1_1_i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)1(i) INSU COMM</field>
+                        <field name="formula">-TDS 393(1)1(i) INSU COMM</field>
                     </record>
                 </field>
             </record>
@@ -39,7 +39,7 @@
                     <record id="tds_report_line_section_393_1_1_ii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)1(ii) COMM / BROK</field>
+                        <field name="formula">-TDS 393(1)1(ii) COMM / BROK</field>
                     </record>
                 </field>
             </record>
@@ -49,7 +49,7 @@
                     <record id="tds_report_line_section_393_1_2_i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)2(i) RENT</field>
+                        <field name="formula">-TDS 393(1)2(i) RENT</field>
                     </record>
                 </field>
             </record>
@@ -59,7 +59,7 @@
                     <record id="tds_report_line_section_393_1_2_ii_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)2(ii)(a) RENT MACH</field>
+                        <field name="formula">-TDS 393(1)2(ii)(a) RENT MACH</field>
                     </record>
                 </field>
             </record>
@@ -69,7 +69,7 @@
                     <record id="tds_report_line_section_393_1_2_ii_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)2(ii)(b) RENT LAND</field>
+                        <field name="formula">-TDS 393(1)2(ii)(b) RENT LAND</field>
                     </record>
                 </field>
             </record>
@@ -79,7 +79,7 @@
                     <record id="tds_report_line_section_393_1_3_i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)3(i) IMM PROP</field>
+                        <field name="formula">-TDS 393(1)3(i) IMM PROP</field>
                     </record>
                 </field>
             </record>
@@ -89,7 +89,7 @@
                     <record id="tds_report_line_section_393_1_3_ii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)3(ii) PROP 67 (14)</field>
+                        <field name="formula">-TDS 393(1)3(ii) PROP 67 (14)</field>
                     </record>
                 </field>
             </record>
@@ -99,7 +99,7 @@
                     <record id="tds_report_line_section_393_1_3_iii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)3(iii) COMP ACQ</field>
+                        <field name="formula">-TDS 393(1)3(iii) COMP ACQ</field>
                     </record>
                 </field>
             </record>
@@ -109,7 +109,7 @@
                     <record id="tds_report_line_section_393_1_4_i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)4(i) MF UNITS</field>
+                        <field name="formula">-TDS 393(1)4(i) MF UNITS</field>
                     </record>
                 </field>
             </record>
@@ -119,7 +119,7 @@
                     <record id="tds_report_line_section_393_1_4_ii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)4(ii) BT DIST</field>
+                        <field name="formula">-TDS 393(1)4(ii) BT DIST</field>
                     </record>
                 </field>
             </record>
@@ -129,7 +129,7 @@
                     <record id="tds_report_line_section_393_1_4_iii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)4(iii) INV FUND</field>
+                        <field name="formula">-TDS 393(1)4(iii) INV FUND</field>
                     </record>
                 </field>
             </record>
@@ -139,7 +139,7 @@
                     <record id="tds_report_line_section_393_1_4_iv_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)4(iv) SEC TRUST</field>
+                        <field name="formula">-TDS 393(1)4(iv) SEC TRUST</field>
                     </record>
                 </field>
             </record>
@@ -149,7 +149,7 @@
                     <record id="tds_report_line_section_393_1_6_i_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)6(i)(a) CONT IND</field>
+                        <field name="formula">-TDS 393(1)6(i)(a) CONT IND</field>
                     </record>
                 </field>
             </record>
@@ -159,7 +159,7 @@
                     <record id="tds_report_line_section_393_1_6_i_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)6(i)(b) CONT OTH</field>
+                        <field name="formula">-TDS 393(1)6(i)(b) CONT OTH</field>
                     </record>
                 </field>
             </record>
@@ -169,7 +169,7 @@
                     <record id="tds_report_line_section_393_1_6_ii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)6(ii) IND CONT</field>
+                        <field name="formula">-TDS 393(1)6(ii) IND CONT</field>
                     </record>
                 </field>
             </record>
@@ -179,7 +179,7 @@
                     <record id="tds_report_line_section_393_1_6_iii_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)6(iii)(a) TECH</field>
+                        <field name="formula">-TDS 393(1)6(iii)(a) TECH</field>
                     </record>
                 </field>
             </record>
@@ -189,7 +189,7 @@
                     <record id="tds_report_line_section_393_1_6_iii_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)6(iii)(b) PROF</field>
+                        <field name="formula">-TDS 393(1)6(iii)(b) PROF</field>
                     </record>
                 </field>
             </record>
@@ -199,7 +199,7 @@
                     <record id="tds_report_line_section_393_1_7_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)7 DIV</field>
+                        <field name="formula">-TDS 393(1)7 DIV</field>
                     </record>
                 </field>
             </record>
@@ -209,7 +209,7 @@
                     <record id="tds_report_line_section_393_1_8_i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)8(i) LIC</field>
+                        <field name="formula">-TDS 393(1)8(i) LIC</field>
                     </record>
                 </field>
             </record>
@@ -219,7 +219,7 @@
                     <record id="tds_report_line_section_393_1_8_ii_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)8(ii) GOODS</field>
+                        <field name="formula">-TDS 393(1)8(ii) GOODS</field>
                     </record>
                 </field>
             </record>
@@ -229,7 +229,7 @@
                     <record id="tds_report_line_section_393_1_8_iv_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)8(iv) PERQ</field>
+                        <field name="formula">-TDS 393(1)8(iv) PERQ</field>
                     </record>
                 </field>
             </record>
@@ -239,7 +239,7 @@
                     <record id="tds_report_line_section_393_1_8_v_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)8(v) ECOMM</field>
+                        <field name="formula">-TDS 393(1)8(v) ECOMM</field>
                     </record>
                 </field>
             </record>
@@ -249,7 +249,7 @@
                     <record id="tds_report_line_section_393_1_8_vi_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(1)8(vi) VDA</field>
+                        <field name="formula">-TDS 393(1)8(vi) VDA</field>
                     </record>
                 </field>
             </record>
@@ -259,7 +259,7 @@
                     <record id="tds_report_line_section_393_2_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)1 SPORT NR</field>
+                        <field name="formula">-TDS 393(2)1 SPORT NR</field>
                     </record>
                 </field>
             </record>
@@ -269,7 +269,7 @@
                     <record id="tds_report_line_section_393_2_2_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)2 INT FOREX</field>
+                        <field name="formula">-TDS 393(2)2 INT FOREX</field>
                     </record>
                 </field>
             </record>
@@ -279,7 +279,7 @@
                     <record id="tds_report_line_section_393_2_3_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)3 INT RUPEE</field>
+                        <field name="formula">-TDS 393(2)3 INT RUPEE</field>
                     </record>
                 </field>
             </record>
@@ -289,7 +289,7 @@
                     <record id="tds_report_line_section_393_2_4_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)4(a) INT IFSC</field>
+                        <field name="formula">-TDS 393(2)4(a) INT IFSC</field>
                     </record>
                 </field>
             </record>
@@ -299,7 +299,7 @@
                     <record id="tds_report_line_section_393_2_4_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)4(b) INT IFSC</field>
+                        <field name="formula">-TDS 393(2)4(b) INT IFSC</field>
                     </record>
                 </field>
             </record>
@@ -309,7 +309,7 @@
                     <record id="tds_report_line_section_393_2_5_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)5 INT INFRA</field>
+                        <field name="formula">-TDS 393(2)5 INT INFRA</field>
                     </record>
                 </field>
             </record>
@@ -319,7 +319,7 @@
                     <record id="tds_report_line_section_393_2_6_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)6(a) DIST BT</field>
+                        <field name="formula">-TDS 393(2)6(a) DIST BT</field>
                     </record>
                 </field>
             </record>
@@ -329,7 +329,7 @@
                     <record id="tds_report_line_section_393_2_6_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)6(b) DIST BT</field>
+                        <field name="formula">-TDS 393(2)6(b) DIST BT</field>
                     </record>
                 </field>
             </record>
@@ -339,7 +339,7 @@
                     <record id="tds_report_line_section_393_2_7_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)7 DIST BT4</field>
+                        <field name="formula">-TDS 393(2)7 DIST BT4</field>
                     </record>
                 </field>
             </record>
@@ -349,7 +349,7 @@
                     <record id="tds_report_line_section_393_2_8_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)8 INV FUND</field>
+                        <field name="formula">-TDS 393(2)8 INV FUND</field>
                     </record>
                 </field>
             </record>
@@ -359,7 +359,7 @@
                     <record id="tds_report_line_section_393_2_9_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)9 SEC TRUST</field>
+                        <field name="formula">-TDS 393(2)9 SEC TRUST</field>
                     </record>
                 </field>
             </record>
@@ -369,7 +369,7 @@
                     <record id="tds_report_line_section_393_2_10_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)10 MF UNITS</field>
+                        <field name="formula">-TDS 393(2)10 MF UNITS</field>
                     </record>
                 </field>
             </record>
@@ -379,7 +379,7 @@
                     <record id="tds_report_line_section_393_2_11_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)11 OFFSHORE</field>
+                        <field name="formula">-TDS 393(2)11 OFFSHORE</field>
                     </record>
                 </field>
             </record>
@@ -389,7 +389,7 @@
                     <record id="tds_report_line_section_393_2_12_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)12 LTCG OFF</field>
+                        <field name="formula">-TDS 393(2)12 LTCG OFF</field>
                     </record>
                 </field>
             </record>
@@ -399,7 +399,7 @@
                     <record id="tds_report_line_section_393_2_13_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)13 GDR</field>
+                        <field name="formula">-TDS 393(2)13 GDR</field>
                     </record>
                 </field>
             </record>
@@ -409,7 +409,7 @@
                     <record id="tds_report_line_section_393_2_14_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)14 GDR LTCG</field>
+                        <field name="formula">-TDS 393(2)14 GDR LTCG</field>
                     </record>
                 </field>
             </record>
@@ -419,7 +419,7 @@
                     <record id="tds_report_line_section_393_2_15_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)15 FII</field>
+                        <field name="formula">-TDS 393(2)15 FII</field>
                     </record>
                 </field>
             </record>
@@ -429,7 +429,7 @@
                     <record id="tds_report_line_section_393_2_16_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)16 SPEC FUND</field>
+                        <field name="formula">-TDS 393(2)16 SPEC FUND</field>
                     </record>
                 </field>
             </record>
@@ -439,7 +439,7 @@
                     <record id="tds_report_line_section_393_2_17_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(2)17 NR INT</field>
+                        <field name="formula">-TDS 393(2)17 NR INT</field>
                     </record>
                 </field>
             </record>
@@ -449,7 +449,7 @@
                     <record id="tds_report_line_section_393_3_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)1 LOTTERY</field>
+                        <field name="formula">-TDS 393(3)1 LOTTERY</field>
                     </record>
                 </field>
             </record>
@@ -459,7 +459,7 @@
                     <record id="tds_report_line_section_393_3_2_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)2 ONLINE GAME</field>
+                        <field name="formula">-TDS 393(3)2 ONLINE GAME</field>
                     </record>
                 </field>
             </record>
@@ -469,7 +469,7 @@
                     <record id="tds_report_line_section_393_3_3_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)3 HORSE</field>
+                        <field name="formula">-TDS 393(3)3 HORSE</field>
                     </record>
                 </field>
             </record>
@@ -479,7 +479,7 @@
                     <record id="tds_report_line_section_393_3_4_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)4 LOTTERY COMM</field>
+                        <field name="formula">-TDS 393(3)4 LOTTERY COMM</field>
                     </record>
                 </field>
             </record>
@@ -489,7 +489,7 @@
                     <record id="tds_report_line_section_393_3_5_a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)5(a) CASH COOP</field>
+                        <field name="formula">-TDS 393(3)5(a) CASH COOP</field>
                     </record>
                 </field>
             </record>
@@ -499,7 +499,7 @@
                     <record id="tds_report_line_section_393_3_5_b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)5(b) CASH OTH</field>
+                        <field name="formula">-TDS 393(3)5(b) CASH OTH</field>
                     </record>
                 </field>
             </record>
@@ -509,7 +509,7 @@
                     <record id="tds_report_line_section_393_3_6_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)6 NSS</field>
+                        <field name="formula">-TDS 393(3)6 NSS</field>
                     </record>
                 </field>
             </record>
@@ -519,7 +519,7 @@
                     <record id="tds_report_line_section_393_3_7_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">TDS 393(3)7 PARTNER</field>
+                        <field name="formula">-TDS 393(3)7 PARTNER</field>
                     </record>
                 </field>
             </record>


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/17a6117ed88c29b5bc4db0c872bcdbc109a7d98b, the automatic +/- sign handling was removed from the tax grid logic. To stay consistent with this change, the newly added TDS Report 2025 has been updated accordingly.

task-6097997