### PR TITLE
[FIX] hr_attendance: regenerate overtime only on selected ruleset.

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -296,7 +296,7 @@ class HrAttendance(models.Model):
             return Domain.FALSE
         return Domain.OR(domain_list) if len(domain_list) > 1 else domain_list[0]
 
-    def _update_overtime(self, attendance_domain=None):
+    def _update_overtime(self, attendance_domain=None, target_ruleset=None):
         if not attendance_domain:
             attendance_domain = self._get_overtimes_to_update_domain()
         all_overtime_lines = self.env['hr.attendance.overtime.line'].search(attendance_domain)
@@ -340,7 +340,7 @@ class HrAttendance(models.Model):
                     continue
                 version = inter._items[0][2]
                 ruleset = version.ruleset_id
-                if ruleset:
+                if ruleset and (not target_ruleset or ruleset == target_ruleset):
                     attendances_by_ruleset[ruleset] += attendance
         employees = all_attendances.employee_id
         schedules_intervals_by_employee = employees._get_schedules_by_employee_by_work_type(min_check_in, max_check_out, version_periods_by_employee)

--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
+from odoo.fields import Domain
 
 
 class HrAttendanceOvertimeRuleset(models.Model):
@@ -41,10 +42,13 @@ class HrAttendanceOvertimeRuleset(models.Model):
         elligible_version = self.env['hr.version'].search([('ruleset_id', '=', self.id)])
         if not elligible_version:
             return self.env['hr.attendance']
-        elligible_attendances = self.env['hr.attendance'].search([
-            ('employee_id', 'in', elligible_version.employee_id.ids),
-            ('date', '>=', min(elligible_version.mapped('date_version'))),
-        ])
+        big_domain = Domain.FALSE
+        for version in elligible_version:
+            version_domain = [('employee_id', '=', version.employee_id.id), ('date', '>=', version.date_start)]
+            if version.date_end:
+                version_domain = Domain.AND([version_domain, [('date', '<=', version.date_end)]])
+            big_domain = big_domain.OR([big_domain, version_domain])
+        elligible_attendances = self.env['hr.attendance'].search(big_domain)
         return elligible_attendances
 
     def action_regenerate_overtimes(self):

--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -48,4 +48,5 @@ class HrAttendanceOvertimeRuleset(models.Model):
         return elligible_attendances
 
     def action_regenerate_overtimes(self):
-        self._attendances_to_regenerate_for()._update_overtime()
+        self.ensure_one()
+        self._attendances_to_regenerate_for()._update_overtime(target_ruleset=self)

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -98,6 +98,7 @@
                 <field name="active" invisible="1"/>
                 <header>
                     <button name="action_regenerate_overtimes"
+                        confirm="This will reset all manual edit on overtime period linked to those rules. Do you confirm ?"
                         class="btn"
                         string="Regenerate overtimes"
                         icon="fa-clock-o"


### PR DESCRIPTION
When you click on "regenerate overtime", currently, it reset all overtimes of all overtime ruleset, it should only act on the selected one. Second, it should display a confirmation message:
"This will reset all manual edit on overtime period linked to those rules. Do you confirm ?"

Task-6095714