### PR TITLE
[FIX] web: prevent multiple property creation for same model

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -34,6 +34,7 @@ export class PropertiesField extends Component {
         },
         editMode: { type: Boolean, optional: true },
     };
+    static hasCreatedProperty = false;
 
     setup() {
         this.notification = useService("notification");
@@ -85,7 +86,8 @@ export class PropertiesField extends Component {
                 const isInEditMode = canChangeDefinition && !this.props.readonly;
                 this.state.canChangeDefinition = !!canChangeDefinition;
                 this.state.isInEditMode = isInEditMode;
-                if (isInEditMode && this.propertiesList.length === 0) {
+                if (isInEditMode && this.propertiesList.length === 0 && !PropertiesField.hasCreatedProperty) {
+                    PropertiesField.hasCreatedProperty = true;
                     this.onPropertyCreate();
                 }
             });


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install `hr_payroll` with demo data.
2. Go to Payroll > Employee > Open Employee (e.g; _Abigail Peterson_) form view.
3. Click Payroll tab > Gear Icon > Edit Properties.

**Error:**
`TypeError: Cannot read properties of undefined (reading 'getRootNode')`

Cause:
`onPropertyCreate()` triggers multiple times, creating duplicate property fields for the same model (`employee_properties` and `payroll_properties`). In such cases, the DOM query may not find a matching `o_field_property_open_popover` element, resulting in an empty labels NodeList. Accessing the last element then returns undefined, which causes a traceback when `_openPropertyDefinition()` is called.

Fix:
This commit ensures that the property field is created only once, preventing multiple executions of `onPropertyCreate()`.

No task id