### PR TITLE
[FIX] stock: prevent crash when opening picking form

### DIFF
--- a/addons/stock/static/src/widgets/stock_package_m2m.js
+++ b/addons/stock/static/src/widgets/stock_package_m2m.js
@@ -8,6 +8,7 @@ import { _t } from "@web/core/l10n/translation";
 
 export class Many2ManyPackageTagsField extends Many2ManyTagsField {
     setup() {
+        super.setup();
         this.hasNoneTag = this.props.record.data?.has_lines_without_result_package || false;
     }
 


### PR DESCRIPTION
Issue Before This Commit:
========================
When "Packages" option is enabled, opening the picking form leads to a crash,
preventing users from accessing or editing the transfer.

Steps to Reproduce:
=========================
- Install the `stock` module.
- Enable "Packages" (Inventory > Configuration > Settings > Operations > Packages).
- Go to Inventory > Transfers and open any picking form view.
- The page crashes immediately with an error `TypeError: Cannot read properties
  of undefined (reading 'expanded')`.

Cause of the issue:
=========================
In this PR (https://github.com/odoo/odoo/pull/251159), the parent component `Many2ManyTagsField` introduced a state 
`expanded` initialized in its `setup()`, but the child component  `Many2ManyPackageTagsField` 
overrides `setup()` without calling the parent `setup()`, so this state is never initialized and 
the inherited rendering logic crashes with a TypeError when accessing `expanded`.

After This Commit:
========================
The parent setup() is invoked, ensuring that the expanded state is 
initialized before being used, which prevents the crash.
