### PR TITLE
[FIX] hr_attendance: various fixes

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -116,8 +116,14 @@ export class ActivityMenu extends Component {
         });
     }
 
+    get closeSystrayOnCheckIn() {
+        return true;
+    }
+
     async signInOut() {
-        this.dropdown.close();
+        if (this.closeSystrayOnCheckIn) {
+            this.dropdown.close();
+        }
         if (this._attendanceInProgress) {
             return;
         }

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -16,8 +16,8 @@
 
             <t t-set-slot="content">
                 <div class="att_container d-flex flex-column">
-                    <div class="d-flex justify-content-between align-items-center gap-5 border-bottom p-3">
-                        <h3 class="mb-0">
+                    <div class="d-flex justify-content-between align-items-center gap-5 p-3">
+                        <h3 class="mb-0 ps-1">
                             <t t-if="this.hasCheckedInToday">
                                 <small>Welcome back</small> <span class="d-block"><t t-esc="this.employeeName"/>!</span>
                             </t>
@@ -26,9 +26,9 @@
                             </t>
                         </h3>
                     </div>
-                    
+
                     <div class="o_att_today_wrap px-3">
-                        <table class="table mb-0">
+                        <table class="table table-sm table-borderless">
                             <tbody>
                                 <tr t-foreach="this.attendancesToday" t-as="attendance" t-key="attendance.id">
                                     <td>
@@ -50,11 +50,11 @@
                                         <t t-esc="duration.h"/>h<span class="text-muted"><t t-esc="duration.m"/></span>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <td colspan="3" class="border-bottom-0">
+                                <tr class="border-top">
+                                    <td colspan="3">
                                         Today
                                     </td>
-                                    <td class="border-bottom-0 ps-4 text-end">
+                                    <td class="ps-4 text-end">
                                         <t t-set="total" t-value="this.splitTime(this.hoursToday)"/>
                                         <t t-esc="total.h"/>h<span class="text-muted"><t t-esc="total.m"/></span>
                                     </td>
@@ -63,7 +63,7 @@
                         </table>
                     </div>
 
-                    <div class="o_wrap_btn_sign_out position-md-sticky bottom-0 p-3 z-2">
+                    <div class="o_wrap_btn_sign_out position-md-sticky bottom-0 p-3 pt-0 z-2">
                         <button t-on-click="() => this.signInOut()"
                                 t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'primary' }} w-100">
                             <span t-if="!this.state.checkedIn">Check in</span>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -10,10 +10,10 @@
                     <field name="order_id" string="Sales Order" filter_domain="['|', ('so_line', 'ilike', self), ('order_id', 'ilike', self)]"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable" string="Billable" domain="[('so_line', '!=', False)]"
+                    <filter name="billable" string="Billable" domain="[('billable_type', '!=', '09_non_billable')]"
                         context="{'show_target_left': True}"
                         groups="sales_team.group_sale_salesman"/>
-                    <filter name="non_billable" string="Non-Billable" domain="[('so_line', '=', False)]"
+                    <filter name="non_billable" string="Non-Billable" domain="[('billable_type', '=', '09_non_billable')]"
                         groups="sales_team.group_sale_salesman"/>
                     <separator/>
                 </xpath>


### PR DESCRIPTION
# [FIX] hr_attendance: alignment
This commits revamps the attendance systray by aligning items and removing horizontal lines between attendance entries.

# [FIX] hr_attendance: allow not to close systray based on condition
This commits allows components inheriting from the attendance menu to conditionally close the systray.

By default, the dropdown will be closed on check-in and check-out to preserve the original behaviour.

See odoo/enterprise#113189

task-6088779