### PR TITLE
[FIX] iot_drivers: return early when `import_ctypes_library` returns `None`

### DIFF
--- a/addons/iot_drivers/iot_handlers/interfaces/ctep_interface.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/ctep_interface.py
@@ -64,6 +64,9 @@ class CTEPInterface(Interface):
             return
 
         self.easy_ctep = import_ctypes_library(self.connection_type, lib_name)
+        if self.easy_ctep is None:
+            return
+
         self.easy_ctep.createCTEPManager.restype = ctypes.c_void_p
         extra_args = [ctypes.c_void_p] if IS_RPI else []
         self.easy_ctep.connectedTerminal.argtypes = [ctypes.c_void_p, ctypes.c_char_p, *extra_args]

--- a/addons/iot_drivers/iot_handlers/interfaces/tim_interface.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/tim_interface.py
@@ -56,6 +56,8 @@ class TIMInterface(Interface):
             return
 
         self.tim_api = import_ctypes_library(self.connection_type, lib_name)
+        if not self.tim_api:
+            return
 
         # void *six_initialize_manager(int buffer_size) {
         self.tim_api.six_initialize_manager.argtypes = [ctypes.c_int]


### PR DESCRIPTION
An error occurs when attempting to access `createCTEPManager` from
`self.easy_ctep`, because `self.easy_ctep` is `None`.

Error: `AttributeError: 'NoneType' object has no attribute 'createCTEPManager'`

This commit resolves the issue by adding an early return when
`self.easy_ctep` is `None`. It also introduces a safeguard in
`tim_interface.py` to return early when `self.tim_api` is None to
preventing unintended errors from accessing an uninitialized object.


sentry-7334805653