### PR TITLE
[FIX] iot_drivers: abstract supported init fix

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_driver_base.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from abc import ABC, abstractmethod
 from typing import NamedTuple
 from contextlib import contextmanager
 import logging
@@ -57,7 +56,7 @@ def serial_connection(path, protocol, is_probing=False):
     connection.close()
 
 
-class SerialDriver(Driver, ABC):
+class SerialDriver(Driver):
     """Abstract base class for serial drivers."""
 
     _protocol = None
@@ -85,7 +84,6 @@ class SerialDriver(Driver, ABC):
             name = 'Unknown Serial Device'
         self.device_name = name
 
-    @abstractmethod
     def _take_measure(self):
         """Reads the device's value, and pushes that value to the frontend."""
         pass


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/odoo/odoo/pull/221948/changes#diff-2ff0ee6ef17f1cbd35afdf07878383c136c6900df361c520083d7608c1266db2R35

Since the SerialDriver class is a child of ABC class and has an abstract method decorator used + take_measure is not implemented for fiscal data module drivers, the check lead to 'supported' method never being called for fdm

This PR adds the removes the abstract property for SerialDriver class to allow fingerpringting of fdms again

