### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: add warning before Peppol sending

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models
+from odoo import fields, models, _
 
 
 class AccountMove(models.Model):
@@ -8,3 +8,14 @@ class AccountMove(models.Model):
     buyer_reference = fields.Char(help="'Code de Service' in Chorus PRO.")
     contract_reference = fields.Char(help="'Numéro de Marché' in Chorus PRO.")
     purchase_order_reference = fields.Char(help="'Engagement Juridique' in Chorus PRO.")
+
+    def _get_alerts(self):
+        alerts = super()._get_alerts()
+
+        if self.peppol_move_state in ('ready', 'to_send', 'error') and self.env['account.edi.xml.ubl_bis3']._is_customer_behind_chorus_pro(self.partner_id):
+            alerts['chorus_endpoint'] = {
+                'level': 'warning',
+                'message': _('Ensure all Chorus Pro fields are correctly filled before sending to Peppol'),
+            }
+
+        return alerts


### PR DESCRIPTION
If a customer have the chorus endpoint enabled for a customer,
a warning will be added on the invoice to remind to fill
the Chorus Pro fields

You can rely on the Odoo documentation to setup the endpoint:
https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations/france.html?highlight=chorus#configuration

### Steps to reproduce:
- Install `l10n_fr_facturx_chorus_pro` and switch to FR Company
- Enable Peppol
- Create a Customer (Country: France, VAT: any value, SIRET: any value)
- In the customer's Accounting Tab set France SIRET to 11000201100044
- Create an invoice, the warning should be displayed at the top of the page

opw-6047840