### PR TITLE
[FIX] l10n_hr_edi: fix credit note export without recipient bank account

### DIFF
--- a/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
+++ b/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
@@ -78,7 +78,8 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
         constraints = {}
         if vals['document_type'] in ['invoice', 'credit_note']:
             for node in vals['document_node']['cac:PaymentMeans']:
-                if any(char.isspace() for char in node.get('cac:PayeeFinancialAccount', {}).get('cbc:ID', {}).get('_text', '')):
+                payee_account = node.get('cac:PayeeFinancialAccount')
+                if payee_account and any(char.isspace() for char in payee_account['cbc:ID']['_text']):
                     constraints['ubl_hr_br_1'] = self.env._("HR-BR-1: The account number must not contain whitespace characters.")
             if invoice.amount_residual > 0 and not invoice.invoice_date_due:
                 constraints.update({'ubl_hr_br_4': self.env._("HR-BT-4: In the case of a positive amount due for payment (BT-115), the payment due date (BT-9) must be specified.")})
@@ -200,10 +201,8 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             vals['document_node']['cac:BillingReference'] = [{
                 'cac:InvoiceDocumentReference': {
                     'cbc:ID': {'_text': invoice.ref},
+                    'cbc:IssueDate': {'_text': invoice.reversed_entry_id.invoice_date},
                 },
-                'cbc:IssueDate': {
-                    '_text': invoice.reversed_entry_id.invoice_date
-                }
             }]
 
     def _add_hr_extension_node(self, document_node):

--- a/addons/l10n_hr_edi/tests/test_ubl_hr.py
+++ b/addons/l10n_hr_edi/tests/test_ubl_hr.py
@@ -283,3 +283,43 @@ class TestL10nHrEdiXml(TestL10nHrEdiCommon, AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(actual_content),
             self.get_xml_tree_from_string(expected_content),
         )
+
+    def test_export_credit_note_without_bank_account(self):
+        """
+        Test that a credit note referencing an original invoice can be exported without a
+        recipient bank account. Covers two bugs:
+        1. AttributeError: 'NoneType' has no attribute 'get' when PayeeFinancialAccount is None
+        2. ValueError: cbc:IssueDate placed as a sibling of cac:InvoiceDocumentReference
+           instead of a child, causing dict_to_xml template validation to fail
+        """
+        self.setup_partner_as_hr(self.env.company.partner_id)
+        self.setup_partner_as_hr_alt(self.partner_a)
+        self.partner_a.bank_ids.unlink()
+        tax = self.env['account.chart.template'].ref('VAT_S_IN_ROC_25')
+
+        original_invoice = self._create_invoice(
+            move_type='out_invoice',
+            partner_id=self.partner_a,
+            invoice_date='2025-01-01',
+            post=True,
+            invoice_line_ids=[self._prepare_invoice_line(product_id=self.product_a, price_unit=100.0, tax_ids=tax)],
+        )
+        credit_note = self._reverse_invoice(original_invoice, post=True, date='2025-01-02')
+        credit_note.l10n_hr_edi_addendum_id = self.env['l10n_hr_edi.addendum'].create({
+            'move_id': credit_note.id,
+            'invoice_sending_time': '2025-01-03',
+            'fiscalization_number': self.env['account.move']._get_l10n_hr_fiscalization_number(credit_note.name),
+        })
+
+        actual_content, errors = self.env['account.edi.xml.ubl_hr'].with_context(lang='en_US')._export_invoice(credit_note)
+        self.assertFalse(errors)
+
+        tree = self.get_xml_tree_from_string(actual_content)
+
+        billing_ref = tree.find('.//{*}BillingReference')
+        self.assertIsNotNone(billing_ref)
+        invoice_doc_ref = billing_ref.find('{*}InvoiceDocumentReference')
+        self.assertIsNotNone(invoice_doc_ref)
+        self.assertIsNotNone(invoice_doc_ref.find('{*}IssueDate'))
+        self.assertIsNone(billing_ref.find('{*}IssueDate'))
+        self.assertIsNone(tree.find('.//{*}PayeeFinancialAccount'))


### PR DESCRIPTION
**Steps to reproduce:**
* Install `l10n_hr_edi` module.
* Generate an invoice and validate it.
* Generate a credit note from that invoice.
* Without a recipient bank account, try to send the credit note to Mojeracun.

**Observed behavior:**
* Two errors are raised before the XML is generated:
  1. `AttributeError: 'NoneType' object has no attribute 'get'` in `_invoice_constraints_eracun_new` when checking for whitespace in the bank account number.
  2. `ValueError: The following child node is not defined in the template: CreditNote/cac:BillingReference/cbc:IssueDate` during XML serialization.

**Cause:**
* issue 1 : https://github.com/odoo/odoo/commit/96cf6626d2b3e75637b908244cf2fa4da615c16b#diff-16f43166a8e5a637cb57b5695a1332845ba5440d989e25fcd59c828aa55cb036R81
* In the mentioned commit `_invoice_constraints_eracun_new`, `node.get('cac:PayeeFinancialAccount', {})` returns `None` instead of `{}` when the key exists but its value is explicitly set to `None` (which happens when no bank account is set). Chaining `.get()` on `None` raises `AttributeError`.
* issue 2 : https://github.com/odoo/odoo/commit/47ef0c2cb96be9fffdc4985255661807980839c6#diff-16f43166a8e5a637cb57b5695a1332845ba5440d989e25fcd59c828aa55cb036R146
* In the mentioned commit in `_ubl_add_billing_reference_nodes`, `cbc:IssueDate` was added as a direct child of `cac:BillingReference`. The UBL template only allows `cac:InvoiceDocumentReference` as a child of `BillingReference`, while `cbc:IssueDate` belongs inside `cac:InvoiceDocumentReference`.

**Fix:**
* Replace `.get('cac:PayeeFinancialAccount', {})` with `.get('cac:PayeeFinancialAccount')` to safely handle an explicitly `None` value before chaining further calls.
* Move `cbc:IssueDate` inside `cac:InvoiceDocumentReference` in the `BillingReference` node, matching the structure defined in `ubl_21_common.py`.

opw-6088424