### PR TITLE
[FIX] account_edi_ubl_cii: predictive only exists in enterprise

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -882,7 +882,7 @@ class ResPartner(models.Model):
                  against the provided or guessed country. None if no country was available
                  for the check, and no conclusion could be made with certainty.
         """
-        return default_country.code.lower()
+        return default_country.code.lower() if default_country else None
 
     @api.model
     def _build_vat_error_message(self, country_code, wrong_vat, record_label):

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -513,6 +513,9 @@ class AccountEdiCommon(models.AbstractModel):
                             'zip': zip_code, 'city': city, 'is_company': True}
             if peppol_eas and peppol_endpoint:
                 partner_vals.update({'peppol_eas': peppol_eas, 'peppol_endpoint': peppol_endpoint})
+            if country_code == 'GB':
+                # While the code is gb, the xml_id is uk
+                country_code = 'UK'
             country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False) if country_code else False
             if country:
                 partner_vals['country_id'] = country.id

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2941,6 +2941,9 @@ class AccountEdiUBL(models.AbstractModel):
                         product_uom_values['uom'] = uom
 
     def _import_ubl_invoice_retrieve_accounts(self, collected_values):
+        if not self.module_installed('account_accountant'):
+            # _predict_specific_account is defined in account_accountant
+            return
         lines_collected_values = collected_values['lines_collected_values']
         for line_collected_values in lines_collected_values:
             account_values = line_collected_values['account_values']

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2111,6 +2111,9 @@ class AccountEdiUBL(models.AbstractModel):
             partner_create_values['peppol_endpoint'] = peppol_endpoint
 
         if country_code := customer_values.get('country_code'):
+            if country_code == 'GB':
+                # While the code is gb, the xml_id is uk
+                country_code = 'UK'
             country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False)
             if country:
                 partner_create_values['country_id'] = country.id


### PR DESCRIPTION
If you're in community, the retrieval of account results in a traceback, failing the import

**[FIX] account_edi_ubl_cii: empty country fails the import**
If you don't find a country, we try to run _run_vat_test
with False as a value, resulting in an Error when we do apply
a lower() on it.
A simple way to reproduce is to put the GB code in the UBL
(which is the right value), while the xml_id is uk.
We also fix it there.

Runbot-242379




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
