### PR TITLE
[FIX] mail: prevent permission prompt when hiding camera preview

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -94,13 +94,13 @@ export class CallInvitation extends Component {
                         this.state.showCameraPreview ? "fa fa-chevron-up" : "fa fa-chevron-down",
                     onSelected: () => {
                         this.state.showCameraPreview = !this.state.showCameraPreview;
-                        if (this.rtc.cameraPermission !== "denied") {
-                            this.state.activateCamera++;
-                        }
-                        if (this.state.hasMicrophone) {
-                            this.state.activateMicrophone++;
-                        }
                         if (this.state.showCameraPreview) {
+                            if (this.rtc.cameraPermission !== "denied") {
+                                this.state.activateCamera++;
+                            }
+                            if (this.state.hasMicrophone) {
+                                this.state.activateMicrophone++;
+                            }
                             this.props.channel.self_member_id?.cancelInvitationTimeout();
                         } else {
                             this.props.channel.self_member_id?.startInvitationTimeout();

--- a/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
+++ b/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
@@ -58,10 +58,6 @@ registry.category("web_tour.tours").add("discuss_call_invitation.js", {
                 run: "click",
             },
             {
-                trigger: ".o-discuss-CallPermissionDeniedDialog",
-                run: "press Escape",
-            },
-            {
                 trigger: ".o-discuss-CallInvitation-cameraPreview:not(:visible)",
             },
         ];


### PR DESCRIPTION
Before this commit, hiding the camera preview in the call invitation would prompt the user for device permissions again. This is unnecessary since we are hiding the camera preview. This commit fixes the issue by aksing for device permissions only when showing the camera preview.
This commit also indirectly fixes the `discuss_call_invitation_tour` failing locally.

task-6095245