### PR TITLE
[FIX] web: incohenrence datetime_field state~record

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -392,6 +392,9 @@ export class DateTimeField extends Component {
     }
 
     onInputBlured() {
+        if (!areDatesEqual(this.getRecordValue(), this.state.value)) {
+            this.state.value = this.getRecordValue();
+        }
         if (!this.isPickerOpen()) {
             this.picker.activeInput = "";
         }

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -753,3 +753,29 @@ test("DateTimeField: placeholder", async () => {
         "mm yyyy dd hh:mm"
     );
 });
+
+test("DateField: incoherent state and record value", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <group>
+                    <field name="date"/>
+                </group>
+            </form>`,
+    });
+
+    await contains(".o_field_widget[name=date] input").click();
+    await edit("11/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=date] button").toHaveValue("11/10/2019");
+
+    await contains(".o_form_button_save").click();
+    await animationFrame();
+
+    await contains(".o_field_widget[name=date] button").click();
+    await edit("10/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=date] button").toHaveValue("10/10/2019");
+});


### PR DESCRIPTION
Step to reproduce:
- Go on view form with a date field
- Set the date with the input by typing the date with day and month (mm/dd or dd/mm), then press enter
- Save the record
- Redo the second step by with a different date
- Save the record

The field on the view is not updated, but the value on the record is.

To fix the incoherence, when the field is blurr and that there is an incoherence between the state of the field and the record, we take the value of the record and put it in the state.

task-6095467




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
