### PR TITLE
[FIX] mail: sync push-to-talk settings UI with stored values

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -54,7 +54,7 @@
                         <label class="d-flex flex-column align-items-start flex-wrap w-100" title="Push-to-talk key" aria-label="Push-to-talk key">
                             <span class="me-2 my-1 text-truncate text-wrap">Push-to-talk key</span>
                             <span class="d-flex border border-2 rounded w-100" t-attf-class="{{ this.store.settings.isRegisteringKey ? 'border-success' : 'border-primary' }}">
-                                <span t-if="this.store.settings.push_to_talk_key" class="ms-1 px-3 fs-3 flex-grow-1" t-out="this.store.settings.pushToTalkKeyText"/>
+                                <span t-if="this.store.settings.pushToTalkKey" class="o-discuss-CallSettings-pushToTalkKeyText ms-1 px-3 fs-3 flex-grow-1" t-out="this.store.settings.pushToTalkKeyText"/>
                                 <button class="btn btn-link px-2 py-0 text-black" t-on-click="this.onClickRegisterKeyButton">
                                     <i t-if="this.store.settings.isRegisteringKey" title="Discard" aria-label="Discard" class="fa fa-2x fa-times-circle text-muted"/>
                                     <i t-else="" title="Set new key" aria-label="Register new key" class="fa fa-2x fa-keyboard-o"/>
@@ -66,8 +66,8 @@
                         <label class="d-flex flex-column align-items-start flex-wrap h-100 w-100" title="Delay after releasing push-to-talk" aria-label="Delay after releasing push-to-talk">
                             <span class="me-2 my-1 text-truncate text-wrap">Delay after releasing push-to-talk</span>
                             <div class="d-flex w-100 align-items-center">
-                                <input class="flex-grow-1 form-range" type="range" min="0" max="2000" step="1" t-att-value="this.store.settings.voice_active_duration" t-on-input="this.onChangeDelay"/>
-                                <span class="p-1 text-end"><t t-out="this.store.settings.voice_active_duration"/>ms</span>
+                                <input class="o-discuss-CallSettings-delayInput flex-grow-1 form-range" type="range" min="0" max="2000" step="1" t-att-value="this.store.settings.voiceActiveDuration" t-on-input="this.onChangeDelay"/>
+                                <span class="o-discuss-CallSettings-voiceActiveDuration p-1 text-end"><t t-out="this.store.settings.voiceActiveDuration"/>ms</span>
                             </div>
                         </label>
                     </div>

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -12,7 +12,7 @@ import {
 import { parseRawValue, toRawValue } from "@mail/utils/common/local_storage";
 import { Settings } from "@mail/core/common/settings_model";
 import { makeRecordFieldLocalId } from "@mail/model/misc";
-import { describe, test, expect } from "@odoo/hoot";
+import { describe, keyDown, test, expect } from "@odoo/hoot";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
@@ -93,6 +93,13 @@ test("activate push to talk", async () => {
     await contains("i[aria-label='Register new key']");
     await contains("label:has(:text('Delay after releasing push-to-talk'))");
     await contains("span:text('Voice detection sensitivity')", { count: 0 });
+    // ensure push to talk settings updates reflect in UI
+    await click("label[title='Push-to-talk key']");
+    await keyDown("Ctrl+m");
+    await contains(".o-discuss-CallSettings-pushToTalkKeyText:text('Ctrl+m')");
+    await contains(".o-discuss-CallSettings-voiceActiveDuration:text('200ms')");
+    await editInput(document.body, ".o-discuss-CallSettings-delayInput", 560);
+    await contains(".o-discuss-CallSettings-voiceActiveDuration:text('560ms')");
 });
 
 test("activate blur", async () => {


### PR DESCRIPTION
**Current behavior before PR:**
The push-to-talk settings UI does not reflect changes and stored values correctly. This occurs because the UI reads `push_to_talk_key` and `voice_active_duration`, while the settings model stores those values as `pushToTalkKey` and `voiceActiveDuration`.

**Desired behavior after PR is merged:**
The push-to-talk settings UI uses the correct fields, so the push-to-talk key is reflected immediately and the delay slider and label updates properly.

Introduced by: #255566

task-[6098345](https://www.odoo.com/odoo/project/1519/tasks/6098345)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
