### PR TITLE
[FIX] account: set account required for couterpart in reconciliation model

### DIFF
--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -96,7 +96,7 @@
                                             <field name="sequence"
                                                    widget="handle"/>
                                             <field name="partner_id"/>
-                                            <field name="account_id"/>
+                                            <field name="account_id" required="not partner_id"/>
                                             <field name="amount_type"/>
                                             <field name="amount_string"/>
                                             <field name="tax_ids"


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Accounting dashboard
- From Bank journal, open Reconciliation Models list
- Create a new reconciliation model
- Add counterpart line without partner and account
- Click on "Automate"

**Issue:**
The operation fails because the default account of the bank journal is used as there is no user and no account configured for the counterpart. Which results on several lines using a liquidity account (i.e. the cause of the error).
Either a partner or an account should be set on a counterpart line.

opw-6056737



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
