### PR TITLE
Fixing printIframContent in portal sidebar

### DIFF
--- a/addons/portal/static/src/interactions/sidebar.js
+++ b/addons/portal/static/src/interactions/sidebar.js
@@ -45,8 +45,10 @@ export class Sidebar extends Interaction {
         if (!this.printContent) {
             const iframeEl = document.createElement("iframe");
             iframeEl.setAttribute("id", "print_iframe_content");
-            iframeEl.setAttribute("href", href);
-            iframeEl.style.display = "none";
+            iframeEl.setAttribute("src", href);
+            iframeEl.style.position = "fixed";
+            iframeEl.style.right = "100%";
+            iframeEl.style.bottom = "100%";
             this.printContent = iframeEl;
             this.insert(this.printContent, this.el);
             this.addListener(this.printContent, "load", () => this.printContent.contentWindow.print());


### PR DESCRIPTION
The source of iframe should be 'src' tag and not 'href'. Second some browser many not load a hidden iframe, so we have to keep it visually hidden. Thanks.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
