### PR TITLE
Show signature image conditionally in report

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -324,7 +324,7 @@
                     <strong>Signature</strong>
                 </div>
                 <div class="offset-8">
-                    <img t-att-src="image_data_uri(doc.signature)" style="max-height: 4cm; max-width: 8cm;"/>
+                    <img t-if="doc.signature" t-att-src="image_data_uri(doc.signature)" style="max-height: 4cm; max-width: 8cm;"/>
                 </div>
                 <div class="offset-8 text-center">
                     <span t-field="doc.signed_by">Oscar Morgan</span>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The sales order report (sale.report_saleorder_document) attempts to render a signature image using image_data_uri(doc.signature) without ensuring that the field contains valid image data. When the signature is not set, the field evaluates to False, causing a QWeb rendering error.

**Current behavior before PR:**

If doc.signature is empty (False), rendering the report raises a TypeError: 'bool' object is not subscriptable because image_data_uri is called with an invalid value. This can occur even if the image is wrapped in a parent t-if, due to how QWeb evaluates attribute expressions.

**Desired behavior after PR is merged:**

The report safely renders regardless of whether a signature is present. The image is only rendered when doc.signature contains valid data by adding a t-if condition directly on the <img> element, preventing evaluation of image_data_uri when the field is empty.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
