### PR TITLE
[FIX] *: forms: boxed title and adjusted font size

### DIFF
--- a/addons/account/views/account_cash_rounding_view.xml
+++ b/addons/account/views/account_cash_rounding_view.xml
@@ -20,7 +20,9 @@
                     <sheet>
                         <div class="oe_title">
                             <label for="name"/>
-                            <h1><field name="name" class="oe_inline"/></h1>
+                            <h1 class="o_outlined">
+                                <field name="name"/>
+                            </h1>
                         </div>
                         <group>
                             <group>

--- a/addons/account/views/account_full_reconcile_views.xml
+++ b/addons/account/views/account_full_reconcile_views.xml
@@ -6,14 +6,14 @@
             <field name="name">account.full.reconcile.form</field>
             <field name="model">account.full.reconcile</field>
             <field name="arch" type="xml">
-                <form string="Matching">
-                    <group>
-                        <div class="oe_title" colspan="4">
-                            <h1><field name="id" readonly="1"/></h1>
-                        </div>
-                        <separator string="Matched Journal Items" colspan="4"/>
-                        <field name="reconciled_line_ids" readonly="1" colspan="4" nolabel="1"/>
-                    </group>
+                <form string="Matching" edit="0">
+                    <div class="oe_title">
+                        <h1 class="o_outlined">
+                            <field name="id"/>
+                        </h1>
+                    </div>
+                    <separator string="Matched Journal Items" />
+                    <field name="reconciled_line_ids"/>
                 </form>
             </field>
         </record>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -116,11 +116,9 @@
                     <field name="user_can_edit" invisible="1"/>
                     <field name="invalid_email_partner_ids" invisible="1"/> <!-- this field will be used in
                         many2many_attendees widget -->
-                    <div class="oe_title mb-3">
-                        <div>
-                            <label for="name"/>
-                        </div>
-                        <h1>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1 class="o_outlined">
                             <field name="name" placeholder="e.g. Business Lunch" readonly="not user_can_edit"/>
                         </h1>
                     </div>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -52,60 +52,61 @@
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or won_status in ['lost', 'won']"/>
                         <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="won_status != 'lost'"/>
                         <widget name="web_ribbon" title="Won" invisible="won_status != 'won'"/>
-                        <div class="oe_title mw-100">
-                            <div class="o_input_box">
-                                <h1>
+                        <div class="d-flex flex-column-reverse flex-md-row align-items-center">
+                            <div class="oe_title w-100">
+                                <h1 class="o_outlined">
                                     <field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/>
                                 </h1>
-                                <div class="o_input_box_overlay_end"
-                                    data-tooltip="Convert into an Opportunity to see it in your Pipeline"
-                                    invisible="type == 'opportunity'">
-                                    <field name="type" widget="badge"/>
+                            </div>
+                            <div
+                                class="ms-auto"
+                                data-tooltip="Convert into an Opportunity to see it in your Pipeline"
+                                invisible="type == 'opportunity'">
+                                <field name="type" widget="badge"/>
+                            </div>
+                        </div>
+                        <h2 class="d-none d-sm-flex d-touch-none align-items-end">
+                            <!-- in this view, we want to have a different desktop UI, so we have two different 'touch' and 'desktop' templates -->
+                            <div class="col-3 d-flex flex-column justify-content-between"  invisible="type == 'lead'">
+                                <field name="company_currency" invisible="1"/>
+                                <label for="expected_revenue" class="oe_edit_only"/>
+                                <field name="expected_revenue" widget='monetary' options="{'currency_field': 'company_currency'}"/>
+                                <div class="o_input_box" groups="crm.group_use_recurring_revenues">
+                                    <span class="o_input_box_overlay_start"> + </span>
+                                    <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                                 </div>
                             </div>
-                            <h2 class="d-none d-sm-flex d-touch-none align-items-end">
-                                <!-- in this view, we want to have a different desktop UI, so we have two different 'touch' and 'desktop' templates -->
-                                <div class="col-3 d-flex flex-column justify-content-between"  invisible="type == 'lead'">
-                                    <field name="company_currency" invisible="1"/>
-                                    <label for="expected_revenue" class="oe_edit_only"/>
-                                    <field name="expected_revenue" widget='monetary' options="{'currency_field': 'company_currency'}"/>
-                                    <div class="o_input_box" groups="crm.group_use_recurring_revenues">
-                                        <span class="o_input_box_overlay_start"> + </span>
-                                        <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                    </div>
+                            <div style="width: 15ch;" groups="crm.group_use_recurring_revenues">
+                                <field name="recurring_plan" placeholder='e.g. "Monthly"'
+                                    required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
+                            </div>
+                            <div class="col-auto d-flex flex-column">
+                                <div>
+                                    <label for="probability" class="d-inline-block"/>
+                                    <a class="border-0 mx-1 p-0 mb-1 mb-md-0 btn btn-light"
+                                        name="action_set_automated_probability"
+                                        role="button" type="object"
+                                        invisible="is_automated_probability or won_status == 'lost'">
+                                            <img class="m-1 o_lead_opportunity_form_AI_switch_img"
+                                                title="Switch to AI-computed probabilities"
+                                                aria-label="Switch to AI-computed probabilities"
+                                                src="/crm/static/src/img/pls-tooltip-ai-icon.png"
+                                                alt="AI"/>
+                                    </a>
+                                    <widget name="pls_tooltip_button" class="d-inline-block"
+                                        invisible="won_status != 'pending' or not is_automated_probability"/>
+                                    <small class="d-inline-block opacity-50 h6 mb-0" invisible="is_automated_probability or won_status == 'lost'">
+                                        ~ <field class="w-auto" name="automated_probability" force_save="1"/> %
+                                    </small>
                                 </div>
-                                <div style="width: 15ch;" groups="crm.group_use_recurring_revenues">
-                                    <field name="recurring_plan" placeholder='e.g. "Monthly"'
-                                        required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
+                                <div id="probability" class="o_input_box mb-0" style="width: 10ch;">
+                                    <field name="is_automated_probability" invisible="1"/>
+                                    <span class="o_input_box_overlay_start">at</span>
+                                    <field name="probability" widget="float" readonly="won_status != 'pending'"/>
+                                    <span class="o_input_box_overlay_end">%</span>
                                 </div>
-                                <div class="col-auto d-flex flex-column">
-                                    <div>
-                                        <label for="probability" class="d-inline-block"/>
-                                        <a class="border-0 mx-1 p-0 mb-1 mb-md-0 btn btn-light"
-                                            name="action_set_automated_probability"
-                                            role="button" type="object"
-                                            invisible="is_automated_probability or won_status == 'lost'">
-                                                <img class="m-1 o_lead_opportunity_form_AI_switch_img"
-                                                    title="Switch to AI-computed probabilities"
-                                                    aria-label="Switch to AI-computed probabilities"
-                                                    src="/crm/static/src/img/pls-tooltip-ai-icon.png"
-                                                    alt="AI"/>
-                                        </a>
-                                        <widget name="pls_tooltip_button" class="d-inline-block"
-                                            invisible="won_status != 'pending' or not is_automated_probability"/>
-                                        <small class="d-inline-block opacity-50 h6 mb-0" invisible="is_automated_probability or won_status == 'lost'">
-                                            ~ <field class="w-auto" name="automated_probability" force_save="1"/> %
-                                        </small>
-                                    </div>
-                                    <div id="probability" class="o_input_box mb-0" style="width: 10ch;">
-                                        <field name="is_automated_probability" invisible="1"/>
-                                        <span class="o_input_box_overlay_start">at</span>
-                                        <field name="probability" widget="float" readonly="won_status != 'pending'"/>
-                                        <span class="o_input_box_overlay_end">%</span>
-                                    </div>
-                                </div>
-                            </h2>
-                        </div>
+                            </div>
+                        </h2>
                         <group class="d-flex d-sm-none d-touch-flex">
                             <group>
                                 <field name="expected_revenue" widget='monetary' options="{'currency_field': 'company_currency'}"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -40,7 +40,9 @@
                 <sheet>
                     <div class="oe_title">
                         <label for="name"/>
-                        <h1><field name="name" placeholder="e.g. Qualification"/></h1>
+                        <h1 class="o_outlined">
+                            <field name="name" placeholder="e.g. Qualification"/>
+                        </h1>
                     </div>
                     <group>
                         <group>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -10,7 +10,9 @@
                <sheet>
                     <div class="oe_title" name="event_type_title">
                         <label for="name" string="Event Template"/>
-                        <h1><field name="name" placeholder="e.g. Online Conferences" class="mb-2"/></h1>
+                        <h1 class="o_outlined">
+                            <field name="name" placeholder="e.g. Online Conferences"/>
+                        </h1>
                     </div>
                    <group>
                        <group>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -313,9 +313,9 @@
                         </button>
                     </div>
                     <div class="oe_title">
-                        <h1 class="d-flex align-items-center gap-2">
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="priority" widget="priority"/>
-                            <field name="name" placeholder="Manufacturing Reference" nolabel="1"/>
+                            <field name="name" placeholder="Manufacturing Reference"/>
                         </h1>
                     </div>
                     <group>

--- a/addons/product/views/product_tag_views.xml
+++ b/addons/product/views/product_tag_views.xml
@@ -7,17 +7,19 @@
         <field name="arch" type="xml">
             <form string="Product Tag">
                 <sheet>
-                    <field
-                        name="image"
-                        widget="image"
-                        class="oe_avatar"
-                        invisible="not visible_to_customers"
-                    />
-                    <div name="product_tag_form_div" class="oe_title">
-                        <label for="name" string="Tag"/>
-                        <h1>
-                            <field name="name"/>
-                        </h1>
+                    <div class="d-flex flex-column flex-md-row align-items-center gap-3">
+                        <field
+                            name="image"
+                            widget="image"
+                            class="oe_avatar"
+                            invisible="not visible_to_customers"
+                        />
+                        <div name="product_tag_form_div" class="oe_title w-100">
+                            <label for="name" string="Tag"/>
+                            <h1 class="o_outlined">
+                                <field name="name"/>
+                            </h1>
+                        </div>
                     </div>
                     <group>
                         <field name="visible_to_customers" widget="boolean_toggle"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -50,10 +50,10 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="id" invisible="True"/>
                     <div class="d-flex flex-column-reverse flex-md-row align-items-center gap-3">
-                        <group class="d-flex flex-column w-100">
-                            <label for="name" class="d-md-none"/>
+                        <div class="w-100">
                             <div class="oe_title">
-                                <h1 class="d-flex align-items-center gap-2">
+                                <label for="name" class="d-md-none"/>
+                                <h1 class="o_outlined d-flex align-items-center gap-2">
                                     <field name="is_favorite" widget="boolean_favorite" nolabel="1" class="w-auto"/>
                                     <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                                 </h1>
@@ -68,7 +68,7 @@
                                     <label for="purchase_ok"/>
                                 </span>
                             </div>
-                        </group>
+                        </div>
                         <field
                             name="image_1920"
                             widget="image_with_media_dialog"

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -93,7 +93,8 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not (is_template and active)"/>
                     <div class="oe_title">
-                        <h1 class="d-flex align-items-center gap-2">
+                        <label for="name" string="Project name" class="d-md-none"/>
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="is_favorite" nolabel="1" widget="project_is_favorite" options="{'autosave': False}"/>
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_text_overflow" placeholder="e.g. Office Party"/>
                         </h1>
@@ -385,9 +386,9 @@
             <field name="model">project.project</field>
             <field name="arch" type="xml">
                 <form string="Project">
-                    <div class="oe_title mb-lg-3 mb-md-2">
+                    <div class="oe_title">
                         <label for="name" string="Name"/>
-                        <h1>
+                        <h1 class="o_outlined">
                             <field name="name" class="o_project_name" placeholder="e.g. Office Party"/>
                         </h1>
                     </div>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -430,7 +430,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_template"/>
                     <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not is_template"/>
                     <div class="d-flex flex-wrap-reverse flex-lg-nowrap justify-content-between align-items-center gap-2 mb-3 mb-lg-0">
-                        <h1 class="d-flex w-100">
+                        <h1 class="o_outlined d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
                         <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template or has_project_template">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -198,7 +198,7 @@
                     <div class="oe_title">
                         <span class="o_form_label" invisible="state not in ('draft', 'sent')">Request for Quotation</span>
                         <span class="o_form_label" invisible="state in ('draft', 'sent')">Purchase Order</span>
-                        <h1 class="d-flex align-items-center gap-2">
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="priority" widget="priority"/>
                             <field name="name" readonly="1"/>
                         </h1>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -99,8 +99,8 @@
                         </button>
                     </div>
                     <div class="oe_title">
-                        <label class="o_form_label" for="name"/>
-                        <h1 class="d-flex align-items-center gap-2">
+                        <label for="name"/>
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="priority" widget="priority"/>
                             <field name="name"/>
                         </h1>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -495,7 +495,7 @@
                     Locked
                 </div>
                 <div class="oe_title">
-                    <h1>
+                    <h1 class="o_outlined">
                         <field name="name" readonly="1"/>
                     </h1>
                 </div>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -36,7 +36,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="oe_title">
                         <label for="name" string="Sales Team"/>
-                        <h1>
+                        <h1 class="o_outlined">
                             <field class="text-break" name="name" placeholder="e.g. North America"/>
                         </h1>
                         <div name="options_active" class="o_row"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -208,7 +208,7 @@
                         </button>
                     </div>
                     <div class="oe_title">
-                        <h1 class="d-flex align-items-center gap-2">
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="priority" widget="priority"/>
                             <div invisible="id">New <field name="picking_type_code"/></div>
                             <field name="name" invisible="not id"/>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -134,7 +134,7 @@
                             groups="stock.group_reception_report"/>
                     </div>
                     <div class="oe_title">
-                        <h1 class="d-flex align-items-center gap-2">
+                        <h1 class="o_outlined d-flex align-items-center gap-2">
                             <field name="priority" widget="priority"/>
                             <field name="name"/>
                         </h1>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -343,26 +343,21 @@
 
         @include media-breakpoint-up(sm) {
             max-width: 75%;
-        }
 
-        > h1, > h2, > h3 {
-            width: 100%; // Needed because inline-block when is a hx.o_row
-            margin-top: 0;
-            margin-bottom: 0;
-            line-height: $headings-line-height;
+            > h1, > h2, > h3 {
+                width: 100%; // Needed because inline-block when is a hx.o_row
+                margin-top: 0;
+                margin-bottom: map-get($spacers, 3);
+                line-height: $headings-line-height;
 
-            &.d-flex > .o_input {
-                height: max-content;
+                &.d-flex > .o_input {
+                    height: max-content;
+                }
             }
-        }
-        .o_priority > .o_priority_star, .o_favorite.btn, .o_favorite i.fa {
-            font-size: inherit !important;
-        }
-        > h1 {
-            min-height: 55px;
-        }
-        > h2 {
-            min-height: 42px;
+
+            .o_priority > .o_priority_star, .o_favorite.btn, .o_favorite i.fa {
+                font-size: inherit !important;
+            }
         }
     }
 
@@ -377,12 +372,6 @@
             object-fit: contain;
             vertical-align: top;
             border: 1px solid $o-gray-300;
-        }
-
-        @include media-breakpoint-down(sm) {
-            + .oe_title {
-                max-width: calc(100% - #{$o-form-picture-size} - #{map-get($spacers, 2)});
-            }
         }
     }
 

--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -144,6 +144,10 @@
         .o_outlined {
             @extend %-o-field-box;
 
+            &:is(h1, h2, h3, h4, h5, h6), :is(h1, h2, h3, h4, h5, h6) {
+                font-size: inherit;
+            }
+
             .o_field_widget {
                 --fieldWidget-margin-bottom: 0px;
             }

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -16,11 +16,11 @@
                                 string="Branches"/>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <div class="d-flex gap-2">
+                    <div class="d-flex flex-column flex-md-row align-items-center gap-3">
                         <field name="logo" widget="contact_image" class="oe_avatar text-start float-none" nolabel="1" options="{'size': [100,100], 'img_class': 'rounded-4'}"/>
-                        <div class="oe_title">
+                        <div class="oe_title w-100">
                             <label for="name"/>
-                            <h1>
+                            <h1 class="o_outlined">
                                 <field name="name" placeholder="e.g. My Company"/>
                             </h1>
                         </div>


### PR DESCRIPTION
In this commit, we now use the `o_outlined` class, previously introduced, to also display a box around the name field.

We also reduce the font size of "<h*>" elements, as titles can be long and there is limited space on small screens.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
