### PR TITLE
[FIX] pos_self_order: limit the number of loaded fields

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -314,7 +314,7 @@ class PosConfig(models.Model):
 
     @api.model
     def _load_pos_self_data_read(self, records, config):
-        read_records = super()._load_pos_data_read(records, config)
+        read_records = super()._load_pos_self_data_read(records, config)
         if not read_records:
             return read_records
         record = read_records[0]

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -14,6 +14,10 @@ class PosSession(models.Model):
         return data
 
     @api.model
+    def _load_pos_self_data_fields(self, config):
+        return ['id', 'user_id', 'config_id', 'payment_method_ids', 'state']
+
+    @api.model
     def _load_pos_self_data_domain(self, data, config):
         return [('config_id', '=', config.id), ('state', '=', 'opened')]
 

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -231,3 +231,28 @@ class TestSelfOrderController(SelfOrderCommonTest):
         self.assertIn(stva_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
         self.assertNotIn(lowe_categ.id, loaded_category_ids, "The category not linked to any printer should not be loaded")
         self.start_tour(self_route, "test_preparation_categories_are_loaded")
+
+    def test_config_session_loaded_fields(self):
+        self.pos_config.write({
+            'use_presets': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        data = self.make_request_to_controller('/pos-self/data/' + str(self.pos_config.id), {})
+
+        self.assertEqual(len(data['pos.config']), 1)
+        config_data = data['pos.config'][0]
+        self.assertEqual(config_data['id'], self.pos_config.id)
+        self.assertEqual(config_data['self_ordering_mode'], 'mobile')
+        self.assertTrue(len(config_data['_self_ordering_image_home_ids']) > 1)
+        self.assertFalse(config_data.get('access_token'))
+        self.assertFalse(config_data.get('self_ordering_url'))
+
+        self.assertEqual(len(data['pos.session']), 1)
+        session_data = data['pos.session'][0]
+        self.assertEqual(session_data['id'], self.pos_config.current_session_id.id)
+        self.assertEqual(session_data['state'], 'opened')
+        self.assertFalse(config_data.get('access_token'))


### PR DESCRIPTION
This commit optimizes pos_config and pos_session data loading by only loading the fields required for self-ordering.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
