### PR TITLE
[FIX] stock: Prevent traceback when printing product labels via IoT

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -2065,7 +2065,9 @@ class StockPicking(models.Model):
         pickings_by_print_formats = pickings_print_product_label.grouped(lambda p: p.picking_type_id.product_label_format)
         for print_format in pickings_print_product_label.picking_type_id.mapped("product_label_format"):
             pickings = pickings_by_print_formats.get(print_format)
-            wizard = self.env['product.label.layout'].create({
+            wizard = self.env['product.label.layout'].with_context(
+                active_ids=pickings.ids
+            ).create({
                 'product_ids': pickings.move_ids.product_id.ids,
                 'move_ids': pickings.move_ids.ids,
                 'move_quantity': 'move',


### PR DESCRIPTION
#### **Description**

This PR fixes a traceback that occurs when printing product labels from a stock picking using an IoT device.

#### **Precondition**

* Set up an IoT printer to enable product label printing

#### **Steps to Reproduce**

1. Go to **Inventory → Transfers → Receipts**
2. Create a new receipt
3. Add the required product details
4. Click on **Validate**
5. Attempt to print product labels via the configured IoT printer
6. The operation crashes with a traceback

#### **Root Cause**

The `product.label.layout` wizard was instantiated without including `active_ids` in its context.

However, the IoT report handler (`iot_report_action.js`) expects `active_ids` to be present and executes:

```javascript id="n31m7z"
action.context.active_ids.filter((e) => typeof e === "number")
```

When `active_ids` is missing, it results in:

```id="f3k8p2"
TypeError: Cannot read properties of undefined (reading 'filter')
```

#### **Behavior Before Fix**

* Printing product labels via IoT fails
* JavaScript error due to missing `active_ids` in context

#### **Behavior After Fix**

* `active_ids` is properly passed (picking IDs) to the wizard context
* IoT report action correctly filters and processes the IDs
* Product label printing works as expected without errors

opw-6024490

#### Video
▶️ **Reproduction video:**  
[Click here to watch](https://drive.google.com/file/d/1wIBRPllXHV68NfAuEerxLmO_8o19QRJq/view?usp=sharing)