### PR TITLE
[FIX] point_of_sale: set default preset on order creation

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -572,8 +572,8 @@ class PosOrder(models.Model):
         values.setdefault('pricelist_id', session.config_id.pricelist_id.id)
         values.setdefault('fiscal_position_id', session.config_id.default_fiscal_position_id.id)
         values.setdefault('company_id', session.config_id.company_id.id)
-        if session.config_id.use_presets and session.config_id.default_preset_id:
-            values.setdefault('preset_id', session.config_id.default_preset_id.id)
+        if session.config_id.use_presets and session.config_id.default_preset_id and not values.get('preset_id'):
+            values['preset_id'] = session.config_id.default_preset_id.id
 
         if not values.get('pos_reference'):
             reference, tracking_number = session.config_id._get_next_order_refs()


### PR DESCRIPTION
When creating a new order, the default preset of the session should be set on the order if the session is configured to use presets and has a default preset.

opw-5919795

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
