### PR TITLE
[FIX] hr_holidays: fix left/taken balance report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -51,8 +51,8 @@ class LeaveReport(models.Model):
                     WHERE l.state IN ('validate', 'validate1')
                 ),
 
-                /* FIFO-ordered validated allocations */
-                ordered_allocations as (
+                /* Base allocations with overlap group detection */
+                base_allocations as (
                     SELECT
 						allocation.id as allocation_id,
 						allocation.employee_id as employee_id,
@@ -65,23 +65,61 @@ class LeaveReport(models.Model):
 						allocation.date_from as date_from,
 						allocation.date_to as date_to,
 						allocation.employee_company_id as company_id,
-						ROW_NUMBER() OVER (
-							PARTITION BY allocation.employee_id, allocation.holiday_status_id
-							ORDER BY allocation.date_from, allocation.id
-						) as fifo_rank,
-						SUM(allocation.number_of_days) OVER (
-							PARTITION BY allocation.employee_id, allocation.holiday_status_id
-							ORDER BY allocation.date_from, allocation.id
-							ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-						) as cumulative_allocated_days,
-						SUM(allocation.number_of_hours_display) OVER (
-							PARTITION BY allocation.employee_id, allocation.holiday_status_id
-							ORDER BY allocation.date_from, allocation.id
-							ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-						) as cumulative_allocated_hours
+						CASE
+							WHEN allocation.date_from > MAX(COALESCE(allocation.date_to, 'infinity'::date)) OVER (
+								PARTITION BY allocation.employee_id, allocation.holiday_status_id
+								ORDER BY allocation.date_from, allocation.id
+								ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+							)
+							THEN 1
+							ELSE 0
+						END as is_new_group
                     FROM hr_leave_allocation allocation
                     JOIN hr_employee employee ON (allocation.employee_id = employee.id)
                     WHERE allocation.state = 'validate'
+                ),
+
+                /* Assign overlap group ids */
+                grouped_allocations as (
+                    SELECT
+						ba.*,
+						SUM(ba.is_new_group) OVER (
+							PARTITION BY ba.employee_id, ba.leave_type
+							ORDER BY ba.date_from, ba.allocation_id
+							ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+						) as overlap_group
+                    FROM base_allocations ba
+                ),
+
+                /* FIFO-ordered allocations with cumulative sums within each overlap group */
+                ordered_allocations as (
+                    SELECT
+						ga.allocation_id as allocation_id,
+						ga.employee_id as employee_id,
+						ga.active_employee as active_employee,
+						ga.number_of_days as number_of_days,
+						ga.number_of_hours as number_of_hours,
+						ga.department_id as department_id,
+						ga.leave_type as leave_type,
+						ga.state as state,
+						ga.date_from as date_from,
+						ga.date_to as date_to,
+						ga.company_id as company_id,
+						ROW_NUMBER() OVER (
+							PARTITION BY ga.employee_id, ga.leave_type, ga.overlap_group
+							ORDER BY ga.date_from, ga.allocation_id
+						) as fifo_rank,
+						SUM(ga.number_of_days) OVER (
+							PARTITION BY ga.employee_id, ga.leave_type, ga.overlap_group
+							ORDER BY ga.date_from, ga.allocation_id
+							ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+						) as cumulative_allocated_days,
+						SUM(ga.number_of_hours) OVER (
+							PARTITION BY ga.employee_id, ga.leave_type, ga.overlap_group
+							ORDER BY ga.date_from, ga.allocation_id
+							ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+						) as cumulative_allocated_hours
+                    FROM grouped_allocations ga
                 ),
 
                 /* Leaves applicable to each allocation */
@@ -149,8 +187,8 @@ class LeaveReport(models.Model):
 						fb.department_id as department_id,
 						fb.leave_type as leave_type,
 						fb.state as state,
-						fb.date_from as date_from,
-						fb.date_to as date_to,
+						fb.date_from::timestamp + interval '12 hours' as date_from,
+						fb.date_to::timestamp + interval '12 hours' as date_to,
 						'left' as holiday_status,
 						fb.company_id as company_id
                     FROM fifo_balances fb


### PR DESCRIPTION
__ISSUE__:
- FIFO balance miscalculation for non-overlapping allocations. cumulative_allocated_days was partitioned globally by (employee, leave_type), but taken_per_allocation scoped leaves to each allocation's date range. This caused the FIFO formula to silently absorb leaves from one period into another's allocation capacity.

ex:
    Alloc A (20 days) 2025, taken leaves 15 days
    Alloc B (20 days) 2026, taken leaves 5 days

    report: 2025: (15 taken), (5 left)
            2026: (7 taken), (20 left)

- Left" rows shifted by one year in non-UTC timezones. Allocation date_from/date_to (Date fields) were cast to timestamp as midnight UTC. In negative-UTC /positive-UTC timezones midnight UTC of Dec 31 renders as the prev/next day.

__FIX__:
- detect overlap groups using a running MAX(date_to) and partition the cumulative sums within each overlap group. This way non-overlapping allocations are treated as independent, while overlapping or open-ended allocations still share FIFO within their group.

- offset allocation dates by 12 hours so no timezone can shift them across a day boundary.

- opw-5169606
- opw-5352114
