### PR TITLE
[FIX] web: AutoComplete: do not close dropdown directly

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -121,7 +121,6 @@ export class AutoComplete extends Component {
                     this.state.value = nextProps.value;
                     this.inputRef.el.value = nextProps.value;
                 }
-                this.close();
             }
         });
 

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -508,8 +508,6 @@ test("autocomplete in edition keep edited value before select option", async () 
     expect(".o-autocomplete input").toHaveValue("Yolo");
 
     // Leave inEdition mode when selecting an option
-    await contains(".o-autocomplete input").click();
-    await runAllTimers();
     await contains(queryFirst(".o-autocomplete--dropdown-item")).click();
     expect(".o-autocomplete input").toHaveValue("My Selection");
 
@@ -645,6 +643,30 @@ test("autocomplete always closes on click away", async () => {
     expect(".o-autocomplete--dropdown-item").toHaveCount(2);
     await contains(document.body).click();
     expect(".o-autocomplete--dropdown-item").toHaveCount(0);
+});
+
+test("autocomplete dropdown remains open when props.value changes", async () => {
+    let state;
+    class Parent extends Component {
+        static template = xml`<AutoComplete value="state.value" sources="sources" autoSelect="true"/>`;
+        static components = { AutoComplete };
+        static props = [];
+
+        setup() {
+            this.sources = buildSources(() => [item("World"), item("Hello")]);
+            this.state = useState({ value: "" });
+            state = this.state;
+        }
+    }
+    await mountWithCleanup(Parent);
+    expect(".o-autocomplete input").toHaveValue("");
+    await contains(".o-autocomplete input").click();
+    expect(".o-autocomplete--dropdown-item").toHaveCount(2);
+
+    state.value = "World";
+    await animationFrame();
+    expect(".o-autocomplete input").toHaveValue("World");
+    expect(".o-autocomplete--dropdown-item").toHaveCount(2);
 });
 
 test("autocomplete trim spaces for search", async () => {

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -3150,6 +3150,7 @@ test("leaving an empty many2one by pressing tab (after backspace or delete)", as
     await press("backspace");
     await press("tab");
     await animationFrame();
+    await runAllTimers();
     expect(".o_field_many2one input").toHaveValue("");
 
     // reset a value
@@ -4037,7 +4038,8 @@ test("many2one search with formatted name", async () => {
         {
             id: 1,
             display_name: "Paul Eric",
-            __formatted_display_name: "Research & Development Test: **Paul** --Eric-- `good guy`\n\tMore text",
+            __formatted_display_name:
+                "Research & Development Test: **Paul** --Eric-- `good guy`\n\tMore text",
         },
     ]);
     await mountView({


### PR DESCRIPTION
Before this commit, when the props of the AutoComplete were updated such that the value changed while the dropdown was opened, but the user didn't type anything yet, the dropdown was closed.

This could be reproduced in Expenses:
 - click "New" to create a new expense
 - set a description
 - blur the description field by clicking on the category many2one => the autocomplete dropdown briefly opened and closed itself again while the onchange returned, as it set the value of category_id.

This commit fixes the issue by never closing the dropdown when the value is changed.

Issue reported in the rd-framework-js channel

Part of task 5491410