### PR TITLE
[IMP] web: validate search through shortcut

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -86,6 +86,8 @@ export class Dialog extends Component {
                     return styles.display !== "none";
                 });
                 if (firstVisibleBtn) {
+                    // Allows the active element to be blurred before triggering the click on the button
+                    firstVisibleBtn.focus();
                     firstVisibleBtn.click();
                 }
             },

--- a/addons/web/static/tests/core/dialog.test.js
+++ b/addons/web/static/tests/core/dialog.test.js
@@ -102,6 +102,49 @@ test("hotkeys work on dialogs", async () => {
     expect.verifySteps(["clickOk"]);
 });
 
+test("hotkey control+enter on input triggers blur event before clicking dialog button", async () => {
+    class Parent extends Component {
+        static components = { Dialog };
+        static template = xml`
+            <Dialog title="'Test Dialog'">
+                <input type="text" t-on-blur="onInputBlur" class="test_input"/>
+                
+                <t t-set-slot="footer">
+                    <button t-on-click="onConfirm">Confirm</button>
+                </t>
+            </Dialog>
+        `;
+        static props = ["*"];
+
+        setup() {
+            this.state = useState({ value: "" });
+        }
+
+        onInputBlur(ev) {
+            this.state.value = ev.target.value;
+            expect.step("inputBlur: " + ev.target.value);
+        }
+
+        onConfirm() {
+            expect.step("confirmed with value: " + this.state.value);
+        }
+    }
+
+    await makeDialogMockEnv();
+    await mountWithCleanup(Parent);
+
+    await contains(".test_input").edit("new value", { confirm: false });
+
+    expect.verifySteps([]);
+
+    await press("control+enter");
+
+    expect.verifySteps([
+        "inputBlur: new value",
+        "confirmed with value: new value"
+    ]);
+});
+
 test("simple rendering with two dialogs", async () => {
     expect.assertions(3);
     class Parent extends Component {


### PR DESCRIPTION
When searching for a string in the custom filters, hitting CTRL + Enter empties the focused input.

task-6095918
