### PR TITLE
[IMP] spreadsheet: set global filter with pivot `None` header

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
@@ -190,9 +190,8 @@ export class PivotCoreViewGlobalFilterPlugin extends OdooCoreViewPlugin {
                         }
                         // A group by value of "none"
                         if (value === false) {
-                            break;
-                        }
-                        if (JSON.stringify(currentValue?.ids) !== `[${value}]`) {
+                            transformedValue = { operator: "not set" };
+                        } else if (JSON.stringify(currentValue?.ids) !== `[${value}]`) {
                             transformedValue = { operator: "in", ids: [value] };
                         }
                         break;

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -2330,7 +2330,9 @@ test("getFiltersMatchingPivot return correctly matching filter according to cell
         model,
         '=PIVOT.HEADER(1,"#product_id",1)'
     );
-    expect(relationalFiltersWithNoneValue).toEqual([{ filterId: "42", value: undefined }]);
+    expect(relationalFiltersWithNoneValue).toEqual([
+        { filterId: "42", value: { operator: "not set" } },
+    ]);
     const dateFilters1 = getFiltersMatchingPivot(model, '=PIVOT.HEADER(1,"date:month","08/2016")');
     expect(dateFilters1).toEqual([
         { filterId: "43", value: { type: "month", year: 2016, month: 8 } },


### PR DESCRIPTION
When clicking on a pivot header with the value `None` in dashboard, it would do nothing instead of setting the corresponding global filter to `not set`.

Task: [4634195](https://www.odoo.com/web#id=4634195&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
