### PR TITLE
[16.0][FIX] mrp_subcontracting: Auto-record components for serial assignment

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -202,3 +202,20 @@ class MrpProduction(models.Model):
                 if sml.tracking != 'none' and not sml.lot_id:
                     raise UserError(_('You must enter a serial number for each line of %s') % sml.product_id.display_name)
         return True
+
+    def action_generate_serial(self):
+        res = super().action_generate_serial()
+        if (
+            not self._get_subcontract_move()
+            or self.product_id.tracking != 'serial'
+            or self.subcontracting_has_been_recorded
+            or self.state in ('done', 'cancel')
+            or not self.lot_producing_id
+        ):
+            return res
+        subcontract_move = self._get_subcontract_move().filtered(
+            lambda m: m.state not in ('done', 'cancel')
+        )[:1]
+        if subcontract_move:
+            subcontract_move._auto_record_components(self.product_qty)
+        return res

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1182,6 +1182,52 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         cmp1_consumed_qty = sum(productions.move_raw_ids.filtered(lambda m: m.state == 'done').mapped("quantity_done"))
         self.assertEqual(cmp1_consumed_qty, 2)
 
+    def test_subcontracting_serial_mass_produce(self):
+        """
+        Test that Mass Produce on a subcontracting MO with serial-tracked finished
+        products properly records subcontracted components and syncs serials to receipt.
+        """
+        self.finished.tracking = 'serial'
+        subcontract_location = self.subcontractor_partner1.property_stock_subcontractor
+        self.env['stock.quant']._update_available_quantity(
+            self.comp1, subcontract_location, 2
+        )
+        self.env['stock.quant']._update_available_quantity(
+            self.comp2, subcontract_location, 2
+        )
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.partner_id = self.subcontractor_partner1
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.finished
+            move.product_uom_qty = 2
+        receipt = picking_form.save()
+        receipt.action_confirm()
+        production = receipt.move_ids.move_orig_ids.production_id
+        production.action_assign()
+        action = production.action_serial_mass_produce_wizard()
+        wizard = Form(self.env['stock.assign.serial'].with_context(**action['context']))
+        wizard.next_serial_number = 'SN0001'
+        wizard.next_serial_count = 2
+        action = wizard.save().generate_serial_numbers_production()
+        wizard = Form(self.env['stock.assign.serial'].browse(action['res_id']))
+        wizard.save().apply()
+        productions = receipt.move_ids.move_orig_ids.production_id.sorted('id')
+        self.assertEqual(len(productions), 2)
+        self.assertEqual(
+            productions.mapped('subcontracting_has_been_recorded'), [True, True],
+            "Mass Produce should have recorded subcontracted components for both MOs"
+        )
+        self.assertEqual(
+            productions.mapped('lot_producing_id.name'), ['SN0001', 'SN0002'],
+            "Serial numbers should be assigned to split productions"
+        )
+        self.assertEqual(
+            sorted(receipt.move_line_ids.mapped('lot_id.name')),
+            ['SN0001', 'SN0002'],
+            "Serial numbers should be synced to receipt move lines"
+        )
+
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):

--- a/addons/mrp_subcontracting/wizard/__init__.py
+++ b/addons/mrp_subcontracting/wizard/__init__.py
@@ -4,3 +4,4 @@
 from . import stock_picking_return
 from . import mrp_consumption_warning
 from . import change_production_qty
+from . import stock_assign_serial_numbers

--- a/addons/mrp_subcontracting/wizard/stock_assign_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/stock_assign_serial_numbers.py
@@ -1,0 +1,32 @@
+from odoo import models
+
+
+class StockAssignSerialNumbers(models.TransientModel):
+    _inherit = 'stock.assign.serial'
+
+    def _assign_serial_numbers(self, cancel_remaining_quantity=False):
+        if (
+            not self.production_id._get_subcontract_move()
+            or self.production_id.product_id.tracking != 'serial'
+        ):
+            return super()._assign_serial_numbers(cancel_remaining_quantity)
+        serial_numbers = set(self._get_serial_numbers())
+        res = super()._assign_serial_numbers(cancel_remaining_quantity)
+        if not serial_numbers:
+            return res
+        productions = (
+            self.production_id.procurement_group_id.mrp_production_ids.filtered(
+                lambda mo: mo.state not in ('done', 'cancel')
+                and not mo.subcontracting_has_been_recorded
+                and mo._get_subcontract_move()
+                and mo.lot_producing_id
+                and mo.lot_producing_id.name in serial_numbers
+            )
+        )
+        for production in productions:
+            subcontract_move = production._get_subcontract_move().filtered(
+                lambda m: m.state not in ('done', 'cancel')
+            )[:1]
+            if subcontract_move:
+                subcontract_move._auto_record_components(production.product_qty)
+        return res


### PR DESCRIPTION
When using Mass Produce or Generate Serial on a subcontracting MO with serial-tracked finished products, the standard flow assigns serials but does not automatically record components. As a result, subcontracting_has_been_recorded remains False and the finished serials are never synced to the receipt move lines.

This PR extends the serial assignment flow to automatically call stock.move._auto_record_components() for subcontracted productions with serial-tracked finished products in the following cases:

1. Mass Produce wizard (multiple or single serials)
2. Generate Serial button (single serial generation)

OPW ticket: #6108489

@qrtl QT6138