### PR TITLE
[FIX] web: incohenrence datetime_field state~record

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -171,7 +171,6 @@ export class DateTimeField extends Component {
             },
             onClose: () => {
                 this.picker.activeInput = "";
-                this.state.value = this.getRecordValue();
             },
             onApply: async () => {
                 const toUpdate = {};

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -681,3 +681,45 @@ test("list datetime: column widths (numeric format)", async () => {
     ]);
     expect(queryAllProperties(".o_list_table thead th", "offsetWidth")).toEqual([40, 144, 616]);
 });
+
+test("DateField: incoherent state and record value", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <group>
+                    <field name="date"/>
+                    <field name="datetime"/>
+                </group>
+            </form>`,
+    });
+
+    // Date field
+    await contains(".o_field_widget[name=date] input").click();
+    await edit("11/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=date] button").toHaveValue("11/10/2019");
+
+    await contains(".o_form_button_save").click();
+    await animationFrame();
+
+    await contains(".o_field_widget[name=date] button").click();
+    await edit("10/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=date] button").toHaveValue("10/10/2019");
+
+    // Datetime field
+    await contains(".o_field_widget[name=datetime] input").click();
+    await edit("11/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=datetime] button").toHaveValue("11/10/2019 00:00:00");
+
+    await contains(".o_form_button_save").click();
+    await animationFrame();
+
+    await contains(".o_field_widget[name=datetime] button").click();
+    await edit("10/10", { confirm: "Enter" });
+    await animationFrame();
+    expect(".o_field_widget[name=datetime] button").toHaveValue("10/10/2019 00:00:00");
+});


### PR DESCRIPTION
Step to reproduce:
- Go on view form with a date field
- Set the date with the input by typing the date with day and month (mm/dd or dd/mm), then press enter
- Save the record
- Redo the second step by with a different date
- Save the record

The assignation of the state.value done when closing the datepicker
is useless and can put old a value in the state. The datepicker hasn't
finished to update of the record that the assignation put back the old
value of the record back in the state. The reason why it happens only
after a save is still unknown.

task-6095467


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
