### PR TITLE
[FIX] website_forum: replace incorrect steps in tour

### DIFF
--- a/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
+++ b/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
@@ -1,4 +1,4 @@
-import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
     "forum_cover_dropzone",
@@ -15,23 +15,28 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Add the s_title into the forum cover.",
+            content: "Select the 'Title' snippet in the dialog.",
             trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_title"]:not(.d-none)',
             run: "click",
         },
         {
-            content: "Check that the s_title was inserted in the forum cover.",
+            content: "Check that the 'Title' snippet was inserted in the forum cover.",
             trigger: ":iframe .s_cover .s_title",
         },
         // Add a snippet with drag and drop.
-        ...insertSnippet({
-            id: "s_text_block",
-            name: "Text",
-            groupName: "Text",
-        }),
         {
-            content: "Check that the s_text was inserted in the forum cover.",
-            trigger: ":iframe .s_cover .s_text_block",
+            content: "Drag the Form snippet group into the forum cover.",
+            trigger: `#oe_snippets .oe_snippet[name="Contact & Forms"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
+            run: "drag_and_drop :iframe #wrapwrap .s_cover",
+        },
+        {
+            content: "Select the 'Title - Form' snippet in the dialog",
+            trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_title_form"]:not(.d-none)',
+            run: "click",
+        },
+        {
+            content: "Check that the 'Title - Form' snippet was inserted in the forum cover.",
+            trigger: ":iframe .s_cover .s_title_form",
         },
         // Check that it is impossible to drop "Embed Code" (= sanitized area).
         {


### PR DESCRIPTION
This commit fixes the incorrect steps in the forum_cover_dropzone tour added in #257527. The tour util adding the s_text snippet was removed to add a snippet using the drag and drop method. The snippet added was changed to form snippet to also check that forms can be dropped in the s_cover in website_forum.