### PR TITLE
[REF] web: removes 'Invalid Datetime' from predefined filters

### DIFF
--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -230,7 +230,7 @@
                     domain="[('my_activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
-                <filter string="Last 30 days" name="filter_last_month_creation" domain="[('create_date','&gt;', 'today -30d')]"/>
+                <filter string="Last 30 days" name="filter_last_month_creation" domain="[('create_date', '&gt;=', 'today -30d'), ('create_date', '&lt;', 'today')]"/>
                 <separator/>
                 <filter string="Archived" name="filter_inactive" domain="[('active', '=', False)]"/>
                 <group>

--- a/addons/im_livechat/tests/test_session_views.py
+++ b/addons/im_livechat/tests/test_session_views.py
@@ -1,9 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests import new_test_user
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+from odoo.addons.mail.tests.common import freeze_all_time
 from odoo.tests.common import users
+
+from datetime import timedelta
 
 
 class TestImLivechatSessionViews(TestImLivechatCommon):
@@ -13,16 +16,18 @@ class TestImLivechatSessionViews(TestImLivechatCommon):
             login="operator",
             groups="base.group_user,im_livechat.im_livechat_group_manager",
         )
-        self.env["mail.presence"]._update_presence(operator)
         self.livechat_channel.user_ids |= operator
         self.authenticate(None, None)
-        data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            "channel_id": self.livechat_channel.id,
-            "previous_operator_id": operator.partner_id.id
-        })
-        channel = self.env["discuss.channel"].browse(data["channel_id"])
-        channel.with_user(operator).message_post(body="Hello, how can I help you?")
-        self._reset_bus()
+        # Freeze time to get around the last 30 days default filter hidding messages in tours
+        with freeze_all_time(fields.Datetime.now() - timedelta(days=15)):
+            self.env["mail.presence"]._update_presence(operator)
+            data = self.make_jsonrpc_request("/im_livechat/get_session", {
+                "channel_id": self.livechat_channel.id,
+                "previous_operator_id": operator.partner_id.id
+            })
+            channel = self.env["discuss.channel"].browse(data["channel_id"])
+            channel.with_user(operator).message_post(body="Hello, how can I help you?")
+            self._reset_bus()
         action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
         self.start_tour(
             f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}",
@@ -38,28 +43,30 @@ class TestImLivechatSessionViews(TestImLivechatCommon):
             groups="base.group_user,im_livechat.im_livechat_group_manager",
         )
         [user_1, user_2] = self.env["res.partner"].create([{"name": "test 1"}, {"name": "test 2"}])
-        [channel1, channel2] = self.env["discuss.channel"].create(
-            [
-                {
-                    "name": "test 1",
-                    "channel_type": "livechat",
-                    "livechat_channel_id": self.livechat_channel.id,
-                    "channel_member_ids": [Command.create({"partner_id": user_1.id})],
-                },
-                {
-                    "name": "test 2",
-                    "channel_type": "livechat",
-                    "livechat_channel_id": self.livechat_channel.id,
-                    "channel_member_ids": [Command.create({"partner_id": user_2.id})],
-                },
-            ]
-        )
-        channel1.message_post(
-            body="Test Channel 1 Msg", message_type="comment", subtype_xmlid="mail.mt_comment"
-        )
-        channel2.message_post(
-            body="Test Channel 2 Msg", message_type="comment", subtype_xmlid="mail.mt_comment"
-        )
+        # Freeze time to get around the last 30 days default filter hidding messages in tours
+        with freeze_all_time(fields.Datetime.now() - timedelta(days=15)):
+            [channel1, channel2] = self.env["discuss.channel"].create(
+                [
+                    {
+                        "name": "test 1",
+                        "channel_type": "livechat",
+                        "livechat_channel_id": self.livechat_channel.id,
+                        "channel_member_ids": [Command.create({"partner_id": user_1.id})],
+                    },
+                    {
+                        "name": "test 2",
+                        "channel_type": "livechat",
+                        "livechat_channel_id": self.livechat_channel.id,
+                        "channel_member_ids": [Command.create({"partner_id": user_2.id})],
+                    },
+                ]
+            )
+            channel1.message_post(
+                body="Test Channel 1 Msg", message_type="comment", subtype_xmlid="mail.mt_comment"
+            )
+            channel2.message_post(
+                body="Test Channel 2 Msg", message_type="comment", subtype_xmlid="mail.mt_comment"
+            )
         action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
         self.start_tour(
             f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}",

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -22,10 +22,10 @@
                         <filter name="fiter_session_rating_unhappy" domain="[('livechat_rating', '=', '1') ]" string="Unhappy"/>
                     </filter>
                     <filter name="filter_session_date" date="create_date" string="Session Date">
-                        <filter name="rated_on_last_24_hours" string="Last 24 Hours" domain="[('create_date', '&gt;', '-1d')]"/>
-                        <filter name="rated_on_last_7_days" string="Last 7 Days" domain="[('create_date', '&gt;', 'today -7d +1d')]"/>
-                        <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('create_date', '&gt;', 'today -30d +1d')]"/>
-                        <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;', 'today -365d +1d')]"/>
+                        <filter name="rated_on_last_24_hours" string="Last 24 Hours" domain="[('create_date', '&gt;=', 'now -24H'), ('create_date', '&lt;=', 'now')]"/>
+                        <filter name="rated_on_last_7_days" string="Last 7 Days" domain="[('create_date', '&gt;=', 'today -7d'), ('create_date', '&lt;', 'today')]"/>
+                        <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('create_date', '&gt;=', 'today -30d'), ('create_date', '&lt;', 'today')]"/>
+                        <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;=', 'today -365d'), ('create_date', '&lt;', 'today')]"/>
                     </filter>
                     <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -24,8 +24,8 @@
                     <filter string="Closed" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
                     <filter string="Closed On" name="closed_on" domain="[('is_closed', '=', True)]" date="date_last_stage_update"
                         invisible="context.get('template_project')">
-                        <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d +1d')]"/>
-                        <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
+                        <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d'), ('date_last_stage_update', '&lt;', 'today')]"/>
+                        <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d'), ('date_last_stage_update', '&lt;', 'today')]"/>
                     </filter>
                     <separator/>
                     <filter string="Templates" context="{'render_task_templates': True}" name="templates" domain="[('has_template_ancestor', '=', True)]"/>

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -196,9 +196,9 @@
                     <filter string="Unhappy" name="rating_unhappy" domain="[('rating_text', '=', 'ko')]"/>
                     <separator/>
                     <filter name="filter_rated_on" string="Rated On" date="rated_on">
-                        <filter name="rated_on_last_7_days" string="Last 7 Days" domain="[('rated_on', '&gt;', 'today -7d +1d')]"/>
-                        <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('rated_on', '&gt;', 'today -30d +1d')]"/>
-                        <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('rated_on', '&gt;', 'today -365d +1d')]"/>
+                        <filter name="rated_on_last_7_days" string="Last 7 Days" domain="[('rated_on', '&gt;=', 'today -7d'), ('rated_on', '&lt;', 'today')]"/>
+                        <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('rated_on', '&gt;=', 'today -30d'), ('rated_on', '&lt;', 'today')]"/>
+                        <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('rated_on', '&gt;=', 'today -365d'), ('rated_on', '&lt;', 'today')]"/>
                     </filter>
                     <group>
                         <filter string="Rated Operator" name="responsible" context="{'group_by':'rated_partner_id'}"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -148,7 +148,7 @@
                 <filter string="Scrapped" name="scrapped" domain="[('is_scrap', '=', True)]"/>
                 <separator/>
                 <filter name="date" date="date" default_period="month"/>
-                <filter string="Last 30 Days" name="filter_last_30_days" domain="[('date','&gt;=', 'today -30d')]"/>
+                <filter string="Last 30 Days" name="filter_last_30_days" domain="[('date', '&gt;=', 'today -30d'), ('date', '&lt;', 'today')]"/>
                 <filter string="Last 3 Months" name="filter_last_3_months" domain="[('date','&gt;=', 'today -3m')]"/>
                 <filter string="Last 12 Months" name="filter_last_12_months" domain="[('date','&gt;=', 'today -12m')]"/>
                 <separator/>

--- a/addons/test_discuss_full/tests/test_livechat_session_open.py
+++ b/addons/test_discuss_full/tests/test_livechat_session_open.py
@@ -2,6 +2,10 @@
 
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.tests import new_test_user
+from odoo import fields
+
+from datetime import timedelta
+from freezegun import freeze_time
 
 
 class TestImLivechatSessions(TestImLivechatCommon):
@@ -11,11 +15,13 @@ class TestImLivechatSessions(TestImLivechatCommon):
             login="operator",
             groups="base.group_user,im_livechat.im_livechat_group_manager",
         )
-        self.make_jsonrpc_request(
-            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
-        )
+        target_date = fields.Datetime.now() - timedelta(days=15)
+        with freeze_time(target_date):  # Freeze time to make sure record appears with default filter
+            self.make_jsonrpc_request(
+                "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
+            )
         action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
         self.start_tour(
             f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}", "im_livechat_session_open",
-            login="operator"
+            login="operator",
         )

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -41,7 +41,7 @@ export class InRange extends Component {
         ["month to date", _t("Month to date")],
         ["last month", _t("Last month")],
         ["year to date", _t("Year to date")],
-        ["last 12 months", _t("Last 12 months")],
+        ["last 365 days", _t("Last 365 days")],
         ["custom range", _t("Custom range")],
     ];
     updateValueType(newValueType) {

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -182,7 +182,7 @@ const BOUNDS_SMART_DATES = [
     ["month to date", "today =1d", "today +1d"],
     ["last month", "today =1d -1m", "today =1d"],
     ["year to date", "today =1m =1d", "today +1d"],
-    ["last 12 months", "today =1d -12m", "today =1d"],
+    ["last 365 days", "today -365d", "today"],
 ];
 const DELTAS = [
     ["today", "", "days = 1"],
@@ -191,7 +191,7 @@ const DELTAS = [
     ["month to date", "day = 1", "days = 1"],
     ["last month", "day = 1, months = -1", "day = 1"],
     ["year to date", "day = 1, month = 1", "days = 1"],
-    ["last 12 months", "day = 1, months = -12", "day = 1"],
+    ["last 365 days", "days = -365", ""],
 ];
 const BOUNDS_DATE = DELTAS.map(([k, l, r]) => [k, boundDate(l), boundDate(r)]);
 const BOUNDS_DATETIME = DELTAS.map(([k, l, r]) => [k, boundDatetime(l), boundDatetime(r)]);

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2553,7 +2553,7 @@ test(`datetime: "in range" operator`, async () => {
         "Month to date",
         "Last month",
         "Year to date",
-        "Last 12 months",
+        "Last 365 days",
         "Custom range",
     ]);
 
@@ -2581,11 +2581,9 @@ test(`datetime: "in range" operator`, async () => {
         `["&", ("datetime", ">=", "today =1m =1d"), ("datetime", "<", "today +1d")]`,
     ]);
 
-    await selectValue("last 12 months");
-    expect(getCurrentValue()).toBe("Last 12 months");
-    expect.verifySteps([
-        `["&", ("datetime", ">=", "today =1d -12m"), ("datetime", "<", "today =1d")]`,
-    ]);
+    await selectValue("last 365 days");
+    expect(getCurrentValue()).toBe("Last 365 days");
+    expect.verifySteps([`["&", ("datetime", ">=", "today -365d"), ("datetime", "<", "today")]`]);
 
     await selectValue("custom range");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
@@ -2630,7 +2628,7 @@ test(`date: "in range" operator`, async () => {
         "Month to date",
         "Last month",
         "Year to date",
-        "Last 12 months",
+        "Last 365 days",
         "Custom range",
     ]);
 
@@ -2654,9 +2652,9 @@ test(`date: "in range" operator`, async () => {
     expect(getCurrentValue()).toBe("Year to date");
     expect.verifySteps([`["&", ("date", ">=", "today =1m =1d"), ("date", "<", "today +1d")]`]);
 
-    await selectValue("last 12 months");
-    expect(getCurrentValue()).toBe("Last 12 months");
-    expect.verifySteps([`["&", ("date", ">=", "today =1d -12m"), ("date", "<", "today =1d")]`]);
+    await selectValue("last 365 days");
+    expect(getCurrentValue()).toBe("Last 365 days");
+    expect.verifySteps([`["&", ("date", ">=", "today -365d"), ("date", "<", "today")]`]);
 
     await selectValue("custom range");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
@@ -2845,9 +2843,9 @@ test("properties field: date & datetime", async () => {
         {
             fields: ["product", "product_properties", "datetime_properties"],
             operator: "in range",
-            treeValue: "last 12 months",
+            treeValue: "last 365 days",
             expectedDomain:
-                '[("product_id", "any", ["&", ("properties.datetime_properties", ">=", "today =1d -12m"), ("properties.datetime_properties", "<", "today =1d")])]',
+                '[("product_id", "any", ["&", ("properties.datetime_properties", ">=", "today -365d"), ("properties.datetime_properties", "<", "today")])]',
         },
         {
             fields: ["product", "product_properties", "date_properties"],

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -20,6 +20,8 @@ import {
     isNotSupportedPath,
     label,
     openModelFieldSelectorPopover,
+    pyDateStr as pyDate,
+    pyDatetimeStr as pyDatetime,
     Partner,
     Player,
     Product,
@@ -455,15 +457,7 @@ test(`"in range" operator`, async () => {
         },
     });
     await selectOperator("in range");
-    expect.verifySteps([
-        formatExpr(
-            `
-                date >= context_today().strftime("%Y-%m-%d")
-                    and
-                date < (context_today() + relativedelta(days = 1)).strftime("%Y-%m-%d")
-            `
-        ),
-    ]);
+    expect.verifySteps([formatExpr(`date >= ${pyDate("today")} and date < ${pyDate("days = 1")}`)]);
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         {
@@ -487,11 +481,7 @@ test(`date: "in range" operator`, async () => {
     ).click();
     expect(getCurrentOperator()).toBe(label("in range"));
     expect(getCurrentValue()).toBe("Today");
-    expect.verifySteps([
-        formatExpr(
-            `date >= context_today().strftime("%Y-%m-%d") and date < (context_today() + relativedelta(days = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
+    expect.verifySteps([formatExpr(`date >= ${pyDate("today")} and date < ${pyDate("days = 1")}`)]);
 
     expect(getValueOptions()).toEqual([
         "Today",
@@ -504,53 +494,44 @@ test(`date: "in range" operator`, async () => {
         "Custom range",
     ]);
 
-    await selectValue("last 7 days");
-    expect(getCurrentValue()).toBe("Last 7 days");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(days = -7)).strftime("%Y-%m-%d") and date < context_today().strftime("%Y-%m-%d")`
-        ),
-    ]);
+    const dateRangeTests = [
+        {
+            val: "last 7 days",
+            label: "Last 7 days",
+            expr: `date >= ${pyDate("days = -7")} and date < ${pyDate()}`,
+        },
+        {
+            val: "last 30 days",
+            label: "Last 30 days",
+            expr: `date >= ${pyDate("days = -30")} and date < ${pyDate()}`,
+        },
+        {
+            val: "month to date",
+            label: "Month to date",
+            expr: `date >= ${pyDate("day = 1")} and date < ${pyDate("days = 1")}`,
+        },
+        {
+            val: "last month",
+            label: "Last month",
+            expr: `date >= ${pyDate("day = 1, months = -1")} and date < ${pyDate("day = 1")}`,
+        },
+        {
+            val: "year to date",
+            label: "Year to date",
+            expr: `date >= ${pyDate("day = 1, month = 1")} and date < ${pyDate("days = 1")}`,
+        },
+        {
+            val: "last 12 months",
+            label: "Last 12 months",
+            expr: `date >= ${pyDate("day = 1, months = -12")} and date < ${pyDate("day = 1")}`,
+        },
+    ];
 
-    await selectValue("last 30 days");
-    expect(getCurrentValue()).toBe("Last 30 days");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(days = -30)).strftime("%Y-%m-%d") and date < context_today().strftime("%Y-%m-%d")`
-        ),
-    ]);
-
-    await selectValue("month to date");
-    expect(getCurrentValue()).toBe("Month to date");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(day = 1)).strftime("%Y-%m-%d") and date < (context_today() + relativedelta(days = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
-
-    await selectValue("last month");
-    expect(getCurrentValue()).toBe("Last month");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(day = 1, months = -1)).strftime("%Y-%m-%d") and date < (context_today() + relativedelta(day = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
-
-    await selectValue("year to date");
-    expect(getCurrentValue()).toBe("Year to date");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(day = 1, month = 1)).strftime("%Y-%m-%d") and date < (context_today() + relativedelta(days = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
-
-    await selectValue("last 12 months");
-    expect(getCurrentValue()).toBe("Last 12 months");
-    expect.verifySteps([
-        formatExpr(
-            `date >= (context_today() + relativedelta(day = 1, months = -12)).strftime("%Y-%m-%d") and date < (context_today() + relativedelta(day = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
+    for (const { val, label, expr } of dateRangeTests) {
+        await selectValue(val);
+        expect(getCurrentValue()).toBe(label);
+        expect.verifySteps([formatExpr(expr)]);
+    }
 
     await selectValue("custom range");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
@@ -565,11 +546,7 @@ test(`date: "in range" operator`, async () => {
     await selectValue("today");
     expect(getCurrentOperator()).toBe(label("in range"));
     expect(getCurrentValue()).toBe("Today");
-    expect.verifySteps([
-        formatExpr(
-            `date >= context_today().strftime("%Y-%m-%d") and date < (context_today() + relativedelta(days = 1)).strftime("%Y-%m-%d")`
-        ),
-    ]);
+    expect.verifySteps([formatExpr(`date >= ${pyDate("today")} and date < ${pyDate("days = 1")}`)]);
 });
 
 test(`datetime: "in range" operator`, async () => {
@@ -587,13 +564,7 @@ test(`datetime: "in range" operator`, async () => {
     expect(getCurrentOperator()).toBe(label("in range"));
     expect(getCurrentValue()).toBe("Today");
     expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
+        formatExpr(`datetime >= ${pyDatetime()} and datetime < ${pyDatetime("days = 1")}`),
     ]);
 
     expect(getValueOptions()).toEqual([
@@ -607,77 +578,50 @@ test(`datetime: "in range" operator`, async () => {
         "Custom range",
     ]);
 
-    await selectValue("last 7 days");
-    expect(getCurrentValue()).toBe("Last 7 days");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(days = -7), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
+    const datetimeRangeTests = [
+        {
+            val: "last 7 days",
+            label: "Last 7 days",
+            expr: `datetime >= ${pyDatetime("days = -7")} and datetime < ${pyDatetime()}`,
+        },
+        {
+            val: "last 30 days",
+            label: "Last 30 days",
+            expr: `datetime >= ${pyDatetime("days = -30")} and datetime < ${pyDatetime()}`,
+        },
+        {
+            val: "month to date",
+            label: "Month to date",
+            expr: `datetime >= ${pyDatetime("day = 1")} and datetime < ${pyDatetime("days = 1")}`,
+        },
+        {
+            val: "last month",
+            label: "Last month",
+            expr: `datetime >= ${pyDatetime("day = 1, months = -1")} and datetime < ${pyDatetime(
+                "day = 1"
+            )}`,
+        },
+        {
+            val: "year to date",
+            label: "Year to date",
+            expr: `datetime >= ${pyDatetime("day = 1, month = 1")} and datetime < ${pyDatetime(
+                "days = 1"
+            )}`,
+        },
+        {
+            val: "last 12 months",
+            label: "Last 12 months",
+            expr: `datetime >= ${pyDatetime("day = 1, months = -12")} and datetime < ${pyDatetime(
+                "day = 1"
+            )}`,
+        },
+    ];
 
-    await selectValue("last 30 days");
-    expect(getCurrentValue()).toBe("Last 30 days");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(days = -30), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
-
-    await selectValue("month to date");
-    expect(getCurrentValue()).toBe("Month to date");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
-
-    await selectValue("last month");
-    expect(getCurrentValue()).toBe("Last month");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(day = 1, months = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
-
-    await selectValue("year to date");
-    expect(getCurrentValue()).toBe("Year to date");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(day = 1, month = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
-
-    await selectValue("last 12 months");
-    expect(getCurrentValue()).toBe("Last 12 months");
-    expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today() + relativedelta(day = 1, months = -12), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
-    ]);
+    for (const { val, label, expr } of datetimeRangeTests) {
+        await selectValue(val);
+        expect(getCurrentValue()).toBe(label);
+        expect.verifySteps([formatExpr(expr)]);
+    }
 
     await selectValue("custom range");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
@@ -697,13 +641,7 @@ test(`datetime: "in range" operator`, async () => {
     expect(getCurrentOperator()).toBe(label("in range"));
     expect(getCurrentValue()).toBe("Today");
     expect.verifySteps([
-        formatExpr(
-            `
-                datetime >= datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-                    and
-                datetime < datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")
-            `
-        ),
+        formatExpr(`datetime >= ${pyDatetime()} and datetime < ${pyDatetime("days = 1")}`),
     ]);
 });
 

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -490,7 +490,7 @@ test(`date: "in range" operator`, async () => {
         "Month to date",
         "Last month",
         "Year to date",
-        "Last 12 months",
+        "Last 365 days",
         "Custom range",
     ]);
 
@@ -521,9 +521,9 @@ test(`date: "in range" operator`, async () => {
             expr: `date >= ${pyDate("day = 1, month = 1")} and date < ${pyDate("days = 1")}`,
         },
         {
-            val: "last 12 months",
-            label: "Last 12 months",
-            expr: `date >= ${pyDate("day = 1, months = -12")} and date < ${pyDate("day = 1")}`,
+            val: "last 365 days",
+            label: "Last 365 days",
+            expr: `date >= ${pyDate("days = -365")} and date < ${pyDate()}`,
         },
     ];
 
@@ -574,7 +574,7 @@ test(`datetime: "in range" operator`, async () => {
         "Month to date",
         "Last month",
         "Year to date",
-        "Last 12 months",
+        "Last 365 days",
         "Custom range",
     ]);
 
@@ -609,11 +609,9 @@ test(`datetime: "in range" operator`, async () => {
             )}`,
         },
         {
-            val: "last 12 months",
-            label: "Last 12 months",
-            expr: `datetime >= ${pyDatetime("day = 1, months = -12")} and datetime < ${pyDatetime(
-                "day = 1"
-            )}`,
+            val: "last 365 days",
+            label: "Last 365 days",
+            expr: `datetime >= ${pyDatetime("days = -365")} and datetime < ${pyDatetime()}`,
         },
     ];
 

--- a/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
@@ -468,3 +468,25 @@ export async function followRelation(index, target) {
 export function getFocusedFieldName() {
     return queryText(".o_model_field_selector_popover_item.active");
 }
+
+/**
+ * Generates a Python expression string representing a UTC datetime at midnight (00:00:00)
+ * for a specific date relative to the user's current context date.
+ * @param {string} [delta="today"] - The relative delta argument (e.g., "days=1", "months=-1") or "today".
+ * @returns {string} The formatted Python expression for the target datetime.
+ */
+export function pyDatetimeStr(delta = "today") {
+    const b = delta === "today" ? "context_today()" : `context_today() + relativedelta(${delta})`;
+    return `datetime.datetime.combine(${b}, datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`;
+}
+
+/**
+ * Generates a Python expression string representing a formatted date ('YYYY-MM-DD')
+ * relative to the user's current context date.
+ * @param {string} [delta="today"] - The relative delta argument (e.g., "days=1", "months=-1") or "today".
+ * @returns {string} The formatted Python expression for the target date.
+ */
+export function pyDateStr(delta = "today") {
+    const b = delta === "today" ? "context_today()" : `(context_today() + relativedelta(${delta}))`;
+    return `${b}.strftime("%Y-%m-%d")`;
+}

--- a/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
@@ -229,14 +229,14 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
         },
         {
             tree_py: and([
-                condition("dt_1", ">=", pyDatetime("day = 1, months = -12")),
-                condition("dt_1", "<", pyDatetime("day = 1")),
+                condition("dt_1", ">=", pyDatetime("days = -365")),
+                condition("dt_1", "<", pyDatetime()),
             ]),
-            tree: inRange("dt_1", ["datetime", "last 12 months", false, false]),
+            tree: inRange("dt_1", ["datetime", "last 365 days", false, false]),
             domain: [
                 "&",
-                ["dt_1", ">=", "2024-06-30 23:00:00"],
-                ["dt_1", "<", "2025-06-30 23:00:00"],
+                ["dt_1", ">=", "2024-07-02 23:00:00"],
+                ["dt_1", "<", "2025-07-02 23:00:00"],
             ],
         },
         {
@@ -337,11 +337,11 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
         },
         {
             tree_py: and([
-                condition("date_1", ">=", pyDate("day = 1, months = -12")),
-                condition("date_1", "<", pyDate("day=1")),
+                condition("date_1", ">=", pyDate("days = - 365")),
+                condition("date_1", "<", pyDate()),
             ]),
-            tree: inRange("date_1", ["date", "last 12 months", false, false]),
-            domain: ["&", ["date_1", ">=", "2024-07-01"], ["date_1", "<", "2025-07-01"]],
+            tree: inRange("date_1", ["date", "last 365 days", false, false]),
+            domain: ["&", ["date_1", ">=", "2024-07-03"], ["date_1", "<", "2025-07-03"]],
         },
         {
             tree_py: and(
@@ -539,12 +539,9 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
             domain: ["&", ["dt_1", ">=", "today =1m =1d"], ["dt_1", "<", "today +1d"]],
         },
         {
-            tree_py: and([
-                condition("dt_1", ">=", "today =1d -12m"),
-                condition("dt_1", "<", "today =1d"),
-            ]),
-            tree: inRange("dt_1", ["datetime", "last 12 months", false, false]),
-            domain: ["&", ["dt_1", ">=", "today =1d -12m"], ["dt_1", "<", "today =1d"]],
+            tree_py: and([condition("dt_1", ">=", "today -365d"), condition("dt_1", "<", "today")]),
+            tree: inRange("dt_1", ["datetime", "last 365 days", false, false]),
+            domain: ["&", ["dt_1", ">=", "today -365d"], ["dt_1", "<", "today"]],
         },
         {
             tree_py: and(
@@ -635,11 +632,11 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
         },
         {
             tree_py: and([
-                condition("date_1", ">=", "today =1d -12m"),
-                condition("date_1", "<", "today =1d"),
+                condition("date_1", ">=", "today -365d"),
+                condition("date_1", "<", "today"),
             ]),
-            tree: inRange("date_1", ["date", "last 12 months", false, false]),
-            domain: ["&", ["date_1", ">=", "today =1d -12m"], ["date_1", "<", "today =1d"]],
+            tree: inRange("date_1", ["date", "last 365 days", false, false]),
+            domain: ["&", ["date_1", ">=", "today -365d"], ["date_1", "<", "today"]],
         },
         {
             tree_py: and([

--- a/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
@@ -385,30 +385,6 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                     "datetime_1",
                     ">=",
                     expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1, month = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "year to date", false, false]),
-            domain: [
-                "&",
-                ["datetime_1", ">=", "2024-12-31 23:00:00"],
-                ["datetime_1", "<", "2025-07-03 23:00:00"],
-            ],
-        },
-        {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
                         `datetime.datetime.combine(context_today() + relativedelta(day = 1, months = -12), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
                     )
                 ),
@@ -610,24 +586,6 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
             ]),
             tree: condition("date_1", "in range", ["date", "last month", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-01"], ["date_1", "<", "2025-07-01"]],
-        },
-        {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(
-                        `(context_today() + relativedelta(day = 1, month = 1)).strftime('%Y-%m-%d')`
-                    )
-                ),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(days = 1)).strftime('%Y-%m-%d')`)
-                ),
-            ]),
-            tree: condition("date_1", "in range", ["date", "year to date", false, false]),
-            domain: ["&", ["date_1", ">=", "2025-01-01"], ["date_1", "<", "2025-07-04"]],
         },
         {
             tree_py: connector("&", [
@@ -937,14 +895,6 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
             ]),
             tree: condition("datetime_1", "in range", ["datetime", "last month", false, false]),
             domain: ["&", ["datetime_1", ">=", "today =1d -1m"], ["datetime_1", "<", "today =1d"]],
-        },
-        {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today =1m =1d"),
-                condition("datetime_1", "<", "today +1d"),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "year to date", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today =1m =1d"], ["datetime_1", "<", "today +1d"]],
         },
         {
             tree_py: connector("&", [

--- a/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
@@ -10,70 +10,78 @@ import {
     eliminateVirtualOperators,
     introduceVirtualOperators,
 } from "@web/core/tree_editor/virtual_operators";
+import { pyDateStr, pyDatetimeStr } from "./condition_tree_editor_test_helpers";
 
 describe.current.tags("headless");
 
 const options = {
     getFieldDef: (name) => {
         if (name === "m2o") {
-            return { type: "man2one" };
+            return { type: "many2one" };
         }
-        if (name === "m2o.date_2" || name === "date_1" || name === "date_3") {
+        if (name === "m2o.date_2" || name === "date_1" || name === "date_2" || name === "date_3") {
             return { type: "date" };
         }
-        if (name === "m2o.datetime_2" || name === "datetime_1" || name === "datetime_3") {
+        if (name === "m2o.dt_2" || name === "dt_1" || name === "dt_2" || name === "dt_3") {
             return { type: "datetime" };
         }
         return null;
     },
 };
-
 const fullOptions = { ...options, generateSmartDates: false };
+
+const DATE_START = "2025-07-02 00:00:00";
+const DATE_END = "2025-07-03 00:00:00";
+const complexPath = expression("path");
+
+const pyDate = (delta) => expression(pyDateStr(delta));
+const pyDatetime = (delta) => expression(pyDatetimeStr(delta));
+
+const and = (c, negate) => connector("&", c, negate);
+const or = (c, negate) => connector("|", c, negate);
+const inRange = (f, v, negate) => condition(f, "in range", v, negate);
+const m2oAny = (c, negate = false) => condition("m2o", "any", c, negate);
 
 test(`"in range" operator: no introduction for complex paths (generateSmartDates=false)`, async () => {
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition(complexPath, ">=", DATE_START),
+                condition(complexPath, "<=", DATE_END),
             ]),
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                    condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: m2oAny(
+                and([
+                    condition(complexPath, ">=", DATE_START),
+                    condition(complexPath, "<=", DATE_END),
                 ])
             ),
         },
         {
-            tree_py: connector("&", [
-                condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition(complexPath, ">=", DATE_START),
+                condition(complexPath, "<=", DATE_END),
             ]),
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                    condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: m2oAny(
+                and([
+                    condition(complexPath, ">=", DATE_START),
+                    condition(complexPath, "<=", DATE_END),
                 ])
             ),
         },
         {
-            tree_py: connector("&", [
-                condition("m2o.datetime_2", ">=", "2025-07-02 00:00:00"),
-                condition("m2o.datetime_2", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("m2o.dt_2", ">=", DATE_START),
+                condition("m2o.dt_2", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("m2o.date_2", ">=", "2025-07-02 00:00:00"),
-                condition("m2o.date_2", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("m2o.date_2", ">=", DATE_START),
+                condition("m2o.date_2", "<=", DATE_END),
             ]),
         },
     ];
@@ -85,127 +93,63 @@ test(`"in range" operator: no introduction for complex paths (generateSmartDates
 test(`"in range" operator: no introduction if condition negated or "|" or different path (generateSmartDates=false)`, async () => {
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00", true),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START, true),
+                condition("date_1", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00", true),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END, true),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00", true),
-                condition("date_1", "<=", "2025-07-03 00:00:00", true),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START, true),
+                condition("date_1", "<=", DATE_END, true),
             ]),
         },
         {
-            tree_py: connector("|", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: or([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_3", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_3", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    ),
-                    true
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("today"), true),
+                condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    ),
-                    true
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("today")),
+                condition("dt_1", "<", pyDatetime("days = 1"), true),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    ),
-                    true
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    ),
-                    true
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("today"), true),
+                condition("dt_1", "<", pyDatetime("days = 1"), true),
             ]),
         },
         {
-            tree_py: connector("|", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: or([
+                condition("dt_1", ">=", pyDatetime("today")),
+                condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_3",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("today")),
+                condition("dt_3", "<", pyDatetime("days = 1")),
             ]),
         },
     ];
@@ -219,271 +163,106 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
     await makeMockEnv();
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "2025-07-02 00:00:00"),
-                condition("datetime_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)]),
+            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END]),
+            domain: ["&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("days = -7")),
+                condition("dt_1", "<", pyDatetime("today")),
             ]),
-            tree: condition("datetime_1", "in range", [
-                "datetime",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
+            tree: inRange("dt_1", ["datetime", "last 7 days", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-07-02 00:00:00"],
-                ["datetime_1", "<=", "2025-07-03 00:00:00"],
+                ["dt_1", ">=", "2025-06-25 23:00:00"],
+                ["dt_1", "<", "2025-07-02 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("days = -30")),
+                condition("dt_1", "<", pyDatetime("today")),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "today", false, false]),
+            tree: inRange("dt_1", ["datetime", "last 30 days", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-07-02 23:00:00"],
-                ["datetime_1", "<", "2025-07-03 23:00:00"],
+                ["dt_1", ">=", "2025-06-02 23:00:00"],
+                ["dt_1", "<", "2025-07-02 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = -7), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("day = 1")),
+                condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 7 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "month to date", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-06-25 23:00:00"],
-                ["datetime_1", "<", "2025-07-02 23:00:00"],
+                ["dt_1", ">=", "2025-06-30 23:00:00"],
+                ["dt_1", "<", "2025-07-03 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = -30), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("day = 1, months = -1")),
+                condition("dt_1", "<", pyDatetime("day = 1")),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 30 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last month", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-06-02 23:00:00"],
-                ["datetime_1", "<", "2025-07-02 23:00:00"],
+                ["dt_1", ">=", "2025-05-31 23:00:00"],
+                ["dt_1", "<", "2025-06-30 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("day = 1, month = 1")),
+                condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "month to date", false, false]),
+            tree: inRange("dt_1", ["datetime", "year to date", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-06-30 23:00:00"],
-                ["datetime_1", "<", "2025-07-03 23:00:00"],
+                ["dt_1", ">=", "2024-12-31 23:00:00"],
+                ["dt_1", "<", "2025-07-03 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1, months = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("day = 1, months = -12")),
+                condition("dt_1", "<", pyDatetime("day = 1")),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last month", false, false]),
+            tree: inRange("dt_1", ["datetime", "last 12 months", false, false]),
             domain: [
                 "&",
-                ["datetime_1", ">=", "2025-05-31 23:00:00"],
-                ["datetime_1", "<", "2025-06-30 23:00:00"],
+                ["dt_1", ">=", "2024-06-30 23:00:00"],
+                ["dt_1", "<", "2025-06-30 23:00:00"],
             ],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1, month = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "year to date", false, false]),
-            domain: [
-                "&",
-                ["datetime_1", ">=", "2024-12-31 23:00:00"],
-                ["datetime_1", "<", "2025-07-03 23:00:00"],
-            ],
-        },
-        {
-            tree_py: connector("&", [
-                condition(
-                    "datetime_1",
-                    ">=",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1, months = -12), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-                condition(
-                    "datetime_1",
-                    "<",
-                    expression(
-                        `datetime.datetime.combine(context_today() + relativedelta(day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-                    )
-                ),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 12 months", false, false]),
-            domain: [
-                "&",
-                ["datetime_1", ">=", "2024-06-30 23:00:00"],
-                ["datetime_1", "<", "2025-06-30 23:00:00"],
-            ],
-        },
-        {
-            tree_py: connector(
-                "&",
-                [
-                    condition("datetime_1", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_1", "<=", "2025-07-03 00:00:00"),
-                ],
+            tree_py: and(
+                [condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)],
                 true
             ),
-            tree: condition(
-                "datetime_1",
-                "in range",
-                ["datetime", "custom range", "2025-07-02 00:00:00", "2025-07-03 00:00:00"],
+            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END], true),
+            domain: ["!", "&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)])
+            ),
+            tree: inRange("m2o.dt_2", ["datetime", "custom range", DATE_START, DATE_END]),
+            domain: [["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)]),
                 true
             ),
+            tree: m2oAny(inRange("dt_2", ["datetime", "custom range", DATE_START, DATE_END]), true),
             domain: [
                 "!",
-                "&",
-                ["datetime_1", ">=", "2025-07-02 00:00:00"],
-                ["datetime_1", "<=", "2025-07-03 00:00:00"],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("datetime_2", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_2", "<=", "2025-07-03 00:00:00"),
-                ])
-            ),
-            tree: condition("m2o.datetime_2", "in range", [
-                "datetime",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["datetime_2", ">=", "2025-07-02 00:00:00"],
-                        ["datetime_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("datetime_2", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_2", "<=", "2025-07-03 00:00:00"),
-                ]),
-                true
-            ),
-            tree: condition(
-                "m2o",
-                "any",
-                condition("datetime_2", "in range", [
-                    "datetime",
-                    "custom range",
-                    "2025-07-02 00:00:00",
-                    "2025-07-03 00:00:00",
-                ]),
-                true
-            ),
-            domain: [
-                "!",
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["datetime_2", ">=", "2025-07-02 00:00:00"],
-                        ["datetime_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
+                ["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]],
             ],
         },
     ];
@@ -501,209 +280,95 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
     await makeMockEnv();
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END),
             ]),
-            tree: condition("date_1", "in range", [
-                "date",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                "&",
-                ["date_1", ">=", "2025-07-02 00:00:00"],
-                ["date_1", "<=", "2025-07-03 00:00:00"],
-            ],
+            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END]),
+            domain: ["&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", expression(`context_today().strftime("%Y-%m-%d")`)),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(days = 1)).strftime('%Y-%m-%d')`)
-                ),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("today")),
+                condition("date_1", "<", pyDate("days = 1")),
             ]),
-            tree: condition("date_1", "in range", ["date", "today", false, false]),
+            tree: inRange("date_1", ["date", "today", false, false]),
             domain: ["&", ["date_1", ">=", "2025-07-03"], ["date_1", "<", "2025-07-04"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(`(context_today() + relativedelta(days = -7)).strftime('%Y-%m-%d')`)
-                ),
-                condition("date_1", "<", expression(`context_today().strftime("%Y-%m-%d")`)),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("days = -7")),
+                condition("date_1", "<", pyDate("today")),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 7 days", false, false]),
+            tree: inRange("date_1", ["date", "last 7 days", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-26"], ["date_1", "<", "2025-07-03"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(`(context_today() + relativedelta(days = -30)).strftime('%Y-%m-%d')`)
-                ),
-                condition("date_1", "<", expression(`context_today().strftime("%Y-%m-%d")`)),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("days = -30")),
+                condition("date_1", "<", pyDate("today")),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 30 days", false, false]),
+            tree: inRange("date_1", ["date", "last 30 days", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-03"], ["date_1", "<", "2025-07-03"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(`(context_today() + relativedelta(day = 1)).strftime('%Y-%m-%d')`)
-                ),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(days = 1)).strftime('%Y-%m-%d')`)
-                ),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("day = 1")),
+                condition("date_1", "<", pyDate("days = 1")),
             ]),
-            tree: condition("date_1", "in range", ["date", "month to date", false, false]),
+            tree: inRange("date_1", ["date", "month to date", false, false]),
             domain: ["&", ["date_1", ">=", "2025-07-01"], ["date_1", "<", "2025-07-04"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(
-                        `(context_today() + relativedelta(day = 1, months = -1)).strftime('%Y-%m-%d')`
-                    )
-                ),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(day = 1)).strftime('%Y-%m-%d')`)
-                ),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("day = 1, months = -1")),
+                condition("date_1", "<", pyDate("day = 1")),
             ]),
-            tree: condition("date_1", "in range", ["date", "last month", false, false]),
+            tree: inRange("date_1", ["date", "last month", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-01"], ["date_1", "<", "2025-07-01"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(
-                        `(context_today() + relativedelta(day = 1, month = 1)).strftime('%Y-%m-%d')`
-                    )
-                ),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(days = 1)).strftime('%Y-%m-%d')`)
-                ),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("day = 1, month = 1")),
+                condition("date_1", "<", pyDate("days = 1")),
             ]),
-            tree: condition("date_1", "in range", ["date", "year to date", false, false]),
+            tree: inRange("date_1", ["date", "year to date", false, false]),
             domain: ["&", ["date_1", ">=", "2025-01-01"], ["date_1", "<", "2025-07-04"]],
         },
         {
-            tree_py: connector("&", [
-                condition(
-                    "date_1",
-                    ">=",
-                    expression(
-                        `(context_today() + relativedelta(day = 1, months = -12)).strftime('%Y-%m-%d')`
-                    )
-                ),
-                condition(
-                    "date_1",
-                    "<",
-                    expression(`(context_today() + relativedelta(day = 1)).strftime('%Y-%m-%d')`)
-                ),
+            tree_py: and([
+                condition("date_1", ">=", pyDate("day = 1, months = -12")),
+                condition("date_1", "<", pyDate("day=1")),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 12 months", false, false]),
+            tree: inRange("date_1", ["date", "last 12 months", false, false]),
             domain: ["&", ["date_1", ">=", "2024-07-01"], ["date_1", "<", "2025-07-01"]],
         },
         {
-            tree_py: connector(
-                "&",
-                [
-                    condition("date_1", ">=", "2025-07-02 00:00:00"),
-                    condition("date_1", "<=", "2025-07-03 00:00:00"),
-                ],
+            tree_py: and(
+                [condition("date_1", ">=", DATE_START), condition("date_1", "<=", DATE_END)],
                 true
             ),
-            tree: condition(
-                "date_1",
-                "in range",
-                ["date", "custom range", "2025-07-02 00:00:00", "2025-07-03 00:00:00"],
-                true
+            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END], true),
+            domain: ["!", "&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)])
             ),
+            tree: inRange("m2o.date_2", ["date", "custom range", DATE_START, DATE_END]),
             domain: [
-                "!",
-                "&",
-                ["date_1", ">=", "2025-07-02 00:00:00"],
-                ["date_1", "<=", "2025-07-03 00:00:00"],
+                ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("date_2", ">=", "2025-07-02 00:00:00"),
-                    condition("date_2", "<=", "2025-07-03 00:00:00"),
-                ])
-            ),
-            tree: condition("m2o.date_2", "in range", [
-                "date",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["date_2", ">=", "2025-07-02 00:00:00"],
-                        ["date_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("date_2", ">=", "2025-07-02 00:00:00"),
-                    condition("date_2", "<=", "2025-07-03 00:00:00"),
-                ]),
+            tree_py: m2oAny(
+                and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)]),
                 true
             ),
-            tree: condition(
-                "m2o",
-                "any",
-                condition("date_2", "in range", [
-                    "date",
-                    "custom range",
-                    "2025-07-02 00:00:00",
-                    "2025-07-03 00:00:00",
-                ]),
-                true
-            ),
+            tree: m2oAny(inRange("date_2", ["date", "custom range", DATE_START, DATE_END]), true),
             domain: [
                 "!",
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["date_2", ">=", "2025-07-02 00:00:00"],
-                        ["date_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
+                ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
         },
     ];
@@ -719,47 +384,43 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
 test(`"in range" operator: no introduction for complex paths`, async () => {
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition(complexPath, ">=", DATE_START),
+                condition(complexPath, "<=", DATE_END),
             ]),
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                    condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: m2oAny(
+                and([
+                    condition(complexPath, ">=", DATE_START),
+                    condition(complexPath, "<=", DATE_END),
                 ])
             ),
         },
         {
-            tree_py: connector("&", [
-                condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition(complexPath, ">=", DATE_START),
+                condition(complexPath, "<=", DATE_END),
             ]),
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition(expression("path"), ">=", "2025-07-02 00:00:00"),
-                    condition(expression("path"), "<=", "2025-07-03 00:00:00"),
+            tree_py: m2oAny(
+                and([
+                    condition(complexPath, ">=", DATE_START),
+                    condition(complexPath, "<=", DATE_END),
                 ])
             ),
         },
         {
-            tree_py: connector("&", [
-                condition("m2o.datetime_2", ">=", "2025-07-02 00:00:00"),
-                condition("m2o.datetime_2", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("m2o.dt_2", ">=", DATE_START),
+                condition("m2o.dt_2", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("m2o.date_2", ">=", "2025-07-02 00:00:00"),
-                condition("m2o.date_2", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("m2o.date_2", ">=", DATE_START),
+                condition("m2o.date_2", "<=", DATE_END),
             ]),
         },
     ];
@@ -771,64 +432,58 @@ test(`"in range" operator: no introduction for complex paths`, async () => {
 test(`"in range" operator: no introduction if condition negated or "|" or different path`, async () => {
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00", true),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START, true),
+                condition("date_1", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00", true),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END, true),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00", true),
-                condition("date_1", "<=", "2025-07-03 00:00:00", true),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START, true),
+                condition("date_1", "<=", DATE_END, true),
             ]),
         },
         {
-            tree_py: connector("|", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
+            tree_py: or([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_3", "<=", "2025-07-03 00:00:00"),
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_3", "<=", DATE_END),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today", true),
-                condition("datetime_1", "<", "today +1d"),
+            tree_py: and([
+                condition("dt_1", ">=", "today", true),
+                condition("dt_1", "<", "today +1d"),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today"),
-                condition("datetime_1", "<", "today +1d", true),
+            tree_py: and([
+                condition("dt_1", ">=", "today"),
+                condition("dt_1", "<", "today +1d", true),
             ]),
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today", true),
-                condition("datetime_1", "<", "today +1d", true),
+            tree_py: and([
+                condition("dt_1", ">=", "today", true),
+                condition("dt_1", "<", "today +1d", true),
             ]),
         },
         {
-            tree_py: connector("|", [
-                condition("datetime_1", ">=", "today"),
-                condition("datetime_1", "<", "today +1d"),
-            ]),
+            tree_py: or([condition("dt_1", ">=", "today"), condition("dt_1", "<", "today +1d")]),
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today"),
-                condition("datetime_3", "<", "today +1d"),
-            ]),
+            tree_py: and([condition("dt_1", ">=", "today"), condition("dt_3", "<", "today +1d")]),
         },
     ];
     for (const { tree_py } of toTest) {
@@ -840,159 +495,81 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
     await makeMockEnv();
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "2025-07-02 00:00:00"),
-                condition("datetime_1", "<=", "2025-07-03 00:00:00"),
-            ]),
-            tree: condition("datetime_1", "in range", [
-                "datetime",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                "&",
-                ["datetime_1", ">=", "2025-07-02 00:00:00"],
-                ["datetime_1", "<=", "2025-07-03 00:00:00"],
-            ],
+            tree_py: and([condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)]),
+            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END]),
+            domain: ["&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today"),
-                condition("datetime_1", "<", "today +1d"),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "today", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today"], ["datetime_1", "<", "today +1d"]],
+            tree_py: and([condition("dt_1", ">=", "today"), condition("dt_1", "<", "today +1d")]),
+            tree: inRange("dt_1", ["datetime", "today", false, false]),
+            domain: ["&", ["dt_1", ">=", "today"], ["dt_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today -7d"),
-                condition("datetime_1", "<", "today"),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 7 days", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today -7d"], ["datetime_1", "<", "today"]],
+            tree_py: and([condition("dt_1", ">=", "today -7d"), condition("dt_1", "<", "today")]),
+            tree: inRange("dt_1", ["datetime", "last 7 days", false, false]),
+            domain: ["&", ["dt_1", ">=", "today -7d"], ["dt_1", "<", "today"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today -30d"),
-                condition("datetime_1", "<", "today"),
-            ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 30 days", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today -30d"], ["datetime_1", "<", "today"]],
+            tree_py: and([condition("dt_1", ">=", "today -30d"), condition("dt_1", "<", "today")]),
+            tree: inRange("dt_1", ["datetime", "last 30 days", false, false]),
+            domain: ["&", ["dt_1", ">=", "today -30d"], ["dt_1", "<", "today"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today =1d"),
-                condition("datetime_1", "<", "today +1d"),
+            tree_py: and([
+                condition("dt_1", ">=", "today =1d"),
+                condition("dt_1", "<", "today +1d"),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "month to date", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today =1d"], ["datetime_1", "<", "today +1d"]],
+            tree: inRange("dt_1", ["datetime", "month to date", false, false]),
+            domain: ["&", ["dt_1", ">=", "today =1d"], ["dt_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today =1d -1m"),
-                condition("datetime_1", "<", "today =1d"),
+            tree_py: and([
+                condition("dt_1", ">=", "today =1d -1m"),
+                condition("dt_1", "<", "today =1d"),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last month", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today =1d -1m"], ["datetime_1", "<", "today =1d"]],
+            tree: inRange("dt_1", ["datetime", "last month", false, false]),
+            domain: ["&", ["dt_1", ">=", "today =1d -1m"], ["dt_1", "<", "today =1d"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today =1m =1d"),
-                condition("datetime_1", "<", "today +1d"),
+            tree_py: and([
+                condition("dt_1", ">=", "today =1m =1d"),
+                condition("dt_1", "<", "today +1d"),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "year to date", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today =1m =1d"], ["datetime_1", "<", "today +1d"]],
+            tree: inRange("dt_1", ["datetime", "year to date", false, false]),
+            domain: ["&", ["dt_1", ">=", "today =1m =1d"], ["dt_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
-                condition("datetime_1", ">=", "today =1d -12m"),
-                condition("datetime_1", "<", "today =1d"),
+            tree_py: and([
+                condition("dt_1", ">=", "today =1d -12m"),
+                condition("dt_1", "<", "today =1d"),
             ]),
-            tree: condition("datetime_1", "in range", ["datetime", "last 12 months", false, false]),
-            domain: ["&", ["datetime_1", ">=", "today =1d -12m"], ["datetime_1", "<", "today =1d"]],
+            tree: inRange("dt_1", ["datetime", "last 12 months", false, false]),
+            domain: ["&", ["dt_1", ">=", "today =1d -12m"], ["dt_1", "<", "today =1d"]],
         },
         {
-            tree_py: connector(
-                "&",
-                [
-                    condition("datetime_1", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_1", "<=", "2025-07-03 00:00:00"),
-                ],
+            tree_py: and(
+                [condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)],
                 true
             ),
-            tree: condition(
-                "datetime_1",
-                "in range",
-                ["datetime", "custom range", "2025-07-02 00:00:00", "2025-07-03 00:00:00"],
+            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END], true),
+            domain: ["!", "&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)])
+            ),
+            tree: inRange("m2o.dt_2", ["datetime", "custom range", DATE_START, DATE_END]),
+            domain: [["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)]),
                 true
             ),
+            tree: m2oAny(inRange("dt_2", ["datetime", "custom range", DATE_START, DATE_END]), true),
             domain: [
                 "!",
-                "&",
-                ["datetime_1", ">=", "2025-07-02 00:00:00"],
-                ["datetime_1", "<=", "2025-07-03 00:00:00"],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("datetime_2", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_2", "<=", "2025-07-03 00:00:00"),
-                ])
-            ),
-            tree: condition("m2o.datetime_2", "in range", [
-                "datetime",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["datetime_2", ">=", "2025-07-02 00:00:00"],
-                        ["datetime_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("datetime_2", ">=", "2025-07-02 00:00:00"),
-                    condition("datetime_2", "<=", "2025-07-03 00:00:00"),
-                ]),
-                true
-            ),
-            tree: condition(
-                "m2o",
-                "any",
-                condition("datetime_2", "in range", [
-                    "datetime",
-                    "custom range",
-                    "2025-07-02 00:00:00",
-                    "2025-07-03 00:00:00",
-                ]),
-                true
-            ),
-            domain: [
-                "!",
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["datetime_2", ">=", "2025-07-02 00:00:00"],
-                        ["datetime_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
+                ["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]],
             ],
         },
     ];
@@ -1009,159 +586,95 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
     await makeMockEnv();
     const toTest = [
         {
-            tree_py: connector("&", [
-                condition("date_1", ">=", "2025-07-02 00:00:00"),
-                condition("date_1", "<=", "2025-07-03 00:00:00"),
-            ]),
-            tree: condition("date_1", "in range", [
-                "date",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
-            ]),
-            domain: [
-                "&",
-                ["date_1", ">=", "2025-07-02 00:00:00"],
-                ["date_1", "<=", "2025-07-03 00:00:00"],
-            ],
-        },
-        {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today"),
                 condition("date_1", "<", "today +1d"),
             ]),
-            tree: condition("date_1", "in range", ["date", "today", false, false]),
+            tree: inRange("date_1", ["date", "today", false, false]),
             domain: ["&", ["date_1", ">=", "today"], ["date_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today -7d"),
                 condition("date_1", "<", "today"),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 7 days", false, false]),
+            tree: inRange("date_1", ["date", "last 7 days", false, false]),
             domain: ["&", ["date_1", ">=", "today -7d"], ["date_1", "<", "today"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today -30d"),
                 condition("date_1", "<", "today"),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 30 days", false, false]),
+            tree: inRange("date_1", ["date", "last 30 days", false, false]),
             domain: ["&", ["date_1", ">=", "today -30d"], ["date_1", "<", "today"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today =1d"),
                 condition("date_1", "<", "today +1d"),
             ]),
-            tree: condition("date_1", "in range", ["date", "month to date", false, false]),
+            tree: inRange("date_1", ["date", "month to date", false, false]),
             domain: ["&", ["date_1", ">=", "today =1d"], ["date_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today =1d -1m"),
                 condition("date_1", "<", "today =1d"),
             ]),
-            tree: condition("date_1", "in range", ["date", "last month", false, false]),
+            tree: inRange("date_1", ["date", "last month", false, false]),
             domain: ["&", ["date_1", ">=", "today =1d -1m"], ["date_1", "<", "today =1d"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today =1m =1d"),
                 condition("date_1", "<", "today +1d"),
             ]),
-            tree: condition("date_1", "in range", ["date", "year to date", false, false]),
+            tree: inRange("date_1", ["date", "year to date", false, false]),
             domain: ["&", ["date_1", ">=", "today =1m =1d"], ["date_1", "<", "today +1d"]],
         },
         {
-            tree_py: connector("&", [
+            tree_py: and([
                 condition("date_1", ">=", "today =1d -12m"),
                 condition("date_1", "<", "today =1d"),
             ]),
-            tree: condition("date_1", "in range", ["date", "last 12 months", false, false]),
+            tree: inRange("date_1", ["date", "last 12 months", false, false]),
             domain: ["&", ["date_1", ">=", "today =1d -12m"], ["date_1", "<", "today =1d"]],
         },
         {
-            tree_py: connector(
-                "&",
-                [
-                    condition("date_1", ">=", "2025-07-02 00:00:00"),
-                    condition("date_1", "<=", "2025-07-03 00:00:00"),
-                ],
-                true
-            ),
-            tree: condition(
-                "date_1",
-                "in range",
-                ["date", "custom range", "2025-07-02 00:00:00", "2025-07-03 00:00:00"],
-                true
-            ),
-            domain: [
-                "!",
-                "&",
-                ["date_1", ">=", "2025-07-02 00:00:00"],
-                ["date_1", "<=", "2025-07-03 00:00:00"],
-            ],
-        },
-        {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("date_2", ">=", "2025-07-02 00:00:00"),
-                    condition("date_2", "<=", "2025-07-03 00:00:00"),
-                ])
-            ),
-            tree: condition("m2o.date_2", "in range", [
-                "date",
-                "custom range",
-                "2025-07-02 00:00:00",
-                "2025-07-03 00:00:00",
+            tree_py: and([
+                condition("date_1", ">=", DATE_START),
+                condition("date_1", "<=", DATE_END),
             ]),
+            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END]),
+            domain: ["&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: and(
+                [condition("date_1", ">=", DATE_START), condition("date_1", "<=", DATE_END)],
+                true
+            ),
+            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END], true),
+            domain: ["!", "&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
+        },
+        {
+            tree_py: m2oAny(
+                and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)])
+            ),
+            tree: inRange("m2o.date_2", ["date", "custom range", DATE_START, DATE_END]),
             domain: [
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["date_2", ">=", "2025-07-02 00:00:00"],
-                        ["date_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
+                ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
         },
         {
-            tree_py: condition(
-                "m2o",
-                "any",
-                connector("&", [
-                    condition("date_2", ">=", "2025-07-02 00:00:00"),
-                    condition("date_2", "<=", "2025-07-03 00:00:00"),
-                ]),
+            tree_py: m2oAny(
+                and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)]),
                 true
             ),
-            tree: condition(
-                "m2o",
-                "any",
-                condition("date_2", "in range", [
-                    "date",
-                    "custom range",
-                    "2025-07-02 00:00:00",
-                    "2025-07-03 00:00:00",
-                ]),
-                true
-            ),
+            tree: m2oAny(inRange("date_2", ["date", "custom range", DATE_START, DATE_END]), true),
             domain: [
                 "!",
-                [
-                    "m2o",
-                    "any",
-                    [
-                        "&",
-                        ["date_2", ">=", "2025-07-02 00:00:00"],
-                        ["date_2", "<=", "2025-07-03 00:00:00"],
-                    ],
-                ],
+                ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
         },
     ];

--- a/addons/website_sale/report/sale_report_views.xml
+++ b/addons/website_sale/report/sale_report_views.xml
@@ -29,9 +29,9 @@
                     <separator orientation="vertical"/>
                     <filter string="Order Date" name="groupby_order_date" context="{'group_by':'date'}"/>
                     <!-- Dashboard filter - used by context -->
-                    <filter string="Last Week" invisible="1" name="week" domain="[('date','&gt;=', 'today -7d')]"/>
-                    <filter string="Last Month" invisible="1" name="month" domain="[('date','&gt;=', 'today -30d')]"/>
-                    <filter string="Last Year" invisible="1"  name="year" domain="[('date','&gt;=', 'today -365d')]"/>
+                    <filter string="Last Week" invisible="1" name="week" domain="[('date','&gt;=', 'today -7d'), ('date', '&lt;', 'today')]"/>
+                    <filter string="Last Month" invisible="1" name="month" domain="[('date','&gt;=', 'today -30d'), ('date', '&lt;', 'today')]"/>
+                    <filter string="Last Year" invisible="1"  name="year" domain="[('date','&gt;=', 'today -365d'), ('date', '&lt;', 'today')]"/>
                 </group>
             </search>
         </field>

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -22,9 +22,9 @@
                 <filter string="To Invoice" name="to_invoice" domain="[('invoice_status', '=', 'to invoice')]"/>
                 <separator/>
                 <!-- Dashboard filter - used by context -->
-                <filter string="Last Week" invisible="1" name="week" domain="[('date_order', '&gt;', 'today -7d')]"/>
-                <filter string="Last Month" invisible="1" name="month" domain="[('date_order', '&gt;', 'today -30d')]"/>
-                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order', '&gt;', 'today -365d')]"/>
+                <filter string="Last Week" invisible="1" name="week" domain="[('date_order', '&gt;=', 'today -7d'), ('date_order', '&lt;', 'today')]"/>
+                <filter string="Last Month" invisible="1" name="month" domain="[('date_order', '&gt;=', 'today -30d'), ('date_order', '&lt;', 'today')]"/>
+                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order', '&gt;=', 'today -365d'), ('date_order', '&lt;', 'today')]"/>
             </filter>
         </field>
     </record>
@@ -215,9 +215,9 @@
                     <filter string="Order Date" name="order_date" context="{'group_by':'date_order'}"/>
                 </group>
                 <!-- Dashboard filter - used by context -->
-                <filter string="Last Week" invisible="1" name="week" domain="[('date_order','&gt;', 'today -7d')]"/>
-                <filter string="Last Month" invisible="1" name="month" domain="[('date_order','&gt;', 'today -30d')]"/>
-                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order','&gt;', 'today -365d')]"/>
+                <filter string="Last Week" invisible="1" name="week" domain="[('date_order','&gt;=', 'today -7d'), ('date_order', '&lt;', 'today')]"/>
+                <filter string="Last Month" invisible="1" name="month" domain="[('date_order','&gt;=', 'today -30d'), ('date_order', '&lt;', 'today')]"/>
+                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order','&gt;=', 'today -365d'), ('date_order', '&lt;', 'today')]"/>
             </search>
         </field>
     </record>


### PR DESCRIPTION
In many predefined custom filters (eg. `Project > All tasks > Search Bar > Closed On > Last 30 days`), when editing the filter (eg. click on the label), the editor opens on "Invalid Datetime". This PR makes the predefined filters that match an existing smart date land on the smart dates instead of "Invalid Datetime".

WHY: The way the date ranges are coded in the python files does not match the expected structure of the smart dates.

FIX: By reformatting the domain of the predefined filter the search model is able to interpret that as smart ranges and displays the correct label and dropdown option when editing the filter. 

NOTE:
- The reformatting of the domain sometimes also changes the  logic (ie which records that are displayed). Notably in the IM livechat the "Last 7 days", "Last 30 days" ... filters now exclude today. This was asked by the framework PO (CTH) and I double checked with the discuss PO (FHE).
- The task also include making a new relative range filter, but was split in 2 so that this part can be merged before the freeze (see odoo/odoo#252484)
- We also change the smart date "Last 12 months" to "Last 365 days" as this is clearer from a user perspective and last 365 days was more used in arch filters. (previously when applying last 12 months smart date the range was set to the the 1st of 12 months ago to the 1st of the current month)
- I also added some helpers to the test files to make them more readable and shorter.

NOTE TO REVIEWER:
For the IM livechat some tests broke when changing the Last 7 days filter to exclude today (see above). The way I fixed it was: 
- When the test sessions are created with the orm, simply freezing time is not enough we also have to patch cr._now because the cursor is opened before I can freeze time
- When the test sessions were created via RPC --> no need to patch the cr._now because the RPC spawns a new transaction and cursor inside frozen time.
--> Let me know if there is a better way

Enterprise PR: odoo/enterprise#113169


task#5959944
