### PR TITLE
[FIX] mrp: hide warnings for components not for current variant

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1777,7 +1777,8 @@ class MrpProduction(models.Model):
                 for bom, data in order.bom_id.explode(order.bom_id.product_id, order.product_qty)[0]:
                     if bom.type == 'phantom' or bom == order.bom_id:
                         bom_factors[bom.id] = bom_factor * data['qty'] / data['original_qty']
-                        all_lines |= bom.bom_line_ids.filtered(lambda line: line.child_bom_id.type != 'phantom')
+                        all_lines |= bom.bom_line_ids.filtered(lambda line: line.child_bom_id.type != 'phantom'
+                            and not line._skip_bom_line(order.product_id, order.never_product_template_attribute_value_ids))
                 missing_lines = all_lines - order.move_raw_ids.bom_line_id
             for move in order.move_raw_ids:
                 # If there's no BoM, we simply rely on the quantity specified by the user.

--- a/addons/mrp/tests/test_consumption_warning.py
+++ b/addons/mrp/tests/test_consumption_warning.py
@@ -411,3 +411,32 @@ class TestConsumptionWarning(common.TransactionCase):
                 self.assertEqual(move.quantity, 1.2, "Wrong quantity of the component was consumed.")
             else:
                 self.assertEqual(move.product_id, self.salt, "Foreign component in the MO.")
+
+    def test_consumption_warning_for_variants(self):
+        """Ensure that the consumption warning wizard does not trigger when a
+        BOM component is not intended for the current variant and has not been
+        consumed."""
+        soup_template = self.soup.product_tmpl_id
+        flavour_attribute = self.env['product.attribute'].create({
+            'name': 'Flavor',
+            'value_ids': [
+                Command.create({'name': 'Spicy'}),
+                Command.create({'name': 'Salted'}),
+            ],
+            'create_variant': 'always',
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': soup_template.id,
+            'attribute_id': flavour_attribute.id,
+            'value_ids': [Command.set(flavour_attribute.value_ids.ids)],
+        })
+        self.soup_recipe.bom_line_ids = [Command.create({
+            'product_id': self.env['product.product'].create({'name': 'Ghost Pepper', 'type': 'consu'}).id,
+            'product_qty': 1,
+            'bom_product_template_attribute_value_ids': [
+                Command.link(soup_template.product_variant_ids[0].product_template_attribute_value_ids[0].id),
+            ],
+        })]
+        mo = self._make_mo(self.soup_recipe, 5, self.uom_m3)
+        mo.product_id = soup_template.product_variant_ids[1].id
+        self.assertIs(mo.button_mark_done(), True, 'Avoid unused component warnings meant for other variants')


### PR DESCRIPTION
Currently when the user produces a product, the system shows warnings for components that don't apply to that variant.

## Steps to replicate:
- Install Manufacturing
- Enable Variants from settings
- Create a Product 'Car' with color attribute value: Red and Blue
- Create Bill of material for car:
   - Components: Engine, Radiator
- For the 'Engine' component set color: Blue on 'Apply on Variants' field on
  bom lines (unhide the field as it is hidden by default).
- Create and confirm an MO for Red Car
- Produce All

## Observed Behavior:
A consumption warning is being triggered indicating that the radiator has not been consumed, even though this component is intended only for the blue car variant and not the red car.

## Root cause:
When the Produce All button is pressed, it calls the `button_mark_done` function, which in turn invokes `pre_button_mark_done` as shown in [1]. This eventually leads to the execution of `_get_consumption_issues` as shown at [2].

The issue arises in the loop at [3], where BoM lines are checked for missing components. The filtering logic used to populate the `all_lines` variable incorrectly includes BoM lines that belong to other variants. Specifically, it does not take into account the "Apply on Variants" field, causing lines meant for different variants to be considered.

As a result, these irrelevant lines are treated as missing components and are added to the `missing_lines`, which is then included in the issues list at [4].

**Why this did not occur in versions prior to 19.2?:**
This behavior was introduced unintentionally after [commit](
https://github.com/odoo/odoo/commit/7a406f26c3c846b347498a3cb60b4ac12df53c6e), which revamped the warning wizard to support showing warning without a BoM.

Previously, the expected component values were derived solely from `_get_moves_raw_values`. However, after the change, the logic also considers BoM lines directly. This change led to the inclusion of variant-specific lines without properly filtering them based on the `"Apply on Variants"` field, resulting in the observed issue.
[1]:
https://github.com/odoo/odoo/blob/4f04f26886393843cfdcec97ed1248a8cf0d1957/addons/mrp/models/mrp_production.py#L2214-L2227 [2]:
https://github.com/odoo/odoo/blob/4f04f26886393843cfdcec97ed1248a8cf0d1957/addons/mrp/models/mrp_production.py#L2348-L2366 [3]:
https://github.com/odoo/odoo/blob/5b907e1235e37b2e6f90ac3289d1947f1abd57df/addons/mrp/models/mrp_production.py#L1763-L1781 [4]:
https://github.com/odoo/odoo/blob/5b907e1235e37b2e6f90ac3289d1947f1abd57df/addons/mrp/models/mrp_production.py#L1811-L1813 

## Solution:
To prevent confusion, users should not see warnings for component lines that are not applicable to the current product variant.

This can be achieved by refining the filtering logic to exclude irrelevant BoM lines, using the `_skip_bom_line` which ensures that only BoM lines valid for the current product variant are considered.

By tightening this condition, variant-specific components that do not apply to the selected variant will be ignored, thereby avoiding incorrect consumption warnings.


opw-6086167