### PR TITLE
[FIX] mail: sub thread list hard to read

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/action_panel.scss
@@ -30,6 +30,11 @@
 
 .popover:has(.o-mail-ActionPanel-content) {
     width: Min(95vw, 400px);
+
+    &.o-mail-SubChannelList-panel {
+        width: Min(95vw, 500px);
+
+    }
 }
 
 .popover .o-mail-ActionPanel-content {

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
@@ -1,5 +1,6 @@
 import { AvatarStack } from "@mail/discuss/core/common/avatar_stack";
 import { isToday } from "@mail/utils/common/dates";
+import { htmlToTextContentInline } from "@mail/utils/common/format";
 
 import { Component } from "@odoo/owl";
 
@@ -17,6 +18,10 @@ export class SubChannelPreview extends Component {
             return message.datetime?.toLocaleString(DateTime.TIME_SIMPLE);
         }
         return message.datetime?.toLocaleString(DateTime.DATE_MED);
+    }
+
+    bodyText(message) {
+        return htmlToTextContentInline(message.body);
     }
 
     onClick() {

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -24,7 +24,7 @@
                 <t t-if="message.isSelfAuthored">You</t>
                 <t t-else="" t-esc="message.authorName"/>:
             </span>
-            <span class="text-truncate ms-1" t-out="message.bodyPreview"/>
+            <span class="text-truncate ms-1" t-att-title="bodyText(message)" t-out="message.bodyPreview"/>
             <span class="flex-grow-1"/>
             <AvatarStack t-if="!env.inMessage" containerClass="'ms-1'" personas="props.channel.channel_member_ids.map((m) => m.persona)" size="22" spacing="10" total="props.channel.member_count"/>
             <span t-elif="props.channel.message_count" class="text-primary smaller flex-shrink-0 d-flex fw-bold align-items-center ms-1">

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -1,5 +1,6 @@
 import { registerThreadAction } from "@mail/core/common/thread_actions";
 import { SubChannelList } from "@mail/discuss/core/public_web/sub_channel_list";
+import { attClassObjectToString } from "@mail/utils/common/format";
 import { useChildSubEnv } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
@@ -14,7 +15,10 @@ registerThreadAction("show-threads", {
         });
     },
     actionPanelOuterClass: ({ owner, store }) =>
-        owner.env.inMeetingView ? "" : store.discussDropdownMenuClass(owner),
+        attClassObjectToString({
+            "o-mail-SubChannelList-panel": true,
+            [store.discussDropdownMenuClass(owner)]: !owner.env.inMeetingView,
+        }),
     condition: ({ channel, owner }) =>
         (channel?.hasSubChannelFeature || channel?.parent_channel_id?.hasSubChannelFeature) &&
         !owner.isDiscussSidebarChannelActions,


### PR DESCRIPTION
Before this commit, the sub thread list had two issues:

- It was too small, making it hard to grasp the content of the thread. The last message of the thread was shown, but due to limited space, it was often truncated so much that displaying it was not useful.

This commit slightly increases the width of the sub thread list and adds the last message body as a title, displayed on hover.


|Before|After|
|--|-|
|<img width="396" height="627" alt="image" src="https://github.com/user-attachments/assets/f329cbe2-07d7-48d5-a114-0b2528a77848" />|<img width="512" height="637" alt="image" src="https://github.com/user-attachments/assets/cf08d099-6fb5-4b62-97f2-39660014c5f2" />|