### PR TITLE
[FIX] im_livechat: fix chatbot restart on feedback panel

### DIFF
--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -139,7 +139,7 @@ export class Chatbot extends Record {
     }
 
     get canRestart() {
-        return this.completed && !this.currentStep?.operatorFound;
+        return this.currentStep?.isLast && !this.currentStep.operatorFound;
     }
 
     /**

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -1,3 +1,4 @@
+import { CW_LIVECHAT_STEP } from "@im_livechat/core/common/chat_window_model_patch";
 import { registerThreadAction, threadActionsRegistry } from "@mail/core/common/thread_actions";
 import "@mail/discuss/call/common/thread_actions";
 
@@ -10,6 +11,7 @@ registerThreadAction("restart", {
     icon: "fa fa-fw fa-refresh",
     name: _t("Restart Conversation"),
     open: ({ owner, thread }) => {
+        owner.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.NONE;
         thread.chatbot.restart();
         owner.props.chatWindow.open({ focus: true });
     },

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_restart.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_restart.js
@@ -1,0 +1,72 @@
+import { registry } from "@web/core/registry";
+
+const stepsUntilLastMessage = [
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Enter your email address)",
+    },
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+        run: "edit test@example.com",
+    },
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+        run: "press Enter",
+    },
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains(Do you want to restart the conversation?)",
+    },
+];
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_restart_on_feedback_tour", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        ...stepsUntilLastMessage,
+        // restart in chat window
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Yes, restart please.)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        ...stepsUntilLastMessage,
+        // restart in feedback
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Yes, restart please.)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Continue)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow div:contains(Did we correctly answer your question?)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        ...stepsUntilLastMessage,
+        // restart not displayed as chatbot did not finish
+        {
+            trigger: ".o-livechat-root:shadow button[title='Close Chat Window (ESC)']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Yes, leave conversation)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow div:contains(Did we correctly answer your question?)",
+        },
+        {
+            trigger:
+                '.o-livechat-root:shadow .o-mail-ChatWindow-header:not(:has(button[title="Restart Conversation"]))',
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -372,6 +372,29 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
         self.assertIn("test@example.com", user_answer_message.user_raw_answer, "Email was saved on last step")
         self.assertTrue(user_answer_message.discuss_channel_id.livechat_end_dt, "Livechat ended after last step")
 
+    def test_chatbot_restart_on_feedback(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Restart on feedback Bot"})
+        _, restart_step = self.env["chatbot.script.step"].create([
+            {
+                "step_type": "question_email",
+                "chatbot_script_id": chatbot_script.id,
+                "message": "Enter your email address",
+            },
+            {
+                "step_type": "question_selection",
+                "chatbot_script_id": chatbot_script.id,
+                "message": "Do you want to restart the conversation?",
+            },
+        ])
+        self.env["chatbot.script.answer"].create({
+            "name": "Yes, restart please.",
+            "script_step_id": restart_step.id,
+        })
+        self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create(
+            {"chatbot_script_id": chatbot_script.id}
+        )
+        self.start_tour("/", "website_livechat.chatbot_restart_on_feedback_tour")
+
 
 @tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotUIMoblie(TestLivechatChatbotUICommon):


### PR DESCRIPTION
Before this commit, it was possible to restart the chatbot on the
feedback panel when closing the chat window. This was actually failing
when the chatbot was stopped before the last step was completed and left
the livechat state in error.

Now, the button is simply disabled on feedback when we did not reach the
end of the chatbot to avoid any issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
