### PR TITLE
[IMP] account: automatically remove sequence when switching move type in draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6136,10 +6136,10 @@ class AccountMove(models.Model):
         return self.adjusting_entry_origin_move_ids._get_records_action(name=label)
 
     def action_switch_move_type(self):
-        if any((move.posted_before and move.name) for move in self):
-            raise ValidationError(_("You cannot switch the type of a document with an existing sequence number."))
         if any(move.move_type == "entry" for move in self):
             raise ValidationError(_("This action isn't available for this document."))
+        if any(move.state != 'draft' for move in self):
+            raise ValidationError(self.env._("You can only switch the type of a draft document."))
 
         for move in self:
             in_out, old_move_type = move.move_type.split('_')

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6094,10 +6094,10 @@ class AccountMove(models.Model):
         return self.adjusting_entry_origin_move_ids._get_records_action(name=label)
 
     def action_switch_move_type(self):
-        if any((move.posted_before and move.name) for move in self):
-            raise ValidationError(_("You cannot switch the type of a document with an existing sequence number."))
         if any(move.move_type == "entry" for move in self):
             raise ValidationError(_("This action isn't available for this document."))
+        if any(move.state != 'draft' for move in self):
+            raise ValidationError(self.env._("You can only switch the type of a draft document."))
 
         for move in self:
             in_out, old_move_type = move.move_type.split('_')


### PR DESCRIPTION
Before this commit: If posted invoice is reset to draft it has sequence number and when we click switch to invoice/credit note it raises error because of existing sequence. Now user have to first remove sequence and then switching move type is allowed.

After this commit: Only posted and cancelled moves are being restricted from switching move type, if it is in draft and have sequence allow changing move type and clear existing sequence in backend.

Task [link](https://www.odoo.com/odoo/project.task/6089932)
task-6089932