### PR TITLE
[FIX] core: avoid "studio_customization" from module list

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2687,7 +2687,7 @@ class IrQWeb(models.AbstractModel):
         modules = self.env['ir.module.module'].search([('state', '=', 'installed')]).mapped('name')
         lazy_bundle_regex = re.compile(r'\bloadBundle\((["\'`])([\w\.-]+)\1\)', flags=re.ASCII)
         bundles = set()
-        for modroot in map(get_module_path, modules):
+        for modroot in filter(None, map(get_module_path, modules)):
             for fname in glob.iglob('**/static/src/**/*.js', root_dir=modroot, recursive=True):
                 with file_open(opj(modroot, fname)) as f:
                     fcontent = f.read()


### PR DESCRIPTION
Step to reproduce:
- start a fresh db, install studio and pos
- using studio, edit any view (add or remove a field)
- run any tour

Observation:
- we are not able to run any tour Traceback
```
File "/home/odoo/odoo/codebase/odoo/18.0/odoo/addons/base/models/ir_qweb.py", line 2703, in _get_lazy_bundles_from_js
    for fname in glob.iglob('**/static/src/**/*.js', root_dir=modroot, recursive=True):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/glob.py", line 46, in iglob
    root_dir = os.fspath(root_dir)
               ^^^^^^^^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not bool
```

Cause:
- `_get_lazy_bundles_from_js` fetches module path for all installed module in addons
https://github.com/odoo/odoo/blob/05d0944a7640e196db989039140ae5ddb12152ac/odoo/addons/base/models/ir_qweb.py#L2686-L2697
- in case we have a view edited, we get the `studio_customization` as installled module, which doesn't have any path in addons. i.e. False

Fix:
- filter out such pseudo-modules from the list

Note: this is not a reported issue, i stumbled across it, hence made a fix


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
