### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: fix method rename to match parent class

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -332,9 +332,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         })
         return partner_vals
 
-    def _import_fill_invoice_form(self, invoice, tree, qty_factor):
+    def _import_fill_invoice(self, invoice, tree, qty_factor):
         # EXTENDS account.edi.xml.ubl_20
-        logs = super()._import_fill_invoice_form(invoice, tree, qty_factor)
+        logs = super()._import_fill_invoice(invoice, tree, qty_factor)
 
         # ==== Nilvera UUID ====
         if uuid_node := tree.findtext('./{*}UUID'):


### PR DESCRIPTION
# Description of the issue/feature this PR addresses
The parent class `account.edi.xml.ubl_20` renamed `_import_fill_invoice_form`
to `_import_fill_invoice`. The override in `l10n_tr_nilvera_einvoice` was not
updated to match, causing the override to be silently ignored.

# Current behavior before PR
The `_import_fill_invoice_form` override in `l10n_tr_nilvera_einvoice` is never
called because the parent method no longer exists under that name.

# Desired behavior after PR is merged
The override is renamed to `_import_fill_invoice` to match the parent class,
restoring correct behaviour for Nilvera invoice imports.

task-id: None
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr