### PR TITLE
[FIX] stock: auto-reserve outbound moves when stock arrives at child location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2257,7 +2257,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
         domains = []
         for move in self:
-            domains.append([('product_id', '=', move.product_id.id), ('location_id', '=', move.location_dest_id.id)])
+            domains.append([('product_id', '=', move.product_id.id), ('location_id', 'parent_of', move.location_dest_id.id)])
         static_domain = [('state', 'in', ['confirmed', 'partially_available']),
                          ('procure_method', '=', 'make_to_stock'),
                          '|',

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3874,6 +3874,59 @@ class TestAutoAssign(TestStockCommon):
         self.assertEqual(customer_picking4.move_ids.quantity, 10, "Reservation Method: 'by_date' should auto-assign when within reservation date range at confirmation")
         self.assertEqual(customer_picking5.move_ids.quantity, 10, "Reservation Method: 'at_confirm' should auto-assign at confirmation")
 
+    def test_auto_assign_receipt_to_child_location(self):
+        """When a receipt puts stock into a child location of an outbound move's
+        source location, the outbound move should be automatically reserved.
+
+        A delivery sourced from WH/Stock should be triggered for assignment when
+        stock arrives at WH/Stock/Shelf 1, because WH/Stock/Shelf 1 is a child
+        of WH/Stock and the quant gather logic already uses child_of when
+        searching for available stock.
+        """
+        self.env['ir.config_parameter'].sudo().set_param('stock.picking_no_auto_reserve', False)
+        stock_location = self.env['stock.location'].browse(self.stock_location)
+        child_location = stock_location.child_ids[0]
+        picking_type_out = self.env['stock.picking.type'].browse(self.picking_type_out)
+        picking_type_out.reservation_method = 'at_confirm'
+
+        customer_picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out,
+        })
+        self.env['stock.move'].create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': customer_picking.id,
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+        })
+        customer_picking.action_confirm()
+        self.assertEqual(customer_picking.move_ids.quantity, 0)
+
+        supplier_picking = self.env['stock.picking'].create({
+            'location_id': self.supplier_location,
+            'location_dest_id': child_location.id,
+            'picking_type_id': self.picking_type_in,
+        })
+        self.env['stock.move'].create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': supplier_picking.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': child_location.id,
+        })
+        supplier_picking.action_confirm()
+        supplier_picking.move_ids.quantity = 10
+        supplier_picking.move_ids.picked = True
+        supplier_picking.button_validate()
+
+        self.assertEqual(customer_picking.move_ids.quantity, 10)
+
     def test_serial_lot_ids(self):
         self.stock_location = self.env.ref('stock.stock_location_stock')
         self.customer_location = self.env.ref('stock.stock_location_customers')


### PR DESCRIPTION
Steps to reproduce
1. Create a product with no stock
2. Confirm a delivery order sourced from WH/Stock
3. Receive the product via a purchase order into WH/Stock/Shelf 1 (a child of WH/Stock)
4. Observe that the delivery is not automatically reserved

Issue
_trigger_assign builds a domain to find outbound moves to re-attempt reservation after a receipt is validated. The domain used an exact match ('location_id', '=', move.location_dest_id.id), so only moves whose source location was identical to the receipt's destination were considered. A move sourced from WH/Stock was never found when stock arrived at a child like WH/Stock/Shelf 1, even though _action_assign already uses child_of internally to gather available quants from sub-locations.

Solution
Replace '=' with 'parent_of' so that when stock arrives at a child location, _trigger_assign also wakes up moves sourced from any ancestor of that location. The reservation attempt itself is already correct — _action_assign with strict=False searches child locations — so only the trigger was missing.

opw-6052753