### PR TITLE
[FIX] point_of_sale, pos_self_order: fix time display in email templates

### DIFF
--- a/addons/point_of_sale/data/mail_template_data.xml
+++ b/addons/point_of_sale/data/mail_template_data.xml
@@ -16,7 +16,7 @@
                 <div style="margin: 0; padding: 0; font-size: 14px;">
                     <t t-set="client_name" t-value="object.partner_id.name"/>
                     <t t-set="store_name" t-value="object.config_id.name"/>
-                    <t t-set="tz" t-value="object.env.user.tz"/>
+                    <t t-set="tz" t-value="object.company_id.partner_id.tz"/>
                     <t t-set="lg" t-value="object.partner_id.lang or user.lang"/>
                     <div>
                         <t t-if="client_name">Hello <t t-out="client_name">Client name</t>,</t>

--- a/addons/pos_self_order/data/mail_template_data.xml
+++ b/addons/pos_self_order/data/mail_template_data.xml
@@ -15,7 +15,7 @@
             <field name="body_html" type="html">
                 <div style="margin: 0; padding: 0; font-size: 14px;">
                     <t t-set="store_name" t-value="object.config_id.name"/>
-                    <t t-set="tz" t-value="object.env.user.tz"/>
+                    <t t-set="tz" t-value="object.company_id.partner_id.tz"/>
                     <t t-set="lg" t-value="object.partner_id.lang or user.lang"/>
                     <div>
                         <t t-if="client_name">Hello <t t-out="client_name">Client name</t>,</t>
@@ -55,7 +55,7 @@
                     <t t-set="city" t-value="client.city or ''"/>
                     <t t-set="country" t-value="client.country_id.name or ''"/>
                     <t t-set="store_name" t-value="object.config_id.name"/>
-                    <t t-set="tz" t-value="object.env.user.tz"/>
+                    <t t-set="tz" t-value="object.company_id.partner_id.tz"/>
                     <t t-set="lg" t-value="object.partner_id.lang or user.lang"/>
                     <div>
                         <t t-if="client_name">Hello <t t-out="client_name">Client name</t>,</t>


### PR DESCRIPTION
The tz variable in POS email templates was set using object.env.user.tz, which resolves to UTC when emails are sent by the Public User.

Fix by using `object.company_id.partner_id.tz` instead, which reliably reflects the store's timezone regardless of which user triggers the email.

opw-6052244

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
