### PR TITLE
[FIX] resource: preserve time in flexible calendar interval computation

### DIFF
--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date
+from datetime import date, datetime, time
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
+import pytz
 
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
@@ -581,9 +582,11 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          "All the remaining days of the allocation will expire")
 
         # Days between the target date and the expiration date (accrual_plan's carryover date)
-        remaining_days_before_expiration = (allocation._get_carryover_date(target_date) - target_date).days
-        working_days_equivalent_needed = remaining_days_before_expiration * 24 / self.flex_40h_calendar.hours_per_day
-    
+        # Adapt to the updated resource_calendar logic that uses precise datetimes instead of dates for flexible calendars
+        start_dt = datetime.combine(target_date, time.min).replace(tzinfo=pytz.UTC)
+        end_dt = datetime.combine(allocation._get_carryover_date(target_date), time.max).replace(tzinfo=pytz.UTC)
+        expected_hours = self.flex_40h_calendar.get_work_hours_count(start_dt, end_dt, compute_leaves=False)
+        working_days_equivalent_needed = expected_hours / self.flex_40h_calendar.hours_per_day
         # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
                             "The closest allocation duration should be the number of working days equivalent (8 hours/day) remaining before the allocation expires")

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -384,9 +384,9 @@ class ResourceCalendar(models.Model):
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
                     # and weekly range for time offs and overtime calculations and work entry generation
-                    start_date = start_datetime.date()
+                    start_date = start_datetime
                     end_datetime_adjusted = end_datetime - relativedelta(seconds=1)
-                    end_date = end_datetime_adjusted.date()
+                    end_date = end_datetime_adjusted
 
                     calendar = resource_calendars[resource] if resource else self
 


### PR DESCRIPTION
Flexible calendar intervals are computed with date-only boundaries, which can shift the range used for worked time calculations.

### **Steps to reproduce:**
1) Install hr_payroll
2) Create a flexible working schedule with 56 hr per week and 8hrs avg per day 
3) Create an employee with this working schedule and joined from `16th Feb 2026`. 
4) Create a payslip for this employee for the February period.

### **Observed Behavior:**
"out of contract"  working hours are 120:59hr
<img width="1213" height="406" alt="image" src="https://github.com/user-attachments/assets/3f7104fb-3a59-48e3-aaf6-052dcf18c0c0" />

### **Expected Behavior:**
"out of contract"  working hours should be 120hr
<img width="1225" height="429" alt="image" src="https://github.com/user-attachments/assets/98898b16-4e36-4a30-9460-633f32c53ec3" />


### **Root Cause:**
The flexible calendar interval computation trims the interval boundaries by converting them to dates at [1], and assumes `end_datetime` is always midnight at [2]. This ignores timezone effects, depending on the user timezone, `end_datetime_adjusted`, may still fall on the same day, so an extra day can be included in the computation. This produces incorrect worked-hours totals for flexible calendars.

[1]- https://github.com/odoo/odoo/blob/a9a63976372d3b5411fd798a48cc5302c2de8af0/addons/resource/models/resource_calendar.py#L387-L389

[2]- https://github.com/odoo/odoo/blob/e49536031f61b90212eb6f0d1a8a3e15927e723d/addons/resource/models/resource_calendar.py#L402

### **Fix:**
Keep the full datetime values when computing flexible calendar intervals.

Related Enterprise PR https://github.com/odoo/enterprise/pull/113119

**opw-6017569**