### PR TITLE
[FIX] account: include next installment(s) only in group payments

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -2142,3 +2142,40 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
             {'amount_currency': 300, 'date_maturity': fields.Date.from_string('2017-01-06')},
             {'amount_currency': 600, 'date_maturity': fields.Date.from_string('2017-01-11')},
         ])
+
+    def test_group_payment_multi_partner_with_installments(self):
+        """
+        When "Group Payments" is selected and vendor bills from different partners are selected,
+        and at least one bill has multiple installments, only the next installment should be
+        included, not all installments of that bill.
+        """
+        in_invoice_with_installments = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_date': '2026-01-01',
+            'invoice_payment_term_id': self.term_0_5_10_days.id,
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 1000.0,
+                'tax_ids': [],
+            })],
+        })
+        in_invoice_with_installments.action_post()
+
+        wizard = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=(self.in_invoice_1 + in_invoice_with_installments + self.in_invoice_3).ids,
+        ).create({
+            'group_payment': True,
+            'payment_date': '2026-01-01',
+        })
+
+        payments = wizard._create_payments()
+
+        self.assertEqual(len(payments), 2)
+
+        payment_a = payments.filtered(lambda p: p.partner_id == self.partner_a)
+        payment_b = payments.filtered(lambda p: p.partner_id == self.partner_b)
+
+        self.assertRecordValues(payment_a, [{'amount': 1100.0, 'partner_id': self.partner_a.id}])
+        self.assertRecordValues(payment_b, [{'amount': 3000.0, 'partner_id': self.partner_b.id}])

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1247,9 +1247,9 @@ class AccountPaymentRegister(models.TransientModel):
 
             to_process.append(to_process_values)
         else:
+            lines_to_pay = self._get_total_amounts_to_pay(batches)['lines'] if self.installments_mode in ('next', 'overdue', 'before_date') else self.line_ids
             if not self.group_payment:
                 # Don't group payments: Create one batch per move.
-                lines_to_pay = self._get_total_amounts_to_pay(batches)['lines'] if self.installments_mode in ('next', 'overdue', 'before_date') else self.line_ids
                 new_batches = []
                 for batch_result in batches:
                     for line in batch_result['lines']:
@@ -1266,6 +1266,7 @@ class AccountPaymentRegister(models.TransientModel):
                 batches = new_batches
 
             for batch_result in batches:
+                batch_result['lines'] = batch_result['lines'] & lines_to_pay
                 to_process.append({
                     'create_vals': self._create_payment_vals_from_batch(batch_result),
                     'to_reconcile': batch_result['lines'],


### PR DESCRIPTION
Steps to reproduce:
1- Install Accounting and make sure "Batch Payments" is enabled in settings
2- Go to [Accounting -> Vendors -> Bills]
3- Create two bills for the same vendor, ensuring one of them has multiple installments (i.e payment term with 3 installments)
4- Confirm the bills
5- In list view, select both bills and another bill from a different vendor and click on Pay
6- Select "Group Payments" and confirm the payment

Description of issue:
The batch payment of the first vendor has the full amount for both bills

Expected behavior:
The payment should consider the full amount of the first bill and the first installment only of the second bill

opw-5969972