### PR TITLE
[FIX] html_editor: respect default font size boundary in nested lists

### DIFF
--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -1,7 +1,7 @@
 import { normalizeCSSColor } from "@web/core/utils/colors";
 import { removeClass } from "./dom";
 import { isBold, isDirectionSwitched, isItalic, isStrikeThrough, isUnderline } from "./dom_info";
-import { closestElement, closestPath, findNode } from "./dom_traversal";
+import { closestElement, closestPath, findNode, findUpTo } from "./dom_traversal";
 import { closestBlock, isBlock } from "./blocks";
 
 /**
@@ -260,20 +260,18 @@ export function getHtmlStyle(document) {
  */
 export function getFontSizeDisplayValue(sel, document) {
     const tagNameRelatedToFontSize = ["h1", "h2", "h3", "h4", "h5", "h6"];
-    const styleClassesRelatedToFontSize = [
-        "display-1",
-        "display-2",
-        "display-3",
-        "display-4",
-        "lead",
-    ];
     const closestStartContainerEl = closestElement(sel.startContainer);
-    const closestFontSizedEl = closestStartContainerEl.closest(`
-        [style*='font-size'],
-        ${FONT_SIZE_CLASSES.map((className) => `.${className}`)},
-        ${styleClassesRelatedToFontSize.map((className) => `.${className}`)},
-        ${tagNameRelatedToFontSize}
-    `);
+    const closestFontSizedEl = findUpTo(
+        closestStartContainerEl,
+        closestStartContainerEl.closest(".o_default_font_size"),
+        (n) =>
+            n.matches(`
+                [style*='font-size'],
+                ${FONT_SIZE_CLASSES.map((className) => `.${className}`)},
+                ${TEXT_STYLE_CLASSES.map((className) => `.${className}`)},
+                ${tagNameRelatedToFontSize}
+            `)
+    );
     let remValue;
     const htmlStyle = getHtmlStyle(document);
     if (closestFontSizedEl) {
@@ -298,7 +296,7 @@ export function getFontSizeDisplayValue(sel, document) {
             fsName = fontSizeClass.substring(0, fontSizeClass.length - 3); // Without -fs
         } else {
             fsName =
-                styleClassesRelatedToFontSize.find((className) =>
+                TEXT_STYLE_CLASSES.find((className) =>
                     closestFontSizedEl.classList.contains(className)
                 ) || closestFontSizedEl.tagName.toLowerCase();
         }

--- a/addons/html_editor/static/tests/format/font.test.js
+++ b/addons/html_editor/static/tests/format/font.test.js
@@ -28,3 +28,21 @@ test("should have font tool only if the block is content editable", async () => 
         expect(".btn[name='font']").toHaveCount(count);
     }
 });
+
+test("Should show the default font display name", async () => {
+    const { el } = await setupEditor(`
+        <ul>
+            <li class="display-2-fs">
+                <div class="o-paragraph">abc</div>
+                <ul class="o_default_font_size">
+                    <li>[def]</li>
+                </ul>
+            </li>
+        </ul>    
+    `);
+    await waitFor(".btn[name='font_size_selector']");
+    const fontSelectorInput = el.ownerDocument
+        .querySelector("iframe")
+        .contentDocument.querySelector("input");
+    expect(fontSelectorInput.value).toBe("14");
+});


### PR DESCRIPTION
Problem:
When using nested lists where a parent list item has a custom font size, the child list does not display the default font size in the toolbar.

Cause:
`getFontSizeDisplayValue` does not treat `.o_default_font_size` as a boundary element. It continues searching up the DOM and may retrieve a font size from a parent element outside the intended default font size scope.

Solution:
Stop the font-size lookup when reaching `.o_default_font_size`, since this class defines the default font size boundary.

Steps to reproduce:
- Go to a "To do" note.
- Insert a bullet list with sub-items.
- Select the top list item and set its font size to 72.
- Select a sub-item.
- Observe the toolbar does not show the default font size.

task-6105581

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
