### PR TITLE
[IMP] crm: add team switcher

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -72,10 +72,16 @@
     'assets': {
         'web.assets_backend': [
             'crm/static/src/**',
+            ('remove', 'crm/static/src/views/crm_activity/**'),
+            ('remove', 'crm/static/src/views/crm_graph/**'),
+            ('remove', 'crm/static/src/views/crm_pivot/**'),
             ('remove', 'crm/static/src/views/forecast_graph/**'),
             ('remove', 'crm/static/src/views/forecast_pivot/**'),
         ],
         'web.assets_backend_lazy': [
+            'crm/static/src/views/crm_activity/**',
+            'crm/static/src/views/crm_graph/**',
+            'crm/static/src/views/crm_pivot/**',
             'crm/static/src/views/forecast_graph/**',
             'crm/static/src/views/forecast_pivot/**',
         ],

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -995,8 +995,10 @@ class CrmLead(models.Model):
         # - OR ('fold', '=', False): add default columns that are not folded
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
         team_id = self.env.context.get('default_team_id')
-        team_ids = self.env.user.crm_team_ids._ids if self.env.context.get('show_user_team_stages') else ()
-        team_ids += (team_id,) if team_id else ()
+        team_ids = (team_id,) if team_id else ()
+        # Only consider the user team stages if there's no specific team selection in the team switcher.
+        if self.env.context.get('show_user_team_stages') and not self.env.context.get('has_team_selection'):
+            team_ids += self.env.user.crm_team_ids._ids
         search_domain = ['|', ('id', 'in', stages.ids), ('team_ids', '=', False)]
         if team_ids:
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_ids)]

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -17,3 +17,7 @@
 .o_settings_container .mt16:has(.crm_settings_block) {
     margin-top: 0 !important;
 }
+
+.o_team_switcher_dropdown_toggler {
+    max-width: 30ch;
+}

--- a/addons/crm/static/src/views/crm_activity/crm_activity_view.js
+++ b/addons/crm/static/src/views/crm_activity/crm_activity_view.js
@@ -1,0 +1,10 @@
+import { activityView } from "@mail/views/web/activity/activity_view";
+import { CrmSearchModel } from "@crm/views/crm_search_model";
+import { registry } from "@web/core/registry";
+
+export const crmActivityView = {
+    ...activityView,
+    SearchModel: CrmSearchModel,
+}
+
+registry.category("views").add("crm_activity", crmActivityView);

--- a/addons/crm/static/src/views/crm_calendar/crm_calendar_view.js
+++ b/addons/crm/static/src/views/crm_calendar/crm_calendar_view.js
@@ -1,0 +1,9 @@
+import { calendarView } from "@web/views/calendar/calendar_view";
+import { CrmSearchModel } from "@crm/views/crm_search_model";
+import { registry } from "@web/core/registry";
+
+export const crmCalendarView = {
+    ...calendarView,
+    SearchModel: CrmSearchModel,
+};
+registry.category("views").add("crm_calendar", crmCalendarView);

--- a/addons/crm/static/src/views/crm_graph/crm_graph_view.js
+++ b/addons/crm/static/src/views/crm_graph/crm_graph_view.js
@@ -1,0 +1,10 @@
+import { CrmSearchModel } from "@crm/views/crm_search_model";
+import { graphView } from "@web/views/graph/graph_view";
+import { registry } from "@web/core/registry";
+
+export const crmGraphView = {
+    ...graphView,
+    SearchModel: CrmSearchModel,
+}
+
+registry.category("views").add("crm_graph", crmGraphView);

--- a/addons/crm/static/src/views/crm_kanban/crm_kanban_view.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_kanban_view.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { CrmKanbanModel } from "@crm/views/crm_kanban/crm_kanban_model";
 import { CrmKanbanArchParser } from "@crm/views/crm_kanban/crm_kanban_arch_parser";
 import { CrmKanbanRenderer } from "@crm/views/crm_kanban/crm_kanban_renderer";
+import { CrmSearchModel } from "@crm/views/crm_search_model";
 import { rottingKanbanView } from "@mail/js/rotting_mixin/rotting_kanban_view";
 import { LeadGenerationDropdown } from "../../components/lead_generation_dropdown/lead_generation_dropdown";
 
@@ -25,6 +26,7 @@ export const crmKanbanView = {
     },
     Model: CrmKanbanModel,
     Renderer: CrmKanbanRenderer,
+    SearchModel: CrmSearchModel,
     buttonTemplate: "crm.Kanban.Buttons",
 };
 

--- a/addons/crm/static/src/views/crm_list/crm_list_view.js
+++ b/addons/crm/static/src/views/crm_list/crm_list_view.js
@@ -1,3 +1,4 @@
+import { CrmSearchModel } from "@crm/views/crm_search_model";
 import { registry } from "@web/core/registry";
 import { listView } from "@web/views/list/list_view";
 import { LeadGenerationDropdown } from "../../components/lead_generation_dropdown/lead_generation_dropdown";
@@ -10,6 +11,7 @@ export const crmListView = {
             LeadGenerationDropdown,
         }
     },
+    SearchModel: CrmSearchModel,
     buttonTemplate: "crm.List.Buttons",
 };
 

--- a/addons/crm/static/src/views/crm_pivot/crm_pivot_view.js
+++ b/addons/crm/static/src/views/crm_pivot/crm_pivot_view.js
@@ -1,0 +1,10 @@
+import { CrmSearchModel } from "@crm/views/crm_search_model";
+import { pivotView } from "@web/views/pivot/pivot_view";
+import { registry } from "@web/core/registry";
+
+export const crmPivotView = {
+    ...pivotView,
+    SearchModel: CrmSearchModel,
+}
+
+registry.category("views").add("crm_pivot", crmPivotView);

--- a/addons/crm/static/src/views/crm_search_bar_menu/crm_search_bar_menu_patch.js
+++ b/addons/crm/static/src/views/crm_search_bar_menu/crm_search_bar_menu_patch.js
@@ -1,0 +1,37 @@
+import { patch } from "@web/core/utils/patch";
+import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * Add team switcher dropdown menu in search bar
+ */
+patch(SearchBarMenu.prototype, {
+    /**
+     * @override
+     * Hide team switcher filter item from the search bar menu.
+     */
+    get filterItems() {
+        return this.env.searchModel.getSearchItems((searchItem) =>
+            ["filter", "dateFilter", "parentFilter", "lazyParentFilter"].includes(searchItem.type) &&
+            searchItem.name !== this.env.searchModel.tsFilterName
+        );
+    },
+    get tsAllTeamLabel() {
+        return _t("All");
+    },
+    get tsFilterItem() {
+        return this.env.searchModel.getSearchItems((searchItem) =>
+            ["parentFilter", "lazyParentFilter"].includes(searchItem.type) &&
+            searchItem.name === this.env.searchModel.tsFilterName
+        )?.[0];
+    },
+    get tsSelectedName() {
+        return (
+            this.tsFilterItem?.options.find((o) => o.id === this.tsSelectedOptionId)?.description ||
+            this.tsAllTeamLabel
+        );
+    },
+    get tsSelectedOptionId() {
+        return this.env.searchModel.tsSelectedOptionId;
+    },
+});

--- a/addons/crm/static/src/views/crm_search_bar_menu/crm_search_bar_menu_patch.xml
+++ b/addons/crm/static/src/views/crm_search_bar_menu/crm_search_bar_menu_patch.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="crm.TeamSearchBarMenu" t-inherit="web.SearchBarMenu" t-inherit-mode="extension">
+        <xpath expr="//Dropdown" position="after">
+            <Dropdown
+                t-if="this.tsFilterItem and this.tsFilterItem.options?.length"
+                menuClass="'o_team_switcher_dropdown o_search_bar_menu d-flex flex-wrap flex-lg-nowrap w-100 w-md-auto mx-md-auto'"
+                position="'bottom-end'"
+                bottomSheet="false">
+                <button
+                    t-attf-class="{{this.env.isSmall ? '' : 'o-dropdown-caret'}} o_team_switcher_dropdown_toggler d-print-none btn btn-outline-secondary rounded ms-2"
+                    title="Toggle Crm Team Search Dropdown">
+                    <i class="fa fa-users"/>
+                    <span t-if="!this.env.isSmall" class="text-truncate" t-out="this.tsSelectedName"/>
+                </button>
+                <t t-set-slot="content">
+
+                    <div class="o_dropdown_container w-100 w-lg-auto h-100 border-end">
+
+                        <!-- "All": unselect current option or do nothing if current is already "All" -->
+                        <CheckboxItem class="{ o_item_option: true, selected: !this.tsSelectedOptionId, 'text-truncate': true }"
+                            t-out="this.tsAllTeamLabel"
+                            checked="!this.tsSelectedOptionId"
+                            closingMode="'closest'"
+                            onSelected="() => this.onFilterSelected({ itemId: this.tsFilterItem.id, optionId: this.tsSelectedOptionId })"
+                        />
+
+                        <t t-foreach="this.tsFilterItem.options" t-as="option" t-key="option.id">
+                            <CheckboxItem class="{ o_item_option: true, selected: option.isActive, 'text-truncate': true }"
+                                t-out="option.description"
+                                checked="option.isActive"
+                                closingMode="'closest'"
+                                onSelected="() => this.onFilterSelected({ itemId: this.tsFilterItem.id, optionId: option.id })"
+                            />
+                        </t>
+                        <DropdownItem t-if="this.tsFilterItem.optionsParams.limit and this.tsFilterItem.optionsParams.count > this.tsFilterItem.optionsParams.limit"
+                            class="'o_item_option'"
+                            closingMode="'none'"
+                            onSelected.bind="() => this.onLoadMoreOptions({ itemId: this.tsFilterItem.id})">
+                            More...
+                        </DropdownItem>
+                    </div>
+
+                </t>
+            </Dropdown>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/crm/static/src/views/crm_search_model.js
+++ b/addons/crm/static/src/views/crm_search_model.js
@@ -1,0 +1,143 @@
+import { browser } from "@web/core/browser/browser";
+import { Domain } from "@web/core/domain";
+import { SearchModel } from "@web/search/search_model";
+
+/**
+ * Give the possibility to add a team switcher.
+ * Renaming the "team_id" field search filter into "crm_team_switcher" will change it into a team switcher where:
+ * - Only one team can be selected at a time ("All" option available)
+ * - The selected team is saved in local storage to be restored as default filter (fallback on first team if no selection).
+ * - The context is updated to set selected team as default on crm.lead record creation and display the related stages.
+ */
+export class CrmSearchModel extends SearchModel {
+    /**
+     * @override
+     * Load filter team options to restore selected team or fallback on first.
+     */
+    async load(config) {
+        await super.load(config);
+        if (!this.tsSearchItem) {
+            return;
+        }
+        await this.loadLazyParentFilter(this.tsSearchItem.id);
+        const savedOptionId = browser.localStorage.getItem("selectedTeamOptionId");
+        if (savedOptionId === this.tsAllOptionId) {
+            return;
+        }
+        const optionId = this.tsSearchItem.options.find((o) => o.id === savedOptionId)
+            ? savedOptionId
+            : this.tsSearchItem.options[0]?.id;
+        if (optionId && this.tsSelectedOptionId !== optionId) {
+            this.toggleTeamSwitcherFilter(optionId);
+        }
+    }
+
+    get tsAllOptionId() {
+        return "all";
+    }
+
+    /**
+     * Name of the "team_id" search filter used to activate the team switcher.
+     */
+    get tsFilterName() {
+        return "crm_team_switcher";
+    }
+
+    get tsSearchItem() {
+        return this.getSearchItems(
+            (i) => i.name === this.tsFilterName && i.optionsParams.fieldName === "team_id"
+        )?.[0];
+    }
+
+    /**
+     * Get the team switcher selected option id directly from the query object.
+     */
+    get tsSelectedOptionId() {
+        if (!this.tsSearchItem) {
+            return null;
+        }
+        const queryItem = this.query.find((queryElem) => queryElem.searchItemId === this.tsSearchItem.id);
+        return queryItem?.generatorId || null;
+    }
+
+    /**
+     * @override
+     * Remove team switcher facet.
+     * Selected team filter only editable from the switcher dropdown.
+     */
+    _getFacets() {
+        const facets = super._getFacets();
+        const tsGroupId = this._getGroups().find((g) =>
+            g.activeItems[0].searchItemId === this.tsSearchItem?.id
+        )?.id;
+        if (!tsGroupId) {
+            return facets;
+        }
+        const index = facets.findIndex((f) => f.groupId === tsGroupId);
+        if (index !== -1) {
+            facets.splice(index, 1);
+        }
+        return facets;
+    }
+
+    /**
+     * @override
+     * Set selected team as default team on crm.lead record creation.
+     * Notify that a team has been selected so stages can be updated accordingly (cf _read_group_stage_ids).
+     */
+    _getSearchItemContext(activeItem) {
+        const context = super._getSearchItemContext(activeItem);
+        if (activeItem.searchItemId !== this.tsSearchItem?.id) {
+            return context;
+        }
+        const tsSelectedOption = this.tsSearchItem.optionsParams.customOptions.find(
+            (o) => o.id === this.tsSelectedOptionId
+        );
+        if (!tsSelectedOption) {
+            return context;
+        }
+        return {
+            ...(context ?? {}),
+            default_team_id: new Domain(tsSelectedOption.domain).toList()[0][2], // TODO do not work for list view ?
+            has_team_selection: true,
+        };
+    }
+
+    /**
+     * @override
+     */
+    toggleParentFilter(searchItemId, generatorId) {
+        if (searchItemId !== this.tsSearchItem?.id) {
+            super.toggleParentFilter(searchItemId, generatorId);
+            return;
+        }
+        this.toggleTeamSwitcherFilter(generatorId);
+    }
+
+    /**
+     * Toggle team option in the team switcher.
+     * - Only one team can be selected at a time.
+     * - Selecting a different team automatically unselects the previous active team.
+     */
+    toggleTeamSwitcherFilter(optionId) {
+        // Unselect current: fallback on "All"
+        if (optionId === this.tsSelectedOptionId) {
+            super.toggleParentFilter(this.tsSearchItem.id, optionId);
+            browser.localStorage.setItem("selectedTeamOptionId", this.tsAllOptionId);
+            return;
+        }
+        // Unselect previous active option
+        const index = this.query.findIndex(
+            (queryElem) =>
+                queryElem.searchItemId === this.tsSearchItem.id &&
+                "generatorId" in queryElem &&
+                queryElem.generatorId === this.tsSelectedOptionId
+        );
+        if (index !== -1) {
+            this.query.splice(index, 1);
+        }
+        // Select new option
+        super.toggleParentFilter(this.tsSearchItem.id, optionId);
+        browser.localStorage.setItem("selectedTeamOptionId", optionId);
+    }
+}

--- a/addons/crm/static/tests/crm_team_switcher.test.js
+++ b/addons/crm/static/tests/crm_team_switcher.test.js
@@ -1,0 +1,178 @@
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import {
+    contains,
+    defineActions,
+    defineModels,
+    fields,
+    getService,
+    models,
+    mountWithCleanup,
+    switchView,
+} from "@web/../tests/web_test_helpers";
+import { WebClient } from "@web/webclient/webclient";
+import { expect, test } from "@odoo/hoot";
+
+class Users extends models.Model {
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "Mario" },
+        { id: 2, name: "Luigi" },
+        { id: 3, name: "Link" },
+        { id: 4, name: "Zelda" },
+    ];
+}
+
+class Team extends models.Model {
+    _name = "crm.team";
+
+    name = fields.Char();
+    member_ids = fields.Many2many({ string: "Members", relation: "users" });
+
+    _records = [
+        { id: 1, name: "Mushroom Kingdom", member_ids: [1, 2] },
+        { id: 2, name: "Hyrule", member_ids: [3, 4] },
+    ];
+}
+
+class Stage extends models.Model {
+    _name = "crm.stage";
+
+    name = fields.Char();
+    is_won = fields.Boolean({ string: "Is won" });
+    team_ids = fields.Many2many({ relation: "crm.team" });
+
+    _records = [
+        { id: 1, name: "Start" },
+        { id: 2, name: "Middle" },
+        { id: 3, name: "Middle Hyrule", team_ids: [2] },
+        { id: 4, name: "Won", is_won: true },
+    ];
+}
+
+class Lead extends models.Model {
+    _name = "crm.lead";
+
+    name = fields.Char();
+    stage_id = fields.Many2one({ string: "Stage", relation: "crm.stage" });
+    team_id = fields.Many2one({ string: "Sales Team", relation: "crm.team" });
+    user_id = fields.Many2one({ string: "Salesperson", relation: "users" });
+
+    _records = [
+        {
+            id: 1,
+            name: "Lead 1",
+            stage_id: 1,
+            team_id: 1,
+            user_id: 1,
+        },
+        {
+            id: 2,
+            name: "Lead 2",
+            stage_id: 1,
+            team_id: 2,
+            user_id: 2,
+        },
+        {
+            id: 3,
+            name: "Lead 3",
+            stage_id: 2,
+            team_id: 1,
+            user_id: 3,
+        },
+        {
+            id: 4,
+            name: "Lead 4",
+            stage_id: 2,
+            team_id: 2,
+            user_id: 4,
+        },
+        {
+            id: 5,
+            name: "Lead 5",
+            stage_id: 3,
+            team_id: 2,
+            user_id: 1,
+        },
+            {
+            id: 6,
+            name: "Lead 6",
+            stage_id: 4,
+            team_id: 1,
+            user_id: 4,
+        },
+            {
+            id: 7,
+            name: "Lead 7",
+            stage_id: 4,
+            team_id: 2,
+            user_id: 2,
+        },
+    ];
+
+    _views = {
+        kanban: `
+            <kanban js_class="crm_kanban" default_group_by="stage_id">
+                <templates>
+                    <t t-name="card">
+                        <field name="name"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+        list: `
+            <list js_class="crm_list">
+                <field name="id"/>
+                <field name="name"/>
+            </list>
+        `,
+        search: `
+            <search>
+                <filter string="Sales Teams" name="crm_team_switcher">
+                    <field name="team_id" domain="[]"/>
+                </filter>
+            </search>
+        `,
+    };
+}
+
+defineModels([Users, Team, Stage, Lead]);
+defineMailModels();
+defineActions([
+    {
+        id: 1,
+        name: "Pipeline",
+        res_model: "crm.lead",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "kanban"],
+            [false, "list"],
+        ],
+    },
+]);
+
+test.tags("desktop");
+test("crm team switcher rendering", async () => {
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    // Changing the selected team should update the displayed stages and records
+    // All: 7 records, 4 stages (Start, Middle, Won, Hyrule Stage)
+    await contains(".o_team_switcher_dropdown_toggler").click();
+    await contains(".o_popover .dropdown-item:text('All')").click();
+    expect(".o_kanban_record").toHaveCount(7);
+    expect(".o_kanban_group").toHaveCount(4);
+    // Mushroom Kingdom: 3 records, 3 stages (Start, Middle, Won)
+    await contains(".o_team_switcher_dropdown_toggler").click();
+    await contains(".o_popover .dropdown-item:text('Mushroom Kingdom')").click();
+    expect(".o_kanban_record").toHaveCount(3);
+    expect(".o_kanban_group").toHaveCount(3);
+    // Hyrule: 4 records, 4 stages (Start, Middle, Won, Hyrule Stage)
+    await contains(".o_team_switcher_dropdown_toggler").click();
+    await contains(".o_popover .dropdown-item:text('Hyrule')").click();
+    expect(".o_kanban_record").toHaveCount(4);
+    expect(".o_kanban_group").toHaveCount(4);
+    // Switching view should keep the current team selection
+    await switchView("list");
+    expect(".o_team_switcher_dropdown_toggler").toHaveText("Hyrule");
+    expect("tr.o_data_row").toHaveCount(4);
+});

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -376,7 +376,8 @@
             <field name="model">crm.lead</field>
             <field name="priority" eval="2"/>
             <field name="arch" type="xml">
-                <calendar string="Leads Generation" create="0" mode="month" date_start="activity_date_deadline" color="user_id" hide_time="true" event_limit="5">
+                <calendar js_class="crm_calendar" string="Leads Generation" create="0" mode="month"
+                    date_start="activity_date_deadline" color="user_id" hide_time="true" event_limit="5">
                     <field name="expected_revenue"/>
                     <field name="partner_id" avatar_field="avatar_128"/>
                     <field name="user_id" filters="1" invisible="1"/>
@@ -458,7 +459,7 @@
             <field name="name">crm.lead.view.activity</field>
             <field name="model">crm.lead</field>
             <field name="arch" type="xml">
-                <activity string="Leads or Opportunities">
+                <activity js_class="crm_activity" string="Leads or Opportunities">
                     <field name="user_id"/>
                     <field name="company_currency"/>
                     <templates>
@@ -818,7 +819,7 @@
             <field name="name">crm.lead.view.graph</field>
             <field name="model">crm.lead</field>
             <field name="arch" type="xml">
-                <graph string="Opportunities" sample="1">
+                <graph js_class="crm_graph" string="Opportunities" sample="1">
                     <field name="stage_id"/>
                     <field name="user_id"/>
                     <field name="color" invisible="1"/>
@@ -860,7 +861,7 @@
             <field name="name">crm.lead.view.pivot</field>
             <field name="model">crm.lead</field>
             <field name="arch" type="xml">
-                <pivot string="Pipeline Analysis" sample="1">
+                <pivot js_class="crm_pivot" string="Pipeline Analysis" sample="1">
                     <field name="create_date" interval="month" type="row"/>
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
@@ -938,6 +939,10 @@
                     <filter string="Open Opportunities" name="open_opportunities"
                         domain="[('probability', '&lt;', 100), ('type', '=', 'opportunity'), ('active', '=', True)]"
                         help="Open Opportunities"/>
+                    <separator/>
+                    <filter string="Sales Teams" name="crm_team_switcher">
+                        <field name="team_id" domain="[]"/>
+                    </filter>
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -34,12 +34,6 @@
         sequence="2"/>
 
     <menuitem
-        id="sales_team_menu_team_pipeline"
-        name="Teams"
-        parent="crm_menu_sales"
-        action="sales_team.crm_team_action_pipeline"
-        sequence="4"/>
-    <menuitem
         id="res_partner_menu_customer"
         name="Customers"
         parent="crm_menu_sales"

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -248,10 +248,6 @@
             <field name="search_view_id" ref="crm.view_crm_case_opportunities_filter"/>
         </record>
 
-        <record id="sales_team.crm_team_action_pipeline" model="ir.actions.act_window">
-            <field name="domain">[('use_opportunities', '=', True)]</field>
-        </record>
-
         <record id="crm_team_view_kanban_dashboard" model="ir.ui.view">
             <field name="name">crm.team.view.kanban.dashboard.inherit.crm</field>
             <field name="model">crm.team</field>

--- a/addons/crm_iap_mine/static/src/components/lead_generation_dropdown/crm_lead_gen_element.js
+++ b/addons/crm_iap_mine/static/src/components/lead_generation_dropdown/crm_lead_gen_element.js
@@ -19,6 +19,10 @@ patch(LeadGenerationDropdown.prototype, {
 
     async openLeadGenerationForm() {
         const action = await this.orm.call("crm.lead", "action_generate_leads", []);
+        const defaultTeamId = this.env.searchModel.context?.default_team_id;
+        if (defaultTeamId) {
+            action.context.default_team_id = defaultTeamId;
+        }
         this.action.doAction(action);
     }
 });

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -192,21 +192,6 @@
         </field>
     </record>
 
-      <record id="crm_team_action_pipeline" model="ir.actions.act_window">
-        <field name="name">Teams</field>
-        <field name="res_model">crm.team</field>
-        <field name="view_mode">kanban,form</field>
-        <field name="context">{}</field>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                Define a new sales team
-            </p><p>
-                Use Sales Teams to organize your sales departments.
-                Each team will work with a separate pipeline.
-            </p>
-        </field>
-    </record>
-
     <record id="crm_team_action_config" model="ir.actions.act_window">
         <field name="name">Sales Teams</field>
         <field name="res_model">crm.team</field>

--- a/addons/web/static/src/core/dropdown/accordion_item.js
+++ b/addons/web/static/src/core/dropdown/accordion_item.js
@@ -21,10 +21,15 @@ export class AccordionItem extends Component {
             type: String,
             optional: true,
         },
+        onWillToggle: {
+            type: Function,
+            optional: true,
+        },
     };
     static defaultProps = {
         class: "",
         selected: false,
+        onWillToggle: () => {},
     };
 
     setup() {
@@ -35,5 +40,10 @@ export class AccordionItem extends Component {
         onPatched(() => {
             this.parentComponent?.accordionStateChanged?.();
         });
+    }
+
+    async toggle() {
+        await this.props.onWillToggle();
+        this.state.open = !this.state.open;
     }
 }

--- a/addons/web/static/src/core/dropdown/accordion_item.xml
+++ b/addons/web/static/src/core/dropdown/accordion_item.xml
@@ -8,7 +8,7 @@
                     t-attf-class="{{ this.props.class }}"
                     t-att-aria-expanded="this.state.open ? 'true' : 'false'"
                     t-out="this.props.description"
-                    t-on-click="() => this.state.open = !this.state.open"
+                    t-on-click="this.toggle"
             />
             <t t-if="this.state.open">
                 <div class="o_accordion_values ms-4 border-start">

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -76,7 +76,11 @@ export class SearchArchParser {
                     this.visitSeparator();
                     break;
                 case "field":
-                    this.visitField(node);
+                    if (this.optionsParams) {
+                        this.visitInnerField(node);
+                    } else {
+                        this.visitField(node);
+                    }
                     break;
                 case "filter":
                     if (this.optionsParams) {
@@ -314,6 +318,22 @@ export class SearchArchParser {
         preInnerFilterOption.description = node.getAttribute("string");
         preInnerFilterOption.domain = node.getAttribute("domain");
         this.optionsParams.customOptions.push(preInnerFilterOption);
+    }
+
+    visitInnerField(node) {
+        this.optionsParams.toBeLoaded = true;
+        this.optionsParams.fieldName = node.getAttribute("name");
+        this.optionsParams.domain = node.getAttribute("domain") || [];
+        this.optionsParams.fieldType = this.fields[this.optionsParams.fieldName]?.type;
+        this.optionsParams.customOptions = [];
+        if (
+            !this.optionsParams.fieldType ||
+            !["many2many", "many2one", "selection"].includes(this.optionsParams.fieldType)
+        ) {
+            throw new Error(
+                `Inner field should only consist in a many2one, many2many or selection field`
+            );
+        }
     }
 
     visitGroup(node, visitChildren) {

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -69,7 +69,7 @@ export class SearchBarMenu extends Component {
     // Filter Panel
     get filterItems() {
         return this.env.searchModel.getSearchItems((searchItem) =>
-            ["filter", "dateFilter", "parentFilter"].includes(searchItem.type)
+            ["filter", "dateFilter", "parentFilter", "lazyParentFilter"].includes(searchItem.type)
         );
     }
 
@@ -88,6 +88,18 @@ export class SearchBarMenu extends Component {
         } else {
             this.env.searchModel.toggleSearchItem(itemId);
         }
+    }
+
+    async onToggle({ itemId, optionsParams }) {
+        if (optionsParams.toBeLoaded) {
+            await this.env.searchModel.loadLazyParentFilter(itemId);
+            this.render();
+        }
+    }
+
+    async onLoadMoreOptions({ itemId }) {
+        await this.env.searchModel.loadMoreOptions(itemId);
+        this.render();
     }
 
     // GroupBy Panel

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -27,13 +27,18 @@
                                 <div class="dropdown-divider" role="separator"/>
                             </t>
                             <t t-if="item.options">
-                                <AccordionItem class="'text-truncate'" description="item.description" selected="item.isActive">
+                                <AccordionItem 
+                                    class="'text-truncate'" 
+                                    description="item.description" 
+                                    selected="item.isActive" 
+                                    onWillToggle="() => this.onToggle({ itemId: item.id, optionsParams: item.optionsParams })"
+                                >
                                     <t t-set="subGroup" t-value="null"/>
                                     <t t-foreach="item.options" t-as="option" t-key="option.id">
                                         <t t-if="subGroup !== null and subGroup !== option.groupNumber">
                                             <div class="dropdown-divider" role="separator"/>
                                         </t>
-                                        <CheckboxItem class="{ o_item_option: true, selected: option.isActive }"
+                                        <CheckboxItem class="{ o_item_option: true, selected: option.isActive, 'text-truncate': true }"
                                                             t-out="option.description"
                                                             checked="option.isActive"
                                                             closingMode="'none'"
@@ -41,6 +46,7 @@
                                         />
                                         <t t-set="subGroup" t-value="option.groupNumber"/>
                                     </t>
+                                    <DropdownItem t-if="item.optionsParams.limit and item.optionsParams.count > item.optionsParams.limit" class="'o_item_option'" closingMode="'none'" onSelected.bind="() => this.onLoadMoreOptions({ itemId: item.id })">More...</DropdownItem>
                                 </AccordionItem>
                             </t>
                             <t t-else="">

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -890,6 +890,68 @@ export class SearchModel extends EventBus {
         this._notify();
     }
 
+    async loadLazyParentFilter(itemId) {
+        const searchItem = this.searchItems[itemId];
+        if (searchItem.optionsParams.fieldType === "selection") {
+            const field = this.searchViewFields[searchItem.optionsParams.fieldName];
+            const values = field.selection;
+            const options = searchItem.optionsParams.customOptions;
+            for (const val of values) {
+                options.push({
+                    description: val[1],
+                    domain: Domain.and([
+                        searchItem.domain,
+                        `[('${searchItem.optionsParams.fieldName}', '=', '${val[0]}')]`,
+                    ]).toString(),
+                    id: `custom_${val[1].toLowerCase()}_${searchItem.optionsParams.fieldName}`,
+                    type: "innerFilter",
+                });
+            }
+        }
+        if (["many2many", "many2one"].includes(searchItem.optionsParams.fieldType)) {
+            await this.loadMoreOptions(itemId);
+        }
+        delete searchItem.optionsParams.toBeLoaded;
+    }
+
+    async loadMoreOptions(itemId) {
+        const searchItem = this.searchItems[itemId];
+        const field = this.searchViewFields[searchItem.optionsParams.fieldName];
+        if (searchItem.optionsParams.limit) {
+            searchItem.optionsParams.limit *= 2;
+        } else {
+            searchItem.optionsParams.limit = 8;
+        }
+        const res = await this.orm
+            .cache({ type: "disk" })
+            .webSearchRead(
+                field.relation,
+                new Domain(searchItem.optionsParams.domain).toList(this.context),
+                {
+                    specification: {
+                        id: {},
+                        display_name: {},
+                    },
+                    limit: searchItem.optionsParams.limit,
+                }
+            );
+        searchItem.optionsParams.count = res.length;
+        const values = res.records.map((r) => [r.id, r.display_name]);
+        const options = [];
+        for (const val of values) {
+            options.push({
+                description: val[1],
+                domain: Domain.and([
+                    searchItem.domain,
+                    `[('${searchItem.optionsParams.fieldName}', '=', ${val[0]})]`,
+                ]).toString(),
+                id: `custom_${val[1].toLowerCase()}_${searchItem.optionsParams.fieldName}`,
+                type: "innerFilter",
+            });
+        }
+        searchItem.optionsParams.customOptions = options;
+    }
+
     /**
      * Set the active value id of a given category.
      * @param {number} sectionId
@@ -1586,6 +1648,7 @@ export class SearchModel extends EventBus {
                 );
                 break;
             case "parentFilter":
+            case "lazyParentFilter":
                 enrichSearchItem.options = _enrichOptions(
                     searchItem.optionsParams.customOptions,
                     queryElements.map((queryElem) => queryElem.generatorId)

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -1153,3 +1153,132 @@ test(`Custom filter with "&"" as value`, async function () {
     expect(getFacetTexts()).toEqual([`Foo contains &`]);
     expect(searchBar.env.searchModel.domain).toEqual([["foo", "ilike", "&"]]);
 });
+
+test("lazy selection filter", async () => {
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Selection" name="selection_filter">
+                    <field name="selection"/>
+                </filter>
+            </search>
+        `,
+    });
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Selection");
+    await contains(`.o_accordion_toggle`).click();
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(3);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual(["ABC", "DEF", "GHI"]);
+    await toggleMenuItemOption("Selection", "ABC");
+    expect(searchBar.env.searchModel.domain).toEqual([["selection", "=", "abc"]]);
+});
+
+test("lazy many2one filter", async () => {
+    Partner._records = [
+        { id: 1, name: "John" },
+        { id: 2, name: "David" },
+        { id: 3, name: "Bertrand" },
+        { id: 4, name: "Christophe" },
+        { id: 5, name: "Jean-Edouard" },
+        { id: 6, name: "Serge" },
+        { id: 7, name: "Amelie" },
+        { id: 8, name: "Sarah" },
+        { id: 9, name: "Tristan" },
+        { id: 10, name: "Paul" },
+    ];
+    onRpc("partner", "web_search_read", ({ kwargs }) => {
+        expect(kwargs.specification).toEqual({
+            display_name: {},
+            id: {},
+        });
+        expect(kwargs.domain).toEqual([["bar", "!=", false]]);
+        expect.step(`web_search_read ${kwargs.limit} partners`);
+    });
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Bar" name="m2o">
+                    <field name="bar" domain="[('bar', '!=', False)]"/>
+                </filter>
+            </search>
+        `,
+    });
+    expect.verifySteps([]);
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Bar");
+    await contains(`.o_accordion_toggle`).click();
+    expect.verifySteps(["web_search_read 8 partners"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(9);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual([
+        "John",
+        "David",
+        "Bertrand",
+        "Christophe",
+        "Jean-Edouard",
+        "Serge",
+        "Amelie",
+        "Sarah",
+        "More...",
+    ]);
+    await toggleMenuItemOption("Bar", "Christophe");
+    expect(searchBar.env.searchModel.domain).toEqual([["bar", "=", 4]]);
+    await toggleMenuItemOption("Bar", "More...");
+    expect.verifySteps(["web_search_read 16 partners"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(10);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual([
+        "John",
+        "David",
+        "Bertrand",
+        "Christophe",
+        "Jean-Edouard",
+        "Serge",
+        "Amelie",
+        "Sarah",
+        "Tristan",
+        "Paul",
+    ]);
+});
+
+test("lazy many2one filter with multiple domains", async () => {
+    Partner._records = [
+        { id: 1, name: "John" },
+        { id: 2, name: "David" },
+    ];
+    onRpc("partner", "web_search_read", ({ kwargs }) => {
+        expect(kwargs.domain).toEqual([["bar", "!=", false]]);
+        expect.step(`web_search_read`);
+    });
+    const searchBar = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Bar" name="m2o" domain="[('foo', '!=', 'a')]">
+                    <field name="bar" domain="[('bar', '!=', False)]"/>
+                </filter>
+            </search>
+        `,
+    });
+    expect.verifySteps([]);
+    await toggleSearchBarMenu();
+    expect(`.o_menu_item`).toHaveCount(2);
+    expect(`.o_accordion_toggle`).toHaveText("Bar");
+    await contains(`.o_accordion_toggle`).click();
+    expect.verifySteps(["web_search_read"]);
+    expect(`.o_accordion_values .o_item_option`).toHaveCount(2);
+    expect(queryAllTexts(`.o_accordion_values .o_item_option`)).toEqual(["John", "David"]);
+    await toggleMenuItemOption("Bar", "David");
+    expect(searchBar.env.searchModel.domain).toEqual(["&", ["foo", "!=", "a"], ["bar", "=", 2]], {
+        message:
+            "domain on filter is combined with the option, field domain is applied to the option search",
+    });
+});

--- a/addons/web/static/tests/search/search_bar_menu/models.js
+++ b/addons/web/static/tests/search/search_bar_menu/models.js
@@ -10,6 +10,13 @@ export class Foo extends models.Model {
         definition_record: "parent_id",
         definition_record_field: "properties_definition",
     });
+    selection = fields.Selection({
+        selection: [
+            ["abc", "ABC"],
+            ["def", "DEF"],
+            ["ghi", "GHI"],
+        ],
+    });
 
     _views = {
         search: `

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -399,9 +399,12 @@
                 <!-- Supported in Search View -->
                 <rng:group>
                     <rng:attribute name="string"/>
-                    <rng:oneOrMore>
-                        <rng:ref name="filter"/>
-                    </rng:oneOrMore>
+                    <rng:choice>
+                        <rng:ref name="field" />
+                        <rng:oneOrMore>
+                            <rng:ref name="filter"/>
+                        </rng:oneOrMore>
+                    </rng:choice>
                 </rng:group>
             </rng:choice>
 


### PR DESCRIPTION
Purpose
=======
Ease the CRM teams navigation by adding a CRM team switcher
in the My Pipeline menu views.

Specification
=============
In the My Pipeline "crm.lead" views, adding a dropdown with all the CRM teams
the user has access to, as well as an "All" option. Only one team can be selected
at a time. The team switcher default selection is the first one.

On a specific team selection, the search domain will be updated to display all
the team related "crm.lead" records. Some context keys will also be set
to display the team stages and add the team as default when creating lead records.
The selected team will also be set as default when generating leads from iap mine,
importing leads from a file or when creating leads from a business card picture.

Removing the "Teams" menu which is now obsolete. Teams settings are still available
from the "Sales Teams" configuration menu.

Task-5887454




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
