### PR TITLE
[FIX] account: land portal invoice backend link in Invoicing app

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -113,7 +113,7 @@
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">
                 <t t-call="portal.portal_back_in_edit_mode">
-                    <t t-set="backend_url" t-value="'/odoo/action-account.action_move_out_invoice_type/%s' % invoice.id"/>
+                    <t t-set="backend_url" t-value="'/odoo/action-account.action_move_out_invoice/%s' % invoice.id"/>
                 </t>
             </t>
 


### PR DESCRIPTION
The "Back to edit mode" link used action_move_out_invoice_type, which isn't bound to any menu, so the backend fell back to whichever app happened to match (e.g. Website when installed) instead of Invoicing.

Switch to action_move_out_invoice (the one referenced by the Invoicing menu) so the webclient resolves the correct app automatically.

task-5882256