### PR TITLE
[IMP] tools: improve generator checking (`safe_eval`)

### DIFF
--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -8,12 +8,14 @@ from odoo.tools import mute_logger
 from odoo.tools.misc import OrderedSet
 from odoo.tools.safe_eval import (
     _BUILTINS,
+    _SafeGenerator,
     UnsafeClassError,
     UnsafeFunctionError,
     UnsafeInstanceError,
     UnsafeModuleError,
     UnsafePolicy,
     const_eval,
+    safe_call,
     safe_checker,
     safe_eval
 )
@@ -173,7 +175,10 @@ class TestSafeEval(BaseCase):
         safe_eval("res = tuple(val + 1 for val in (1, 2))", context=(ctx := {}), mode="exec")
         self.assertEqual(ctx["res"], (2, 3))
 
-        with self.assertRaises(ValueError):
+        with (
+            self.assertRaises(ValueError),
+            mute_logger('odoo.tools.safe_eval.evaluation.runtime')  # Warning because of `async`
+        ):
             # async generator comprehension
             safe_eval("res = tuple(val + 1 async for val in (1, 2))", mode="exec")
 
@@ -192,6 +197,11 @@ class TestSafeEval(BaseCase):
 @tagged('at_install', '-post_install')
 class TestSafeEvalRuntime(TransactionCase):
 
+    class UnsafeClass:  # noqa: OLS03024
+        __module__ = 'odoo.unsafe_module'
+
+        def __init__(self, *args, **kwargs): ...
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -200,12 +210,9 @@ class TestSafeEvalRuntime(TransactionCase):
             lambda: UnsafePolicy.RAISE
         ))
 
-        class UnsafeClass:
-            __module__ = 'odoo.unsafe_module'
-
-            def __init__(self, *args, **kwargs): ...
-
-        cls.unsafe_context = {'UnsafeClass': UnsafeClass}
+    def setUp(self):
+        super().setUp()
+        self.unsafe_context = {'UnsafeClass': self.UnsafeClass}
 
     def test_transform_decorators(self):
         steps = []
@@ -246,6 +253,49 @@ class TestSafeEvalRuntime(TransactionCase):
         """
         with self.assertRaisesRegex(ValueError, '^NameError'):
             safe_eval(dedent(expr), {}, mode='exec')
+
+    def test_transform_generators(self):
+
+        def deco(func):
+
+            def wrapper(*args, **kwargs):
+                gen = func(*args, **kwargs)
+                self.assertTrue(isinstance(gen, _SafeGenerator))
+                return gen
+
+            return wrapper
+
+        expr = """
+            @deco
+            def func_gen(*args, **kwargs):
+                yield 1
+                yield 2
+
+                def other_gen():
+                    yield 3
+                    yield 4
+
+                for value in other_gen():
+                    yield value
+
+            res = list(func_gen())
+        """
+        safe_eval(dedent(expr), context := {'deco': deco}, mode='exec')
+        self.assertListEqual(context['res'], [1, 2, 3, 4])
+
+    def test_transform_generators_assert_number_safe_call(self):
+        expr = """
+            def func_gen(*args, **kwargs):
+                yield 1
+
+            res = list(func_gen())
+        """
+        with patch(
+            'odoo.tools.safe_eval.evaluation.safe_call',
+            wraps=safe_call,
+        ) as mock_safe_call:
+            safe_eval(dedent(expr), {}, mode='exec')
+            self.assertEqual(mock_safe_call.call_count, 1)
 
     @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
     def test_check_callee(self):
@@ -352,22 +402,48 @@ class TestSafeEvalRuntime(TransactionCase):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
     @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
-    def test_check_generator(self):
-        # Not listen `YIELD` event for external generator
+    def test_prevent_async_function(self):
         expr = """
-            gen = get_generator()
-            list(gen)
+            async def func(): ...
+        """
+        with self.assertRaises(SyntaxError):
+            safe_eval(dedent(expr), {}, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_prevent_async_comprehension(self):
+        expr = """
+            (x async for x in [0])
+        """
+        with self.assertRaises(SyntaxError):
+            safe_eval(dedent(expr), {}, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_prevent_async_for(self):
+        expr = """
+            async def bar():
+                async for x in [0]:
+                    pass
+        """
+        with self.assertRaises(SyntaxError):
+            safe_eval(dedent(expr), {}, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_01(self):
+        # Not listen events for external generator
+        expr = """
+            g = get_generator()
         """
 
         def get_generator():
-            _local_var = self.unsafe_context['UnsafeClass']
-            yield self.unsafe_context['UnsafeClass']
+            _local_var = self.UnsafeClass
+            yield self.UnsafeClass
 
-        safe_ctx = {
-            'get_generator': get_generator,
-        }
+        safe_ctx = {'get_generator': get_generator}
         safe_eval(dedent(expr), safe_ctx, mode='exec')
+        list(safe_ctx['g'])
 
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_02(self):
         # Attempt to use a dangerous object (caught in `safe_call`)
         expr = """
             g = (UnsafeClass() for _ in [0])
@@ -376,7 +452,9 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaises(UnsafeClassError):
             list(self.unsafe_context['g'])
 
-        # Attempt to hide a dangerous object (caught by the `YIELD` event)
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_03(self):
+        # Attempt to hide a dangerous object
         expr = """
             g = (UnsafeClass for _ in [0])
             use_generator(g)
@@ -389,66 +467,214 @@ class TestSafeEvalRuntime(TransactionCase):
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
 
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_04(self):
         # Attempt to alter the generator's context by modifying globals
-        # (caught by the `YIELD` event)
         expr = """
             d['g'] = (d['foo'] for _ in [0])
             use_generator(d)
         """
 
-        def use_generator_1(d):
-            # Make the generator's context unsafe
-            d['foo'] = self.unsafe_context['UnsafeClass']
-            # Attempt to consume the generator
-            list(d['g'])  # Triggers `UnsafeObjectError`
+        def use_generator(d):
+            d['foo'] = self.UnsafeClass
+            list(d['g'])
 
-        safe_ctx = {
-            'd': {},
-            'use_generator': use_generator_1,
-        }
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), safe_ctx, mode='exec')
 
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_05(self):
         # Attempt to alter the generator's context by modifying locals
-        # (caught by the `YIELD` event)
         expr = """
-            d={}
+            d = {}
             g = (d['foo'] for d in [d])
             use_generator(g, d)
         """
 
-        def use_generator_2(g, d):
-            # Make the generator's context unsafe
+        def use_generator(g, d):
             d['foo'] = self.unsafe_context['UnsafeClass']
-            # Attempt to consume the generator
-            return list(g)  # Triggers `UnsafeObjectError`
+            return list(g)
 
-        safe_ctx = {
-            'use_generator': use_generator_2,
-        }
+        safe_ctx = {'use_generator': use_generator}
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), safe_ctx, mode='exec')
 
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_06(self):
         # Attempt to alter the generator's context by modifying builtins
-        # and shadow them in globals (caught by the `YIELD` event)
+        # and shadow them in globals
         expr = """
             g = (foo for _ in [0])
             use_generator(g)
         """
 
-        def use_generator_3(g):
-            # Make the generator's context unsafe
+        def use_generator(g):
             frame = inspect.currentframe()
             safe_call_frame = frame.f_back
             generator_frame = safe_call_frame.f_back
-            generator_frame.f_builtins['foo'] = self.unsafe_context['UnsafeClass']
-            # Attempt to consume the generator
-            list(g)  # Triggers `UnsafeObjectError`
+            generator_frame.f_builtins['foo'] = self.UnsafeClass
+            list(g)
 
         safe_ctx = {
             'foo': '',  # Shadow builtin
-            'use_generator': use_generator_3,
+            'use_generator': use_generator,
         }
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_07(self):
+        # Attempt to escape unsafe context using `StopIteration` (`return`)
+        expr = """
+            def gen():
+                return
+                yield d['foo']
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def use_generator(d):
+            d['foo'] = self.UnsafeClass
+            list(d['g'])
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_08(self):
+        # Attempt to escape unsafe context using exception
+        expr = """
+            def gen():
+                raise Exception
+                yield d['foo']
+
+            d['g'] = gen()
+            try:
+                use_generator(d)
+            except Exception:
+                pass
+        """
+
+        def use_generator(d):
+            d['foo'] = self.UnsafeClass
+            list(d['g'])
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_09(self):
+        # Attempt to escape unsafe context using exception injection
+        expr = """
+            def gen():
+                try:
+                    yield
+                except Exception:
+                    yield d['foo']
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def use_generator(d):
+            next(d['g'])
+            d['foo'] = self.UnsafeClass
+            d['g'].throw(Exception())
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_10(self):
+        # Attempt to escape unsafe context using intermediate yield
+        expr = """
+            def gen():
+                yield
+                yield d['foo']
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def use_generator(d):
+            next(d['g'])
+            d['foo'] = self.UnsafeClass
+            list(d['g'])
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_11(self):
+        # Attempt to escape unsafe context using exceptions bypass
+        expr = """
+            def gen():
+                try:
+                    yield
+                except Exception:
+                    d['foo']  # Performs a variety of tasks
+                    raise Exception
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def use_generator(d):
+            next(d['g'])
+            d['foo'] = self.UnsafeClass
+            d['g'].throw(Exception())
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_12(self):
+        # Attempt to escape unsafe context using iterator
+        expr = """
+            def gen():
+                yield
+                yield d['foo']
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def use_generator(d):
+            it = iter(d['g'])
+            next(it)
+            d['foo'] = self.UnsafeClass
+            next(it)
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator}
+        with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.evaluation.runtime')
+    def test_check_generator_13(self):
+        # Attempt to escape unsafe context without re-call the generator
+        expr = """
+            def gen():
+                manipulate(d)
+                yield d['foo']
+
+            d['g'] = gen()
+            use_generator(d)
+        """
+
+        def manipulate(d):
+            d['foo'] = self.UnsafeClass
+
+        def use_generator(d):
+            next(d['g'])  # Return value can be used in external logic
+
+        safe_ctx = {'d': {}, 'use_generator': use_generator, 'manipulate': manipulate}
         with self.assertRaisesRegex(ValueError, '^UnsafeClassError'):
             safe_eval(dedent(expr), safe_ctx, mode='exec')
 

--- a/odoo/tools/safe_eval/evaluation.py
+++ b/odoo/tools/safe_eval/evaluation.py
@@ -12,10 +12,8 @@ condition/math builtins.
 #  - safe_eval in lp:~xrg/openobject-server/optimize-5.0
 #  - safe_eval in tryton http://hg.tryton.org/hgwebdir.cgi/trytond/rev/bbb5f73319ad
 import ast
-import contextvars
 import dis
 import functools
-import inspect
 import logging
 import os
 import re
@@ -24,6 +22,7 @@ import types
 import typing
 import zoneinfo
 from collections import OrderedDict, defaultdict
+from contextvars import ContextVar
 from enum import IntEnum, auto
 from json.encoder import c_make_encoder  # noqa: OLS02001
 from opcode import opmap, opname
@@ -32,6 +31,7 @@ from types import (
     ClassMethodDescriptorType,
     CodeType,
     FunctionType,
+    GeneratorType,
     GetSetDescriptorType,
     MemberDescriptorType,
     MethodDescriptorType,
@@ -68,6 +68,7 @@ __all__ = [
     'UnsafeModuleError',
     'UnsafeObjectError',
     'UnsafePolicy',
+    '_SafeGenerator',
     '_import',
     'assert_valid_codeobj',
     'check_values',
@@ -627,6 +628,9 @@ dateutil.tz.gettz = zoneinfo.ZoneInfo
 # - safe_whitelist: used during verifications
 
 
+is_gen_ctx: ContextVar[bool] = ContextVar('is_gen_ctx', default=False)
+
+
 class _SafeTransformer(ast.NodeTransformer):
     """
     Code transformer that wraps calls with :func:`_safe_eval_call` in
@@ -640,6 +644,8 @@ class _SafeTransformer(ast.NodeTransformer):
 
     CALL_ID = '_safe_eval_call'
     DECO_ID = '_safe_eval_deco'
+    GEN_FUNC_ID = '_safe_eval_gen_func'
+    GEN_ITER_ID = '_safe_eval_gen_iter'
 
     def visit_Call(self, node):
         """
@@ -671,9 +677,19 @@ class _SafeTransformer(ast.NodeTransformer):
             @_safe_eval_deco(decorator_B)
             def func():
                 pass
+
+        Note:
+            If the function produces a generator, a decorator is added to wrap
+            the result with `_safe_eval_gen_func`.
         """
-        self.generic_visit(node)
-        if not node.decorator_list:
+        token = is_gen_ctx.set(False)
+        try:
+            self.generic_visit(node)
+            is_gen = is_gen_ctx.get()
+        finally:
+            is_gen_ctx.reset(token)
+
+        if not node.decorator_list and not is_gen:
             return node
 
         new_decorators = []
@@ -688,11 +704,39 @@ class _SafeTransformer(ast.NodeTransformer):
             ast.copy_location(wrapped_decorator.func, decorator)
             new_decorators.append(wrapped_decorator)
 
+        if is_gen:
+            gen_func_wrapper = ast.Name(id=self.GEN_FUNC_ID, ctx=ast.Load())
+            ast.copy_location(gen_func_wrapper, node)
+            new_decorators.append(gen_func_wrapper)
+
         node.decorator_list = new_decorators
 
         return node
 
-    visit_AsyncFunctionDef = visit_FunctionDef
+    def visit_Yield(self, node):
+        """ Set parent function definition as a generator function """
+        is_gen_ctx.set(True)
+        return self.generic_visit(node)
+
+    visit_YieldFrom = visit_Yield
+
+    def visit_GeneratorExp(self, node):
+        """
+        Transforms:
+            (_ for _ in [])
+
+        Into:
+            _safe_eval_gen_iter((_ for _ in []))
+        """
+        self.generic_visit(node)
+        call = ast.Call(
+            func=ast.Name(id=self.GEN_ITER_ID, ctx=ast.Load()),
+            args=[node],
+            keywords=[],
+        )
+        ast.copy_location(call, node)
+        ast.copy_location(call.func, node)
+        return call
 
     def visit_Try(self, node):
         """ Ensure no bare except is used """
@@ -708,8 +752,31 @@ class _SafeTransformer(ast.NodeTransformer):
 
         return node
 
+    def visit_AsyncFunctionDef(self, node):
+        # Prevent the use of `AsyncFor` node
+        _logger_runtime.warning(
+            'Asynchronous function should not be used'
+        )
+        if unsafe_policy() >= UnsafePolicy.RAISE:
+            raise SyntaxError('You cannot use asynchronous function')
 
-encoder_ctx = contextvars.ContextVar('encoder_ctx')
+        return self.visit_FunctionDef(node)
+
+    def visit_comprehension(self, node):
+        """ Ensure async is not used """
+        self.generic_visit(node)
+
+        if node.is_async:
+            _logger_runtime.warning(
+                'Asynchronous comprehension should not be used'
+            )
+            if unsafe_policy() >= UnsafePolicy.RAISE:
+                raise SyntaxError('You cannot use asynchronous comprehension')
+
+        return node
+
+
+encoder_ctx = ContextVar('encoder_ctx')
 
 
 class _SafeChecker:
@@ -755,7 +822,7 @@ class _SafeChecker:
         for t in self.SEQUENCES: self.add_hook(t, list)  # noqa: E701
         for t in self.MAPPINGS: self.add_hook(t, dict)  # noqa: E701
         for t in self.ITERATORS: self.add_hook(t, self._hook_iterator)  # noqa: E701
-        self.add_hook(types.GeneratorType, None)
+        self.add_hook(GeneratorType, None)
         self.add_hook(functools.partial, self._hook_partial)
         self.add_hook(lazy, self._hook_lazy)
         d = {}
@@ -1064,9 +1131,60 @@ def safe_call_deco(func):
 safe_whitelist.TRUSTED_FUNCTIONS |= {safe_call, safe_call_deco}
 
 
+class _SafeGenerator(types._GeneratorWrapper):  # noqa: OLS01001
+
+    def send(self, *args):
+        assert_safe_context(self)
+        try:
+            return super().send(*args)
+        finally:
+            assert_safe_context(self)
+
+    def throw(self, *args):
+        assert_safe_context(self)
+        try:
+            return super().throw(*args)
+        finally:
+            assert_safe_context(self)
+
+    def close(self, *args):
+        assert_safe_context(self)
+        try:
+            return super().close(*args)
+        finally:
+            assert_safe_context(self)
+
+    def __next__(self, *args):
+        assert_safe_context(self)
+        try:
+            return super().__next__(*args)
+        finally:
+            assert_safe_context(self)
+
+    def __iter__(self, *args):
+        assert_safe_context(self)
+        return self  # Not use `super`, as it leaks the wrapped generator
+
+    __await__ = __iter__
+
+
+def safe_gen_wrapper(func):
+
+    def _wrapper(*args, **kwargs):
+        gen = safe_call(func, *args, **kwargs)
+        return _SafeGenerator(gen)
+
+    return _wrapper
+
+
+safe_checker.add_hook(_SafeGenerator, None)
+safe_whitelist.TRUSTED_CLASSES |= {_SafeGenerator}
+safe_whitelist.TRUSTED_FUNCTIONS |= {safe_gen_wrapper}
+
+
 def monitoring_call(code, instruction_offset, callee, arg0):
     """ Ensure `_MONITORING_BUILTINS` are not overridden """
-    if callee in (safe_call, safe_call_deco):
+    if callee in (safe_call, safe_call_deco, _SafeGenerator, safe_gen_wrapper):
         return
 
     frame = sys._getframe(1)
@@ -1079,15 +1197,17 @@ def monitoring_call(code, instruction_offset, callee, arg0):
             raise UnsafeContextError(f'{identifier} is overridden')
 
 
-def monitoring_yield(code, instruction_offset, retval):
+def assert_safe_context(gen: GeneratorType) -> None:
     """ Ensure mutating context of generator is safe """
-    frame = sys._getframe(1)
+    if not (frame := gen.gi_frame):
+        return  # If there is no frame, the generator is finished
     objs = list(frame.f_locals.values())
-    for name in code.co_names:
+    for name in gen.gi_code.co_names:
         if name in frame.f_globals:
             objs.append(frame.f_globals[name])
         if name in frame.f_builtins:
             objs.append(frame.f_builtins[name])
+    # The use of freevars (closures) is not allowed
     try:
         safe_checker.check(objs)
     except UnsafeObjectError as e:
@@ -1097,6 +1217,8 @@ def monitoring_yield(code, instruction_offset, retval):
 _MONITORING_BUILTINS = {
     safe_transformer.CALL_ID: safe_call,
     safe_transformer.DECO_ID: safe_call_deco,
+    safe_transformer.GEN_FUNC_ID: safe_gen_wrapper,
+    safe_transformer.GEN_ITER_ID: _SafeGenerator,
 }
 _BUILTINS.update(_MONITORING_BUILTINS)
 
@@ -1104,7 +1226,6 @@ EVENTS = sys.monitoring.events
 TOOL_ID = 4  # Not prevent other tools from using "official IDs"
 sys.monitoring.use_tool_id(TOOL_ID, 'ODOO_UNSAFE_POLICY_TOOL')
 sys.monitoring.register_callback(TOOL_ID, EVENTS.CALL, monitoring_call)
-sys.monitoring.register_callback(TOOL_ID, EVENTS.PY_YIELD, monitoring_yield)
 
 
 def add_monitoring(code):
@@ -1112,8 +1233,6 @@ def add_monitoring(code):
     while codes:
         code = codes.pop()
         sys.monitoring.set_local_events(TOOL_ID, code, EVENTS.CALL)
-        if code.co_flags & inspect.CO_GENERATOR:
-            sys.monitoring.set_local_events(TOOL_ID, code, EVENTS.PY_YIELD)
         codes.extend(const for const in code.co_consts if isinstance(const, types.CodeType))
 
 
@@ -1121,6 +1240,8 @@ def add_monitoring(code):
 def _initialize_safe_whitelist():
     # Custom functions
     safe_whitelist.add_function('odoo.tools.safe_eval.evaluation.<evaluated_code>.*')
+    # Generators wrapper
+    safe_whitelist.add_function('odoo.tools.safe_eval.evaluation.safe_gen_wrapper.<locals>._wrapper')
     # Wrapped modules
     safe_whitelist.add_class('datetime.date')
     safe_whitelist.add_class('datetime.datetime')


### PR DESCRIPTION
Before this commit, the context in which a generator would run was checked at the `PY_YIELD` event. However, in certain situations, this event is not triggered, allowing a generator to run in an unsafe context.

Generators created by arbitrary code will be wrapped to verify their context before each method call.

Task-6074677