### PR TITLE
[FIX] Mail: fetching inbox messages

### DIFF
--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -17,7 +17,8 @@ class MailboxController(http.Controller):
             messages,
             extra_fields=[
                 Store.One("thread", [
-                    Store.Attr("message_needaction_counter"),
+                    # sudo: mail.thread: users can read their own message_needaction_counter on the thread
+                    Store.Attr("message_needaction_counter", sudo=True),
                     Store.Attr("message_needaction_counter_bus_id", bus_last_id)
                 ], as_thread=True)
             ],

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -16,20 +16,20 @@ class TestInboxPerformance(HttpCase, MailCommon):
         # Queries (in order):
         #   - search website (get_current_website by domain)
         #   - search website (get_current_website default)
-        #   - search website_rewrite (_get_rewrites) sometimes occurs depending on the routing cache
-        #   - insert res_device_log
+        #   - sometimes could occur depending on the routing cache (website_rewrite, ir_config_parameter, res.lang flag_image)
         #   - _xmlid_lookup (_get_public_users)
         #   - fetch website (_get_cached_values)
-        #   - get_param ir_config_parameter (_pre_dispatch website_sale)
+        #   - user authentication(_get_lock_timeouts)
         #   4 _message_fetch:
         #       2 _search_needaction:
         #           - fetch res_users (current user)
         #           - search ir_rule (_get_rules for mail.notification)
         #       - search ir_rule (_get_rules)
         #       - search mail_message
-        #   30 message _to_store:
+        #   - search bus_bus (_bus_last_id in bus.py)
+        #   29 message _to_store:
+        #       - fetch mail_message (_to_store_defaults)
         #       - search mail_message_schedule
-        #       - fetch mail_message
         #       - search mail_followers
         #       2 thread _to_store:
         #           - fetch slide_channel
@@ -37,33 +37,30 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search mail_message_res_partner_starred_rel (_compute_starred)
         #       - search message_attachment_rel
         #       - search mail_link_preview
-        #       - search mail_message_reaction
         #       - search mail_message_res_partner_rel
-        #       - fetch mail_message_subtype
-        #       - search mail_notification
-        #       7 _filtered_for_web_client:
+        #       - search mail_message_reaction
+        #       4 _filtered_for_web_client:
+        #           - search mail_notification
         #           - fetch mail_notification
-        #           4 _compute_domain:
-        #               - search ir_rule (_get_rules for res.partner)
-        #               - search res_groups_users_rel
-        #               - search rule_group_rel
-        #               - fetch ir_rule
-        #           - fetch res_company
         #           - fetch res_partner
+        #           - fetch mail_message_subtype
         #       2 _compute_rating_id:
         #           - search rating_rating
         #           - fetch rating_rating
-        #       - search mail_tracking_value
-        #       3 _author_to_store:
+        #       3 author:
         #           - fetch res_partner
         #           - search res_users
         #           - fetch res_users
-        #       - search ir_rule (_get_rules for rating.rating)
-        #       - read group rating_rating (_rating_get_stats_per_record for slide.channel)
-        #       - read group rating_rating (_compute_rating_stats for slide.channel)
-        #       - read group rating_rating (_rating_get_stats_per_record for product.template)
-        #       - read group rating_rating (_compute_rating_stats for product.template)
-        #   - get_param ir_config_parameter (_save_session)
+        #       2 compute message_needaction for slide.channel (one query per record due to the lack of batching)
+        #       2 compute message_needaction for product.template (one query per record due to the lack of batching)
+        #       - search mail_tracking_value
+        #       5 compute rating stats
+        #           - search ir_rule (_get_rules for rating.rating)
+        #           - read group rating_rating (_rating_get_stats_per_record for slide.channel)
+        #           - read group rating_rating (_compute_rating_stats for slide.channel)
+        #           - read group rating_rating (_rating_get_stats_per_record for product.template)
+        #           - read group rating_rating (_compute_rating_stats for product.template)
+
         first_model_records = self.env["product.template"].create(
             [{"name": "Product A1"}, {"name": "Product A2"}]
         )
@@ -78,5 +75,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(43):
+        with self.assertQueryCount(40):
             self.make_jsonrpc_request("/mail/inbox/messages")

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -3,6 +3,7 @@
 from itertools import chain
 
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.exceptions import AccessError
 from odoo.tests.common import HttpCase, tagged, warmup
 
 
@@ -27,11 +28,12 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search ir_rule (_get_rules)
         #       - search mail_message
         #   - search bus_bus (_bus_last_id in bus.py)
-        #   29 message _to_store:
+        #   31 message _to_store:
         #       - fetch mail_message (_to_store_defaults)
         #       - search mail_message_schedule
         #       - search mail_followers
-        #       2 thread _to_store:
+        #       3 thread _to_store:
+        #           - fetch hr_employee
         #           - fetch slide_channel
         #           - fetch product_template
         #       - search mail_message_res_partner_starred_rel (_compute_starred)
@@ -51,6 +53,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - fetch res_partner
         #           - search res_users
         #           - fetch res_users
+        #       - compute message_needaction for hr.employee
         #       2 compute message_needaction for slide.channel (one query per record due to the lack of batching)
         #       2 compute message_needaction for product.template (one query per record due to the lack of batching)
         #       - search mail_tracking_value
@@ -61,13 +64,18 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - read group rating_rating (_rating_get_stats_per_record for product.template)
         #           - read group rating_rating (_compute_rating_stats for product.template)
 
+        # rating stats enabled
         first_model_records = self.env["product.template"].create(
             [{"name": "Product A1"}, {"name": "Product A2"}]
         )
         second_model_records = self.env["slide.channel"].create(
             [{"name": "Course B1"}, {"name": "Course B2"}]
         )
-        for record in chain(first_model_records, second_model_records):
+        # group restricted fields
+        third_model_record = self.env["hr.employee"].create({"name": "Employee"})
+        with self.assertRaises(AccessError):
+            third_model_record.with_user(self.user_employee).read("message_needaction_counter")
+        for record in chain(first_model_records, second_model_records, third_model_record):
             record.message_post(
                 body=f"<p>Test message for {record.name}</p>",
                 message_type="comment",
@@ -75,5 +83,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(40):
+        with self.assertQueryCount(42):
             self.make_jsonrpc_request("/mail/inbox/messages")


### PR DESCRIPTION
Since PR #247569, the value of the `message_needaction_counter` field has been added to the store data when fetching inbox messages. The `hr` module adds a specific group to this field, that could cause fetching inbox messages to crash if the needaction message is related to an `hr.employee` record and the user is not involved in that group. This change adds sudo when accessing to this field to get the store data for inbox messages.

Steps to reproduce:
- Set the notification preference to `inbox` for the demo user.
- Log in as admin and mention the demo user in an employee record.
- Go to inbox as demo. The messages will not be fetched, with an access error to `message_needaction_counter` field.