### PR TITLE
[FIX] stock_account, purchase_stock: receive auto-standard product

### DIFF
--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3741,6 +3741,79 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         svls = self.env['stock.valuation.layer'].search([])
         self.assertRecordValues(svls, [{'value': 0, 'quantity': 2}])
 
+    def test_standard_valuation_foreign_currency_several_rates(self):
+        """
+        - Auto Standard
+        - Yesterday, buy and receive
+        - Today, bill
+        - In foreign currency, with different rates
+        The stock valuation account should only be impacted by the standard
+        price defined on the product form, nothing else.
+        """
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self.product1.standard_price = 10
+
+        today = fields.Date.today()
+        yesterday = today - timedelta(days=1)
+
+        self.env['res.currency.rate'].search([]).unlink()
+        self.env['res.currency.rate'].create([{
+            'name': yesterday,
+            'rate': 2.0,
+            'currency_id': self.eur_currency.id,
+            'company_id': self.env.company.id,
+        }, {
+            'name': today,
+            'rate': 2.5,
+            'currency_id': self.eur_currency.id,
+            'company_id': self.env.company.id,
+        }])
+
+        with freeze_time(yesterday):
+            po = self.env['purchase.order'].create({
+                'partner_id': self.partner_id.id,
+                'currency_id': self.eur_currency.id,
+                'order_line': [
+                    (0, 0, {
+                        'name': self.product1.name,
+                        'product_id': self.product1.id,
+                        'product_qty': 1.0,
+                        'product_uom': self.product1.uom_po_id.id,
+                        'price_unit': 20.0,
+                        'taxes_id': False,
+                    }),
+                ],
+            })
+            po.button_confirm()
+
+            receipt = po.picking_ids
+            receipt.move_ids.move_line_ids.quantity = 1.0
+            receipt.button_validate()
+
+        self._bill(po)
+
+        in_stock_amls = self.env['account.move.line'].search([('account_id', '=', self.stock_input_account.id)], order='id')
+        self.assertRecordValues(in_stock_amls, [
+            # Receipt
+            {'debit': 0.0, 'credit': 10.0, 'reconciled': True},
+            # Bill
+            {'debit': 8.0, 'credit': 0.0, 'reconciled': True},
+            # XCH
+            {'debit': 2.0, 'credit': 0.0, 'reconciled': True},
+        ])
+
+        stock_valo_amls = self.env['account.move.line'].search([('account_id', '=', self.stock_valuation_account.id)], order='id')
+        self.assertRecordValues(stock_valo_amls, [
+            {'debit': 10.0, 'credit': 0.0},
+        ])
+
+        xch_amls = self.env['account.move.line'].search([('account_id', '=', self.env.company.income_currency_exchange_account_id.id)], order='id')
+        self.assertRecordValues(xch_amls, [
+            {'debit': 0.0, 'credit': 2.0},
+        ])
+
     def test_standard_valuation_return_credit_note(self):
         self.env.company.anglo_saxon_accounting = True
         self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -325,6 +325,7 @@ class AccountMoveLine(models.Model):
     def _get_exchange_journal(self, company):
         if (
             self and self.move_id.sudo().stock_valuation_layer_ids and
+            self.product_id.categ_id.property_cost_method != 'standard' and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_journal
@@ -333,6 +334,7 @@ class AccountMoveLine(models.Model):
     def _get_exchange_account(self, company, amount):
         if (
             self and self.move_id.sudo().stock_valuation_layer_ids and
+            self.product_id.categ_id.property_cost_method != 'standard' and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_valuation_account_id


### PR DESCRIPTION
This is a backport of https://github.com/odoo/odoo/pull/243029 The same bug is reproducible in 17.0

Processing a buy-receive-bill process in a foreign currency and with an auto-standard product will lead to an incorrect valuation

To reproduce the issue:
(Company in USD)
1. Enable EUR and define the rates as followed:
   - Yesterday: 2
   - Today: 2.5
2. Create a product category:
   - Method: Standard
   - Valuation: Automated
3. Create a product P in that category
   - Cost: 10 USD
4. [Yesterday] Confirm a PO in EUR with 1 x P
5. [Yesterday] Receive it
6. Bill

Error: the stock valuation has two entries: one with 10 USD debit, the receipt. Another one with 2 USD credit, the currency exchange rate difference. The second one is a mistake, in a standard configuration, the stock valuation should be impacted by nothing but the cost defined on the product form.

Since https://github.com/odoo-dev/odoo/commit/bae7feefcb08db7329d52bc36517dfd73f3347a7, in some conditions the method `_get_exchange_account` returns the stock valuation account. This is what happens here, but it's a mistake since in the above case, we should stick with the classic account (i.e. the `super` call). The conditions must be more strict.

opw-5905197