### PR TITLE
[FIX] cloud_storage_google: fix binary value decoding for config settings

### DIFF
--- a/addons/cloud_storage_google/models/res_config_settings.py
+++ b/addons/cloud_storage_google/models/res_config_settings.py
@@ -1,14 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 import json
-import requests
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
+import requests
 from google.auth.transport.requests import Request
 
-from odoo import models, fields, api, _
-from odoo.exceptions import ValidationError, UserError
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools.binary import BinaryBytes
 
 from .ir_attachment import get_cloud_storage_google_credential
 
@@ -29,7 +29,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='cloud_storage_google_bucket_name')
     # Google Service Account Key in JSON format
     cloud_storage_google_service_account_key = fields.Binary(
-        string='Google Service Account Key', store=False
+        string='Google Service Account Key', store=False,
     )
     cloud_storage_google_account_info = fields.Char(
         string='Google Service Account Info',
@@ -43,14 +43,14 @@ class ResConfigSettings(models.TransientModel):
     def get_values(self):
         res = super().get_values()
         if account_info := self.env['ir.config_parameter'].get_str('cloud_storage_google_account_info'):
-            res['cloud_storage_google_service_account_key'] = base64.b64encode(account_info.encode())
+            res['cloud_storage_google_service_account_key'] = BinaryBytes(account_info.encode('utf-8'))
         return res
 
     @api.onchange('cloud_storage_google_service_account_key')
     def _compute_cloud_storage_google_account_info(self):
         for setting in self:
             key = setting.cloud_storage_google_service_account_key
-            setting.cloud_storage_google_account_info = base64.b64decode(key) if key else False
+            setting.cloud_storage_google_account_info = key.decode('utf-8') if key else False
 
     def _setup_cloud_storage_provider(self):
         ICP = self.env['ir.config_parameter']
@@ -60,7 +60,7 @@ class ResConfigSettings(models.TransientModel):
         bucket_name = ICP.get_str('cloud_storage_google_bucket_name')
         # use different blob names in case the credentials are allowed to
         # overwrite an existing blob created by previous tests
-        blob_name = f'0/{datetime.now(timezone.utc)}.txt'
+        blob_name = f'0/{datetime.now(UTC)}.txt'
 
         IrAttachment = self.env['ir.attachment']
         # check blob create permission
@@ -88,7 +88,7 @@ class ResConfigSettings(models.TransientModel):
         url = f"https://storage.googleapis.com/storage/v1/b/{bucket_name}?fields=cors"
         headers = {
             'Authorization': f'Bearer {credential.token}',
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
         }
         data = json.dumps({'cors': cors})
         patch_response = requests.patch(url, data=data, headers=headers, timeout=5)
@@ -116,7 +116,7 @@ class ResConfigSettings(models.TransientModel):
                 WHERE type = 'cloud_storage'
                 AND url LIKE 'https://storage.googleapis.com/%'
                 LIMIT 1
-            """
+            """,
         )
         if cr.fetchone():
             raise UserError(_('Some Google attachments are in use, please migrate cloud storages before disable the provider'))

--- a/addons/cloud_storage_google/tests/__init__.py
+++ b/addons/cloud_storage_google/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_cloud_storage_google
 from . import test_cloud_storage_google_attachment_controller
+from . import test_res_config_settings

--- a/addons/cloud_storage_google/tests/test_res_config_settings.py
+++ b/addons/cloud_storage_google/tests/test_res_config_settings.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from odoo.tests.common import TransactionCase
+from odoo.tools.binary import BinaryBytes
+
+
+class TestResConfigSettings(TransactionCase):
+
+    def test_cloud_storage_google_config_encoding(self):
+        account_info_dict = {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key": "test-key"
+        }
+        account_info_str = json.dumps(account_info_dict)
+
+        # Simulates web client uploading a file
+        settings = self.env['res.config.settings'].create({
+            'cloud_storage_google_service_account_key': BinaryBytes(account_info_str.encode('utf-8')),
+        })
+        settings._compute_cloud_storage_google_account_info()
+        self.assertEqual(settings.cloud_storage_google_account_info, account_info_str, "Human Readable json should be decoded from raw json file bytes")
+
+        # Simulates page refresh;
+        self.env['ir.config_parameter'].sudo().set_str('cloud_storage_google_account_info', account_info_str)
+        values = settings.get_values()
+        key_value = values.get('cloud_storage_google_service_account_key')
+        self.assertTrue(key_value, "Key should be present in values")
+        self.assertEqual(bytes(key_value), account_info_str.encode('utf-8'), "Key value should be raw bytes of account info")


### PR DESCRIPTION
Configuring Google Cloud Storage fails with an encoding error when trying to read or set the Google Service Account Key.

Steps to reproduce:
1. Go to Settings / Cloud Storage
2. Select "Google Cloud Storage" as provider
3. Upload a valid JSON config file => A binascii.Error (Incorrect padding) or TypeError occurs.

Diagnosis
Recent refactoring (Ref.1) changed fields.Binary to return BinaryValue objects containing raw bytes instead of base64-encoded strings. This flow in cloud_storage_google was still attempting to manually base64 decode/encode these values.

Solution: Apply recent BinaryValue convention.

Scope note:
cloud_storage_azure does not use Binary fields; it uses Char for all credentials

Ref.1
41fe2ebdb9cc37341362d7af829c087a5f72f9f1
[IMP] core, *: fields.Binary return BinaryValue

Discovered during the following task:
task-5153790
