### PR TITLE
[FIX] iot_drivers: fix missing printer keys

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -21,15 +21,17 @@ class PrinterDriver(PrinterDriverBase):
         super().__init__(identifier, device)
         self.conn = Connection()
         self.cups_lock = Lock()
-        self.receipt_protocol = 'star' if 'STR_T' in device['device-id'] else 'escpos'
         self.connected_by_usb = device.get("is_usb", False)
         self.device_connection = "direct" if self.connected_by_usb else "network"
-        self.device_name = device['device-make-and-model']
+        self.device_name = device.get('device-make-and-model', identifier)
         self.ip = device.get('ip')
 
-        if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']) or "tm-m30" in self.device_name.lower():
+        device_id = device.get('device-id', '')
+        self.receipt_protocol = 'star' if 'STR_T' in device_id else 'escpos'
+
+        if any(cmd in device_id for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']) or "tm-m30" in self.device_name.lower():
             self.device_subtype = "receipt_printer"
-        elif any(cmd in device['device-id'] for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']) or "zpl" in self.device_name.lower():
+        elif any(cmd in device_id for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']) or "zpl" in self.device_name.lower():
             self.device_subtype = "label_printer"
         else:
             self.device_subtype = "office_printer"


### PR DESCRIPTION
After the PR https://github.com/odoo/odoo/pull/247032 for some printers the keys 'device-id' and 'device-make-and-model' are missing which leads to the drivers not being initialized

This PR adds the possibility of these keys missing

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
