### PR TITLE
[PERF] stock: speedup _free_reservation within stock quants validation action

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -261,20 +261,23 @@ class StockMoveLine(models.Model):
             excluded_smls = set(smls.ids)
             if package.package_type_id:
                 best_loc = smls.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, products=smls.product_id, locations=locations)._get_putaway_strategy(self.env['product.product'], package=package)
-                smls.location_dest_id = smls.package_level_id.location_dest_id = best_loc
+                smls.package_level_id.filtered(lambda pl: pl.location_dest_id != best_loc).location_dest_id = best_loc
             elif package:
                 used_locations = set()
                 for sml in smls:
                     if len(used_locations) > 1:
                         break
-                    sml.location_dest_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, locations=locations)._get_putaway_strategy(sml.product_id, quantity=sml.quantity)
+                    putaway_loc_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, locations=locations)._get_putaway_strategy(sml.product_id, quantity=sml.quantity)
+                    if putaway_loc_id != sml.location_dest_id:
+                        sml.location_dest_id = putaway_loc_id
                     excluded_smls.discard(sml.id)
                     used_locations.add(sml.location_dest_id)
                 if len(used_locations) > 1:
                     for move, grouped_smls in smls.grouped('move_id').items():
                         grouped_smls.location_dest_id = move.location_dest_id
                 else:
-                    smls.package_level_id.location_dest_id = smls.location_dest_id
+                    smls_location_dest_id = smls.location_dest_id
+                    smls.package_level_id.filtered(lambda pl: pl.location_dest_id != smls_location_dest_id).location_dest_id = smls_location_dest_id
             else:
                 for sml in smls:
                     putaway_loc_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls)._get_putaway_strategy(

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1277,8 +1277,11 @@ class Picking(models.Model):
                 subtype_id=subtype_id,
             )
 
+    def _check_move_lines_map_quant(self, move_lines, package):
+        return package._check_move_lines_map_quant(move_lines.filtered(lambda ml: ml.product_id.is_storable))
+
     def _check_move_lines_map_quant_package(self, package):
-        return package._check_move_lines_map_quant(self.move_line_ids.filtered(lambda ml: ml.package_id == package and ml.product_id.is_storable))
+        return self._check_move_lines_map_quant(self.move_line_ids.filtered(lambda ml: ml.package_id == package), package)
 
     def _get_entire_pack_location_dest(self, move_line_ids):
         location_dest_ids = move_line_ids.mapped('location_dest_id')
@@ -1288,11 +1291,13 @@ class Picking(models.Model):
 
     def _check_entire_pack(self):
         """ This function check if entire packs are moved in the picking"""
-        for package in self.move_line_ids.package_id:
-            pickings = self.move_line_ids.filtered(lambda ml: ml.package_id == package).picking_id
-            if pickings._check_move_lines_map_quant_package(package):
+        for package, package_move_lines in self.move_line_ids.grouped('package_id').items():
+            if not package:
+                continue
+            pickings = package_move_lines.picking_id
+            if pickings._check_move_lines_map_quant(package_move_lines, package):
                 package_level_ids = pickings.package_level_ids.filtered(lambda pl: pl.package_id == package)
-                move_lines_to_pack = pickings.move_line_ids.filtered(lambda ml: ml.package_id == package and not ml.result_package_id and ml.state not in ('done', 'cancel'))
+                move_lines_to_pack = package_move_lines.filtered(lambda ml: not ml.result_package_id and ml.state not in ('done', 'cancel'))
                 if not package_level_ids:
                     if len(pickings) == 1:
                         package_location = pickings._get_entire_pack_location_dest(move_lines_to_pack) or pickings.location_dest_id.id
@@ -1316,8 +1321,12 @@ class Picking(models.Model):
                         ml.package_level_id = ml.move_id.package_level_id.id
                     move_lines_without_package_level.package_level_id = package_level_ids[0].id
 
+                    move_line_ids_by_package_level = package_move_lines.grouped(lambda ml: ml.package_level_id.id)
                     for pl in package_level_ids:
-                        pl.location_dest_id = pickings._get_entire_pack_location_dest(pl.move_line_ids) or pickings.location_dest_id.id
+                        pl_move_line_ids = move_line_ids_by_package_level.get(pl.id, self.env['stock.move.line'])
+                        pl_location_dest_id = pickings._get_entire_pack_location_dest(pl_move_line_ids) or pickings.location_dest_id.id
+                        if pl.location_dest_id.id != pl_location_dest_id:
+                            pl.location_dest_id = pl_location_dest_id
                     for move in move_lines_to_pack.move_id:
                         if all(line.package_level_id for line in move.move_line_ids) \
                                 and len(move.move_line_ids.package_level_id) == 1:


### PR DESCRIPTION
Applying stock quants validation was performing poorly due to multiple bottlenecks in `Picking._check_entire_pack` and `StockMoveLine._apply_putaway_strategy`:

* **Redundant updates** were performed on `location_dest_id` in the move lines and the package levels (which internally update all related move lines too), even when the location remained unchanged.
* The main loop inside `_check_entire_pack` was **O(N^2)** time relative to the number of move lines due to internal filtering logic.
* **Cache misses** triggered unnecessary SQL queries when retrieving `move_line_ids` from `package levels`, while they are already cached via the pickings and can be grouped by `package_level`.

---

### Benchmark
Benchmark conducted on a customer database with **400k** `stock_move_line` records within **800** `pickings`, testing performance of the action `StockQuant.action_validate` with different sizes of move lines. Each test was run multiple times and shown is the average mean, all with negligible variance.

| Metric | Before | After | Delta |
| :--- | :--- | :--- | :--- |
| **Benchmark (1k lines)** | 10.5s | 2.2s | -80% |
| **Benchmark (5k lines)** | 121s | 8.5s | -93% |
| **Benchmark (50k lines)** | 887s | 56s | -94% |
| **Benchmark (400k lines)** | timeout | 777s | (within time limit) |

**OPW-6045513**