### PR TITLE
[FIX] l10n_sa_edi_pos: use sudo when processing ZATCA EDI documents

### DIFF
--- a/addons/l10n_sa_edi_pos/models/pos_order.py
+++ b/addons/l10n_sa_edi_pos/models/pos_order.py
@@ -20,7 +20,7 @@ class PosOrder(models.Model):
 
         for order in orders_needing_invoice:
             if order.account_move:
-                order.account_move.edi_document_ids.filtered(
+                order.account_move.sudo().edi_document_ids.filtered(
                     lambda d: d.state == 'to_send' and d.edi_format_id._needs_web_services()
                 )._process_documents_web_services(with_commit=False)
 


### PR DESCRIPTION
The POS cashier user does not have the Accounting group, so calling _process_documents_web_services() on account.edi.document without elevated privileges raises an AccessError on the write() in _postprocess_post_edi_results.

The original flow avoids this because _generate_and_send_invoices uses move.sudo() as the dict key, propagating the sudo context through action_process_edi_web_services() down to the EDI document write. Our override must do the same by accessing edi_document_ids via account_move.sudo().

opw-6106524

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
