### PR TITLE
[IMP] calendar, microsoft_calendar: increase max recurrent events to 730

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -14,7 +14,7 @@ from odoo.tools.misc import clean_context
 from odoo.addons.base.models.res_partner import _tz_get
 
 
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 SELECT_FREQ_TO_RRULE = {
     'daily': rrule.DAILY,

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -15,7 +15,7 @@ from odoo.tools.misc import clean_context
 from odoo.addons.base.models.res_partner import _tz_get
 
 
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 SELECT_FREQ_TO_RRULE = {
     'daily': rrule.DAILY,

--- a/addons/calendar/tests/test_calendar_recurrent_event_case2.py
+++ b/addons/calendar/tests/test_calendar_recurrent_event_case2.py
@@ -69,7 +69,7 @@ class TestRecurrentEvent(common.TransactionCase):
             'recurrency': True,
         }
         for rrule_type, name, expected_count in (
-            ('daily', 'Daily Meeting', 720),
+            ('daily', 'Daily Meeting', 730),
             ('monthly', 'Monthly Meeting', 180),
             ('yearly', 'Yearly Meeting', 15),
         ):
@@ -85,7 +85,7 @@ class TestRecurrentEvent(common.TransactionCase):
         # Edit the max recurrence years
         self.env['ir.config_parameter'].sudo().set_int('calendar.max_recurrence_years', 5)
         for rrule_type, name, expected_count in (
-            ('daily', 'Custom Daily Meeting', 720),
+            ('daily', 'Custom Daily Meeting', 730),
             ('monthly', 'Custom Monthly Meeting', 60),
             ('yearly', 'Custom Yearly Meeting', 5),
         ):

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -540,10 +540,10 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         self.assertTrue(self.recurrence.wed)
 
     def test_rrule_x_params_no_rrule_prefix(self):
-        self.recurrence.rrule = 'X-EVOLUTION-ENDDATE=20371102T114500Z:FREQ=WEEKLY;COUNT=720;BYDAY=MO'
+        self.recurrence.rrule = 'X-EVOLUTION-ENDDATE=20371102T114500Z:FREQ=WEEKLY;COUNT=730;BYDAY=MO'
         self.assertFalse(self.recurrence.tue)
         self.assertTrue(self.recurrence.mon)
-        self.assertEqual(self.recurrence.count, 720)
+        self.assertEqual(self.recurrence.count, 730)
         self.assertEqual(self.recurrence.rrule_type, 'weekly')
 
     def test_shift_all_base_inactive(self):

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -529,10 +529,10 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         self.assertTrue(self.recurrence.wed)
 
     def test_rrule_x_params_no_rrule_prefix(self):
-        self.recurrence.rrule = 'X-EVOLUTION-ENDDATE=20371102T114500Z:FREQ=WEEKLY;COUNT=720;BYDAY=MO'
+        self.recurrence.rrule = 'X-EVOLUTION-ENDDATE=20371102T114500Z:FREQ=WEEKLY;COUNT=730;BYDAY=MO'
         self.assertFalse(self.recurrence.tue)
         self.assertTrue(self.recurrence.mon)
-        self.assertEqual(self.recurrence.count, 720)
+        self.assertEqual(self.recurrence.count, 730)
         self.assertEqual(self.recurrence.rrule_type, 'weekly')
 
     def test_shift_all_base_inactive(self):

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -30,7 +30,7 @@ ATTENDEE_CONVERTER_M2O = {
 VIDEOCALL_URL_PATTERNS = (
     r'https://teams.microsoft.com',
 )
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -31,7 +31,7 @@ ATTENDEE_CONVERTER_M2O = {
 VIDEOCALL_URL_PATTERNS = (
     r'https://teams.microsoft.com',
 )
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -18,7 +18,7 @@ from odoo.addons.microsoft_account.models.microsoft_service import TIMEOUT
 
 _logger = logging.getLogger(__name__)
 
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 # API requests are sent to Microsoft Calendar after the current transaction ends.
 # This ensures changes are sent to Microsoft only if they really happened in the Odoo database.

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -20,7 +20,7 @@ from odoo.addons.microsoft_account.models.microsoft_service import TIMEOUT
 
 _logger = logging.getLogger(__name__)
 
-MAX_RECURRENT_EVENT = 720
+MAX_RECURRENT_EVENT = 730
 
 # API requests are sent to Microsoft Calendar after the current transaction ends.
 # This ensures changes are sent to Microsoft only if they really happened in the Odoo database.


### PR DESCRIPTION
Google Calendar supports creating recurring events up to 730 occurrences. The previous limit in Odoo was 720, which prevented syncing the full duration of a two-year recurrence, causing it to fall 10 days short.

This increases `MAX_RECURRENT_EVENT` to 730 in both calendar and microsoft_calendar to properly accommodate this maximum limit set by Google Calendar.

Reference: https://support.google.com/calendar/answer/37115?hl=en&ref_topic=10510646&sjid=12144381878884228757-EU

opw-6024835