### PR TITLE
[FIX] hr_attendance: various fixes

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -116,8 +116,14 @@ export class ActivityMenu extends Component {
         });
     }
 
+    get closeSystrayOnCheckIn() {
+        return true;
+    }
+
     async signInOut() {
-        this.dropdown.close();
+        if (this.closeSystrayOnCheckIn) {
+            this.dropdown.close();
+        }
         if (this._attendanceInProgress) {
             return;
         }

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -16,8 +16,8 @@
 
             <t t-set-slot="content">
                 <div class="att_container d-flex flex-column">
-                    <div class="d-flex justify-content-between align-items-center gap-5 border-bottom p-3">
-                        <h3 class="mb-0">
+                    <div class="d-flex justify-content-between align-items-center gap-5 p-3">
+                        <h3 class="mb-0 ps-1">
                             <t t-if="this.hasCheckedInToday">
                                 <small>Welcome back</small> <span class="d-block"><t t-esc="this.employeeName"/>!</span>
                             </t>
@@ -26,9 +26,9 @@
                             </t>
                         </h3>
                     </div>
-                    
-                    <div class="o_att_today_wrap px-3">
-                        <table class="table mb-0">
+
+                    <div class="o_att_today_wrap px-2">
+                        <table class="table table-borderless mb-0">
                             <tbody>
                                 <tr t-foreach="this.attendancesToday" t-as="attendance" t-key="attendance.id">
                                     <td>
@@ -50,11 +50,11 @@
                                         <t t-esc="duration.h"/>h<span class="text-muted"><t t-esc="duration.m"/></span>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <td colspan="3" class="border-bottom-0">
+                                <tr class="border-top">
+                                    <td colspan="3">
                                         Today
                                     </td>
-                                    <td class="border-bottom-0 ps-4 text-end">
+                                    <td class="ps-4 text-end">
                                         <t t-set="total" t-value="this.splitTime(this.hoursToday)"/>
                                         <t t-esc="total.h"/>h<span class="text-muted"><t t-esc="total.m"/></span>
                                     </td>


### PR DESCRIPTION
# [FIX] hr_attendance: alignment
This commits revamps the attendance systray by aligning items and removing horizontal lines between attendance entries.

# [FIX] hr_attendance: allow not to close systray based on condition
This commits allows components inheriting from the attendance menu to conditionally close the systray.

By default, the dropdown will be closed on check-in and check-out to preserve the original behaviour.

See odoo/enterprise#113189

task-6088779