### PR TITLE
[FIX] web: add property visibility and edit properties state reset

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_definition_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_definition_field.js
@@ -30,7 +30,7 @@ export class PropertiesDefinitionField extends PropertiesField {
         }
         const isInEditMode = canChangeDefinition && !this.props.readonly;
         this.state.canChangeDefinition = !!canChangeDefinition;
-        this.state.isInEditMode = isInEditMode;
+        this.setEditMode(isInEditMode);
         if (isInEditMode && this.propertiesList.length === 0) {
             const newName = this.generatePropertyName("char");
             const propertiesDefinitions = [{

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -63,7 +63,7 @@ export class PropertiesField extends Component {
 
         this.state = useState({
             canChangeDefinition: false,
-            isInEditMode: false,
+            isInEditMode: this.env.propertiesState?.editable || false,
             isDragging: false,
             isPopoverOpen: false,
         });
@@ -72,7 +72,7 @@ export class PropertiesField extends Component {
         if (this.env.config?.viewType === "form") {
             useBus(this.env.model.bus, "PROPERTY_FIELD:EDIT", async (ev) => {
                 if (!ev.detail.editable) {
-                    this.state.isInEditMode = false;
+                    this.setEditMode(false);
                     return;
                 }
 
@@ -90,7 +90,7 @@ export class PropertiesField extends Component {
                 }
                 const isInEditMode = canChangeDefinition && !this.props.readonly;
                 this.state.canChangeDefinition = !!canChangeDefinition;
-                this.state.isInEditMode = isInEditMode;
+                this.setEditMode(isInEditMode);
                 if (isInEditMode && this.propertiesList.length === 0) {
                     this.onPropertyCreate();
                 }
@@ -104,7 +104,7 @@ export class PropertiesField extends Component {
             this.checkDefinitionWriteAccess().then((canChangeDefinition) => {
                 if (canChangeDefinition) {
                     this.state.canChangeDefinition = true;
-                    this.state.isInEditMode = !this.props.readonly;
+                    this.setEditMode(!this.props.readonly);
                 }
             });
         });
@@ -117,10 +117,11 @@ export class PropertiesField extends Component {
                 }
                 this.checkDefinitionWriteAccess().then((canChangeDefinition) => {
                     this.state.canChangeDefinition = !!canChangeDefinition;
-                    this.state.isInEditMode =
+                    const editable =
                         canChangeDefinition &&
                         !this.props.readonly &&
                         (this.state.isInEditMode || this.props.editMode);
+                    this.setEditMode(editable);
                 });
             },
             () => [this.props.record.data[this.definitionRecordField]]
@@ -128,7 +129,7 @@ export class PropertiesField extends Component {
 
         onWillUpdateProps(async (nextProps) => {
             if (nextProps.readonly && !this.props.readonly) {
-                this.state.isInEditMode = false;
+                this.setEditMode(false);
             }
             if (
                 !nextProps.readonly &&
@@ -139,10 +140,11 @@ export class PropertiesField extends Component {
                     canChangeDefinition = await this.checkDefinitionWriteAccess();
                 }
                 this.state.canChangeDefinition = !!canChangeDefinition;
-                this.state.isInEditMode =
+                const editable =
                     canChangeDefinition &&
                     !nextProps.readonly &&
                     (this.state.isInEditMode || nextProps.editMode);
+                this.setEditMode(editable);
             }
         });
 
@@ -608,7 +610,10 @@ export class PropertiesField extends Component {
 
         if (newType === "separator" && oldType !== "separator") {
             // unfold automatically the new separator
-            await this._toggleSeparators([propertyDefinition.name], propertyDefinition.fold_by_default);
+            await this._toggleSeparators(
+                [propertyDefinition.name],
+                propertyDefinition.fold_by_default
+            );
             // layout has been changed, move the definition popover
             this.movePopoverToProperty = propertyDefinition.name;
         } else if (oldType === "separator" && newType !== "separator") {
@@ -617,7 +622,10 @@ export class PropertiesField extends Component {
                 (property, index) => index < propertyIndex && property.type === "separator"
             );
             if (previousSeperator) {
-                await this._toggleSeparators([previousSeperator.name], propertyDefinition.fold_by_default);
+                await this._toggleSeparators(
+                    [previousSeperator.name],
+                    propertyDefinition.fold_by_default
+                );
             }
             // layout has been changed, move the definition popover
             this.movePopoverToProperty = propertyDefinition.name;
@@ -635,7 +643,10 @@ export class PropertiesField extends Component {
             const displayData = this._getDisplayData();
             message += _t(
                 'It will be removed for everyone using the "%(parentName)s" %(parentFieldLabel)s.',
-                { parentName: displayData.parentName, parentFieldLabel: displayData.parentFieldLabel }
+                {
+                    parentName: displayData.parentName,
+                    parentFieldLabel: displayData.parentFieldLabel,
+                }
             );
         } else {
             message += _t("It will be removed for everyone!");
@@ -961,15 +972,15 @@ export class PropertiesField extends Component {
                 parentFieldLabel: displayData.parentFieldLabel,
             });
         }
-        return _t(
-            'Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".',
-            { parentFieldLabel: displayData.parentFieldLabel, parentName: displayData.parentName }
-        );
+        return _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
+            parentFieldLabel: displayData.parentFieldLabel,
+            parentName: displayData.parentName,
+        });
     }
 
     /**
-    * Following functions are utility function overwritten in the component PropertiesDefinitionField
-    */
+     * Following functions are utility function overwritten in the component PropertiesDefinitionField
+     */
     _toggleSeparatorValue(property, forceState) {
         property.value = forceState ?? !(property.value ?? property.fold_by_default);
     }
@@ -988,14 +999,14 @@ export class PropertiesField extends Component {
             string: _t("Property %s", count + 1),
             type: "char",
             definition_changed: true,
-        }
+        };
     }
 
     _getDisplayData() {
         return {
-            'parentName': this.props.record.data[this.definitionRecordField].display_name,
-            'parentFieldLabel': this.props.record.fields[this.definitionRecordField].string,
-        }
+            parentName: this.props.record.data[this.definitionRecordField].display_name,
+            parentFieldLabel: this.props.record.fields[this.definitionRecordField].string,
+        };
     }
 
     _onDeleteConfirm(propertiesDefinitions, propertyName) {
@@ -1006,6 +1017,13 @@ export class PropertiesField extends Component {
 
     _isPropertyDefinitionWidget() {
         return false;
+    }
+
+    setEditMode(editable) {
+        this.state.isInEditMode = !!editable;
+        if (this.env.propertiesState) {
+            this.env.propertiesState.editable = this.state.isInEditMode;
+        }
     }
 }
 

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -14,7 +14,7 @@ import { standardFieldProps } from "../standard_field_props";
 import { PropertyDefinition } from "./property_definition";
 import { PropertyValue } from "./property_value";
 
-import { Component, onWillStart, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillStart, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
 
 export class PropertiesField extends Component {
     static template = "web.PropertiesField";
@@ -68,11 +68,15 @@ export class PropertiesField extends Component {
             isPopoverOpen: false,
         });
 
+        onMounted(() => {
+            const editable = this.env.propertiesState?.editable;
+            this.setEditMode(editable);
+        });
         // Properties can be added from the cog menu of the form controller
         if (this.env.config?.viewType === "form") {
             useBus(this.env.model.bus, "PROPERTY_FIELD:EDIT", async (ev) => {
                 if (!ev.detail.editable) {
-                    this.state.isInEditMode = false;
+                    this.setEditMode(false);
                     return;
                 }
 
@@ -90,7 +94,7 @@ export class PropertiesField extends Component {
                 }
                 const isInEditMode = canChangeDefinition && !this.props.readonly;
                 this.state.canChangeDefinition = !!canChangeDefinition;
-                this.state.isInEditMode = isInEditMode;
+                this.setEditMode(isInEditMode);
                 if (isInEditMode && this.propertiesList.length === 0) {
                     this.onPropertyCreate();
                 }
@@ -104,7 +108,7 @@ export class PropertiesField extends Component {
             this.checkDefinitionWriteAccess().then((canChangeDefinition) => {
                 if (canChangeDefinition) {
                     this.state.canChangeDefinition = true;
-                    this.state.isInEditMode = !this.props.readonly;
+                    this.setEditMode(!this.props.readonly);
                 }
             });
         });
@@ -117,10 +121,11 @@ export class PropertiesField extends Component {
                 }
                 this.checkDefinitionWriteAccess().then((canChangeDefinition) => {
                     this.state.canChangeDefinition = !!canChangeDefinition;
-                    this.state.isInEditMode =
+                    const editable =
                         canChangeDefinition &&
                         !this.props.readonly &&
                         (this.state.isInEditMode || this.props.editMode);
+                    this.setEditMode(editable);
                 });
             },
             () => [this.props.record.data[this.definitionRecordField]]
@@ -128,7 +133,7 @@ export class PropertiesField extends Component {
 
         onWillUpdateProps(async (nextProps) => {
             if (nextProps.readonly && !this.props.readonly) {
-                this.state.isInEditMode = false;
+                this.setEditMode(false);
             }
             if (
                 !nextProps.readonly &&
@@ -139,10 +144,11 @@ export class PropertiesField extends Component {
                     canChangeDefinition = await this.checkDefinitionWriteAccess();
                 }
                 this.state.canChangeDefinition = !!canChangeDefinition;
-                this.state.isInEditMode =
+                const editable =
                     canChangeDefinition &&
                     !nextProps.readonly &&
                     (this.state.isInEditMode || nextProps.editMode);
+                this.setEditMode(editable);
             }
         });
 
@@ -1006,6 +1012,13 @@ export class PropertiesField extends Component {
 
     _isPropertyDefinitionWidget() {
         return false;
+    }
+
+    setEditMode(editable) {
+        this.state.isInEditMode = !!editable;
+        if (this.env.propertiesState) {
+            this.env.propertiesState.editable = this.state.isInEditMode;
+        }
     }
 }
 

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -80,7 +80,7 @@
                     </div>
                     <div
                         t-if="propertiesListGroup_index === _groupedPropertiesList.length - 1 and this.displayAddPropertyButton"
-                        class="o_field_property_add d-none d-sm-block"
+                        class="o_field_property_add"
                         t-att-class="{'g-col-2': props.columns !== 1}">
                         <button
                             t-if="state.isInEditMode and definitionRecordId"

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -349,6 +349,7 @@ export class FormController extends Component {
         this.propertiesState = useState({
             editable: false,
         });
+        useSubEnv({ propertiesState: this.propertiesState });
     }
 
     get cogMenuProps() {
@@ -400,6 +401,11 @@ export class FormController extends Component {
      */
     onWillLoadRoot() {
         this.duplicateId = undefined;
+        if (this.propertiesState.editable) {
+            // Reset properties edit mode
+            this.propertiesState.editable = false;
+            this.model.bus.trigger("PROPERTY_FIELD:EDIT", { editable: false });
+        }
     }
 
     onRecordChanged() {

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1802,6 +1802,8 @@ test("properties: default value date", async () => {
     // save the form and check that the default value is not reset
     await click(".o_form_button_save");
     await animationFrame();
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
     await click(".o_property_field:nth-last-child(2) .o_field_property_open_popover");
     await animationFrame();
     expect(".o_property_field_popover .o_field_property_definition_value input").toHaveValue(
@@ -2462,6 +2464,8 @@ test("new property, change record, change property type", async () => {
 
     await contains(".o_property_field .o_property_field_value input").edit("aze");
     await contains(".o_pager_next").click();
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
     expect(".o_property_field .o_property_field_value input").toHaveValue("");
     // Change second record's property type
     await contains(".o_property_field .o_field_property_open_popover").click();
@@ -2878,9 +2882,6 @@ test("properties definition: default value should not add value key", async () =
         actionMenus: {},
     });
 
-    await toggleActionMenu();
-    await toggleMenuItem("Edit Properties");
-
     await click(".o_field_property_add button");
     await waitFor(".o_property_field_popover");
     await changeType("boolean");
@@ -2923,8 +2924,6 @@ test("properties definition: test display and edit", async () => {
     });
 
     // Edit an existing definition
-    await toggleActionMenu();
-    await toggleMenuItem("Edit Properties");
     expect(".o_field_property_open_popover").toHaveCount(4, {
         message: "4 popover buttons should be present : 1 for each definition.",
     });
@@ -3023,9 +3022,7 @@ test("properties: no parent document set", async () => {
     patchWithCleanup(formView.env.services.notification, {
         add: (message, options) => {
             expect.step("notification");
-            expect(message).toBe(
-                "Oops! A Company is needed to add property fields."
-            );
+            expect(message).toBe("Oops! A Company is needed to add property fields.");
             expect(options.type).toBe("warning");
         },
     });
@@ -3044,5 +3041,53 @@ test("properties: no parent document set", async () => {
 
     expect(".o_field_properties:first-child .o_field_property_open_popover").toHaveCount(0, {
         message: "The edit definition button must not be in the view",
+    });
+});
+
+test("add button visible in edit mode and during notebook switch", async () => {
+    onRpc("has_access", () => true);
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <notebook>
+                        <page string="Properties">
+                            <group>
+                                <field name="company_id"/>
+                                <field name="properties"/>
+                            </group>
+                        </page>
+                        <page string="Other">
+                            <group>
+                                <field name="display_name"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>`,
+        actionMenus: {},
+    });
+
+    expect(".o_field_property_add button").toHaveCount(0, {
+        message: "Add Property button should be hidden before enabling edit mode",
+    });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
+
+    expect(".o_field_property_add button").toHaveCount(1, {
+        message: "Add Property button should be visible in edit mode",
+    });
+
+    await contains(".o_notebook_headers .nav-link:contains(Other)").click();
+    await contains(".o_notebook_headers .nav-link:contains(Properties)").click();
+    await waitFor(".o_field_property_add button");
+
+    expect(".o_field_property_add button").toHaveCount(1, {
+        message: "Add Property button should remain visible after notebook switch",
     });
 });

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1802,6 +1802,8 @@ test("properties: default value date", async () => {
     // save the form and check that the default value is not reset
     await click(".o_form_button_save");
     await animationFrame();
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
     await click(".o_property_field:nth-last-child(2) .o_field_property_open_popover");
     await animationFrame();
     expect(".o_property_field_popover .o_field_property_definition_value input").toHaveValue(
@@ -2462,6 +2464,8 @@ test("new property, change record, change property type", async () => {
 
     await contains(".o_property_field .o_property_field_value input").edit("aze");
     await contains(".o_pager_next").click();
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
     expect(".o_property_field .o_property_field_value input").toHaveValue("");
     // Change second record's property type
     await contains(".o_property_field .o_field_property_open_popover").click();
@@ -3044,5 +3048,53 @@ test("properties: no parent document set", async () => {
 
     expect(".o_field_properties:first-child .o_field_property_open_popover").toHaveCount(0, {
         message: "The edit definition button must not be in the view",
+    });
+});
+
+test("add button visible in edit mode and during notebook switch", async () => {
+    onRpc("has_access", () => true);
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <notebook>
+                        <page string="Properties">
+                            <group>
+                                <field name="company_id"/>
+                                <field name="properties"/>
+                            </group>
+                        </page>
+                        <page string="Other">
+                            <group>
+                                <field name="display_name"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>`,
+        actionMenus: {},
+    });
+
+    expect(".o_field_property_add button").toHaveCount(0, {
+        message: "Add Property button should be hidden before enabling edit mode",
+    });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
+
+    expect(".o_field_property_add button").toHaveCount(1, {
+        message: "Add Property button should be visible in edit mode",
+    });
+
+    await contains(".o_notebook_headers .nav-link:contains(Other)").click();
+    await contains(".o_notebook_headers .nav-link:contains(Properties)").click();
+    await waitFor(".o_field_property_add button");
+
+    expect(".o_field_property_add button").toHaveCount(1, {
+        message: "Add Property button should remain visible after notebook switch",
     });
 });


### PR DESCRIPTION
Before this commit:
- The “+ Add Property” button was not visible when switching between notebook pages if it was present initially.
- when we are doing edit properties from the cog menu and without doing save properties if we are creating new record or switch to other record at that time button still shows “Save Properties.” leading to inconsistent UI behavior.

After this commit:
- The “+ Add Property” button remains visible when switching between pages.
- When in property edit mode, switching records or creating a new record now correctly resets the button state back to “Edit Properties”, ensuring consistent UI behavior.

task-6051322

ENT PR: https://github.com/odoo/enterprise/pull/113248

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
