### PR TITLE
[FIX] mail: add `direction` to whitelisted css style

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -85,7 +85,7 @@ class _Cleaner(clean.Cleaner):
     _style_whitelist = [
         'font-size', 'font-family', 'font-weight', 'font-style', 'background-color', 'color', 'text-align',
         'line-height', 'letter-spacing', 'text-transform', 'text-decoration', 'text-decoration', 'opacity',
-        'float', 'vertical-align', 'display', 'object-fit',
+        'float', 'vertical-align', 'display', 'object-fit', 'direction',
         'padding', 'padding-top', 'padding-left', 'padding-bottom', 'padding-right',
         'margin', 'margin-top', 'margin-left', 'margin-bottom', 'margin-right',
         'white-space',


### PR DESCRIPTION
**Steps to reproduce:**
- Install Mail Marketing app
- Change user language to a RTL language (such as Arabic)
- Create a marketing campaign with RTL content
- Send it (with the campaign, test mail works properly)
- Mail received changes from RTL to LTR

**Issue:**
Table `direction` style is removed by the `_Cleaner` as it is not in its `_style_whitelist` during the composer creation.

**Fix:**
Add it to the valid styling to ensure rtl mails are properly formatted by the rtlcss library.

related fix: https://github.com/odoo/odoo/commit/4ac3766fa5b458864c1728441cf4a157df943d39
sanitize on `mail.composer.mixin`: https://github.com/odoo/odoo/commit/24731938f75358fd3c72b91465b72ab80d62d208

opw-5982854