### PR TITLE
[18.0][FIX] fleet: Apply the appropriate field (company_ids) to the manager_id field

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -34,7 +34,7 @@ class FleetVehicle(models.Model):
     active = fields.Boolean('Active', default=True, tracking=True)
     manager_id = fields.Many2one(
         'res.users', 'Fleet Manager',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('fleet.fleet_group_manager').id), ('company_id', 'in', self.env.companies.ids)],
+        domain=lambda self: [('groups_id', 'in', self.env.ref('fleet.fleet_group_manager').id), ('share', '=', False), ('company_ids', 'in', self.env.companies.ids)],
     )
     company_id = fields.Many2one(
         'res.company', 'Company',

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -107,7 +107,7 @@
                                 <field name="odometer"/>
                                 <field name="odometer_unit"/>
                             </div>
-                            <field name="manager_id" domain="[('share', '=', False), ('company_id', '=', company_id)]" widget="many2one_avatar_user"/>
+                            <field name="manager_id" widget="many2one_avatar_user"/>
                             <field name="location"/>
                         </group>
                     </group>


### PR DESCRIPTION
Apply the appropriate field (`company_ids`) to the manager_id field

Similar to what is done in other modules (such as Sales), you should filter by users using the company_ids field; this is important when working with multiple companies.

Please @pedrobaeza can you review it?

@Tecnativa TT61863

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
