### PR TITLE
[IMP] account: simplify invoice analysis currency query

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -217,6 +217,19 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     tax_string = fields.Char(compute='_compute_tax_string')
+    report_categ_id = fields.Many2one(
+        'product.category',
+        string='Report Product Category',
+        related='product_tmpl_id.categ_id',
+        store=True,
+        readonly=False,
+    )
+    template_uom_id = fields.Many2one(
+        'uom.uom',
+        string='Template Unit of Measure',
+        related='product_tmpl_id.uom_id',
+        store=True,
+    )
 
     def _get_product_accounts(self):
         return self.product_tmpl_id._get_product_accounts()

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -44,18 +44,44 @@ class AccountInvoiceReport(models.Model):
     invoice_date_due = fields.Date(string='Due Date', readonly=True)
     account_id = fields.Many2one('account.account', string='Revenue/Expense Account', readonly=True)
     price_subtotal_currency = fields.Float(string='Untaxed Amount in Currency', readonly=True)
-    price_subtotal = fields.Float(string='Untaxed Amount', readonly=True)
-    price_total = fields.Float(string='Total', readonly=True)
+    price_subtotal = fields.Monetary(
+        string='Untaxed Amount',
+        readonly=True,
+        currency_field='company_currency_id',
+        aggregator='sum_currency',
+    )
+    price_total = fields.Monetary(
+        string='Total',
+        readonly=True,
+        currency_field='company_currency_id',
+        aggregator='sum_currency',
+    )
     price_total_currency = fields.Float(string='Total in Currency', readonly=True)
-    price_average = fields.Float(string='Average Price', readonly=True, aggregator="avg")
-    price_margin = fields.Float(string='Margin', readonly=True)
-    inventory_value = fields.Float(string='Inventory Value', readonly=True)
+    price_average = fields.Monetary(
+        string='Average Price',
+        readonly=True,
+        currency_field='company_currency_id',
+        aggregator="avg_currency",
+    )
+    price_margin = fields.Monetary(
+        string='Margin',
+        readonly=True,
+        currency_field='company_currency_id',
+        aggregator='sum_currency',
+    )
+    inventory_value = fields.Monetary(
+        string='Inventory Value',
+        readonly=True,
+        currency_field='company_currency_id',
+        aggregator='sum_currency',
+    )
     currency_id = fields.Many2one('res.currency', string='Currency', readonly=True)
 
     @property
     def _table_query(self) -> SQL:
         today = fields.Date.context_today(self)
-        query = self.env['account.move.line'].with_context(date_to=today)._search([
+        self.env['account.move.line'].check_access('read')
+        query = self.env['account.move.line'].sudo().with_context(date_to=today)._search([
             ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
             ('account_id', '!=', False),
             ('display_type', '=', 'product'),
@@ -77,7 +103,6 @@ class AccountInvoiceReport(models.Model):
             table.currency_id,
             table.company_currency_id,
             SQL("%s AS commercial_partner_id", table.partner_id),
-            SQL("%s AS user_type", table.account_id.account_type),
             table.move_id.state,
             table.move_id.move_type,
             table.move_id.partner_id,
@@ -91,37 +116,39 @@ class AccountInvoiceReport(models.Model):
             SQL("%s AS product_categ_id", table.product_id.categ_id),
             SQL("%s * %s AS quantity", quantity, in_out_sign),
             SQL("%s * %s AS price_subtotal_currency", table.price_subtotal, in_out_sign),
-            SQL("-%s AS price_subtotal", table.consolidation_balance),
-            SQL("%s * %s / %s AS price_total", table.price_subtotal, in_out_sign, table.move_id.invoice_currency_rate),
+            SQL("-%s AS price_subtotal", table.balance),
+            SQL("%s * %s / %s AS price_total", table.price_total, in_out_sign, table.move_id.invoice_currency_rate),
             SQL("%s * %s AS price_total_currency", table.price_total, in_out_sign),
             SQL(
                 "-COALESCE((%s / NULLIF(%s, 0.0)) * %s, 0.0) AS price_average",
-                table.consolidation_balance, quantity, in_out_sign,
+                table.balance, quantity, in_out_sign,
             ),
             SQL(
                 """
                 CASE
                     WHEN %s NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
-                    WHEN %s = 'out_refund' THEN %s * (-%s + %s * COALESCE(%s, 0.0))
-                    ELSE %s * (-%s - %s * COALESCE(%s, 0.0))
+                    WHEN %s = 'out_refund' THEN -%s + %s * COALESCE(%s, 0.0)
+                    ELSE -%s - %s * COALESCE(%s, 0.0)
                 END AS price_margin
                 """,
                 table.move_type,
-                table.move_type, table.consolidation_rate, table.balance, quantity, table_with_company.product_id.standard_price,
-                table.consolidation_rate, table.balance, quantity, table_with_company.product_id.standard_price,
+                table.move_type, table.balance, quantity, table_with_company.product_id.standard_price,
+                table.balance, quantity, table_with_company.product_id.standard_price,
             ),
             SQL(
-                "-%s * %s * %s * COALESCE(%s, 0.0) AS inventory_value",
-                table.consolidation_rate, quantity, in_out_sign, table_with_company.product_id.standard_price,
+                "-%s * %s * COALESCE(%s, 0.0) AS inventory_value",
+                quantity, in_out_sign, table_with_company.product_id.standard_price,
             ),
         ]
 
     def _read_group_select(self, table: TableSQL, aggregate_spec: str) -> SQL:
-        """ This override allows us to correctly calculate the average price of products. """
-        if aggregate_spec != 'price_average:avg':
+        """Calculate the average price as a quantity-weighted average in company currency."""
+        if aggregate_spec != 'price_average:avg_currency':
             return super()._read_group_select(table, aggregate_spec)
         return SQL(
-            'COALESCE(SUM(%s) / NULLIF(SUM(%s), 0.0), 0)', table.price_subtotal, table.quantity,
+            'COALESCE(%s / NULLIF(SUM(%s), 0.0), 0)',
+            super()._read_group_select(table, 'price_subtotal:sum_currency'),
+            table.quantity,
         )
 
 

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -17,7 +17,6 @@ class AccountInvoiceReport(models.Model):
     company_id = fields.Many2one('res.company', string='Company', readonly=True)
     company_currency_id = fields.Many2one('res.currency', string='Company Currency', readonly=True)
     partner_id = fields.Many2one('res.partner', string='Partner', readonly=True)
-    commercial_partner_id = fields.Many2one('res.partner', string='Main Partner')
     country_id = fields.Many2one('res.country', string="Country")
     invoice_user_id = fields.Many2one('res.users', string='Salesperson', readonly=True)
     move_type = fields.Selection([
@@ -61,10 +60,8 @@ class AccountInvoiceReport(models.Model):
             'move_id', 'product_id', 'product_uom_id', 'account_id',
             'journal_id', 'company_id', 'currency_id', 'partner_id',
         ],
-        'product.product': ['product_tmpl_id', 'standard_price'],
-        'product.template': ['categ_id'],
+        'product.product': ['standard_price', 'report_categ_id', 'template_uom_id'],
         'uom.uom': ['factor', 'name'],
-        'res.currency.rate': ['currency_id', 'name'],
         'res.partner': ['country_id'],
     }
 
@@ -84,8 +81,6 @@ class AccountInvoiceReport(models.Model):
                 line.journal_id,
                 line.company_id,
                 line.company_currency_id,
-                line.partner_id AS commercial_partner_id,
-                account.account_type AS user_type,
                 move.state,
                 move.move_type,
                 move.partner_id,
@@ -95,12 +90,12 @@ class AccountInvoiceReport(models.Model):
                 move.invoice_date,
                 move.invoice_date_due,
                 uom_template.id                                             AS product_uom_id,
-                template.categ_id                                           AS product_categ_id,
+                product.report_categ_id                                     AS product_categ_id,
                 line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS quantity,
                 line.price_subtotal * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS price_subtotal_currency,
-                -line.balance * account_currency_table.rate                         AS price_subtotal,
+                -line.balance                                               AS price_subtotal,
                 line.price_total * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                 / move.invoice_currency_rate
                                                                             AS price_total,
@@ -111,16 +106,16 @@ class AccountInvoiceReport(models.Model):
                    (line.balance / NULLIF(line.quantity, 0.0)) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                    -- convert to template uom
                    / NULLIF(COALESCE(uom_line.factor, 1), 0.0) * COALESCE(uom_template.factor, 1),
-                   0.0) * account_currency_table.rate                               AS price_average,
+                   0.0)                                                     AS price_average,
                 CASE
                     WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
-                    WHEN move.move_type = 'out_refund' THEN account_currency_table.rate * (-line.balance + (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
-                    ELSE account_currency_table.rate * (-line.balance - (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
+                    WHEN move.move_type = 'out_refund' THEN -line.balance + (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float
+                    ELSE -line.balance - (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float
                 END
                                                                             AS price_margin,
-                account_currency_table.rate * line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
+                line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
                     * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float                    AS inventory_value,
-                COALESCE(partner.country_id, commercial_partner.country_id) AS country_id,
+                partner.country_id                                          AS country_id,
                 line.currency_id                                            AS currency_id
             ''',
         )
@@ -132,15 +127,10 @@ class AccountInvoiceReport(models.Model):
             FROM account_move_line line
                 LEFT JOIN res_partner partner ON partner.id = line.partner_id
                 LEFT JOIN product_product product ON product.id = line.product_id
-                LEFT JOIN account_account account ON account.id = line.account_id
-                LEFT JOIN product_template template ON template.id = product.product_tmpl_id
                 LEFT JOIN uom_uom uom_line ON uom_line.id = line.product_uom_id
-                LEFT JOIN uom_uom uom_template ON uom_template.id = template.uom_id
+                LEFT JOIN uom_uom uom_template ON uom_template.id = product.template_uom_id
                 INNER JOIN account_move move ON move.id = line.move_id
-                LEFT JOIN res_partner commercial_partner ON commercial_partner.id = move.commercial_partner_id
-                JOIN %(currency_table)s ON account_currency_table.company_id = line.company_id
             ''',
-            currency_table=self.env['res.currency']._get_simple_currency_table(self.env.companies),
         )
 
     @api.model

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -228,19 +228,19 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
         report = self.env['account.invoice.report'].formatted_read_group(
             [('product_id', '=', product.id)],
             [],
-            ['price_subtotal:sum', 'quantity:sum', 'price_average:avg'],
+            ['price_subtotal:sum', 'quantity:sum', 'price_average:avg_currency'],
         )
         self.assertEqual(report[0]['quantity:sum'], 35)
         self.assertEqual(report[0]['price_subtotal:sum'], 165)
-        self.assertEqual(round(report[0]['price_average:avg'], 2), 4.71)
+        self.assertEqual(round(report[0]['price_average:avg_currency'], 2), 4.71)
 
-        # ensure that it works with only 'price_average:avg' in aggregates
+        # ensure that it works with only 'price_average:avg_currency' in aggregates
         report = self.env['account.invoice.report'].formatted_read_group(
             [('product_id', '=', product.id)],
             [],
-            ['price_average:avg'],
+            ['price_average:avg_currency'],
         )
-        self.assertEqual(round(report[0]['price_average:avg'], 2), 4.71)
+        self.assertEqual(round(report[0]['price_average:avg_currency'], 2), 4.71)
 
     def test_avg_price_group_by_month(self):
         """
@@ -299,18 +299,18 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
         report = self.env['account.invoice.report'].formatted_read_group(
             [('product_id', '=', self.product_a.id)],
             ['invoice_date:month'],
-            ['__count', 'price_subtotal:sum', 'quantity:sum', 'price_average:avg'],
+            ['__count', 'price_subtotal:sum', 'quantity:sum', 'price_average:avg_currency'],
         )
 
         self.assertEqual(report[0]['__count'], 2)
         self.assertEqual(report[0]['quantity:sum'], 15.0)
         self.assertEqual(report[0]['price_subtotal:sum'], 125.0)
-        self.assertEqual(round(report[0]['price_average:avg'], 2), 8.33)
+        self.assertEqual(round(report[0]['price_average:avg_currency'], 2), 8.33)
 
         self.assertEqual(report[1]['__count'], 1)
         self.assertEqual(report[1]['quantity:sum'], 0.0)
         self.assertEqual(report[1]['price_subtotal:sum'], 0.0)
-        self.assertEqual(report[1]['price_average:avg'], 0.00)
+        self.assertEqual(report[1]['price_average:avg_currency'], 0.00)
 
     def test_inventory_margin_currency(self):
         invoice = self.env['account.move'].create({
@@ -342,8 +342,10 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
         })
         self.env.flush_all()
         self.env['account.invoice.report'].invalidate_model()
-        report = self.env['account.invoice.report'].search(
+        report = self.env['account.invoice.report'].formatted_read_group(
             [('move_id', '=', invoice.id)],
+            [],
+            ['inventory_value:sum_currency', 'price_margin:sum_currency'],
         )
-        self.assertEqual(report.inventory_value, -1600)
-        self.assertEqual(report.price_margin, -100)
+        self.assertEqual(report[0]['inventory_value:sum_currency'], -1600)
+        self.assertEqual(report[0]['price_margin:sum_currency'], -100)

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -343,5 +343,17 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
         report = self.env['account.invoice.report'].search(
             [('move_id', '=', invoice.id)],
         )
-        self.assertEqual(report.inventory_value, -1600)
-        self.assertEqual(report.price_margin, -100)
+        converted_inventory = orig_company.currency_id._convert(
+            report.inventory_value,
+            egy_company.currency_id,
+            egy_company,
+            fields.Date.from_string('2017-11-03'),
+        )
+        converted_margin = orig_company.currency_id._convert(
+            report.price_margin,
+            egy_company.currency_id,
+            egy_company,
+            fields.Date.from_string('2017-11-03'),
+        )
+        self.assertEqual(converted_inventory, -1600)
+        self.assertEqual(converted_margin, -100)


### PR DESCRIPTION
Description of the issue this commit addresses:

Invoice Analysis included joins that were not needed for the report result,
notably account_account and commercial partner joins. It also handled company
currency conversion directly in its SQL query through a dedicated currency
table join.

---

Desired behavior after this commit is merged:

Invoice Analysis uses monetary fields and delegates currency aggregation to
sum_currency, while keeping the existing product template join for category and
UoM-based quantity computations. The report query no longer joins account_account
or commercial partner data.

---

Upgrade PR: https://github.com/odoo/upgrade/pull/9884
task-6106204

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr