### PR TITLE
[FIX] stock, product: display lot labels with custom paper format

### DIFF
--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -2,8 +2,6 @@
     margin-left: -4mm;
     margin-right: -4mm;
     overflow: hidden;
-    width: 210mm;
-    height: 297mm;
     page-break-before: always;
     &.o_label_dymo {
         font-size:90%;

--- a/addons/stock/models/ir_actions_report.py
+++ b/addons/stock/models/ir_actions_report.py
@@ -13,4 +13,8 @@ class IrActionsReport(models.Model):
                 'doc_ids': docids,
                 'docs': docs,
             })
+        if report.paperformat_id:
+            data.update({
+                'report': report
+            })
         return data

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -3,10 +3,12 @@
 <data>
 <template id="report_lot_label">
     <t t-call="web.basic_layout">
-        <t t-set='nRows' t-value='12'/>
-        <t t-set='nCols' t-value='4'/>
+        <t t-set='nCols' t-value='int(report.paperformat_id.print_page_width // 41)'/>
+        <t t-set='nRows' t-value='int(len(docs) // nCols)+1'/>
+        <t t-set='padding_width' t-value='int(report.paperformat_id.print_page_width // 26)'/>
+        <t t-set='padding_height' t-value='int(report.paperformat_id.print_page_height // 15)'/>
         <div class="oe_structure"></div>
-        <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: 20mm 8mm'">
+        <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: %smm %smm' % (padding_height, padding_width)">
             <table class="my-0 table table-sm table-borderless">
                 <t t-foreach="range(nRows)" t-as="row">
                     <tr>
@@ -14,31 +16,29 @@
                             <t t-set="barcode_index" t-value="(row * nCols + col)"/>
                             <t t-if="barcode_index &lt; len(page_docs)">
                                 <t t-set="o" t-value="page_docs[barcode_index]"/>
+
+                                <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
+                                    <div t-att-style="'position:relative; width:41mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
+                                        <t t-set="final_barcode" t-value="''"/>
+                                        <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
+                                            <t t-if="o.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(o.product_id.barcode)) + o.product_id.barcode"/>
+                                            <t name="gs1_datamatrix_lot" t-if="o.product_id.tracking == 'lot'" t-set="final_barcode" t-value="(final_barcode or '') + '10' + o.name"/>
+                                            <t t-elif="o.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + o.name"/>
+                                        </t>
+                                        <div class="o_label_4x12" t-if="o.product_id.default_code" t-att-style="'width:22mm' if final_barcode else ''">[<t t-out="o.product_id.default_code"/>]</div>
+                                        <div class="o_label_4x12" t-field="o.product_id.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Product</div>
+                                        <div class="o_label_4x12" name="lot_name" t-field="o.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Lot/SN</div>
+                                        <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
+                                            <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'">
+                                                <span t-out="final_barcode" t-options="{'widget': 'barcode', 'symbology': 'ECC200DataMatrix', 'img_style': 'width:17mm; height:17mm'}">12345678901</span>
+                                            </div>
+                                        </t>
+                                        <t t-else="">
+                                            <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}">Demo Lot/SN</span>
+                                        </t>
+                                    </div>
+                                </td>
                             </t>
-                            <t t-else="">
-                                <t t-set="o" t-value="page_docs[0]"/>
-                            </t>
-                            <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
-                                <div t-att-style="'position:relative; width:43mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
-                                    <t t-set="final_barcode" t-value="''"/>
-                                    <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
-                                        <t t-if="o.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(o.product_id.barcode)) + o.product_id.barcode"/>
-                                        <t name="gs1_datamatrix_lot" t-if="o.product_id.tracking == 'lot'" t-set="final_barcode" t-value="(final_barcode or '') + '10' + o.name"/>
-                                        <t t-elif="o.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + o.name"/>
-                                    </t>
-                                    <div class="o_label_4x12" t-if="o.product_id.default_code" t-att-style="'width:22mm' if final_barcode else ''">[<t t-out="o.product_id.default_code"/>]</div>
-                                    <div class="o_label_4x12" t-field="o.product_id.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Product</div>
-                                    <div class="o_label_4x12" name="lot_name" t-field="o.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Lot/SN</div>
-                                    <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
-                                        <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'">
-                                            <span t-out="final_barcode" t-options="{'widget': 'barcode', 'symbology': 'ECC200DataMatrix', 'img_style': 'width:17mm; height:17mm'}">12345678901</span>
-                                        </div>
-                                    </t>
-                                    <t t-else="">
-                                        <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}">Demo Lot/SN</span>
-                                    </t>
-                                </div>
-                            </td>
                         </t>
                     </tr>
                 </t>

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -2084,3 +2084,22 @@ class TestReportsPostInstall(TestReportsCommon):
         self.assertEqual(picking_out.move_ids.mapped('quantity'), [0.0, 2.0])
         self.env['report.stock.report_reception'].action_assign(out_move.ids, [1.0], picking_in.move_ids.ids)
         self.assertEqual(picking_out.move_ids.mapped('quantity'), [1.0, 2.0])
+
+    def test_product_label_barcode_custom_paper_format_reports(self):
+        """ Test that the barcodes are correctly rendered with a custom paper format"""
+        report = self.env['ir.actions.report'].search([('report_name', '=', 'stock.report_lot_label')])
+        paper_format = self.env.ref('base.paperformat_euro')
+        paper_format.print_page_width = 57
+        paper_format.print_page_height = 32
+        paper_format.page_width = 32
+        paper_format.page_height = 57
+        report.paperformat_id = paper_format.id
+        doc = self.env['stock.lot'].create({
+            'name': 'lot2',
+            'product_id': self.serial_product.id,
+        })
+        collected_stream = self.env['ir.actions.report']._render_qweb_pdf('stock.report_lot_label', doc.id)[0]
+        # Only one product should give only one appearance of simple prod
+        self.assertEqual(collected_stream.decode('utf-8').count("simple prod"), 1)
+        # Padding should be smaller with smaller page dimensions
+        self.assertEqual(collected_stream.decode('utf-8').count("padding: 2mm 2mm"), 1)


### PR DESCRIPTION
__

## Short functional explanation of the error
When printing labels of lot or serial products with a custom paper format, the obtained pdf contains several empty pages.

## Reproduction Steps
1. Enable Debug Mode. In Settings, click on the Technical tab. In the reporting section, click on Paper Format.
2. Click on New. Give a name to your paper format. In the Paper Size field, select Custom. For Page Height and Page Width, make sure that they're smaller than A4 measurements. For example, set the Page Height at 57 and Page Width at 35. Set Margins at 0. In the Associated Reports field, select `lot/Serial Number (PDF)`.
3. Go to Inventory. Click on the Products tab > Lots / Serial Numbers. Click on any Serial Number. Click on the Cog on the top left > Print > Lots / Serial Number (PDF).

### Expected behavior
We obtain a PDF of only one page containing the barcode of the serial number.

### Unexpected behavior
We obtain a PDF of 5 pages, including 4 blank pages and only one page holding the barcode.

## Origin of the issue
In the XML of the label reports, we use the css class `o_label_sheet`: https://github.com/odoo/odoo/blob/ec2300456599e2b3bed5ba130badb63bb9bf15b3/addons/stock/report/report_lot_barcode.xml#L9 In this class, the height and width of sheets are hardcoded to A4 dimensions:
https://github.com/odoo/odoo/blob/ec2300456599e2b3bed5ba130badb63bb9bf15b3/addons/product/static/src/scss/report_label_sheet.scss#L5-L6 Therefore, if we set the dimensions of the custom paper format to be smaller than an A4 page, we'll obtain several blank pages, until the dimensions of an A4 pages are met.
Moreover, the dimensions of the padding are also hardcoded, which can be an issue in the case of very small custom dimensions. Finally, we nest barcodes in an HTML table:
https://github.com/odoo/odoo/blob/ec2300456599e2b3bed5ba130badb63bb9bf15b3/addons/stock/report/report_lot_barcode.xml#L10 for which we hardcode the dimensions:
https://github.com/odoo/odoo/blob/ec2300456599e2b3bed5ba130badb63bb9bf15b3/addons/stock/report/report_lot_barcode.xml#L6-L7 This will result in always printing the same amount of barcodes per row in the case of batch printing, even if the dimensions are too small to hold them all. This will also result in always nesting 12x4 barcodes, even when only printing one, while hiding the others, which also produces additional unrequired blank pages.

Therefore, we need the dimensions indicated in the paper format of the report to dynamically compute
the dimensions of the padding and the rows/columns of the HTML table.
__
opw-6071885

