### PR TITLE
[IMP] {hr_}calendar: add a getter method for `businessHours`

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -205,6 +205,14 @@ export class AttendeeCalendarModel extends CalendarModel {
         await this._archiveRecord(record.id, recurrenceUpdate);
     }
 
+    /**
+     * Specify if business hours is enabled.
+     * It is currently used in the appointment & hr_calendar.
+     */
+    get isBusinessHoursEnabled() {
+        return true;
+    }
+
     async _archiveRecord(id, recurrenceUpdate) {
         if (!recurrenceUpdate && recurrenceUpdate !== "self_only") {
             await this.orm.call(this.resModel, "action_archive", [[id]]);

--- a/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -10,9 +10,11 @@ const { DateTime } = luxon;
 patch(AttendeeCalendarCommonRenderer.prototype, {
 	setup() {
 		super.setup(...arguments);
-		onWillUpdateProps(() => {
-			this.fc.api.setOption("businessHours", this.props.model.workingHours)
-		});
+        if (this.props.model.isBusineesHoursEnabled) {
+            onWillUpdateProps(() => {
+                this.fc.api.setOption("businessHours", this.props.model.workingHours)
+            });
+        }
 		onPatched(() => {
             // Force to rerender the FC.
             // As it doesn't redraw the header when the event's data changes
@@ -33,7 +35,9 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
 	get options() {
 		return {
             ...super.options,
-			businessHours: this.props.model.workingHours,
+            businessHours: this.props.model.isBusineesHoursEnabled
+                ? this.props.model.workingHours
+                : [],
             dayCellDidMount: this.onDayCellDidMount,
         };
 	},

--- a/addons/hr_calendar/static/src/calendar/common/calendar_model.js
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_model.js
@@ -248,6 +248,6 @@ patch(AttendeeCalendarModel.prototype, {
         await super.updateData(...arguments);
         this.partnerColorMap = this.mapPartnersToColor(data);
         data.worklocations = await this.loadWorkLocations(data);
-        data.workingHours = await this.fetchWorkingHours(data);
+        data.workingHours = this.isBusinessHoursEnabled ? await this.fetchWorkingHours(data) : [];
     },
 });


### PR DESCRIPTION
This commit adds a getter method to define if `businessHours` is enabled. The need for this getter is to provide a way to avoid fetching working hours when not shown

The enterprise part adds the unavailabilities in the calendar view of appointments events. We show the unavailabilities other than the working hours therefore we don't need to fetch working hours.

Task-5416962
