### PR TITLE
[REF] hr: move hourly_cost to employee versioning model

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -158,6 +158,7 @@ class HrVersion(models.Model):
                                         groups="hr.group_hr_manager", default=_default_salary_structure)
     active_employee = fields.Boolean(related="employee_id.active", string="Active Employee", groups="hr.group_hr_user")
     currency_id = fields.Many2one(string="Currency", related='company_id.currency_id', readonly=True)
+    hourly_cost = fields.Monetary('Hourly Cost', groups="hr.group_hr_user", default=0.0, tracking=True)
     wage = fields.Monetary('Wage', tracking=True, help="Employee's monthly gross wage.", aggregator="avg",
                            groups="hr.group_hr_manager")
     contract_wage = fields.Monetary('Contract Wage', compute='_compute_contract_wage', groups="hr.group_hr_manager")

--- a/addons/hr_hourly_cost/models/hr_employee.py
+++ b/addons/hr_hourly_cost/models/hr_employee.py
@@ -6,5 +6,4 @@ from odoo import fields, models
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
-    hourly_cost = fields.Monetary('Hourly Cost', currency_field='currency_id',
-        groups="hr.group_hr_user", default=0.0, tracking=True)
+    hourly_cost = fields.Monetary(readonly=False, related='version_id.hourly_cost', inherited=True, groups="hr.group_hr_user")

--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -36,7 +36,7 @@ class HrTimesheetAttendanceReport(models.Model):
             FROM (
                 SELECT
                     -hr_attendance.id AS id,
-                    hr_employee.hourly_cost AS emp_cost,
+                    v.hourly_cost AS emp_cost,
                     hr_attendance.employee_id AS employee_id,
                     hr_attendance.worked_hours AS attendance,
                     NULL AS timesheet,
@@ -51,11 +51,12 @@ class HrTimesheetAttendanceReport(models.Model):
                     hr_employee.company_id as company_id
                 FROM hr_attendance
                 LEFT JOIN hr_employee ON hr_employee.id = hr_attendance.employee_id
+                LEFT JOIN hr_version v ON v.id = hr_employee.current_version_id
                 WHERE check_in::date <= CURRENT_DATE
             UNION ALL
                 SELECT
                     ts.id AS id,
-                    hr_employee.hourly_cost AS emp_cost,
+                    v.hourly_cost AS emp_cost,
                     ts.employee_id AS employee_id,
                     NULL AS attendance,
                     ts.unit_amount AS timesheet,
@@ -63,6 +64,7 @@ class HrTimesheetAttendanceReport(models.Model):
                     ts.company_id AS company_id
                 FROM account_analytic_line AS ts
                 LEFT JOIN hr_employee ON hr_employee.id = ts.employee_id
+                LEFT JOIN hr_version v ON v.id = hr_employee.current_version_id
                 WHERE ts.project_id IS NOT NULL
                   AND date <= CURRENT_DATE
             ) AS t


### PR DESCRIPTION
This commit will migrate the hourly_cost field from the base employee model to the versioned record model.

**Why:**
Previously, the hourly_cost field was defined directly on the hr.employee model. Because this model represents the "main" record, any changes to the hourly cost would overwrite the value across all historical versions of that employee. This made it impossible to track how an employee's cost to the company evolved over time. By moving this field to the versioning model each historical snapshot of the employee can now maintain its own specific hourly cost.

**What:**
- Added the `hourly_cost` field to the employee versioning model.
- Updated `hourly_cost` of an employee to use the version related field

task-6098429
