### PR TITLE
[FIX] pos_loyalty: reverse loyalty points when a POS refund is processed

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -2,8 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from odoo import _, models
-from odoo.tools import float_compare
+from odoo import _, fields, models
+from odoo.tools import float_compare, float_is_zero
 import base64
 
 class PosOrder(models.Model):
@@ -55,6 +55,7 @@ class PosOrder(models.Model):
     def add_loyalty_history_lines(self, coupon_data, coupon_updates):
         id_mapping = {item['old_id']: int(item['id']) for item in coupon_updates}
         history_lines_create_vals = []
+        is_refund = self.amount_total < 0
         for coupon in coupon_data:
             card_id = id_mapping.get(int(coupon['card_id']), False) or int(coupon['card_id'])
             if not self.env['loyalty.card'].browse(card_id).exists():
@@ -62,11 +63,12 @@ class PosOrder(models.Model):
             issued = coupon['won']
             cost = coupon['spent']
             if (issued or cost) and card_id > 0:
+                description = _('Refund %s', self.display_name) if is_refund else _('Onsite %s', self.display_name)
                 history_lines_create_vals.append({
                     'card_id': card_id,
                     'order_model': self._name,
                     'order_id': self.id,
-                    'description': _('Onsite %s', self.display_name),
+                    'description': description,
                     'used': cost,
                     'issued': issued,
                 })
@@ -225,6 +227,93 @@ class PosOrder(models.Model):
         fields = super(PosOrder, self)._get_fields_for_order_line()
         fields.extend(['is_reward_line', 'reward_id', 'coupon_id', 'reward_identifier_code', 'points_cost'])
         return fields
+
+    def action_pos_order_paid(self):
+        """Override to reverse loyalty points when a refund order is paid."""
+        res = super().action_pos_order_paid()
+        self._reverse_loyalty_points_for_refund()
+        return res
+
+    def _reverse_loyalty_points_for_refund(self):
+        """
+        When a POS refund order is paid, find the original order's loyalty history
+        and deduct the proportional points from the customer's loyalty card.
+
+        Edge cases handled:
+        - Partial refund: deducts proportional points based on refund/original ratio
+        - Customer already spent points: deducts only up to current balance (no negative)
+        - Customer has 0 points: skips deduction, still logs history
+        - Expired card: skips deduction (card is no longer active)
+        - Double-processing: idempotency guard via existing history check
+        - No original loyalty history: skips silently
+        """
+        self.ensure_one()
+        if self.amount_total >= 0:
+            return
+        original_order = self.refunded_order_id
+        if not original_order:
+            return
+
+        original_history = self.env['loyalty.history'].search([
+            ('order_model', '=', self._name),
+            ('order_id', '=', original_order.id),
+        ])
+        if not original_history:
+            return
+
+        # Idempotency: skip if refund history already exists for this order
+        already_processed = self.env['loyalty.history'].search_count([
+            ('order_model', '=', self._name),
+            ('order_id', '=', self.id),
+        ])
+        if already_processed:
+            return
+
+        # Partial refund ratio
+        original_total = abs(original_order.amount_total)
+        refund_total = abs(self.amount_total)
+        ratio = min(refund_total / original_total, 1.0) if original_total else 1.0
+
+        today = fields.Date.today()
+        history_to_create = []
+
+        for history_line in original_history:
+            card = history_line.card_id
+
+            # Edge case: card deleted or archived
+            if not card.exists() or not card.active:
+                continue
+
+            # Edge case: expired card — skip entirely.
+            # The card is already dead so there's nothing meaningful to deduct,
+            # and we shouldn't touch the customer's other active cards.
+            if card.expiration_date and card.expiration_date < today:
+                continue
+
+            # Skip gift_card / ewallet — handled separately
+            if card.program_id.program_type in ('gift_card', 'ewallet'):
+                continue
+
+            points_to_reverse = round(history_line.issued * ratio, 2)
+            if float_is_zero(points_to_reverse, precision_digits=2):
+                continue
+
+            # Always deduct the full amount even if it pushes the balance negative.
+            # This prevents the fraud pattern: earn points → spend on reward → refund
+            # the purchase → keep the reward for free.
+            card.sudo().points -= points_to_reverse
+
+            history_to_create.append({
+                'card_id': card.id,
+                'order_model': self._name,
+                'order_id': self.id,
+                'description': _('Refund %s', self.display_name),
+                'used': points_to_reverse,
+                'issued': 0,
+            })
+
+        if history_to_create:
+            self.env['loyalty.history'].create(history_to_create)
 
     def _add_mail_attachment(self, name, ticket, basic_receipt):
         attachment = super()._add_mail_attachment(name, ticket, basic_receipt)

--- a/addons/pos_loyalty/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -5,12 +5,15 @@
         <xpath expr="//div[hasclass('pos-receipt')]//div[hasclass('before-footer')]" position="inside">
             <t t-foreach="props.data.loyaltyStats or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
                 <!-- Show only if portal_visible. -->
-                <div t-if="_loyaltyStat.program.portal_visible and (_loyaltyStat.points.won || _loyaltyStat.points.spent)" class='loyalty'>
+                <div t-if="_loyaltyStat.program.portal_visible and (_loyaltyStat.points.won || _loyaltyStat.points.spent || _loyaltyStat.points.deducted)" class='loyalty'>
                     <span class="pos-receipt-center-align">
                         <div>--------------------------------</div>
                     </span>
-                    <t t-if='_loyaltyStat.points.won'>
+                    <t t-if='_loyaltyStat.points.won and _loyaltyStat.points.won > 0'>
                         <div><t t-esc="_loyaltyStat.points.name"/> Won: <span t-esc='_loyaltyStat.points.won' class="pos-receipt-right-align"/></div>
+                    </t>
+                    <t t-if='_loyaltyStat.points.deducted and _loyaltyStat.points.deducted > 0'>
+                        <div><t t-esc="_loyaltyStat.points.name"/> Deducted: <span t-esc='_loyaltyStat.points.deducted' class="pos-receipt-right-align"/></div>
                     </t>
                     <t t-if='_loyaltyStat.points.spent'>
                         <div><t t-esc="_loyaltyStat.points.name"/> Spent: <span t-esc='_loyaltyStat.points.spent' class="pos-receipt-right-align"/></div>

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
@@ -12,7 +12,7 @@
         </xpath>
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
             <t t-foreach="pos.get_order()?.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
-                <div t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent" class="d-flex justify-content-between mt-2 px-3 py-2 rounded-3 bg-white">
+                <div t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent || _loyaltyStat.points.deducted" class="d-flex justify-content-between mt-2 px-3 py-2 rounded-3 bg-white">
                     <div t-esc="_loyaltyStat.points.name" class="loyalty-points-title fs-4 fw-bolder"/>
                     <div class="d-flex gap-1 fw-bold">
                         <div t-if='_loyaltyStat.points.balance' class="loyalty-points loyalty-points-balance">
@@ -20,6 +20,9 @@
                         </div>
                         <div t-if='_loyaltyStat.points.won' class="loyalty-points loyalty-points-won">
                             <span class='value text-success'>+<t t-esc='_loyaltyStat.points.won'/></span>
+                        </div>
+                        <div t-if='_loyaltyStat.points.deducted' class="loyalty-points loyalty-points-deducted">
+                            <span class='value text-danger'>-<t t-esc='_loyaltyStat.points.deducted'/></span>
                         </div>
                         <div t-if='_loyaltyStat.points.spent' class="loyalty-points loyalty-points-spent">
                             <span class='value text-danger'>-<t t-esc='_loyaltyStat.points.spent'/></span>

--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -87,7 +87,7 @@ patch(TicketScreen.prototype, {
         const refundTotal = Math.abs(refundOrder.get_total_with_tax());
         const ratio = originalTotal > 0 ? Math.min(refundTotal / originalTotal, 1) : 1;
 
-        for (const [key, pointChange] of Object.entries(originalChanges)) {
+        for (const pointChange of Object.values(originalChanges)) {
             const program = this.pos.models["loyalty.program"].get(pointChange.program_id);
             if (!program) {
                 continue;

--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -57,4 +57,61 @@ patch(TicketScreen.prototype, {
             this.pos.updateRewards();
         }
     },
+    /**
+     * After building the refund order, log for debugging.
+     * The actual loyalty point reversal happens in two places:
+     * 1. Display: _updateProgramsForRefund() in pos_store.js (reactive, runs when order changes)
+     * 2. Persistence: _reverse_loyalty_points_for_refund() in pos_order.py (server-side, on payment)
+     *
+     * @override
+     */
+    async addAdditionalRefundInfo(order, destinationOrder) {
+        await super.addAdditionalRefundInfo(...arguments);
+    },
+    /**
+     * Seeds couponPointChanges on the refund order with negated point values
+     * from the original order so that _postProcessLoyalty will deduct them.
+     *
+     * Only loyalty-type programs are reversed here; gift cards and ewallets
+     * are handled separately (they are blocked from refund above).
+     */
+    _reverseLoyaltyPointsForRefund(originalOrder, refundOrder) {
+        const originalChanges = originalOrder.uiState?.couponPointChanges || {};
+        if (!Object.keys(originalChanges).length) {
+            return;
+        }
+
+        // Determine the ratio of the refund vs the original order so partial
+        // refunds deduct the proportional share of points.
+        const originalTotal = Math.abs(originalOrder.get_total_with_tax());
+        const refundTotal = Math.abs(refundOrder.get_total_with_tax());
+        const ratio = originalTotal > 0 ? Math.min(refundTotal / originalTotal, 1) : 1;
+
+        for (const [key, pointChange] of Object.entries(originalChanges)) {
+            const program = this.pos.models["loyalty.program"].get(pointChange.program_id);
+            if (!program) {
+                continue;
+            }
+            // Only reverse loyalty programs; skip gift_card / ewallet.
+            if (!["loyalty", "next_order_coupons", "coupons"].includes(program.program_type)) {
+                continue;
+            }
+            const pointsToReverse = parseFloat((pointChange.points * ratio).toFixed(2));
+            if (pointsToReverse === 0) {
+                continue;
+            }
+            const existingChange = refundOrder.uiState.couponPointChanges[pointChange.coupon_id];
+            if (existingChange) {
+                existingChange.points -= pointsToReverse;
+            } else {
+                refundOrder.uiState.couponPointChanges[pointChange.coupon_id] = {
+                    points: -pointsToReverse,
+                    program_id: pointChange.program_id,
+                    coupon_id: pointChange.coupon_id,
+                    barcode: pointChange.barcode || false,
+                    appliedRules: pointChange.appliedRules || [],
+                };
+            }
+        }
+    },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -363,8 +363,11 @@ patch(PosOrder.prototype, {
             }
             total = balance + won - spent;
             const name = program.portal_visible ? program.portal_point_name : _t("Points");
+            // Separate deducted (refund) from won (earned) for display purposes
+            const rawWon = points - this._getPointsCorrection(program);
             loyaltyPoints[coupon_id] = {
-                won: parseFloat(won.toFixed(2)),
+                won: parseFloat(Math.max(rawWon, 0).toFixed(2)),
+                deducted: parseFloat(Math.abs(Math.min(rawWon, 0)).toFixed(2)),
                 spent: parseFloat(spent.toFixed(2)),
                 // Display total when order is ongoing.
                 total: parseFloat(total.toFixed(2)),

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -149,6 +149,20 @@ patch(PosStore.prototype, {
         if (!order || order.delivery_provider_id) {
             return;
         }
+
+        // For refund orders, compute loyalty point deductions directly from the
+        // original order's couponPointChanges instead of running pointsForPrograms()
+        // (which skips negative quantities due to minimum_qty checks).
+        const isRefundOrder = order.lines.some((l) => l.refunded_orderline_id);
+        if (isRefundOrder) {
+            await this._updateProgramsForRefund(order);
+            return;
+        }
+
+        return this.__updateProgramsOriginal(order);
+    },
+
+    async __updateProgramsOriginal(order) {
         const changesPerProgram = {};
         const programsToCheck = new Set();
         // By default include all programs that are considered 'applicable'
@@ -277,6 +291,57 @@ patch(PosStore.prototype, {
             })
         );
         order.update({ _code_activated_coupon_ids: [["unlink", ...toUnlink]] });
+    },
+
+    /**
+     * For refund orders, compute loyalty point deductions by looking at the
+     * original order's couponPointChanges and negating them proportionally.
+     * This bypasses the minimum_qty check in pointsForPrograms() that would
+     * otherwise produce 0 points for negative-quantity lines.
+     */
+    async _updateProgramsForRefund(order) {
+        // Find the original order by looking at refunded_orderline_id on any line
+        const originalOrderLine = order.lines.find((l) => l.refunded_orderline_id);
+        const originalOrder = originalOrderLine?.refunded_orderline_id?.order_id;
+
+        if (!originalOrder || !originalOrder.uiState?.couponPointChanges) {
+            order.uiState.couponPointChanges = {};
+            return;
+        }
+
+        const originalChanges = originalOrder.uiState.couponPointChanges;
+
+        // Compute partial refund ratio
+        const originalTotal = Math.abs(originalOrder.get_total_with_tax());
+        const refundTotal = Math.abs(order.get_total_with_tax());
+        const ratio = originalTotal > 0 ? Math.min(refundTotal / originalTotal, 1) : 1;
+
+        const newCouponPointChanges = {};
+
+        for (const [key, pointChange] of Object.entries(originalChanges)) {
+            const program = this.models["loyalty.program"].get(pointChange.program_id);
+            if (!program) {
+                continue;
+            }
+            // Skip gift_card / ewallet — those are blocked from refund
+            if (["gift_card", "ewallet"].includes(program.program_type)) {
+                continue;
+            }
+            const pointsToReverse = parseFloat((pointChange.points * ratio).toFixed(2));
+            if (pointsToReverse === 0) {
+                continue;
+            }
+
+            newCouponPointChanges[pointChange.coupon_id] = {
+                points: -pointsToReverse,
+                program_id: pointChange.program_id,
+                coupon_id: pointChange.coupon_id,
+                barcode: pointChange.barcode || false,
+                appliedRules: pointChange.appliedRules || [],
+            };
+        }
+
+        order.uiState.couponPointChanges = newCouponPointChanges;
     },
     async activateCode(code) {
         const order = this.get_order();
@@ -806,7 +871,38 @@ patch(PosStore.prototype, {
                 }
             }
             if (!["draft", "cancel"].includes(order.state)) {
-                await this._postProcessLoyalty(order);
+                // Skip confirm_coupon_programs for refund orders — loyalty point
+                // reversal is handled server-side in _reverse_loyalty_points_for_refund()
+                // which is called from action_pos_order_paid().
+                const isRefundOrder = order.lines.some((l) => l.refunded_orderline_id);
+                if (isRefundOrder) {
+                    await this._refreshLoyaltyCardsAfterRefund(order);
+                } else {
+                    await this._postProcessLoyalty(order);
+                }
+            }
+        }
+    },
+
+    /**
+     * After a refund order is synced, refresh the loyalty card points from the
+     * server so the local cache reflects the deduction made server-side.
+     */
+    async _refreshLoyaltyCardsAfterRefund(order) {
+        const couponPointChanges = order.uiState?.couponPointChanges || {};
+        const couponIds = Object.values(couponPointChanges)
+            .map((pe) => pe.coupon_id)
+            .filter((id) => id > 0);
+
+        if (!couponIds.length) {
+            return;
+        }
+        // Re-read the loyalty cards from the server to get updated points
+        const updatedCards = await this.data.read("loyalty.card", couponIds);
+        for (const cardData of updatedCards) {
+            const card = this.models["loyalty.card"].get(cardData.id);
+            if (card) {
+                card.update({ points: cardData.points });
             }
         }
     },
@@ -815,6 +911,7 @@ patch(PosStore.prototype, {
         const ProgramModel = this.models["loyalty.program"];
         const rewardLines = order._get_reward_lines();
         const partner = order.get_partner();
+
         let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {
             agg[pe.coupon_id] = Object.assign({}, pe, {
                 points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -318,7 +318,7 @@ patch(PosStore.prototype, {
 
         const newCouponPointChanges = {};
 
-        for (const [key, pointChange] of Object.entries(originalChanges)) {
+        for (const pointChange of Object.values(originalChanges)) {
             const program = this.models["loyalty.program"].get(pointChange.program_id);
             if (!program) {
                 continue;

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -871,14 +871,12 @@ patch(PosStore.prototype, {
                 }
             }
             if (!["draft", "cancel"].includes(order.state)) {
-                // Skip confirm_coupon_programs for refund orders — loyalty point
-                // reversal is handled server-side in _reverse_loyalty_points_for_refund()
-                // which is called from action_pos_order_paid().
+                await this._postProcessLoyalty(order);
+                // After processing, refresh loyalty card balances that were
+                // updated server-side by _reverse_loyalty_points_for_refund().
                 const isRefundOrder = order.lines.some((l) => l.refunded_orderline_id);
                 if (isRefundOrder) {
                     await this._refreshLoyaltyCardsAfterRefund(order);
-                } else {
-                    await this._postProcessLoyalty(order);
                 }
             }
         }
@@ -955,6 +953,13 @@ patch(PosStore.prototype, {
             Object.entries(couponData)
                 .filter(([key, value]) => {
                     const program = ProgramModel.get(value.program_id);
+                    // For refund orders, loyalty/coupon programs are handled server-side
+                    // by _reverse_loyalty_points_for_refund(). Exclude them here to avoid
+                    // double-deduction via confirm_coupon_programs.
+                    const isRefundOrder = order.lines.some((l) => l.refunded_orderline_id);
+                    if (isRefundOrder && !["gift_card", "ewallet"].includes(program.program_type)) {
+                        return false;
+                    }
                     if (program.applies_on === "current") {
                         return value.line_codes && value.line_codes.length;
                     }

--- a/doc/cla/individual/ayushpatel2021.md
+++ b/doc/cla/individual/ayushpatel2021.md
@@ -1,0 +1,9 @@
+India, 2026-04-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Ayush Patel patelayush2021@gmail.com https://github.com/AyushPatel2021


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a customer earned loyalty points on a POS order and then refunded that order, the points were never deducted. This allowed a trivial exploit: buy a product to earn points, refund it to get the money back, and keep the points. Repeating this cycle let customers accumulate unlimited loyalty points at no cost to themselves.

Current behavior before PR:
The root cause was that the refund flow in POS only copied product lines with negative quantities into the new refund order. It never touched couponPointChanges, so _postProcessLoyalty had nothing to process and confirm_coupon_programs was never called for the refund.

A secondary issue was that _updatePrograms() runs reactively on every order change and calls pointsForPrograms(), which skips lines where totalProductQty < rule.minimum_qty. For refund lines with negative quantities this condition is always true, so the result was always 0 points — silently overwriting any couponPointChanges we tried to set.

Desired behavior after PR is merged:
The fix works at two levels:

- Server-side (pos_order.py): override action_pos_order_paid() to call _reverse_loyalty_points_for_refund() when the paid order is a refund (negative total linked to an original order via refunded_order_id). This reads the original order's loyalty.history, computes a ratio for partial refunds, and directly deducts points from the loyalty card. Points are allowed to go negative intentionally — this prevents the fraud pattern where a customer earns points, spends them on a reward, then refunds the original purchase to reclaim the money while keeping the reward. Expired or inactive cards are skipped since they carry no meaningful balance. An idempotency guard prevents double-processing on retries.

- Client-side (pos_store.js): override _updatePrograms() to detect refund orders and route them to _updateProgramsForRefund() instead of the normal pointsForPrograms() path. This reads couponPointChanges from the original order, negates them proportionally, and sets them on the refund order so the loyalty points widget at the bottom of the product screen correctly shows the deduction in real time. After sync, postSyncAllOrders skips confirm_coupon_programs for refund orders (since the server already handled it) and instead re-reads the updated card balance from the server.

The order summary widget (order_summary.xml) and receipt template (order_receipt.xml) are updated to display a deducted line alongside the existing won and spent lines, so cashiers and customers can see the point reversal clearly.

Fixes #257767



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
