### PR TITLE
[FIX] website, website_sale: fix search design

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2517,7 +2517,7 @@ $ribbon-padding: 100px;
 
     &:not(.o_search_result_item_placeholder):hover,
     & .o_search_result_link:focus-visible {
-        background-color: var(--dropdown-link-hover-bg);
+        background-color: $dropdown-link-hover-bg;
     }
 
     .o_search_result_link:focus-visible {

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -3213,7 +3213,7 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
 
 <template id="website.search_result_items">
     <t t-foreach="results" t-as="result">
-        <li class="o_search_result_item rounded">
+        <li t-attf-class="o_search_result_item #{'rounded mx-n2' if is_search_page else ''}">
             <a t-att-href="result['website_url']" class="o_search_result_link d-flex gap-2 p-2 text-decoration-none text-muted">
                 <t t-call="website.search_image_item_view"/>
                 <div class="o_search_result_content d-flex flex-grow-1">
@@ -3277,7 +3277,7 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
                                     </h2>
                                     <!-- Items -->
                                     <ul class="list-unstyled mb-0">
-                                        <t t-call="website.search_result_items" results="bucket['data']"/>
+                                        <t t-call="website.search_result_items" results="bucket['data']" is_search_page="True"/>
                                     </ul>
                                     <t t-set="has_more" t-value="(bucket.get('searchCount') &gt; limit)"/>
                                     <div t-if="has_more" class="d-flex justify-content-center py-2">

--- a/addons/website_sale/templates/website_templates.xml
+++ b/addons/website_sale/templates/website_templates.xml
@@ -420,8 +420,8 @@
 
     <template id="website_sale.search_result_items" inherit_id="website.search_result_items">
         <xpath expr="//div[hasclass('o_search_result_description')]" position="inside">
-            <p t-if="result.get('attribute_value_ids')"
-                class="o_line_clamp mb-0 small"
+            <div t-if="result.get('attribute_value_ids')"
+                class="o_line_clamp mb-0"
                 style="--lines-clamp: 1;"
                 t-out="result['attribute_value_ids']"/>
             <p t-elif="result.get('description_sale')"


### PR DESCRIPTION
In commit[1] the search was refactored but some design broke during the review process.

- The search page and search inside the dropdown now share the same template but only the search page needs the roundness and negative margin.

- `--dropdown-link-hover-bg` is not defined without a `dropdown` class, replaced with the SCSS var instead

- In `website_sale.search_result_items` the `t-out="result['attribute_value_ids']` tries to output a `<div>` inside a paragraph, which leads to an automatic closing of the `<p>` tag and an empty paragraph which makes the search_item not centered anymore due to the empty paragraph margins.

task-6106135

[1]: odoo/odoo@9d0a9754e7dbf309fb692c54a63ff29ac6972350

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
