### PR TITLE
[FIX] sale: fix proforma document title

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -9,6 +9,7 @@
             <t t-else="">Tax ID</t>: <span t-field="doc.partner_id.vat"/>
         </p>
     </t>
+    <t t-set="is_proforma" t-value="env.context.get('proforma', False) or is_pro_forma"/>
     <t t-set="layout_document_title">
         <span t-if="is_proforma">Pro Forma Invoice # </span>
         <span t-elif="doc.state in ['draft','sent']">Quotation # </span>
@@ -43,8 +44,6 @@
         </t>
         <div class="page">
             <div class="oe_structure"/>
-
-            <t t-set="is_proforma" t-value="env.context.get('proforma', False) or is_pro_forma"/>
 
             <div class="row mb-4" id="informations">
                 <div t-if="doc.client_order_ref" class="col" name="informations_reference">


### PR DESCRIPTION
Issue:
---
`layout_document_title` is not correctly set in proforma document.

Steps to reproduce:
1- Create a SO and confirm.
2- Print the Pro forma invoice.

The title is Order while it should be Pro Forma.

Cause:
---
This issue is introduced after #232539. `is_proforma` is not set before setting `layout_document_title`.

opw-6043669

