### PR TITLE
[FIX] l10n_it_edi_withholding: exclude pens fund tax return

### DIFF
--- a/addons/l10n_it_edi_withholding/models/__init__.py
+++ b/addons/l10n_it_edi_withholding/models/__init__.py
@@ -4,3 +4,4 @@
 from . import account_tax
 from . import account_chart_template
 from . import account_move
+from . import account_return

--- a/addons/l10n_it_edi_withholding/models/account_return.py
+++ b/addons/l10n_it_edi_withholding/models/account_return.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class AccountReturn(models.Model):
+    _inherit = 'account.return'
+
+    def _get_amount_to_pay_additional_tax_domain(self):
+        return super()._get_amount_to_pay_additional_tax_domain() + [('l10n_it_pension_fund_type', '=', False)]

--- a/addons/l10n_it_edi_withholding/models/account_return.py
+++ b/addons/l10n_it_edi_withholding/models/account_return.py
@@ -1,8 +1,0 @@
-from odoo import models
-
-
-class AccountReturn(models.Model):
-    _inherit = 'account.return'
-
-    def _get_amount_to_pay_additional_tax_domain(self):
-        return super()._get_amount_to_pay_additional_tax_domain() + [('l10n_it_pension_fund_type', '=', False)]


### PR DESCRIPTION
Adding the method _get_amount_to_pay_additional_tax_domain inside the l10n_it_edi_withholding module to avoid dependency issues

Issue from commit: 29868850b03373b9235308563d0dcd7218c62f1d

runbot-242217

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
