### PR TITLE
[FIX] l10n_sa_edi: prevent resetting parent journal on branch API mode change

### DIFF
--- a/addons/l10n_sa_edi/models/res_company.py
+++ b/addons/l10n_sa_edi/models/res_company.py
@@ -29,7 +29,7 @@ class ResCompany(models.Model):
             if 'l10n_sa_api_mode' in vals:
                 if company.l10n_sa_api_mode == 'prod' and vals['l10n_sa_api_mode'] != 'prod':
                     raise UserError(_("You cannot change the ZATCA Submission Mode once it has been set to Production"))
-                journals = self.env['account.journal'].search(self.env['account.journal']._check_company_domain(company))
+                journals = self.env['account.journal'].search([('company_id', '=', company.id)])
                 journals._l10n_sa_reset_certificates()
                 journals.l10n_sa_latest_submission_hash = False
         return super().write(vals)

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -533,6 +533,27 @@ class TestEdiZatca(TestSaEdiCommon):
             'correctly set on the Company:\n - Street</p>'
         )
 
+    def test_child_company_api_mode_change_does_not_reset_parent_journal(self):
+        """Changing a child company's ZATCA API mode must not reset the parent company's journal."""
+        self.customer_invoice_journal._l10n_sa_load_edi_demo_data()
+        self.assertTrue(self.customer_invoice_journal.l10n_sa_production_csid_json)
+
+        child_journal = self.env['account.journal'].create({
+            'name': 'Child Sales Journal',
+            'code': 'CSAL',
+            'type': 'sale',
+            'company_id': self.sa_branch.id,
+        })
+        child_journal._l10n_sa_load_edi_demo_data()
+        self.assertTrue(child_journal.l10n_sa_production_csid_json)
+
+        self.sa_branch.l10n_sa_api_mode = 'preprod'
+
+        self.assertFalse(child_journal.l10n_sa_production_csid_json,
+            "Child journal should be reset after API mode change")
+        self.assertTrue(self.customer_invoice_journal.l10n_sa_production_csid_json,
+            "Parent journal must not be reset when child company API mode changes")
+
     def test_invoice_cash_rounding_payable_amount(self):
         """Test that payable_amount is correctly computed when using cash rounding"""
         cash_rounding = self.env['account.cash.rounding'].create({


### PR DESCRIPTION
**Steps to reproduce:**
* Install `l10n_sa_edi` module.
* Create a parent company and a child company, both with the same VAT number.
* Onboard the parent company's Sales journal with ZATCA.
* Onboard the child company's Sales journal with ZATCA. Create a journal for the child if there is no journal.
* Change the child company's ZATCA API mode to any other mode.

**Observed behavior:**
* Changing the child company's API mode resets and unboards the parent company's Sales journal as well.

**Cause:**
* In `res.company.write`, when `l10n_sa_api_mode` changes, journals to reset are fetched using `_check_company_domain(company)`.
* `account.journal` uses `check_company_domain_parent_of`, which returns journals where `company_id` is a parent of the given company — so passing a child company also matches journals belonging to the parent.

**Fix:**
* Replace `_check_company_domain(company)` with a direct `('company_id', '=', company.id)` filter, so only journals strictly owned by the company being modified are reset.

opw-6099340