### PR TITLE
[FIX] point_of_sale: fix GS1 barcode scanning test failure

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1336,7 +1336,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         pos_categ = self.env['pos.category'].create({'name': 'GS1 Test'})
         product_tmpl.pos_categ_ids = [Command.set([pos_categ.id])]
         variant = product_tmpl.product_variant_ids[0]
-        variant.write({'barcode': '5123648695416'})
+        variant.write({'barcode': '05123648695416'})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'GS1BarcodeScanningTour', login="pos_user")
 


### PR DESCRIPTION
The test_GS1_pos_barcodes_scan was failing because the "GS1 Variant Product" barcode was defined as a 13-digit string, while the tour scans it using the GS1 AI 01 (GTIN), which expects a 14-digit GTIN-14. By adding a leading zero to the barcode in the test setup, we align it with the GTIN-14 format parsed by the POS barcode parser during the scan, ensuring the product is correctly added to the order.

runbot-error: 242323

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
