### PR TITLE
[18.0][FIX] base: Prevent docutils from logging to stderr.

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -210,20 +210,22 @@ class Module(models.Model):
                             )
                     module.description_html = _apply_description_images(doc)
             except FileNotFoundError:
-                overrides = {
-                    'embed_stylesheet': False,
-                    'doctitle_xform': False,
-                    'output_encoding': 'unicode',
-                    'xml_declaration': False,
-                    'file_insertion_enabled': False,
-                }
-                raw_description = module.description or ''
+                with open(os.devnull, 'w') as warning_stream:
+                    overrides = {
+                        'embed_stylesheet': False,
+                        'doctitle_xform': False,
+                        'output_encoding': 'unicode',
+                        'warning_stream': warning_stream,
+                        'xml_declaration': False,
+                        'file_insertion_enabled': False,
+                    }
+                    raw_description = module.description or ''
 
-                try:
-                    output = publish_string(source=raw_description, settings_overrides=overrides, writer=MyWriter())
-                except Exception as e:  # noqa: BLE001
-                    _logger.warning("Failed to render module description for %s: %s. Falling back to raw description.", module.name, e)
-                    output = Markup('<pre><code>%s</code></pre>') % raw_description
+                    try:
+                        output = publish_string(source=raw_description, settings_overrides=overrides, writer=MyWriter())
+                    except Exception as e:  # noqa: BLE001
+                        _logger.warning("Failed to render module description for %s: %s. Falling back to raw description.", module.name, e)
+                        output = Markup('<pre><code>%s</code></pre>') % raw_description
 
                 module.description_html = _apply_description_images(output)
 


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:

 _Originally posted by @ap-wtioit in [#246661](https://github.com/odoo/odoo/issues/246661#issuecomment-3834049732)_

> This is caused by https://github.com/odoo/odoo/commit/021aaa4fe7d9ae20c06d1a54f0dd81c1b75bc5a3 parsing the description for all modules (previously only for non applications `... not module.application ...`) when the description is not correct. This affects not only mail but also a few other modules in community and a bunch of enterprise modules as well.
> 
> When log level is not set to debug the system messages of docutils still reach stderr which is especially anoying because there is not context for them:
> 
> <img width="1343" height="112" alt="Image" src="https://github.com/user-attachments/assets/d2c8b2e1-4742-4522-83a5-a3d3d6292ed0" /> 

#### Current behavior before PR:

The `docutils` package logs directly to stderr. For example, when installing the `hr` module:

```
2026-04-07 17:37:33,145 1 INFO odoo odoo.modules.registry: module hr: creating or updating database tables 
<string>:49: (WARNING/2) Title underline too short.

Time Off Management
-----------------
<string>:49: (WARNING/2) Title underline too short.

Time Off Management
-----------------
```

#### Desired behavior after PR is merged:

The `docutils` package doesn't add unprefixed lines to the logs.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
