### PR TITLE
[IMP] account{_debit_note}: Smart buttons for credit notes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -638,6 +638,7 @@ class AccountMove(models.Model):
         check_company=True,
     )
     reversal_move_ids = fields.One2many('account.move', 'reversed_entry_id')
+    reversal_move_count = fields.Integer(compute='_compute_reversal_move_count')
 
     # === Vendor bill fields === #
     invoice_vendor_bill_id = fields.Many2one(
@@ -1445,6 +1446,11 @@ class AccountMove(models.Model):
                 len(move.suitable_journal_ids) > 1
                 or move.journal_id and move.journal_id not in move.suitable_journal_ids
             )
+
+    @api.depends('reversal_move_ids')
+    def _compute_reversal_move_count(self):
+        for move in self:
+            move.reversal_move_count = len(move.reversal_move_ids)
 
     def _compute_payments_widget_to_reconcile_info(self):
 
@@ -3837,7 +3843,7 @@ class AccountMove(models.Model):
         :param default: The default values dict passed to copy method
         :return: The message content string
         """
-        return _('This entry has been reversed from %s', self._get_html_link()) if default.get('reversed_entry_id') else _('This entry has been duplicated from %s', self._get_html_link())
+        return _('This entry has been duplicated from %s', self._get_html_link())
 
     def _get_review_state_access_groups(self):
         """Return a tuple (is_user_able_to_review, is_user_able_to_supervise) for the current user."""
@@ -6252,6 +6258,16 @@ class AccountMove(models.Model):
             'views': [(False, 'list')],
             'domain': [('move_id', '=', self.id), ('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))],
         }
+
+    def action_open_reversal_moves(self):
+        return self.reversal_move_ids._get_records_action(
+            name=self.env._("Credit Notes") if self.is_sale_document(include_receipts=True) else self.env._("Refunds"),
+        )
+
+    def action_open_reversed_entry(self):
+        return self.reversed_entry_id._get_records_action(
+            name=self.env._("Invoices") if self.is_purchase_document(include_receipts=True) else self.env._("Vendor Bills"),
+        )
 
     def action_switch_move_type(self):
         if any(move.move_type == "entry" for move in self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -633,6 +633,7 @@ class AccountMove(models.Model):
         check_company=True,
     )
     reversal_move_ids = fields.One2many('account.move', 'reversed_entry_id')
+    reversal_move_count = fields.Integer(compute='_compute_reversal_move_count')
 
     # === Vendor bill fields === #
     invoice_source_email = fields.Char(string='Source Email', tracking=True)
@@ -1429,6 +1430,11 @@ class AccountMove(models.Model):
     def _compute_show_journal(self):
         for move in self:
             move.show_journal = len(move.suitable_journal_ids) > 1
+
+    @api.depends('reversal_move_ids')
+    def _compute_reversal_move_count(self):
+        for move in self:
+            move.reversal_move_count = len(move.reversal_move_ids)
 
     def _compute_payments_widget_to_reconcile_info(self):
 
@@ -3802,7 +3808,7 @@ class AccountMove(models.Model):
         :param default: The default values dict passed to copy method
         :return: The message content string
         """
-        return _('This entry has been reversed from %s', self._get_html_link()) if default.get('reversed_entry_id') else _('This entry has been duplicated from %s', self._get_html_link())
+        return _('This entry has been duplicated from %s', self._get_html_link())
 
     def _check_user_access(self, vals_list):
         if self.env.su:
@@ -6092,6 +6098,16 @@ class AccountMove(models.Model):
         self.ensure_one()
         label = self.adjusting_entry_origin_label if len(self.adjusting_entries_move_ids) == 1 else 'Invoices'
         return self.adjusting_entry_origin_move_ids._get_records_action(name=label)
+
+    def action_open_reversal_moves(self):
+        return self.reversal_move_ids._get_records_action(
+            name=self.env._("Credit Notes") if self.is_sale_document(include_receipts=True) else self.env._("Refunds"),
+        )
+
+    def action_open_reversed_entry(self):
+        return self.reversed_entry_id._get_records_action(
+            name=self.env._("Invoices") if self.is_purchase_document(include_receipts=True) else self.env._("Vendor Bills"),
+        )
 
     def action_switch_move_type(self):
         if any((move.posted_before and move.name) for move in self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -995,6 +995,22 @@
                                         <span class="o_stat_text">Journal Items</span>
                                     </div>
                             </button>
+                            <button name="action_open_reversal_moves"
+                                    class="oe_stat_button"
+                                    icon="fa-pencil-square-o"
+                                    type="object"
+                                    invisible="reversal_move_count == 0">
+                                <field name="reversal_move_count" string="Credit Notes" widget="statinfo" invisible="move_type != 'out_invoice'"/>
+                                <field name="reversal_move_count" string="Refunds" widget="statinfo" invisible="move_type != 'in_invoice'"/>
+                            </button>
+                            <button name="action_open_reversed_entry"
+                                    class="oe_stat_button"
+                                    icon="fa-pencil-square-o"
+                                    type="object"
+                                    invisible="not reversed_entry_id">
+                                <span class="o_stat_text" invisible="move_type != 'out_refund'">Invoice</span>
+                                <span class="o_stat_text" invisible="move_type != 'in_refund'">Vendor Bill</span>
+                            </button>
                         </div>
 
                         <widget name="web_ribbon" title="Sent"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -961,6 +961,22 @@
                                            invisible="adjusting_entry_origin_moves_count == 1"
                                            string="Invoices" widget="statinfo"/>
                             </button>
+                            <button name="action_open_reversal_moves"
+                                    class="oe_stat_button"
+                                    icon="fa-pencil-square-o"
+                                    type="object"
+                                    invisible="reversal_move_count == 0">
+                                <field name="reversal_move_count" string="Credit Notes" widget="statinfo" invisible="move_type != 'out_invoice'"/>
+                                <field name="reversal_move_count" string="Refunds" widget="statinfo" invisible="move_type != 'in_invoice'"/>
+                            </button>
+                            <button name="action_open_reversed_entry"
+                                    class="oe_stat_button"
+                                    icon="fa-pencil-square-o"
+                                    type="object"
+                                    invisible="not reversed_entry_id">
+                                <span class="o_stat_text" invisible="move_type != 'out_refund'">Invoice</span>
+                                <span class="o_stat_text" invisible="move_type != 'in_refund'">Vendor Bill</span>
+                            </button>
                         </div>
 
                         <widget name="web_ribbon" title="Sent"

--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, api, _
+from odoo import models, fields, api
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
     debit_origin_id = fields.Many2one('account.move', 'Original Invoice Debited', readonly=True, copy=False, index='btree_not_null')
+    debit_origin_move_type = fields.Selection(related='debit_origin_id.move_type', string="Debit Origin Move Type")  # String defined to avoid runbot error about same string on different fields.
     debit_note_ids = fields.One2many('account.move', 'debit_origin_id', 'Debit Notes',
                                      help="The debit notes created for this invoice")
     debit_note_count = fields.Integer('Number of Debit Notes', compute='_compute_debit_count')
@@ -21,14 +22,14 @@ class AccountMove(models.Model):
             inv.debit_note_count = data_map.get(inv.id, 0.0)
 
     def action_view_debit_notes(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _('Debit Notes'),
-            'res_model': 'account.move',
-            'view_mode': 'list,form',
-            'domain': [('debit_origin_id', '=', self.id)],
-        }
+        return self.debit_note_ids._get_records_action(
+            name=self.env._("Debit Notes"),
+        )
+
+    def action_open_debit_note_origin_entry(self):
+        return self.debit_origin_id._get_records_action(
+            name=self.env._("Invoices") if self.is_sale_document(include_receipts=True) else self.env._("Vendor Bills"),
+        )
 
     def action_debit_note(self):
         action = self.env.ref('account_debit_note.action_view_account_move_debit')._get_action_dict()
@@ -49,9 +50,3 @@ class AccountMove(models.Model):
         ):
             starting_sequence = "D" + starting_sequence
         return starting_sequence
-
-    def _get_copy_message_content(self, default):
-        """Override to handle debit note specific messages."""
-        if default and default.get('debit_origin_id'):
-            return _('This debit note was created from: %s', self._get_html_link())
-        return super()._get_copy_message_content(default)

--- a/addons/account_debit_note/views/account_move_view.xml
+++ b/addons/account_debit_note/views/account_move_view.xml
@@ -6,10 +6,20 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <div class="oe_button_box" position="inside">
-                <button type="object" class="oe_stat_button" name="action_view_debit_notes" icon="fa-plus" invisible="debit_note_count == 0">
+                <button type="object" class="oe_stat_button" name="action_view_debit_notes" icon="fa-pencil-square-o" invisible="debit_note_count == 0">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="debit_note_count"/></span>
                         <span class="o_stat_text">Debit Notes</span>
+                    </div>
+                </button>
+                <button type="object"
+                        class="oe_stat_button"
+                        name="action_open_debit_note_origin_entry"
+                        icon="fa-pencil-square-o"
+                        invisible="not debit_origin_id">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text" invisible="debit_origin_move_type != 'out_invoice'">Invoice</span>
+                        <span class="o_stat_text" invisible="debit_origin_move_type != 'in_invoice'">Vendor Bill</span>
                     </div>
                 </button>
             </div>


### PR DESCRIPTION
The aim of this commit is to add new smart buttons in the invoices / credit notes / debit notes views. These smart buttons allow the user to be redirected to the according related object.
Before this commit, only a Debit Notes button was
displayed when an invoice got one. Now, we are showing a button for the credit notes as well. We also
displayed this button on the reversed move and debit note to the original invoice.
This commit also improves the existing code for
action_view_debit_notes by using _get_records_action and setting the method to multi instead of single record.

task-6101596


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
