### PR TITLE
[FIX] account: subtotal_footer: amount due alignment

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1398,16 +1398,16 @@
                                     </group>
                                     <!-- Totals (only invoices / receipts) -->
                                     <group colspan="4" class="m-0">
-                                        <group class="oe_subtotal_footer"
+                                        <group class="oe_subtotal_footer gx-0 gx-md-5"
                                             invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') or payment_state == 'invoicing_legacy'">
 
                                             <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" colspan="2"
                                                    readonly="state != 'draft' or (move_type not in ('in_invoice', 'in_refund', 'in_receipt') and not quick_edit_mode)"/>
 
                                             <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment" invisible="not invoice_payments_widget"/>
-                                            <div>
+                                            <div class="d-flex justify-content-end" colspan="2">
                                                 <label for="amount_residual"/>
-                                                <field name="amount_residual" class="oe_subtotal_footer_separator"/>
+                                                <field name="amount_residual" class="oe_subtotal_footer_separator w-auto"/>
                                             </div>
                                         </group>
                                         <group


### PR DESCRIPTION
Since the new input box style was introduced, the "Amount Due" was not correctly aligned.

This has now been fixed for both small screens and desktop.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
