### PR TITLE
[FIX] core: terminate all chrome subprocesses

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1118,12 +1118,21 @@ class ChromeBrowser:
             self.ws.close()
         if self.chrome:
             self._logger.info("Terminating chrome headless with pid %s", self.chrome.pid)
+            main = psutil.Process(self.chrome.pid)
+            children = main.children(recursive=True)
+            children.insert(0, main)
             self.chrome.terminate()
-            try:
-                self.chrome.wait(15)
-            except subprocess.TimeoutExpired:
-                self._logger.warning("Killing chrome headless with pid %s: still alive", self.chrome.pid)
-                self.chrome.kill()
+            _, alive = psutil.wait_procs(children, 15)
+            if alive:
+                self._logger.warning(
+                    "Killing chrome descendants-or-self of %s: %d remaining%s",
+                    self.chrome.pid,
+                    len(alive),
+                    "".join(f"\n- {p.name()} ({p.status()})" for p in alive),
+                )
+                for p in alive:
+                    p.kill()
+                psutil.wait_procs(alive, 1)
                 self.chrome_log_level = logging.RUNBOT
 
         if self.user_data_dir and os.path.isdir(self.user_data_dir) and self.user_data_dir != '/':


### PR DESCRIPTION
It's not clear when it started to happen (possibly forever), but apparently waiting for the main chrome process to terminate does not ensure all subprocesses are also terminated. Depending how long these subprocesses stick around, this can lead to:

- remaining http or websocket requests
- the inability to delete or re-creation of the user directory
- possibly other confusing situations

Update the chrome termination flow to make sure every subprocess is gone before proceeding to the next step.

Kinda-sorta backport of #258062
