### PR TITLE
[FIX] html_editor: clear image shape classes when replacing with icon

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
@@ -6,15 +6,7 @@ import { Component, useState } from "@odoo/owl";
 export class IconSelector extends Component {
     static mediaSpecificClasses = ["fa"];
     static mediaSpecificStyles = ["color", "background-color"];
-    static mediaExtraClasses = [
-        "rounded-circle",
-        "rounded",
-        "img-thumbnail",
-        "shadow",
-        /^text-\S+$/,
-        /^bg-\S+$/,
-        /^fa-\S+$/,
-    ];
+    static mediaExtraClasses = [/^text-\S+$/, /^bg-\S+$/, /^fa-\S+$/];
     static tagNames = ["SPAN", "I"];
     static template = "html_editor.IconSelector";
     static components = {

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -136,6 +136,26 @@ test("should not preserve image styles when replacing an image with an icon", as
     );
 });
 
+test("should not preserve image shape classes when replacing an image with an icon", async () => {
+    onRpc("ir.attachment", "search_read", () => []);
+    const { el } = await setupEditor(
+        `<p><img class="img-fluid rounded rounded-circle shadow img-thumbnail" src="/web/static/img/logo.png"></p>`
+    );
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
+    await click("img");
+    await tick(); // selectionchange
+    await expectElementCount(".o-we-toolbar button[name='replace_image']", 1);
+    await click("button[name='replace_image']");
+    await animationFrame();
+    await click(".nav-link:contains('Icons')");
+    await animationFrame();
+    await click(".fa-glass");
+    await animationFrame();
+    expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>[]\ufeff</p>`
+    );
+});
+
 test.tags("focus required");
 test("Can insert an image, and selection should be collapsed after it", async () => {
     onRpc("ir.attachment", "search_read", () => [


### PR DESCRIPTION
### Steps to Reproduce:
- Go to the To-do app and create a new task.
- Upload an image.
- Apply shape styling to the image (e.g., rounded, shadow, img-thumbnail).
- Replace the image with an icon.

### Description of the issue/feature this PR addresses:

- When an image had shape applied (such as rounded, rounded-circle, shadow, or img-thumbnail) and was replaced with an icon, those classes were carried over to the icon.

### Desired behavior after PR is merged:

- Since these classes are specific to image shape styling, they are now removed when an image is replaced with an icon.

task-6007631

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
