### PR TITLE
[FIX] web: dont allow selecting properties in field selector widget

### DIFF
--- a/addons/web/static/src/views/fields/field_selector/field_selector_field.js
+++ b/addons/web/static/src/views/fields/field_selector/field_selector_field.js
@@ -13,12 +13,16 @@ export class FieldSelectorField extends Component {
         ...standardFieldProps,
         resModel: { type: String, optional: true },
         onlySearchable: { type: Boolean, optional: true },
+        allowProperties: { type: Boolean, optional: true },
         followRelations: { type: Boolean, optional: true },
     };
 
     filter(fieldDef) {
         if (fieldDef.type === "separator") {
             // Don't show properties separator
+            return false;
+        }
+        if (!this.props.allowProperties && fieldDef.type === "properties") {
             return false;
         }
         return !this.props.onlySearchable || fieldDef.searchable;
@@ -75,6 +79,7 @@ export const fieldSelectorField = {
     ],
     extractProps({ options }, dynamicInfo) {
         return {
+            allowProperties: options.allow_properties ?? true,
             followRelations: options.follow_relations ?? true,
             onlySearchable: exprToBoolean(options.only_searchable),
             resModel: options.model,

--- a/addons/web/static/tests/views/fields/field_selector_field.test.js
+++ b/addons/web/static/tests/views/fields/field_selector_field.test.js
@@ -154,3 +154,31 @@ test("follow_relations option", async () => {
         message: "should not allow to follow relations",
     });
 });
+
+test("allow_properties option", async () => {
+    Contact._fields.contact_properties_definition = fields.PropertiesDefinition()
+    Lead._fields.lead_properties = fields.Properties({
+        definition_record: "contact_id",
+        definition_record_field: "contact_properties_definition",
+    })
+
+    await mountView({
+        type: "form",
+        resModel: "update.record.action",
+        arch: /* xml */ `
+            <form>
+                <field name="model"/>
+                <field name="update_path" widget="field_selector" options="{
+                    'model': 'model',
+                    'allow_properties': false,
+                }"/>
+            </form>
+        `,
+    });
+    await contains(".o_field_widget[name='model'] .o_input").edit("lead");
+    await contains(".o_field_widget[name='update_path'] .o_input").click();
+    expect(queryAllTexts(".o_model_field_selector_popover_item")).toEqual(
+        ["Contact", "Created on", "Display name", "Id", "Last Modified on", "Note", "Salesperson"],
+        { message: "should display fields of the specified model, except the properties field" }
+    );
+});


### PR DESCRIPTION
- Backporting this [commit], for adding the `allow_properties` option to `field_selector` widget in `saas-18.2` for using the functionality in linked enterprise commit.
- Also, added a test for `allow_properties` option.
- For forward ports, only the test will be merged, as `allow_properties` is already included in the original commit.

[commit]: https://github.com/odoo/odoo/pull/215767/changes/7cd18c07b5e008bff072d10375c908eb77434fde

sentry-7378769090
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
