### PR TITLE
[FIX] l10n_latam_base: fix required label on address form

### DIFF
--- a/addons/l10n_latam_base/views/portal_address_templates.xml
+++ b/addons/l10n_latam_base/views/portal_address_templates.xml
@@ -4,7 +4,9 @@
     <template id="address_form_fields" inherit_id="portal.address_form_fields">
         <div id="div_vat" position="before">
             <div t-if="is_used_as_billing and is_latam_country" class="col-xl-6 mb-3">
-                <label class="col-form-label" for="l10n_latam_identification_type_id">
+                <label
+                    t-attf-class="col-form-label #{'label-optional' if res_company.country_id.code == 'GT' else ''}"
+                    for="l10n_latam_identification_type_id">
                     Identification Type
                 </label>
                 <select


### PR DESCRIPTION
with this commit:-
 - We are adding `label-optional` on `Identification Type` when country is GT.
 - We can also make this optional by adding more latam country codes.
 - Part of https://github.com/odoo/enterprise/pull/109780

task-4393611