### PR TITLE
[FIX] sale_stock: fix COGS overcalculation when same product appears on multiple SO lines

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -162,8 +162,9 @@ class AccountMoveLine(models.Model):
     def _get_cogs_qty(self):
         self.ensure_one()
         valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']
-        posted_cogs_qty = sum(self.sale_line_ids.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
-            lambda line: line.product_id == self.product_id and line.display_type == 'cogs' and line.account_id == valuation_account
+        sale_lines = self.sale_line_ids
+        posted_cogs_qty = sum(sale_lines.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
+            lambda line: line.display_type == 'cogs' and line.account_id == valuation_account and line.cogs_origin_id.sale_line_ids & sale_lines
         ).mapped('quantity'))
         posted_cogs_qty_prod_uom = self.product_uom_id._compute_quantity(posted_cogs_qty, self.product_id.uom_id)
         return posted_cogs_qty_prod_uom + super()._get_cogs_qty()
@@ -171,7 +172,8 @@ class AccountMoveLine(models.Model):
     def _get_posted_cogs_value(self):
         self.ensure_one()
         valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']
-        posted_cogs_value = - sum(self.sale_line_ids.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
-            lambda line: line.product_id == self.product_id and line.display_type == 'cogs' and line.account_id == valuation_account
+        sale_lines = self.sale_line_ids
+        posted_cogs_value = - sum(sale_lines.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
+            lambda line: line.display_type == 'cogs' and line.account_id == valuation_account and line.cogs_origin_id.sale_line_ids & sale_lines
         ).mapped('balance'))
         return posted_cogs_value + super()._get_posted_cogs_value()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -805,6 +805,61 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
         self.assertEqual(cogs_aml.debit, 56)
         self.assertEqual(cogs_aml.credit, 0)
 
+    def test_fifo_delivered_invoice_post_delivery_same_product_multi_lines(self):
+        """Each separately invoiced SO line should keep the FIFO cost of its own stock move,
+        even when another line on the same sale order uses the same product."""
+        self.product_fifo_auto.invoice_policy = 'delivery'
+
+        self._fifo_in_one_eight_one_ten()
+
+        sale_order = self.env['sale.order'].sudo().create({
+            'partner_id': self.owner.id,
+            'warehouse_id': self.warehouse.id,
+            'order_line': [
+                Command.create({
+                    'name': 'FIFO line 1',
+                    'product_id': self.product_fifo_auto.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 20,
+                }),
+                Command.create({
+                    'name': 'FIFO line 2',
+                    'product_id': self.product_fifo_auto.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 30,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+
+        first_line, second_line = sale_order.order_line.sorted('id')
+        first_delivery = sale_order.picking_ids
+        first_delivery.move_ids.filtered(lambda move: move.sale_line_id == second_line).quantity = 0
+        first_delivery.move_ids.picked = True
+        result = first_delivery.button_validate()
+        Form(self.env[result['res_model']].with_context(result['context'])).save().process()
+
+        invoice_1 = sale_order._create_invoices()
+        invoice_1.invoice_date = fields.Date.today()
+        invoice_1.action_post()
+        self.assertRecordValues(invoice_1.line_ids.filtered(lambda line: line.display_type == 'cogs'), [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0, 'credit': 8},
+            {'account_id': self.account_expense.id, 'debit': 8, 'credit': 0},
+        ])
+
+        second_delivery = sale_order.picking_ids.filtered(lambda picking: picking.state != 'done')
+        second_delivery.move_ids.filtered(lambda move: move.sale_line_id == first_line).quantity = 0
+        second_delivery.move_ids.picked = True
+        second_delivery.button_validate()
+
+        invoice_2 = sale_order._create_invoices()
+        invoice_2.invoice_date = fields.Date.today()
+        invoice_2.action_post()
+        self.assertRecordValues(invoice_2.line_ids.filtered(lambda line: line.display_type == 'cogs'), [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0, 'credit': 10},
+            {'account_id': self.account_expense.id, 'debit': 10, 'credit': 0},
+        ])
+
     def test_fifo_delivered_invoice_post_delivery_4(self):
         """Receive 8@10. Sale order 10@12. Deliver and also invoice it without receiving the 2 missing.
         Now, receive 2@12. Make sure price difference is correctly reflected in expense account at


### PR DESCRIPTION
### Issue:
When a Sale Order has multiple lines for the same FIFO-costed product and each line is invoiced separately, the COGS posted on the second (and any subsequent) invoice is incorrectly inflated, causing the sale to appear less profitable or even at a loss in the accounting records.

### Steps to reproduce:
1. Set a product as storable with FIFO costing and real-time valuation.
2. Create a Sale Order with two lines for the same product at different prices.
3. Confirm the SO and validate the two deliveries (each consumes a different FIFO layer).
4. Invoice the first SO line and post the invoice.
5. Invoice the second SO line and post the invoice.
6. Observe that the COGS on the second invoice is higher than the actual cost of the stock move linked to that line.

### Root Cause:
_get_cogs_qty() and _get_posted_cogs_value() in sale_stock filtered already-posted COGS lines by product_id. This caused them to aggregate quantities and values across ALL SO lines sharing the same product. However, _get_cogs_price_unit() derives the unit cost only from the current line's stock move. The mismatch results in:
  (unit_cost_of_line_2 * total_qty_of_both_lines) - cogs_already_posted

### Fix:
Replace the product_id filter with a sale-line-scoped filter using cogs_origin_id. By checking cogs_origin_id.sale_line_ids & sale_lines, only COGS originating from the same SO line(s) as the current invoice line are considered, correctly isolating each line's COGS from the others.

opw-6004810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
