### PR TITLE
[FIX] pos_viva_com: allow Viva OAuth token refresh for POS users

### DIFF
--- a/addons/pos_viva_com/models/pos_payment_method.py
+++ b/addons/pos_viva_com/models/pos_payment_method.py
@@ -76,7 +76,7 @@ class PosPaymentMethod(models.Model):
 
         access_token = resp.json().get('access_token')
         if access_token:
-            self.viva_com_bearer_token = access_token
+            self.sudo().write({'viva_com_bearer_token': access_token})
             return {'Authorization': f"Bearer {access_token}"}
         else:
             raise UserError(_(

--- a/addons/pos_viva_com/tests/__init__.py
+++ b/addons/pos_viva_com/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_frontend
+from . import test_pos_payment_method

--- a/addons/pos_viva_com/tests/test_pos_payment_method.py
+++ b/addons/pos_viva_com/tests/test_pos_payment_method.py
@@ -1,0 +1,46 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import MagicMock
+
+import odoo.tests
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestVivaComBearerTokenAcl(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        bank_journal = cls.company_data['default_journal_bank']
+        # Only POS administrators may create payment methods (Odoo 19+); test data is not the ACL under test.
+        cls.viva_pm = cls.env['pos.payment.method'].sudo().create({
+            'name': 'Viva ACL Test',
+            'journal_id': bank_journal.id,
+            'use_payment_terminal': 'viva_com',
+            'viva_com_merchant_id': 'm',
+            'viva_com_api_key': 'k',
+            'viva_com_client_id': 'test-client-id',
+            'viva_com_client_secret': 'test-client-secret',
+            'viva_com_terminal_id': '01234543210',
+        })
+        cls.pos_user = cls.env['res.users'].create({
+            'name': 'Pos Only User ACL',
+            'login': 'pos_viva_acl_test',
+            'password': 'pos_viva_acl_test',
+            'group_ids': [(6, 0, [
+                cls.env.ref('base.group_user').id,
+                cls.env.ref('point_of_sale.group_pos_user').id,
+            ])],
+        })
+
+    def test_bearer_token_persists_for_pos_user(self):
+        """Test POS user can use Viva.com payment method"""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'access_token': 'refreshed-token'}
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        self.viva_pm.with_user(self.pos_user)._bearer_token(mock_session)
+
+        self.assertEqual(self.viva_pm.viva_com_bearer_token, 'refreshed-token')


### PR DESCRIPTION
Point of Sale users only have read access on pos.payment.method. When the stored Viva.com bearer token expires or the API returns invalid credentials, _bearer_token() fetches a new token .
That write ran as the POS user and raised an AccessError, although the user was only paying—not editing configuration.

Steps to reproduce:
-------------------
* Configure  Viva.com as payment method.
* Open the POS as a user with only Point of Sale / User (not Administrator).
* Pay with Viva until the OAuth token must be refreshed (e.g. after expiry or after Viva rejects the current token).

> Observation:
 AccessError: You are not allowed to modify 'Point of Sale Payment Methods' (pos.payment.method) records.

Why the fix:
------------
Persist the refreshed viva_com_bearer_token with sudo().write() so the ORM does not require write ACL on pos.payment.method for that internal side effect of an already authorized Viva RPC.

opw-6078131