### PR TITLE
[FIX] web: searchpanel: clear error message after reload

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1207,7 +1207,7 @@ export class SearchModel extends EventBus {
      */
     _createCategoryTree(sectionId, result) {
         const category = this.sections.get(sectionId);
-
+        delete category.errorMsg;
         let { error_msg, parent_field: parentField, values } = result;
         if (error_msg) {
             category.errorMsg = error_msg;
@@ -1250,7 +1250,7 @@ export class SearchModel extends EventBus {
      */
     _createFilterTree(sectionId, result) {
         const filter = this.sections.get(sectionId);
-
+        delete filter.errorMsg;
         let { error_msg, values } = result;
         if (error_msg) {
             filter.errorMsg = error_msg;

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1621,7 +1621,7 @@ export class MockServer {
             domainImage = this.mockSearchPanelFieldImage(model, fieldName, newKwargs);
         }
         if (!expand && !hierarchize && !comodelDomain.length) {
-            if (limit && domainImage.size === limit) {
+            if (limit && domainImage.size >= limit) {
                 return { error_msg: "Too many items to display." };
             }
             return {
@@ -1845,7 +1845,7 @@ export class MockServer {
                 domainImage = this.mockSearchPanelFieldImage(model, fieldName, newKwargs);
             }
             if (!expand && !groupBy && !comodelDomain.length) {
-                if (limit && domainImage.size === limit) {
+                if (limit && domainImage.size >= limit) {
                     return { error_msg: "Too many items to display." };
                 }
                 return { values: [...domainImage.values()] };

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -2271,8 +2271,12 @@ QUnit.module("Search", (hooks) => {
     QUnit.test("scroll kanban view with searchpanel and kept scroll position", async (assert) => {
         for (let i = 10; i < 20; i++) {
             serverData.models.category.records.push({ id: i, name: "Cat " + i });
-            for (let j = 0; j <9; j++)
-            serverData.models.partner.records.push({ id: 100 + i*10 +j, foo: `Record ${i*10 +j}` });
+            for (let j = 0; j < 9; j++) {
+                serverData.models.partner.records.push({
+                    id: 100 + i * 10 + j,
+                    foo: `Record ${i * 10 + j}`,
+                });
+            }
         }
 
         const container = document.createElement("div");
@@ -3315,6 +3319,74 @@ QUnit.module("Search", (hooks) => {
         assert.containsNone(target, ".o_search_panel_filter_value");
     });
 
+    QUnit.test("error message is correctly cleared (category case)", async (assert) => {
+        assert.expect(4);
+        serverData.models.company.records.push({ id: 8, name: "third company", category_id: 6 });
+        serverData.models.partner.records[0].company_id = 8;
+        serverData.views["partner,false,search"] = /* xml */ `
+            <search>
+                <filter name="filter_bar_false" string="Not Bar" domain="[('bar', '=', false)]"/>
+                <searchpanel>
+                    <field name="company_id" limit="2"/>
+                </searchpanel>
+            </search>`;
+
+        const { TestComponent } = makeTestComponent();
+        await makeWithSearch({
+            serverData,
+            Component: TestComponent,
+            resModel: "partner",
+            searchViewId: false,
+        });
+
+        assert.containsOnce(target, "section div.alert.alert-warning");
+        assert.strictEqual(
+            target.querySelector("section div.alert.alert-warning").innerText,
+            "Too many items to display."
+        );
+
+        // Apply a filter that reduces the number of matching companies below the limit
+        await toggleSearchBarMenu(target);
+        await toggleMenuItem(target, "Not Bar");
+
+        assert.containsNone(target, "section div.alert.alert-warning");
+        assert.containsN(target, ".o_search_panel_category_value", 2); // "All" + agrolait
+    });
+
+    QUnit.test("error message is correctly cleared (filter case)", async (assert) => {
+        assert.expect(4);
+        serverData.models.company.records.push({ id: 8, name: "third company", category_id: 6 });
+        serverData.models.partner.records[0].company_id = 8;
+        serverData.views["partner,false,search"] = /* xml */ `
+            <search>
+                <filter name="filter_bar_false" string="Not Bar" domain="[('bar', '=', false)]"/>
+                <searchpanel>
+                    <field name="company_id" select="multi" limit="2"/>
+                </searchpanel>
+            </search>`;
+
+        const { TestComponent } = makeTestComponent();
+        await makeWithSearch({
+            serverData,
+            Component: TestComponent,
+            resModel: "partner",
+            searchViewId: false,
+        });
+
+        assert.containsOnce(target, "section div.alert.alert-warning");
+        assert.strictEqual(
+            target.querySelector("section div.alert.alert-warning").innerText,
+            "Too many items to display."
+        );
+
+        // Apply a filter that reduces the number of matching companies below the limit
+        await toggleSearchBarMenu(target);
+        await toggleMenuItem(target, "Not Bar");
+
+        assert.containsNone(target, "section div.alert.alert-warning");
+        assert.containsOnce(target, ".o_search_panel_filter_value"); // only agrolait
+    });
+
     QUnit.test(
         "a selected value becomming invalid should no more impact the view",
         async (assert) => {
@@ -3525,9 +3597,9 @@ QUnit.module("Search", (hooks) => {
         const webclient = await createWebClient({ serverData });
         await doAction(webclient, 1);
 
-        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, 'auto');
+        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, "auto");
 
         await switchView(target, "list");
-        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, 'auto');
+        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, "auto");
     });
 });


### PR DESCRIPTION
Have a search view with searchpanel having a filter or a category with a limit. For exemple in sale.order:
```
    <searchpanel>
        <field name="partner_id" icon="fa-filter" groupby="parent_id" limit="80" enable_counters="True"/>
    </searchpanel>
```

On a database with a lot of data, in the category partner of search panel, there is an error 'Too many items to display.'.

Now in the search view, add a filter to restrict the number of records, and hence the number of partners in the search panel below the limit.

Before this commit, the error was still displayed. Now, it isn't, and the data are properly displayed.

Closes #257749

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
