### PR TITLE
[FIX] account: Fix the account search behaviour on invoices and bills

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -815,19 +815,14 @@ class AccountAccount(models.Model):
         if not name and suggested_accounts:
             return [(record.id, record.display_name) for record in self.sudo().browse(suggested_accounts)]
 
-        digit_in_search_term = any(c.isdigit() for c in name)
         search_domain = Domain('display_name', 'ilike', name) if name else []
-
-        if digit_in_search_term:
-            domain = Domain.AND([search_domain, domain])
-        else:
-            move_type_accounts = {
-                'out': ['income'],
-                'in': ['expense', 'asset_fixed'],
-            }
-            allowed_account_types = move_type_accounts.get(move_type.split('_')[0])
-            type_domain = [('account_type', 'in', allowed_account_types)] if allowed_account_types else []
-            domain = Domain.AND([search_domain, type_domain, domain])
+        move_type_accounts = {
+            'out': ['income'],
+            'in': ['expense', 'asset_fixed'],
+        }
+        allowed_account_types = move_type_accounts.get(move_type.split('_')[0])
+        type_domain = [('account_type', 'in', allowed_account_types)] if allowed_account_types else []
+        domain = Domain.AND([search_domain, type_domain, domain])
 
         records = self.with_context(preferred_account_ids=suggested_accounts).search_fetch(domain, ['display_name'], limit=limit)
         return [(record.id, record.display_name) for record in records]

--- a/addons/account/static/src/components/many2one_account_account/many2one_account_account.js
+++ b/addons/account/static/src/components/many2one_account_account/many2one_account_account.js
@@ -1,0 +1,50 @@
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+import { Many2One } from "@web/views/fields/many2one/many2one";
+import { Many2OneField, buildM2OFieldDescription } from "@web/views/fields/many2one/many2one_field";
+
+export class Many2XAccountAccountAutocomplete extends Many2XAutocomplete {
+    addSearchMoreSuggestion(options) {
+        return true;
+    }
+
+    async onSearchMore(request) {
+        const { getDomain, context, fieldString } = this.props;
+        let dynamicFilters = [];
+        if (request.length) {
+            dynamicFilters = [
+                {
+                    description: _t("Quick search: %s", request),
+                    domain: [["name", "ilike", request]],
+                },
+            ];
+        }
+        const title = _t("Search: %s", fieldString);
+        this.selectCreate({
+            domain: getDomain(),
+            context,
+            filters: dynamicFilters,
+            title,
+        });
+    }
+}
+
+export class Many2OneAccountAccount extends Many2One {
+    static components = {
+        ...Many2One.components,
+        Many2XAutocomplete: Many2XAccountAccountAutocomplete,
+    };
+}
+
+export class Many2OneFieldAccountAccount extends Many2OneField {
+    static components = {
+        ...Many2OneField.components,
+        Many2One: Many2OneAccountAccount,
+    };
+}
+
+registry.category("fields").add("many2one_account_account", {
+    ...buildM2OFieldDescription(Many2OneFieldAccountAccount),
+    additionalClasses: ["o_field_many2one"],
+});

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1195,8 +1195,9 @@
                                                     'search_default_account_type': 'out_' in parent.move_type and 'income',
                                                     'preferred_account_type': 'out_' in parent.move_type and 'income' or 'in_' in parent.move_type and 'expense',
                                                }"
+                                               widget="many2one_account_account"
                                                groups="account.group_account_readonly"
-                                               options="{'no_quick_create': True}"
+                                               options="{'no_quick_create': True, 'no_open': True}"
                                                domain="[('company_ids', 'parent_of', company_id), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance'))]"
                                                required="display_type not in ('line_section', 'line_subsection', 'line_note')"/>
                                         <field name="analytic_distribution" widget="analytic_distribution"


### PR DESCRIPTION
Currently, on invoices, the account_id many2one field overrides `name_search` to limit search results based on account types, but that is applied only if the account is searched by name. If the account is searched by code, all the accounts appear in search results which is not intended.

This commit fixes that issue.

task-6075233

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
