### PR TITLE
[FIX] cloud_storage: preserve attachment mimetype during cloud upload

### DIFF
--- a/addons/cloud_storage/models/ir_attachment.py
+++ b/addons/cloud_storage/models/ir_attachment.py
@@ -40,6 +40,8 @@ class CloudStorageAttachment(models.Model):
                 raise UserError(_('Cloud Storage is not enabled'))
             for record in self:
                 record.write({
+                    # Preserve the existing mimetype to avoid it being guessed
+                    'mimetype': record.mimetype,
                     'raw': False,
                     'type': 'cloud_storage',
                     'url': record._generate_cloud_storage_url(),

--- a/addons/cloud_storage/tests/__init__.py
+++ b/addons/cloud_storage/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_ir_attachment

--- a/addons/cloud_storage/tests/test_ir_attachment.py
+++ b/addons/cloud_storage/tests/test_ir_attachment.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestIrAttachment(TransactionCase):
+
+    def test_post_add_create_preserves_mimetype(self):
+        def _generate_cloud_storage_url(self):
+            """ Mock _generate_cloud_storage_url to avoid NotImplementedError"""
+            return f"http://cloud.storage/{self.id}"
+
+        # Patch the method on the class to avoid "read-only" errors on recordsets
+        self.patch(self.env.registry['ir.attachment'], '_generate_cloud_storage_url', _generate_cloud_storage_url)
+
+        self.env['ir.config_parameter'].sudo().set_param('cloud_storage_provider', 'dummy')
+        attachment = self.env['ir.attachment'].create({
+            'name': 'test_audio.webm',
+            'mimetype': 'audio/webm',
+            'raw': b'dummy content',
+        })
+        attachment._post_add_create(cloud_storage=True)
+
+        self.assertEqual(attachment.type, 'cloud_storage')
+        self.assertEqual(attachment.mimetype, 'audio/webm', "Attachment mimetype should be preserved")
+        self.assertFalse(attachment.raw, "Raw data should be cleared")
+        self.assertEqual(attachment.url, f"http://cloud.storage/{attachment.id}")


### PR DESCRIPTION
When uploading an attachment to cloud storage via `_post_add_create(cloud_storage=True)`, the attachment's original `mimetype` is guessed even if we specify it. With this commit we explicitly preserve given mimetype

Discovered during task-5153790
