### PR TITLE
[FIX] hr_attendance : Localize midnight in absence attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -803,10 +803,11 @@ class HrAttendance(models.Model):
         filtered_employees = absent_employees.filter_valid(fields.Date.today() - relativedelta(days=1))
 
         for emp in filtered_employees:
-            local_day_start = pytz.utc.localize(yesterday).astimezone(pytz.timezone(emp._get_tz()))
+            local_day_start = pytz.timezone(emp._get_tz()).localize(yesterday)
+            check_in_utc = local_day_start.astimezone(pytz.utc)
             technical_attendances_vals.append({
-                'check_in': local_day_start.strftime('%Y-%m-%d %H:%M:%S'),
-                'check_out': (local_day_start + relativedelta(seconds=1)).strftime('%Y-%m-%d %H:%M:%S'),
+                'check_in': check_in_utc.strftime('%Y-%m-%d %H:%M:%S'),
+                'check_out': (check_in_utc + relativedelta(seconds=1)).strftime('%Y-%m-%d %H:%M:%S'),
                 'in_mode': 'technical',
                 'out_mode': 'technical',
                 'employee_id': emp.id


### PR DESCRIPTION
### Steps to reproduce:
	- Have a database in timezone America/Asuncion for example
	- Create an employee
	- Create an attendance for the day before yesterday from 13h to 19h
	- Run the absence detection cron
	- An error will be raised saying the user is already checked-in on that day

### Cause:
When trying to create an absence attendance we localized yesterday's midnight into UTC and then apply the employee timezone. Which cause a one-day shift when having a timezone behind UTC as at that point we try to create an attendance on the day before yesterday not yesterday

### Fix:
We use the timezone of the employee to localize midnight then get this
time in UTC.
opw-5930309