### PR TITLE
[FIX] l10n_eg_edi_eta: align company and partner address fields in views

### DIFF
--- a/addons/l10n_eg_edi_eta/__manifest__.py
+++ b/addons/l10n_eg_edi_eta/__manifest__.py
@@ -28,6 +28,7 @@ Integrates with the ETA portal to automatically send and sign the Invoices to th
         'views/res_config_settings_view.xml',
         'views/report_invoice.xml',
         'data/res_country_data.xml',
+        'views/res_company_view.xml',
     ],
     'assets': {
         'web.assets_backend': [

--- a/addons/l10n_eg_edi_eta/data/res_country_data.xml
+++ b/addons/l10n_eg_edi_eta/data/res_country_data.xml
@@ -9,17 +9,17 @@
                 <div class="o_address_format">
                     <field name="parent_id" invisible="1"/>
                     <field name="type" invisible="1"/>
-                    <field name="l10n_eg_building_no" placeholder="Building Number..." class="o_address_street"/>
-                    <field name="street" placeholder="Street" class="o_address_street"
+                    <field name="street" placeholder="Street..." class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
-                    <field name="street2" invisible="1"/>
-                    <field name="city"/>
-                    <field name="state_id" class="o_address_state" placeholder="State..." options='{"no_open": True}'
+                    <field name="street2" placeholder="Street 2..."/>
+                    <field name="city" placeholder="City" class="o_address_city"/>
+                    <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'
                            readonly="type == 'contact' and parent_id"/>
                     <field name="zip" placeholder="ZIP" class="o_address_zip"
                            readonly="type == 'contact' and parent_id"/>
                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
                            readonly="type == 'contact' and parent_id"/>
+                    <field name="l10n_eg_building_no" placeholder="Building Number..." class="o_address_street" invisible="country_code != 'EG'"/>
                 </div>
             </form>
         </field>

--- a/addons/l10n_eg_edi_eta/models/res_company.py
+++ b/addons/l10n_eg_edi_eta/models/res_company.py
@@ -14,3 +14,12 @@ class ResCompany(models.Model):
     l10n_eg_invoicing_threshold = fields.Float('Invoicing Threshold', default=0.0,
                                                help="Threshold at which you are required to give the VAT number "
                                                     "of the customer. ")
+    l10n_eg_building_no = fields.Char("Building No.", compute='_compute_address', inverse='_inverse_l10n_eg_building_no')
+
+    def _get_company_address_field_names(self):
+        """Override to add EG specific address fields"""
+        return super()._get_company_address_field_names() + ["l10n_eg_building_no"]
+
+    def _inverse_l10n_eg_building_no(self):
+        for company in self:
+            company.partner_id.l10n_eg_building_no = company.l10n_eg_building_no

--- a/addons/l10n_eg_edi_eta/views/res_company_view.xml
+++ b/addons/l10n_eg_edi_eta/views/res_company_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_company_form_inherit_l10n_eg_edi" model="ir.ui.view">
+            <field name="name">company.form.inherit.l10n_eg_edi</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='country_id']" position="after">
+                    <field name="l10n_eg_building_no" placeholder="Building No..." class="o_address_street"
+                           invisible="country_code != 'EG'"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

Address fields in the Egyptian EDI localization were not consistently exposed
between partner and company views, despite being synchronized internally.

This led to unnecessary navigation between forms and a confusing user experience
when entering or updating address information.

# Current behavior before PR:
Users had to switch between partner and company forms to complete address data.
Some address fields were not accessible from one of the forms.
The layout of address fields was not intuitive.

# Desired behavior after PR is merged:
Users can manage address information from a single form without switching.
Address fields are consistently accessible.
The address layout follows a more logical and user-friendly structure.

Task ID - 4862507

I confirm I have signed the CLA and read the PR guidelines at
[www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)