### PR TITLE
[FIX] snailmail: Error when too many pages

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -317,6 +317,8 @@ class SnailmailLetter(models.Model):
             return _('One or more required fields are empty.')
         if error == 'FORMAT_ERROR':
             return _('The attachment of the letter could not be sent. Please check its content and contact the support if the problem persists.')
+        if error == 'TOO_MANY_PAGES':
+            return _('The document to be sent exceeds the maximum allowed limit of 8 pages.')
         else:
             return _('An unknown error happened. Please contact the support.')
         return error


### PR DESCRIPTION
When a user attempted to send a letter with snailmail that had more than 8 pages, sending would fail, and a generic error message is logged on the letter.

This commit makes the error message generated in that flow more specific to help users better understand the root cause of sending failure.

task-5883011
