### PR TITLE
[FIX] mail: redirect to inbox for inaccessible records notifications

### DIFF
--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -57,18 +57,30 @@ const threadPatch = {
         if (res) {
             return res;
         }
+        const actionService = this.store.env.services.action;
         if (this.model === "mail.box") {
             if (this.store.discuss.isActive) {
                 this.setAsDiscussThread();
             } else {
-                this.store.env.services.action.doAction({
+                actionService.doAction({
                     context: { active_id: `mail.box_${this.id}` },
                     tag: "mail.action_discuss",
                     type: "ir.actions.client",
                 });
             }
         } else {
-            this.store.env.services.action.doAction(this.openRecordActionRequest);
+            actionService.doAction(this.openRecordActionRequest).catch((error) => {
+                if (options?.fromMessagingMenu) {
+                    this.store.inbox.highlightMessage = this.needactionMessages.at(-1);
+                    actionService.doAction({
+                        context: { active_id: "mail.box_inbox" },
+                        tag: "mail.action_discuss",
+                        type: "ir.actions.client",
+                    });
+                } else {
+                    throw error;
+                }
+            });
         }
         return true;
     },

--- a/addons/test_mail/static/tests/tours/access_inbox_records_tour.js
+++ b/addons/test_mail/static/tests/tours/access_inbox_records_tour.js
@@ -1,0 +1,31 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("access_inbox_records_tour", {
+    steps: () => [
+        {
+            trigger: ".o-mail-DiscussSystray-class .fa-comments",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-NotificationItem:has(:text(Inaccessible Record))",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-DiscussContent-threadName[title='Inbox']",
+        },
+        {
+            trigger: ".o-mail-Message-body:text(Message in inaccessible record)",
+        },
+        {
+            trigger: ".o-mail-DiscussSystray-class .fa-comments",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-NotificationItem:has(:text(Accessible Record))",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_view:has(:text(Accessible Record))",
+        },
+    ],
+});

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -8,7 +8,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.addons.mail.tools.discuss import Store
-from odoo.tests import Form, users, warmup, tagged
+from odoo.tests import HttpCase, Form, users, warmup, tagged
 from odoo.tools import mute_logger
 
 
@@ -1157,8 +1157,8 @@ class TestChatterTweaks(ThreadRecipients):
         self.assertTrue(record.name)
 
 
-@tagged('mail_thread')
-class TestDiscuss(MailCommon, TestRecipients):
+@tagged('mail_thread', 'post_install', '-at_install')
+class TestDiscuss(HttpCase, MailCommon, TestRecipients):
 
     @classmethod
     def setUpClass(cls):
@@ -1262,6 +1262,21 @@ class TestDiscuss(MailCommon, TestRecipients):
         self.assertEqual(len(message), 1, "Test message should have been posted")
         self.test_record.unlink()
         self.assertFalse(message.exists(), "Test message should have been deleted")
+
+    @mute_logger("odoo.http")
+    def test_access_inbox_records(self):
+        for access, name in [("admin", "Inaccessible Record"), ("internal", "Accessible Record")]:
+            self.env["mail.test.access"].create(
+                {
+                    "access": access,
+                    "name": name,
+                }
+            ).message_post(
+                body=f"Message in {name.lower()}",
+                message_type="comment",
+                partner_ids=[self.user_employee.partner_id.id],
+            )
+        self.start_tour("/odoo", "access_inbox_records_tour", login=self.user_employee.login)
 
 
 @tagged('mail_thread')


### PR DESCRIPTION
Currently, when a user clicks on a notification in the messaging menu relating to a record they don't have access to, an access error occurs. This PR changes this behavior so that the user is redirected to the inbox instead.

task-5374528

