### PR TITLE
[FIX] account_edi_ubl_cii: Hide the Export XML option in the Form view

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -77,13 +77,17 @@ class AccountMove(models.Model):
     def get_extra_print_items(self):
         print_items = super().get_extra_print_items()
         posted_moves = self.filtered(lambda move: move.state == 'posted')
-        edi_formats = {
-            edi_format
+        can_export_xml = any(
+            (
+                move.ubl_cii_xml_id
+                or (
+                    (edi_format := move.commercial_partner_id.with_company(move.company_id)._get_ubl_cii_edi_format())
+                    and self._need_ubl_cii_xml(edi_format)
+                )
+            )
             for move in posted_moves
-            if (edi_format := move.commercial_partner_id.with_company(move.company_id)
-                    ._get_ubl_cii_edi_format())
-        }
-        if posted_moves.ubl_cii_xml_id or edi_formats:
+        )
+        if can_export_xml:
             print_items.append({
                 'key': 'download_ubl',
                 'description': _('Export XML'),


### PR DESCRIPTION
Problem
---------
Since the UBL export refactor, it was not possible to export the XML of non-imported bills and not self-bills. The Export XML option had been removed from the list view in odoo/odoo#255289.

The Form view was omitted.

Solution
---------
Show the button "Export XML" only if the move can actually be exported.

opw-6083344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
