### PR TITLE
[FIX] product,sale{,_pdf_quote_builder}: update invalid links

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -650,7 +650,7 @@ class ProductTemplate(models.Model):
                     %s
                 </p>
                 <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
+                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/eaa2883bd361273b475c9765f64e3e0c/pdfquotebuilderexamples.zip">
                     %s
                     </a>
                 </p>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -974,7 +974,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/18.0/_downloads/4c54b867f6472b9cbcc233b4821d5c7b/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!
@@ -1011,7 +1011,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/18.0/_downloads/4c54b867f6472b9cbcc233b4821d5c7b/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!

--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -27,7 +27,7 @@
                         If empty, it will use those define in the company settings. <br/>
                         <widget
                             name="documentation_link"
-                            path="/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip"
+                            path="/_downloads/eaa2883bd361273b475c9765f64e3e0c/pdfquotebuilderexamples.zip"
                             icon="fa-arrow-right"
                             label=" Download examples"
                         />


### PR DESCRIPTION
Currently, a 404 error is occurring when the user clicks on the Check the sample button.

**Steps to produce:**
- Install sales module without demo data.
- Click on the check a sample. its clean! button.

**Issue:**
- A 404 error occurs with a blank page.

**Cause:**
- This issue is occurring because the link to open the sample quotation pdf was changed in the Odoo documentation.

**Solution:**
- Give a valid link to open the sample quotation pdf.
- similar fix already did [here1] & [here2].

[here1]: https://github.com/odoo/odoo/commit/38431f3aef57c5b91644b4c5241f226beb917b12
[here2]: https://github.com/odoo/odoo/commit/610cea89c37454a4ddb68939333b4b363f2f81a2

opw-6099641
opw-6074953


