### PR TITLE
[IMP] project: add share link refresh feature in portal share

### DIFF
--- a/addons/project/controllers/__init__.py
+++ b/addons/project/controllers/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import mail
 from . import portal
 from . import project_sharing_chatter
 from . import webmanifest

--- a/addons/project/controllers/mail.py
+++ b/addons/project/controllers/mail.py
@@ -1,0 +1,23 @@
+from odoo.http import request
+from odoo.tools import consteq
+
+from odoo.addons.portal.controllers.mail import MailController
+
+
+class ProjectMailController(MailController):
+
+    @classmethod
+    def _redirect_to_generic_fallback(cls, model, res_id, access_token=None, **kwargs):
+        if model in ('project.project', 'project.task') and access_token and request.session.uid and request.env.user.share:
+            record_sudo = request.env[model].sudo().browse(res_id).exists()
+            if record_sudo and record_sudo.access_token and not consteq(record_sudo.access_token, access_token):
+                return request.redirect_query('/my', {'access_error': 1})
+        return super()._redirect_to_generic_fallback(model, res_id, access_token=access_token, **kwargs)
+
+    @classmethod
+    def _redirect_to_login_with_mail_view(cls, model, res_id, access_token=None, **kwargs):
+        if model in ('project.project', 'project.task') and access_token:
+            record_sudo = request.env[model].sudo().browse(res_id).exists()
+            if record_sudo and record_sudo.access_token and not consteq(record_sudo.access_token, access_token):
+                return request.redirect_query('/web/login', {'access_error': 1})
+        return super()._redirect_to_login_with_mail_view(model, res_id, access_token=access_token, **kwargs)

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
+import uuid
 
 from collections import defaultdict
 
@@ -1038,6 +1039,10 @@ class ProjectProject(models.Model):
             'view_mode': 'form',
             'res_id': self.id,
         }
+
+    def action_regenerate_access_token(self):
+        self.ensure_one()
+        self.write({'access_token': str(uuid.uuid4())})
 
     # ---------------------------------------------
     #  PROJECT UPDATES

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+import uuid
 from collections import defaultdict
 from datetime import timedelta, datetime, time, UTC
 from random import shuffle
@@ -2031,6 +2032,10 @@ class ProjectTask(models.Model):
                 "target": "self",
             }
         return super()._get_access_action(access_uid, force_website)
+
+    def action_regenerate_access_token(self):
+        self.ensure_one()
+        self.write({'access_token': str(uuid.uuid4())})
 
     # ---------------------------------------------------
     # Rating business

--- a/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.js
+++ b/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.js
@@ -1,0 +1,41 @@
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import {
+    CopyClipboardCharField,
+    copyClipboardCharField,
+} from "@web/views/fields/copy_clipboard/copy_clipboard_field";
+
+export class ProjectCopyClipboardRefreshLinkField extends CopyClipboardCharField {
+    static template = "project.ProjectCopyClipboardRefreshLinkField";
+
+    setup() {
+        super.setup();
+        this.dialogService = useService("dialog");
+        this.notificationService = useService("notification");
+        this.orm = useService("orm");
+    }
+
+    onRefreshClick() {
+        this.dialogService.add(ConfirmationDialog, {
+            body: _t("Generating a new link will disable the old one. Do you want to proceed?"),
+            confirmLabel: _t("Refresh Link"),
+            confirm: async () => {
+                const resModel = this.props.record.data.res_model;
+                const resId = this.props.record.data.res_id;
+                await this.orm.call(resModel, "action_regenerate_access_token", [[resId]]);
+                await this.props.record.load();
+                this.notificationService.add(_t("Share link refreshed"), { type: "success" });
+            },
+            cancel: () => {},
+        });
+    }
+}
+
+export const projectCopyClipboardRefreshLinkField = {
+    ...copyClipboardCharField,
+    component: ProjectCopyClipboardRefreshLinkField,
+};
+
+registry.category("fields").add("ProjectCopyClipboardRefreshLink", projectCopyClipboardRefreshLinkField);

--- a/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.scss
+++ b/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.scss
@@ -1,0 +1,4 @@
+.o_field_ProjectCopyClipboardRefreshLink :is(span, input):not(.fa-clipboard, .fa-refresh) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.xml
+++ b/addons/project/static/src/components/copy_clipboard_refresh_link_field/copy_clipboard_refresh_link_field.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="project.ProjectCopyClipboardRefreshLinkField" t-inherit="web.CopyClipboardField" t-inherit-mode="primary">
+        <xpath expr="//CopyButton" position="after">
+            <button t-if="this.props.record.data[this.props.name]" type="button" class="btn btn-link btn-link-inline"
+                    t-on-click.stop="onRefreshClick" title="Refresh link">
+                <span class="mx-1 fa fa-refresh"/>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/project/static/src/interactions/access_error_notification.js
+++ b/addons/project/static/src/interactions/access_error_notification.js
@@ -1,0 +1,24 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+
+export class AccessErrorNotification extends Interaction {
+    static selector = ".o_portal_my_home, .oe_login_form";
+
+    start() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has("access_error")) {
+            this.services.notification.add(
+                _t("This page is no longer accessible. Please ask your contact for a new link."),
+                { type: "danger", sticky: true },
+            );
+            const url = new URL(window.location.href);
+            url.searchParams.delete("access_error");
+            window.history.replaceState({}, document.title, url.href);
+        }
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("project.access_error_notification", AccessErrorNotification);

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_project_flow
 from . import test_project_mail_features
 from . import test_project_milestone
 from . import test_project_recurrence
+from . import test_project_share_link_refresh
 from . import test_project_sharing
 from . import test_project_sharing_portal_access
 from . import test_project_sharing_ui

--- a/addons/project/tests/test_project_share_link_refresh.py
+++ b/addons/project/tests/test_project_share_link_refresh.py
@@ -1,0 +1,71 @@
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+from odoo.tests import tagged, HttpCase
+from odoo.tools import mute_logger
+
+
+@tagged('-at_install', 'post_install')
+class TestShareLinkRefresh(TestProjectCommon, HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_pigs.privacy_visibility = 'portal'
+        cls.project_pigs._portal_ensure_token()
+        cls.task_1._portal_ensure_token()
+
+    def _get_mail_view_url(self, model, res_id, access_token):
+        return f'{self.base_url()}/mail/view?model={model}&res_id={res_id}&access_token={access_token}'
+
+    @mute_logger('werkzeug')
+    def test_valid_token(self):
+        """A valid token should redirect to the portal record page (no access_error)."""
+        for model, record in [
+            ('project.project', self.project_pigs),
+            ('project.task', self.task_1),
+        ]:
+            with self.subTest(model=model):
+                url = self._get_mail_view_url(model, record.id, record.access_token)
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertNotIn('access_error', res.url)
+
+    @mute_logger('werkzeug')
+    def test_portal_user_old_token(self):
+        """Portal user (non-collaborator) with an old token should be redirected to /my?access_error=1."""
+        old_project_token = self.project_pigs.access_token
+        old_task_token = self.task_1.access_token
+        self.project_pigs.action_regenerate_access_token()
+        self.task_1.action_regenerate_access_token()
+        self.assertNotEqual(self.project_pigs.access_token, old_project_token)
+        self.assertNotEqual(self.task_1.access_token, old_task_token)
+
+        self.authenticate(self.user_portal.login, self.user_portal.login)
+        for model, res_id, old_token in [
+            ('project.project', self.project_pigs.id, old_project_token),
+            ('project.task', self.task_1.id, old_task_token),
+        ]:
+            with self.subTest(model=model):
+                url = self._get_mail_view_url(model, res_id, old_token)
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertURLEqual(res.url, f'{self.base_url()}/my?access_error=1')
+
+    @mute_logger('werkzeug')
+    def test_public_user_old_token(self):
+        """Public (not logged in) user with an old token should be redirected to /web/login?access_error=1."""
+        old_project_token = self.project_pigs.access_token
+        old_task_token = self.task_1.access_token
+        self.project_pigs.action_regenerate_access_token()
+        self.task_1.action_regenerate_access_token()
+        self.assertNotEqual(self.project_pigs.access_token, old_project_token)
+        self.assertNotEqual(self.task_1.access_token, old_task_token)
+
+        for model, res_id, old_token in [
+            ('project.project', self.project_pigs.id, old_project_token),
+            ('project.task', self.task_1.id, old_task_token),
+        ]:
+            with self.subTest(model=model):
+                url = self._get_mail_view_url(model, res_id, old_token)
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertURLEqual(res.url, f'{self.base_url()}/web/login?access_error=1')

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -9,7 +9,7 @@
                 <field name="res_model" invisible="1"/>
                 <field name="res_id" invisible="1"/>
                 <group>
-                    <field name="share_link" widget="CopyClipboardChar"/>
+                    <field name="share_link" widget="ProjectCopyClipboardRefreshLink"/>
                 </group>
                 <field name="collaborator_ids" nolabel="1">
                     <list string="Collaborators" editable="bottom">

--- a/addons/project/wizard/project_task_share_wizard_views.xml
+++ b/addons/project/wizard/project_task_share_wizard_views.xml
@@ -7,6 +7,9 @@
         <field name="inherit_id" ref="portal.portal_share_wizard"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='share_link']" position="attributes">
+                <attribute name="widget">ProjectCopyClipboardRefreshLink</attribute>
+            </xpath>
             <xpath expr="//button[hasclass('btn-secondary')]" position="replace">
                 <button class="btn-secondary" special="cancel" data-hotkey="x" />
             </xpath>


### PR DESCRIPTION
Before this commit, users could not invalidate and regenerate share links for projects or tasks allowing anyone with the URL to access the project and its tasks.

This commit introduces a refresh button within the share wizards for projects and tasks. Clicking it generates a new share link. Additionally, if someone tries to access the record using an old link, it redirects the user and shows an access error notification.

task-4043805
