### PR TITLE
[FIX] website: restore searchbar form action

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -257,7 +257,7 @@ export class SearchBar extends Interaction {
 
     openSearchModal() {
         const values = {
-            action: this.el.getAttribute("action"),
+            action: this.el.getAttribute("action") || undefined,
             placeholder: this.inputEl.getAttribute("placeholder"),
             limit: this.inputEl.dataset.limit,
             order: this.inputEl.dataset.orderBy,


### PR DESCRIPTION
After the searchbar refactoring in [1], the mobile searchbar lost its form action, preventing redirection to results.

Restore the form action to fix the issue.

[1]: https://github.com/odoo/odoo/pull/238317

task-6105283

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
