### PR TITLE
[FIX] web: emoji picker search input placeholder not working in owl3

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -164,7 +164,7 @@
 <t t-name="web.EmojiPicker.searchInput">
     <input
         class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1"
-        t-att-placeholder="placeholder"
+        t-att-placeholder="this.placeholder"
         t-model="localState.searchTerm"
         t-ref="autofocus"
         t-att-model="localState.searchTerm"


### PR DESCRIPTION
Before this commit, using owl 3 on current template of emoji picker would not have the placeholder shown.

This happens because `placeholder` is defined in JS component while `placeholder` is being used as if defined as a template variable.

In owl2 this is not a problem because context of template has the component's context in the prototype chain, however that's not the case in owl3. This commit fixes the issue to match with recent changes in template to prepare for owl3.

Before / After (with owl3):
<img width="302" height="371" alt="Screenshot 2026-04-08 at 15 08 48" src="https://github.com/user-attachments/assets/c232d533-0d86-473c-b14b-2e7f406158a8" /> <img width="302" height="371" alt="Screenshot 2026-04-08 at 15 09 33" src="https://github.com/user-attachments/assets/84171fd2-0e54-4874-ac72-181fb27873f5" />
