### PR TITLE
[FIX] l10n_se: fix formula of expressions in tax report

### DIFF
--- a/addons/l10n_se/data/account_tax_report_data.xml
+++ b/addons/l10n_se/data/account_tax_report_data.xml
@@ -338,7 +338,7 @@
                             <record id="tax_report_line_40_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">se_40</field>
+                                <field name="formula">-se_40</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
**Steps to Reproduce:**
1. Create a database in version 19 and install the `l10n_se` module.
2. Create a journal entry using tax grid `se_40`.
3. Open the Tax Report and check the line `Övrig försäljning av tjänster omsatta utanför Sverige`.
4. The value appears negative instead of positive.

- This issue occurred due to the major tax revamp introduced in version 19
[commit](https://github.com/odoo/odoo/commit/17a6117ed88c29b5bc4db0c872bcdbc109a7d98b#diff3441c5d05315ec0562923797f973eae66488452a6772d23e198998c1890aa06c)

- To resolve this issue, the formula has been modified from `se_40` to `-se_40`.

**Before fix**
<img width="1305" height="583" alt="2026-04-03_12-56" src="https://github.com/user-attachments/assets/e086078f-a26f-46d0-bb80-6eceee6a5c85" />

**After fix**
<img width="1307" height="492" alt="image" src="https://github.com/user-attachments/assets/0d5c0fd3-bcbf-4374-a957-6a509d8c968d" />




OPW - 6025463

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
