### PR TITLE
[FIX] stock_dropshipping: link all SOs when merged dropship PO is confirmed

### DIFF
--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -42,6 +42,19 @@ class PurchaseOrder(models.Model):
         self.sudo()._activity_cancel_on_sale()
         return result
 
+    def action_merge(self):
+        tagged = self.filtered(lambda r: r.state in ('draft', 'sent')).order_line.filtered('sale_line_id')
+        originals = {line.id: line.analytic_distribution for line in tagged}
+        try:
+            for line in tagged:
+                dist = dict(line.analytic_distribution or {})
+                dist['_sale_line_id'] = line.sale_line_id.id
+                line.analytic_distribution = dist
+            return super().action_merge()
+        finally:
+            for line in tagged.exists():
+                line.analytic_distribution = originals[line.id] or False
+
     def _get_sale_orders(self):
         return self.order_line.sale_order_id
 

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields
+from collections import defaultdict
+
+from odoo import api, models, fields, SUPERUSER_ID
 
 
 class PurchaseOrder(models.Model):
@@ -28,4 +30,52 @@ class PurchaseOrder(models.Model):
         sale_orders = self.order_line.sale_order_id
         if len(sale_orders) == 1:
             res['sale_id'] = sale_orders.id
+        return res
+
+    def _create_picking(self):
+        multi_so = self.filtered(
+            lambda po: po.state in ('purchase', 'done')
+            and po.picking_type_id.code == 'dropship'
+            and len(po.order_line.sale_line_id.order_id) > 1
+            and not po.picking_ids.filtered(lambda p: p.state not in ('done', 'cancel'))
+            and any(p.type == 'consu' for p in po.order_line.product_id)
+        )
+        super(PurchaseOrder, self - multi_so)._create_picking()
+
+        StockPicking = self.env['stock.picking']
+        for order in multi_so:
+            order = order.with_company(order.company_id)
+            lines_by_so = defaultdict(lambda: self.env['purchase.order.line'])
+            for line in order.order_line:
+                lines_by_so[line.sale_line_id.order_id] |= line
+            created = StockPicking
+            all_moves = self.env['stock.move']
+            for lines in lines_by_so.values():
+                picking = StockPicking.with_user(SUPERUSER_ID).create(order._prepare_picking())
+                moves = lines._create_stock_moves(picking)
+                moves = moves.filtered(lambda m: m.state not in ('done', 'cancel'))._action_confirm()
+                for seq, move in enumerate(sorted(moves, key=lambda m: m.date), start=1):
+                    move.sequence = seq * 5
+                moves._action_assign()
+                picking.message_post_with_source(
+                    'mail.message_origin_link',
+                    render_values={'self': picking, 'origin': order},
+                    subtype_xmlid='mail.mt_note',
+                )
+                created |= picking
+                all_moves |= moves
+            forward_pickings = StockPicking._get_impacted_pickings(all_moves)
+            (created | forward_pickings).action_confirm()
+        return True
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _prepare_stock_moves(self, picking):
+        res = super()._prepare_stock_moves(picking)
+        sale_group = self.sale_line_id.order_id.procurement_group_id
+        if sale_group:
+            for vals in res:
+                vals['group_id'] = sale_group.id
         return res

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import api, models, fields
 
 
@@ -28,4 +30,21 @@ class PurchaseOrder(models.Model):
         sale_orders = self.order_line.sale_order_id
         if len(sale_orders) == 1:
             res['sale_id'] = sale_orders.id
+        return res
+
+    def _create_picking(self):
+        res = super()._create_picking()
+        for picking in self.picking_ids.filtered(
+            lambda p: p.is_dropship and p.state not in ('done', 'cancel')
+        ):
+            moves_by_so = defaultdict(lambda: self.env['stock.move'])
+            for move in picking.move_ids:
+                if move.sale_line_id.order_id:
+                    moves_by_so[move.sale_line_id.order_id] |= move
+            if len(moves_by_so) <= 1:
+                continue
+            for so, so_moves in list(moves_by_so.items())[1:]:
+                new_picking = picking.copy({'move_ids': [], 'move_line_ids': []})
+                so_moves.write({'picking_id': new_picking.id, 'group_id': so.procurement_group_id.id})
+                so_moves.move_line_ids.write({'picking_id': new_picking.id})
         return res

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -607,3 +607,38 @@ class TestDropshipPostInstall(common.TransactionCase):
         purchase_order.button_confirm()
         sale_order._action_cancel()
         self.assertEqual(len(purchase_order.activity_ids), 1)
+
+    def test_merged_dropship_po_links_all_sale_orders(self):
+        """When dropship POs from different SOs are merged and confirmed,
+        each SO must get its own picking so delivery status is updated on validation."""
+        product_b = self.env['product.product'].create({
+            'name': 'Dropshipped Product B',
+            'standard_price': 20,
+            'seller_ids': [Command.create({'partner_id': self.supplier.id})],
+            'route_ids': [Command.link(self.env.ref('stock_dropshipping.route_drop_shipping').id)],
+        })
+        so1, so2 = self.env['sale.order'].create([{
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({'product_id': self.dropship_product.id, 'product_uom_qty': 1})],
+        }, {
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({'product_id': product_b.id, 'product_uom_qty': 1})],
+        }])
+        all_sos = so1 | so2
+        all_sos.action_confirm()
+
+        pos = self.env['purchase.order'].search([('group_id', 'in', all_sos.procurement_group_id.ids)])
+        pos.action_merge()
+        merged_pos = pos.filtered(lambda p: p.state != 'cancel')
+        merged_pos.button_confirm()
+
+        pickings = merged_pos.picking_ids.filtered('is_dropship')
+        self.assertEqual(len(pickings), 2)
+        self.assertEqual(pickings.mapped('group_id'), (so1 | so2).procurement_group_id)
+        self.assertEqual(pickings.mapped('sale_id'), so1 | so2)
+        for picking in pickings:
+            picking.move_ids.write({'quantity': 1, 'picked': True})
+            picking.button_validate()
+
+        for so in [so1, so2]:
+            self.assertEqual(so.delivery_status, 'full')

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -607,3 +607,30 @@ class TestDropshipPostInstall(common.TransactionCase):
         purchase_order.button_confirm()
         sale_order._action_cancel()
         self.assertEqual(len(purchase_order.activity_ids), 1)
+
+    def test_merged_dropship_po_links_all_sale_orders(self):
+        """When dropship POs from different SOs are merged and confirmed,
+        each SO must get its own picking so delivery status is updated on validation."""
+        so1, so2 = self.env['sale.order'].create([{
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({'product_id': self.dropship_product.id, 'product_uom_qty': 1})],
+        }, {
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({'product_id': self.dropship_product.id, 'product_uom_qty': 1})],
+        }])
+        all_sos = so1 | so2
+        all_sos.action_confirm()
+
+        pos = self.env['purchase.order'].search([('group_id', 'in', all_sos.procurement_group_id.ids)])
+        pos.action_merge()
+        merged_pos = pos.filtered(lambda p: p.state != 'cancel')
+        merged_pos.button_confirm()
+
+        pickings = merged_pos.picking_ids.filtered('is_dropship')
+        self.assertEqual(len(pickings), 2)
+        for picking in pickings:
+            picking.move_ids.write({'quantity': 1, 'picked': True})
+            picking.button_validate()
+
+        for so in [so1, so2]:
+            self.assertEqual(so.delivery_status, 'full')


### PR DESCRIPTION
Steps to reproduce
1. Create two products and assign the same vendor to both in the Purchase tab
2. Create two Sales Orders using the dropship route (one product per order)
3. Generate and merge the corresponding Purchase Orders, then confirm the merged PO
4. Validate the dropship transfer

Issue
stock.picking.sale_id is a Many2one (https://github.com/odoo/odoo/blob/18c3a034b7d3772baca62d8d86efba2ca15f17b0/addons/sale_stock/models/stock.py#L99)
computed from procurement.group.sale_id, and stock.picking.group_id is a
stored related on move_ids.group_id (https://github.com/odoo/odoo/blob/18c3a034b7d3772baca62d8d86efba2ca15f17b0/addons/stock/models/stock_picking.py#L186).
A single picking can therefore only resolve to one SO. _create_picking
(https://github.com/odoo/odoo/blob/18c3a034b7d3772baca62d8d86efba2ca15f17b0/addons/purchase_stock/models/purchase_order.py#L290)
builds one picking per PO and _prepare_stock_moves assigns every move
the merged PO's group_id
(https://github.com/odoo/odoo/blob/18c3a034b7d3772baca62d8d86efba2ca15f17b0/addons/purchase_stock/models/purchase_order_line.py#L307),
so when a merged dropship PO carries lines from multiple SOs every move
lands in one picking under the PO group. Only one SO gets linked and
the others stay "not fully delivered" even after validation.

Solution
Override PurchaseOrderLine._prepare_stock_moves to set group_id to the
SO's procurement_group_id when sale_line_id is set, so each dropship
move is created in its originating SO's procurement group.

Override PurchaseOrder._create_picking to detect dropship POs whose
order lines span more than one SO and create one picking per SO group
by calling _prepare_picking and _create_stock_moves per group.
picking.group_id then resolves to the SO group via the stored related
field, picking.sale_id points to the right SO, and delivery_status
updates correctly on validation.

opw-6094608