### PR TITLE
[FIX] stock_account,sale_stock: prevent recomputing delivery date

### DIFF
--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -171,3 +171,8 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
                 invoice.delivery_date, custom_delivery_date,
                 "Custom invoice delivery shouldn't change posting invoice",
             )
+            invoice.button_draft()
+            self.assertEqual(
+                invoice.delivery_date, custom_delivery_date,
+                "Custom invoice delivery shouldn't change resetting to draft invoice",
+            )

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -59,7 +59,8 @@ class AccountMove(models.Model):
         res = super(AccountMove, self).button_draft()
 
         # Unlink the COGS lines generated during the 'post' method.
-        self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
+        with self.env.protecting(self.env['account.move']._get_protected_vals({}, self)):
+            self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
         return res
 
     def button_cancel(self):


### PR DESCRIPTION
Version:
---------
- 17.0

Steps to reproduce:
--------------------

1. Install `sale_management`,`stock` and `account_accountant`modules.
2. Enable `Automatic Accounting` from Settings.
3. Create a storable product with:
     i. Invoicing Policy set to Delivered Quantity.
    ii. A non-zero Cost.
   iii. A category configured with FIFO/AVCO and Automated Valuation.
4. Create and confirm a sales order for this product.
5. Validate the related delivery order.
6. Create an invoice from the sales order.
7. Manually set the Delivery Date on the invoice.
8. Validate the invoice.
9. Reset the invoice to draft.

Issue:
------

Resetting the invoice to draft recomputes the Delivery Date,
overwriting the manually set value with the current date.

Cause:
-----

https://github.com/odoo/odoo/blob/05d0944a7640e196db989039140ae5ddb12152ac/addons/stock_account/models/account_move.py#L62

The `button_draft()` method unlinks some account.move.line
records, which triggers the recomputation of the
delivery_date field.

Backport this commit -https://github.com/odoo/odoo/pull/237612/changes/c1247a11ee380e6a3b5055d2f3accde1e892de8a

---

opw-5886341 
