### PR TITLE
[FIX] point_of_sale: resolve partner selection timeouts in tours

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -22,9 +22,35 @@
             <t t-set="initialPartners" t-value="this.getPartners(this.state.initialPartners)"/>
             <t t-set="loadedPartners" t-value="this.getPartners(this.state.loadedPartners)"/>
             <t t-set="nbrPartners" t-value="initialPartners.length + loadedPartners.length"/>
-            <div class="h-100" t-att-class="{'d-flex justify-content-center align-items-center text-center': !nbrPartners}">
-                <table t-if="nbrPartners" class="table table-hover">
-                    <tbody class="h-100">
+            <div class="h-100" t-att-class="{'d-flex justify-content-center align-items-center text-center': !nbrPartners, 'overflow-y-auto': this.ui.isSmall}">
+                <t t-if="nbrPartners">
+                    <table t-if="!this.ui.isSmall" class="table table-hover">
+                        <tbody class="h-100">
+                            <t t-foreach="initialPartners" t-as="partner" t-key="partner.id">
+                                <PartnerLine
+                                    close="this.props.close"
+                                    partner="partner"
+                                    isSelected="this.props.partner?.id === partner.id"
+                                    isBalanceDisplayed="this.isBalanceDisplayed"
+                                    onClickEdit.bind="(p) => this.editPartner(p)"
+                                    onClickUnselect.bind="() => this.clickPartner()"
+                                    onClickOrders.bind="(p) => this.goToOrders(p)"
+                                    onClickPartner.bind="this.clickPartner"/>
+                            </t>
+                            <t t-foreach="loadedPartners" t-as="partner" t-key="partner.id">
+                                <PartnerLine
+                                    close="this.props.close"
+                                    partner="partner"
+                                    isSelected="this.props.partner?.id === partner.id"
+                                    isBalanceDisplayed="this.isBalanceDisplayed"
+                                    onClickEdit.bind="(p) => this.editPartner(p)"
+                                    onClickUnselect.bind="() => this.clickPartner()"
+                                    onClickOrders.bind="(p) => this.goToOrders(p)"
+                                    onClickPartner.bind="this.clickPartner"/>
+                            </t>
+                        </tbody>
+                    </table>
+                    <t t-else="">
                         <t t-foreach="initialPartners" t-as="partner" t-key="partner.id">
                             <PartnerLine
                                 close="this.props.close"
@@ -47,8 +73,8 @@
                                 onClickOrders.bind="(p) => this.goToOrders(p)"
                                 onClickPartner.bind="this.clickPartner"/>
                         </t>
-                    </tbody>
-                </table>
+                    </t>
+                </t>
                 <div t-else="" t-att-class="{'p-4': this.ui.isSmall}">
                     <div class="text-muted">
                         <i class="fa fa-users fa-3x"></i>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -113,7 +113,7 @@ export function checkContactValues(name, address = "", phone = "", email = "") {
 export function checkCustomerShown(val) {
     return {
         content: `Check "${val}" is shown`,
-        trigger: `.partner-list .partner-info:nth-child(1):contains("${val}")`,
+        trigger: `.partner-list .partner-info:first:contains("${val}")`,
     };
 }
 export function searchCustomer(val) {


### PR DESCRIPTION
This commit fixes recurring timeout failures in POS frontend tours when selecting a partner in the PartnerList component.

The issue was two-fold:
1. Tour Resilience: The `checkCustomerShown` utility used a strict `:nth-child(1)` selector, which is prone to failure in Owl if invisible metadata nodes or placeholders are present in the DOM. Switching to `:first` makes the selector more robust while still ensuring the result is at the top of the list.

2. Mobile Layout Structural Bug: In mobile mode (`ui.isSmall`), the `PartnerLine` component renders as a `<div>`. Previously, `PartnerList` was wrapping these in a `<table>/<tbody>`, which is invalid HTML. Browsers would "hoist" the `<div>` elements outside the table, breaking the DOM structure and causing tour step triggers to fail.

The structural fix uses a standard `div` list for mobile and preserves the `table` layout for desktop. `overflow-y-auto` was also added to the mobile container to ensure smooth scrolling.

runbot-error: 242001

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
