### PR TITLE
[IMP] web: use bottomsheet for colorlist

### DIFF
--- a/addons/web/static/src/core/colorlist/colorlist.js
+++ b/addons/web/static/src/core/colorlist/colorlist.js
@@ -1,4 +1,3 @@
-import { useExternalListener, useRef, useState } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
 
 import { Component } from "@odoo/owl";
@@ -19,47 +18,15 @@ export class ColorList extends Component {
         _t("Violet"),
     ];
     static template = "web.ColorList";
-    static defaultProps = {
-        forceExpanded: false,
-        isExpanded: false,
-    };
     static props = {
-        canToggle: { type: Boolean, optional: true },
-        colors: Array,
-        forceExpanded: { type: Boolean, optional: true },
-        isExpanded: { type: Boolean, optional: true },
+        disableTransparent: { type: Boolean, optional: true },
         onColorSelected: Function,
         selectedColor: { type: Number, optional: true },
     };
-
-    setup() {
-        this.colorlistRef = useRef("colorlist");
-        this.state = useState({ isExpanded: this.props.isExpanded });
-        useExternalListener(window, "click", this.onOutsideClick);
-    }
     get colors() {
         return this.constructor.COLORS;
     }
     onColorSelected(id) {
         this.props.onColorSelected(id);
-        if (!this.props.forceExpanded) {
-            this.state.isExpanded = false;
-        }
-    }
-    onOutsideClick(ev) {
-        if (this.colorlistRef.el.contains(ev.target) || this.props.forceExpanded) {
-            return;
-        }
-        this.state.isExpanded = false;
-    }
-    onToggle(ev) {
-        if (this.props.canToggle) {
-            ev.preventDefault();
-            ev.stopPropagation();
-            this.state.isExpanded = !this.state.isExpanded;
-            setTimeout(() => {
-                this.colorlistRef.el.querySelector("button").focus();
-            });
-        }
     }
 }

--- a/addons/web/static/src/core/colorlist/colorlist.scss
+++ b/addons/web/static/src/core/colorlist/colorlist.scss
@@ -1,5 +1,4 @@
 @mixin o-colorlist($-entry, $-child) {
-    width: var(--ColorListField-width, none);
     padding: var(--ColorListField-padding, 0);
     box-sizing: content-box;
     margin-bottom: var(--ColorListField-marginBottom, 0);
@@ -54,22 +53,20 @@
     :not(.o_field_widget) > & {
         justify-content: center;
     }
+}
 
-    > button {
-        aspect-ratio: 1;
+.o_colorlist > button, .o_colorlist_toggler {
+    // No Color
+    &.o_colorlist_item_color_0 {
+        background: transparent;
+        box-shadow: inset 0 0 0 1px $gray-500;
+    }
 
-        // No Color
-        &.o_colorlist_item_color_0 {
-            background: transparent;
-            box-shadow: inset 0 0 0 1px $gray-500;
-        }
-
-        // Set all the colors but the "no-color" one
-        @for $size from 2 through length($o-colors) {
-            &.o_colorlist_item_color_#{$size - 1} {
-                @include o-print-color(nth($o-colors, $size), background-color, bg-opacity);
-                @include o-print-color(color-contrast(nth($o-colors, $size)), color, text-opacity);
-            }
+    // Set all the colors but the "no-color" one
+    @for $size from 2 through length($o-colors) {
+        &.o_colorlist_item_color_#{$size - 1} {
+            @include o-print-color(nth($o-colors, $size), background-color, bg-opacity);
+            @include o-print-color(color-contrast(nth($o-colors, $size)), color, text-opacity);
         }
     }
 }

--- a/addons/web/static/src/core/colorlist/colorlist.xml
+++ b/addons/web/static/src/core/colorlist/colorlist.xml
@@ -2,12 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ColorList">
-        <div class="o_colorlist d-grid gap-3 gap-md-2" aria-atomic="true" t-custom-ref="colorlist">
-            <t t-if="!this.props.forceExpanded and !this.state.isExpanded">
-                <button t-on-click="this.onToggle" role="menuitem" t-att-title="this.colors[this.props.selectedColor]" t-att-data-color="this.props.selectedColor" t-att-aria-label="this.colors[this.props.selectedColor]" t-attf-class="border-0 rounded-circle o_colorlist_toggler o_colorlist_item_color_{{ this.props.selectedColor }}"/>
-            </t>
-            <t t-else="" t-foreach="this.props.colors" t-as="colorId" t-key="colorId">
-                <button t-on-click.prevent.stop="() => this.onColorSelected(colorId)" role="menuitem" t-att-title="this.colors[colorId]" t-att-data-color="colorId" t-att-aria-label="this.colors[colorId]" t-attf-class="border-0 rounded-circle o_colorlist_item_color_{{ colorId }} {{ colorId === this.props.selectedColor ? 'active' : '' }}"/>
+        <div class="o_colorlist d-grid gap-3" aria-atomic="true" t-custom-ref="colorlist">
+            <t t-foreach="this.colors" t-as="color" t-key="color_index">
+                <button t-if="!this.props.disableTransparent or color_index > 0" t-on-click.prevent.stop="() => this.onColorSelected(color_index)" role="menuitem" t-att-title="color" t-att-data-color="color_index" t-att-aria-label="color" t-attf-class="border-0 rounded-circle o_colorlist_item_color_{{ color_index }} {{ color_index === this.props.selectedColor ? 'active' : '' }}"/>
             </t>
         </div>
     </t>

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.js
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.js
@@ -1,6 +1,8 @@
 import { ColorList } from "@web/core/colorlist/colorlist";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
-import { standardFieldProps } from "../standard_field_props";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 import { Component } from "@odoo/owl";
 
@@ -8,28 +10,35 @@ export class ColorPickerField extends Component {
     static template = "web.ColorPickerField";
     static components = {
         ColorList,
+        Dropdown,
     };
     static props = {
         ...standardFieldProps,
-        canToggle: { type: Boolean },
     };
 
-    static RECORD_COLORS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    setup() {
+        this.dropdownState = useDropdownState();
+    }
 
-    get isExpanded() {
-        return !this.props.canToggle && !this.props.readonly;
+    get selectedColor() {
+        return this.props.record.data[this.props.name] || 0;
+    }
+
+    get colors() {
+        return ColorList.COLORS;
     }
 
     switchColor(colorIndex) {
         this.props.record.update({ [this.props.name]: colorIndex });
+        this.dropdownState.close();
     }
 }
 
 export const colorPickerField = {
     component: ColorPickerField,
     supportedTypes: ["integer"],
-    extractProps: ({ viewType }) => ({
-        canToggle: viewType !== "list",
+    extractProps: ({}, dynamicInfo) => ({
+        readonly: dynamicInfo.readonly,
     }),
 };
 

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.scss
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.scss
@@ -1,14 +1,4 @@
-.o_field_widget.o_field_color_picker > div {
-    // to compensate on the 2px margin used to space the elements relative to each other
-    // we keep the top one cause the widget is a bit to high anyway
-    margin-left: -2px;
-    margin-right: -2px;
-    margin-bottom: -2px;
-
-    > div {
-        display: inline-block;
-        border: 1px solid white;
-        box-shadow: 0 0 0 1px map-get($grays, '300');
-        margin: 2px;
-    }
+.o_field_widget.o_field_color_picker .o_colorlist_toggler {
+    aspect-ratio: 1;
+    width: 20px;
 }

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.xml
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.xml
@@ -2,7 +2,12 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ColorPickerField">
-        <ColorList canToggle="this.props.canToggle" colors="this.constructor.RECORD_COLORS" forceExpanded="this.isExpanded" onColorSelected.bind="this.switchColor" selectedColor="this.props.record.data[this.props.name] || 0"/>
+        <Dropdown state="this.dropdownState" disabled="this.props.readonly">
+            <button t-attf-class="border-0 rounded-circle o_colorlist_toggler o_colorlist_item_color_{{ this.selectedColor }} me-2"  t-att-title="this.colors[this.selectedColor]"  t-att-aria-label="this.colors[this.selectedColor]"/>
+            <t t-set-slot="content">
+                <ColorList onColorSelected.bind="this.switchColor" selectedColor="this.selectedColor"/>
+            </t>
+        </Dropdown>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -1,5 +1,6 @@
 import { useRef, useState } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
+import { hasTouch } from "@web/core/browser/feature_detection";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { ColorList } from "@web/core/colorlist/colorlist";
 import { Domain } from "@web/core/domain";
@@ -29,7 +30,6 @@ class Many2ManyTagsFieldColorListPopover extends Component {
         ColorList,
     };
     static props = {
-        colors: Array,
         tag: Object,
         switchTagColor: Function,
         onTagVisibilityChange: Function,
@@ -74,13 +74,13 @@ export class Many2ManyTagsField extends Component {
         context: {},
     };
 
-    static RECORD_COLORS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-
     setup() {
         this.state = useState({ expanded: false });
         this.orm = useService("orm");
         this.previousColorsMap = {};
-        this.popover = usePopover(this.constructor.components.Popover);
+        this.popover = usePopover(this.constructor.components.Popover, {
+            useBottomSheet: this.isBottomSheet,
+        });
         this.dialog = useService("dialog");
         this.dialogClose = [];
         useTagNavigation("many2ManyTagsField", {
@@ -144,6 +144,10 @@ export class Many2ManyTagsField extends Component {
         }
     }
 
+    get isBottomSheet() {
+        return this.env.isSmall && hasTouch();
+    }
+
     get relation() {
         return this.props.record.fields[this.props.name].relation;
     }
@@ -190,7 +194,6 @@ export class Many2ManyTagsField extends Component {
             this.popover.close();
         } else {
             this.popover.open(ev.currentTarget, {
-                colors: this.constructor.RECORD_COLORS,
                 tag: {
                     id: record.id,
                     colorIndex: record.data[this.props.colorField],

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
@@ -1,4 +1,4 @@
-.o_tag_popover {
+.o_popover .o_tag_popover {
     max-width: 150px;
     min-width: 100px;
 }

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -39,7 +39,7 @@
 
     <t t-name="web.Many2ManyTagsFieldColorListPopover">
         <div class="o_tag_popover m-2">
-            <ColorList colors="this.props.colors" forceExpanded="true" selectedColor="this.props.tag.colorIndex" onColorSelected="(id) => this.props.switchTagColor(id, this.props.tag)"/>
+            <ColorList disableTransparent="true" selectedColor="this.props.tag.colorIndex" onColorSelected="(id) => this.props.switchTagColor(id, this.props.tag)"/>
             <CheckBox className="'pt-2'" value="this.props.tag.colorIndex === 0" onChange.alike="(isChecked) => this.props.onTagVisibilityChange(isChecked, this.props.tag)">Hide in Kanban</CheckBox>
         </div>
     </t>

--- a/addons/web/static/src/views/fields/properties/property_tags.xml
+++ b/addons/web/static/src/views/fields/properties/property_tags.xml
@@ -17,8 +17,6 @@
     <t t-name="web.PropertyTagsColorListPopover">
         <div class="o_tag_popover m-2">
             <ColorList
-                colors="this.props.colors"
-                forceExpanded="true"
                 onColorSelected.bind="(id) => this.props.switchTagColor(id, this.props.tag)"/>
         </div>
     </t>

--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -106,7 +106,7 @@
                 }
             }
 
-            .o_wrap_field_boolean .o_form_label {
+            .o_wrap_field_inline .o_form_label {
                 margin-inline-start: calc(1.5 * var(--field-spacing-unit));
                 font-weight: $font-weight-bold;
             }

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -43,7 +43,7 @@
 </t>
 
 <t t-name="web.Form.InnerGroup.ItemComponent">
-    <t t-if="this.env.isSmall ? cell.props.fieldInfo.type !== 'boolean' : cell.props.fieldInfo.field.component.name !== 'BooleanField'">
+    <t t-if="this.env.isSmall ? cell.props.fieldInfo.type !== 'boolean' and cell.props.fieldInfo.field.component.name !== 'ColorPickerField' : cell.props.fieldInfo.field.component.name !== 'BooleanField'">
         <div class="o_cell o_wrap_label text-break text-900">
             <t t-component="cell.Component" t-if="cell.isVisible" t-props="cell.props"/>
         </div>
@@ -55,7 +55,7 @@
         </div>
     </t>
     <t t-else="">
-        <div class="o_wrap_field_boolean d-flex d-sm-contents" t-attf-class="{{ marginOnSmallScreen }}">
+        <div class="o_wrap_field_inline d-flex d-sm-contents" t-attf-class="{{ marginOnSmallScreen }}">
             <div class="o_cell o_wrap_label flex-sm-grow-0 text-break text-900">
                 <t t-component="cell.Component" t-if="cell.isVisible" t-props="cell.props"/>
             </div>

--- a/addons/web/static/tests/core/colorlist.test.js
+++ b/addons/web/static/tests/core/colorlist.test.js
@@ -25,58 +25,41 @@ class Parent extends Component {
     }
 }
 
-test("basic rendering with forceExpanded props", async () => {
+test("basic rendering", async () => {
     await mountWithCleanup(Parent, {
         props: {
-            colors: [0, 9],
-            forceExpanded: true,
+            onColorSelected:(color) => expect.step(`color ${color} selected`),
         },
     });
 
-    expect(".o_colorlist").toHaveCount(1);
-    expect(".o_colorlist button").toHaveCount(2);
-    expect(".o_colorlist button:eq(1)").toHaveAttribute("title", "Raspberry");
-    expect(".o_colorlist button:eq(1)").toHaveClass("o_colorlist_item_color_9");
+    expect(".o_colorlist button").toHaveCount(12);
+    expect(".o_colorlist button:eq(0)").toHaveAttribute("title", "No color");
+    expect(".o_colorlist button:eq(0)").toHaveClass("o_colorlist_item_color_0");
+    await contains(".o_colorlist button:eq(9)").click();
+    expect.verifySteps(["color 9 selected"]);
 });
 
-test("color click does not open the list if canToggle props is not given", async () => {
-    const selectedColorId = 0;
+test("use 'disableTransparent' props to hide the transparent option", async () => {
     await mountWithCleanup(Parent, {
         props: {
-            colors: [4, 5, 6],
-            selectedColor: selectedColorId,
-            onColorSelected: (colorId) => expect.step("color #" + colorId + " is selected"),
+            disableTransparent: true,
+            onColorSelected:(color) => expect.step(`color ${color} selected`),
         },
     });
-    expect(".o_colorlist").toHaveCount(1);
-    expect("button.o_colorlist_toggler").toHaveCount(1);
 
-    await contains(".o_colorlist").click();
-    expect("button.o_colorlist_toggler").toHaveCount(1);
+    expect(".o_colorlist button").toHaveCount(11);
+    expect(".o_colorlist button:eq(0)").toHaveAttribute("title", "Red");
+    expect(".o_colorlist button:eq(0)").toHaveClass("o_colorlist_item_color_1");
+    await contains(".o_colorlist button:eq(9)").click();
+    expect.verifySteps(["color 10 selected"]);
 });
 
-test("open the list of colors if canToggle props is given", async function () {
-    const selectedColorId = 0;
+test("use 'selectedColor' props to highlight the selected color", async () => {
     await mountWithCleanup(Parent, {
         props: {
-            canToggle: true,
-            colors: [4, 5, 6],
-            selectedColor: selectedColorId,
-            onColorSelected: (colorId) => expect.step("color #" + colorId + " is selected"),
+            selectedColor: 3,
         },
     });
-    expect(".o_colorlist").toHaveCount(1);
-    expect(".o_colorlist button").toHaveClass("o_colorlist_item_color_" + selectedColorId);
 
-    await contains(".o_colorlist button").click();
-    expect("button.o_colorlist_toggler").toHaveCount(0);
-    expect(".o_colorlist button").toHaveCount(3);
-
-    await contains(".outsideDiv").click();
-    expect(".o_colorlist button").toHaveCount(1);
-    expect("button.o_colorlist_toggler").toHaveCount(1);
-
-    await contains(".o_colorlist_toggler").click();
-    await contains(".o_colorlist button:eq(2)").click();
-    expect.verifySteps(["color #6 is selected"]);
+    expect(".o_colorlist button.o_colorlist_item_color_3.active").toHaveCount(1);
 });

--- a/addons/web/static/tests/views/fields/color_picker_field.test.js
+++ b/addons/web/static/tests/views/fields/color_picker_field.test.js
@@ -46,13 +46,12 @@ defineModels([Partner, User]);
 
 test("No chosen color is a red line with a white background (color 0)", async () => {
     await mountView({ type: "form", resModel: "res.partner", resId: 1 });
-
     expect(".o_field_color_picker button.o_colorlist_item_color_0").toHaveCount(1);
     await contains(".o_field_color_picker button").click();
-    expect(".o_field_color_picker button.o_colorlist_item_color_0").toHaveCount(1);
-    await contains(".o_field_color_picker .o_colorlist_item_color_3").click();
+    expect(".o_colorlist button.o_colorlist_item_color_0").toHaveCount(1);
+    await contains(".o_colorlist .o_colorlist_item_color_3").click();
     await contains(".o_field_color_picker button").click();
-    expect(".o_field_color_picker button.o_colorlist_item_color_0").toHaveCount(1);
+    expect(".o_colorlist button.o_colorlist_item_color_0").toHaveCount(1);
 });
 
 test("closes when color selected or outside click", async () => {
@@ -69,8 +68,8 @@ test("closes when color selected or outside click", async () => {
         </form>`,
     });
     await contains(".o_field_color_picker button").click();
-    expect(queryAll(".o_field_color_picker button").length).toBeGreaterThan(1);
-    await contains(".o_field_color_picker .o_colorlist_item_color_3").click();
+    expect(queryAll(".o_colorlist button").length).toBeGreaterThan(1);
+    await contains(".o_colorlist .o_colorlist_item_color_3").click();
     expect(".o_field_color_picker button").toHaveCount(1);
     await contains(".o_field_color_picker button").click();
     await contains(".o_field_widget[name='name'] input").click();
@@ -87,7 +86,8 @@ test("color picker on list view", async () => {
     });
 
     await contains(".o_field_color_picker button").click();
-    expect.verifySteps(["record selected to open"]);
+    expect.verifySteps([]);
+    expect(".o_colorlist button").toHaveCount(12);
 });
 
 test("color picker in editable list view", async () => {
@@ -103,18 +103,14 @@ test("color picker in editable list view", async () => {
                 <field name="display_name" />
             </list>`,
     });
-
     expect(".o_data_row:nth-child(1) .o_field_color_picker button").toHaveCount(1);
     await contains(".o_data_row:nth-child(1) .o_field_color_picker button").click();
-    expect(".o_data_row:nth-child(1).o_selected_row").toHaveCount(1);
-    expect(".o_data_row:nth-child(1) .o_field_color_picker button").toHaveCount(12);
+    expect(".o_data_row:nth-child(1).o_selected_row").toHaveCount(0);
+    expect(".o_colorlist button").toHaveCount(12);
     await contains(
-        ".o_data_row:nth-child(1) .o_field_color_picker .o_colorlist_item_color_6"
+        ".o_colorlist .o_colorlist_item_color_6"
     ).click();
-    expect(".o_data_row:nth-child(1) .o_field_color_picker button").toHaveCount(12);
-    await contains(".o_data_row:nth-child(2) .o_data_cell").click();
-    expect(".o_data_row:nth-child(1) .o_field_color_picker button").toHaveCount(1);
-    expect(".o_data_row:nth-child(2) .o_field_color_picker button").toHaveCount(12);
+    expect(".o_colorlist").toHaveCount(0);
 });
 
 test("column widths: dont overflow color picker in list", async () => {
@@ -145,4 +141,24 @@ test("column widths: dont overflow color picker in list", async () => {
     expect(parseFloat(date_column_width)).toBeLessThan(parseFloat(int_field_column_width), {
         message: "colorpicker should display properly (Horizontly)",
     });
+});
+
+test.tags("mobile");
+test("ColorPicker opens a BottomSheet on mobile", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        arch: `
+        <form>
+            <group>
+                <field name="int_field" widget="color_picker"/>
+                <field name="name"/>
+            </group>
+        </form>`,
+    });
+    await contains(".o_field_color_picker button").click();
+    expect(".o_bottom_sheet").toHaveCount(1);
+    await contains(".o_colorlist .o_colorlist_item_color_3").click();
+    expect(".o_bottom_sheet").toHaveCount(0);
 });

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -200,7 +200,7 @@ test("Many2ManyTagsField with and without color on mobile", async () => {
     expect(".o_colorlist").toHaveCount(0);
     await contains("[name=partner_ids] .o_tag").click();
     expect(".o_colorlist").toHaveCount(1);
-    await contains(getFixture()).click();
+    await click(".o_bottom_sheet_backdrop");
 
     // Add a tag to second field
     expect("[name=timmy] .o_tag").toHaveCount(0);
@@ -817,6 +817,7 @@ test("Many2ManyTagsField: tags data-tooltip attribute", async () => {
     expect(".o_field_many2many_tags .o_tag.badge").toHaveAttribute("data-tooltip", "second record");
 });
 
+test.tags("desktop");
 test("Many2ManyTagsField: toggle colorpicker with multiple tags", async () => {
     Partner._records[0].timmy = [12, 14];
     PartnerType._records[0].color = 0;
@@ -848,6 +849,32 @@ test("Many2ManyTagsField: toggle colorpicker with multiple tags", async () => {
 
     await contains(getFixture()).click();
     expect(".o_colorpicker").toHaveCount(0);
+});
+
+test.tags("mobile");
+test("Many2ManyTagsField: toggle colorpicker with multiple tags on mobile", async () => {
+    Partner._records[0].timmy = [12, 14];
+    PartnerType._records[0].color = 0;
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+                <form>
+                    <field name="timmy" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
+                </form>`,
+        resId: 1,
+    });
+
+    expect(".o_colorlist").toHaveCount(0);
+    // click on the badge to open colorpicker
+    await contains(".o_field_many2many_tags .badge").click();
+    expect(".o_colorlist").toHaveCount(1);
+    await contains(".o_bottom_sheet_backdrop").click();
+    await contains(".o_field_many2many_tags [data-tooltip=silver]").click();
+    expect(".o_colorlist").toHaveCount(1);
+    await contains(".o_bottom_sheet_backdrop").click();
+    expect(".o_colorlist").toHaveCount(0);
 });
 
 test("Many2ManyTagsField: toggle colorpicker multiple times", async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9034,9 +9034,9 @@ test(`form group with newline tag inside`, async () => {
     expect(`.main_inner_group .o_cell`).toHaveCount(6);
     expect(`.main_inner_group > .o_cell.o_wrap_label:first-child`).toHaveCount(1);
     expect(`.main_inner_group > .o_cell.o_wrap_input:nth-child(2)`).toHaveCount(1);
-    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3)`).toHaveCount(1);
-    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3) > .o_wrap_label`).toHaveCount(1);
-    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3) > .o_wrap_input`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_inline:nth-child(3)`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_inline:nth-child(3) > .o_wrap_label`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_inline:nth-child(3) > .o_wrap_input`).toHaveCount(1);
     expect(`.main_inner_group > .o_cell.o_wrap_label:nth-child(4)`).toHaveCount(1);
     expect(`.main_inner_group > .o_cell.o_wrap_input:nth-child(5)`).toHaveCount(1);
 


### PR DESCRIPTION
This commit makes use of the BottomSheet when the ColorPickerField
element is toggled, instead of displaying colors inline. This improves
the style regarding the M3 spec. Now, the toggler is present on the
right of the label, like boolean fields.

Some dead scss was removed, and tests have been adapted to the changes
introduced by this improvement, to verify the intended behavior.

Finally, this commit simplifies the ColorList component, by dissociating
the toggler from the list entirely. This avoids to have a duplicated toggling
implementation when using the component inside a tooltip/dropdown, which required
additionnal props to prevent the toggle implemented by the component. It is the
responsability of the parent component to handle the toggle of the ColorList
component.

For the Many2ManyTags field, the ColorList contained in a tooltip is now
displayed in a BottomSheet as well, and tests have been adapted in
accordance with the new behavior.

task-6054024