### PR TITLE
[FIX] sale_project: correct analytic distribution in multi-company context

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -136,12 +136,12 @@ class SaleOrderLine(models.Model):
     @api.depends('order_id.partner_id', 'product_id', 'order_id.project_id')
     def _compute_analytic_distribution(self):
         ctx_project = self.env['project.project'].browse(self.env.context.get('project_id'))
-        project_lines = self.filtered(lambda l: not l.display_type and (ctx_project or l.product_id.project_id or l.order_id.project_id))
+        project_lines = self.filtered(lambda l: not l.display_type and (ctx_project or l.product_id.with_company(l.company_id).project_id or l.order_id.project_id))
         empty_project_lines = project_lines.filtered(lambda l: not l.analytic_distribution)
         super(SaleOrderLine, (self - project_lines) + empty_project_lines)._compute_analytic_distribution()
 
         for line in project_lines:
-            project = ctx_project or line.product_id.project_id or line.order_id.project_id
+            project = ctx_project or line.product_id.with_company(line.company_id).project_id or line.order_id.project_id
             if line.analytic_distribution:
                 applied_root_plans = self.env['account.analytic.account'].browse(
                     list({int(account_id) for ids in line.analytic_distribution for account_id in ids.split(",")})

--- a/addons/sale_project/tests/test_analytic_distribution.py
+++ b/addons/sale_project/tests/test_analytic_distribution.py
@@ -78,6 +78,65 @@ class TestAnalyticDistribution(HttpCase, TestSaleProjectCommon):
             "The analytic distribution of the SOL should be set to the account of the project set on the product.",
         )
 
+    def test_sol_analytic_distribution_multicompany_task(self):
+        """Test that the analytic distribution on SOL uses the correct company's
+        project when the product's project_id is company-dependent.
+
+        Scenario:
+        - Company A has project_a linked to the product
+        - Company B has project_b linked to the product
+        - Create a SO in Company B
+        - The SOL's analytic distribution should come from project_b, not project_a
+        """
+        company_a = self.env.company
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        analytic_account_a, analytic_account_b = self.env['account.analytic.account'].create([
+            {
+                'name': 'Analytic Account Company A',
+                'plan_id': self.analytic_plan.id,
+                'company_id': company_a.id,
+            },
+            {
+                'name': 'Analytic Account Company B',
+                'plan_id': self.analytic_plan.id,
+                'company_id': company_b.id,
+            }
+        ])
+        project_a, project_b = self.env['project.project'].create([
+            {
+                'name': 'Field Service (A)',
+                'company_id': company_a.id,
+                'account_id': analytic_account_a.id,
+                'allow_billable': True,
+            },
+            {
+                'name': 'Field Service (B)',
+                'company_id': company_b.id,
+                'account_id': analytic_account_b.id,
+                'allow_billable': True,
+            }
+        ])
+        product = self.env['product.product'].create({
+            'name': 'Service Task Global Project MC',
+            'type': 'service',
+            'service_tracking': 'task_global_project',
+            'company_id': False,
+            'taxes_id': False,
+        })
+
+        # Set the company-dependent project_id for each company
+        product.with_company(company_a).project_id = project_a
+        product.with_company(company_b).project_id = project_b
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'company_id': company_b.id,
+            'order_line': [Command.create({'product_id': product.id})],
+        })
+        sale_order_line = sale_order.order_line
+
+        # The analytic distribution should come from project_b (Company B), not project_a
+        self.assertEqual(sale_order_line.analytic_distribution, {str(analytic_account_b.id): 100})
+
     def test_project_analytic_distribution_on_invoice_lines(self):
         """
         Test that Analytic Distribution applies from Project to Invoice Lines (excluding payable/receivable lines).


### PR DESCRIPTION
Pre-requisites:
------------------------------------------
1. Install `sale_project` and `project_account_budget` modules
2. Have two companies configured in the system
3. Enable Timesheets from the Settings app
4. Create two projects (one for each company)
5. Ensure the following settings are enabled on both projects:
     * Timesheets
     * Billable

Steps to Reproduce:
------------------------------------------
1. Switched to Company A
2. Create a product with:
    * Type: Service
    * Create on Order: Task
    * No company restriction
3. Set the product's `project_id` to Company A's project
4. Switch to the newly created company (Company B)
5. Set the product's `project_id` to Company B's project
6. Enable Analytic Distribution from SOL Optional
7. Create a sale order with the configured product, and delete the auto-fetched
Analytic Distribution account for the sale order (Company B's project)
8. Now confirm the sale order

Observation:
----------------------------------------
The SOL's analytic distribution uses the analytic account from Company A's project instead of Company B

Issue:
----------------------------------------
The `project_id` field on `product.template` is `company_dependent=True`, meaning it stores different values per company. However, in `_compute_analytic_distribution()`, the code accesses `line.product_id.project_id` without calling `with_company`, so it resolves the field using the wrong company context

Solution:
----------------------------------------
using `with_company()`, the correct company context is applied when accessing
`project_id`, preventing inconsistencies in multi-company environments and
ensuring the appropriate project is used for the corresponding company.


opw-5864452