### PR TITLE
[IMP] html_editor, web_unsplash, website: AI Website Builder tweaks

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -87,6 +87,78 @@ def get_existing_attachment(IrAttachment, vals):
     return IrAttachment.search(domain, limit=1) or None
 
 
+def attachment_create(IrAttachment, name='', data=False, url=False, res_id=False, res_model='ir.ui.view'):
+    """Create and return a new attachment."""
+    if name.lower().endswith('.bmp'):
+        # Avoid mismatch between content type and mimetype, see commit msg
+        name = name[:-4]
+
+    if not name and url:
+        name = url.split("/").pop()
+
+    if res_model != 'ir.ui.view' and res_id:
+        res_id = int(res_id)
+    else:
+        res_id = False
+
+    attachment_data = {
+        'name': name,
+        'public': res_model == 'ir.ui.view',
+        'res_id': res_id,
+        'res_model': res_model,
+    }
+
+    if data:
+        attachment_data['raw'] = data
+        if url:
+            attachment_data['url'] = url
+    elif url:
+        attachment_data.update({
+            'type': 'url',
+            'url': url,
+        })
+        # The code issues a HEAD request to retrieve headers from the URL.
+        # This approach is beneficial when the URL doesn't conclude with an
+        # image extension. By verifying the MIME type, the code ensures that
+        # only supported image types are incorporated into the data.
+        response = requests.head(url, timeout=10)
+        if response.status_code == 200:
+            mime_type = response.headers.get('content-type')
+            if mime_type in SUPPORTED_IMAGE_MIMETYPES:
+                attachment_data['mimetype'] = mime_type
+    else:
+        raise UserError(_("You need to specify either data or url to create an attachment."))
+
+    # Despite the user having no right to create an attachment, he can still
+    # create an image attachment through some flows
+    if (
+        not IrAttachment.env.is_admin()
+        and IrAttachment._can_bypass_rights_on_media_dialog(**attachment_data)
+    ):
+        attachment = IrAttachment.sudo().create(attachment_data)
+        # When portal users upload an attachment with the wysiwyg widget,
+        # the access token is needed to use the image in the editor. If
+        # the attachment is not public, the user won't be able to generate
+        # the token, so we need to generate it using sudo
+        if not attachment_data['public']:
+            attachment.sudo().generate_access_token()
+
+        if IrAttachment.env.user.share:
+            max_portal_file_size = int(IrAttachment.env["ir.config_parameter"].sudo().get_int(
+                "html_editor.max_portal_file_size",
+                100_000_000,
+            ))
+            if not (attachment.mimetype or '').startswith('image/'):
+                raise AccessError(IrAttachment.env._("Non-internal users can only upload image."))
+            if attachment.file_size >= max_portal_file_size:
+                raise AccessError(IrAttachment.env._("Non-internal users can't upload large files."))
+    else:
+        attachment = get_existing_attachment(IrAttachment, attachment_data) \
+            or IrAttachment.create(attachment_data)
+
+    return attachment
+
+
 class HTML_Editor(Controller):
 
     def _get_shape_svg(self, module, *segments):
@@ -258,79 +330,6 @@ class HTML_Editor(Controller):
         context.pop('allowed_company_ids', None)
         request.update_env(context=context)
 
-    def _attachment_create(self, name='', data=False, url=False, res_id=False, res_model='ir.ui.view'):
-        """Create and return a new attachment."""
-        IrAttachment = request.env['ir.attachment']
-
-        if name.lower().endswith('.bmp'):
-            # Avoid mismatch between content type and mimetype, see commit msg
-            name = name[:-4]
-
-        if not name and url:
-            name = url.split("/").pop()
-
-        if res_model != 'ir.ui.view' and res_id:
-            res_id = int(res_id)
-        else:
-            res_id = False
-
-        attachment_data = {
-            'name': name,
-            'public': res_model == 'ir.ui.view',
-            'res_id': res_id,
-            'res_model': res_model,
-        }
-
-        if data:
-            attachment_data['raw'] = data
-            if url:
-                attachment_data['url'] = url
-        elif url:
-            attachment_data.update({
-                'type': 'url',
-                'url': url,
-            })
-            # The code issues a HEAD request to retrieve headers from the URL.
-            # This approach is beneficial when the URL doesn't conclude with an
-            # image extension. By verifying the MIME type, the code ensures that
-            # only supported image types are incorporated into the data.
-            response = requests.head(url, timeout=10)
-            if response.status_code == 200:
-                mime_type = response.headers.get('content-type')
-                if mime_type in SUPPORTED_IMAGE_MIMETYPES:
-                    attachment_data['mimetype'] = mime_type
-        else:
-            raise UserError(_("You need to specify either data or url to create an attachment."))
-
-        # Despite the user having no right to create an attachment, he can still
-        # create an image attachment through some flows
-        if (
-            not request.env.is_admin()
-            and IrAttachment._can_bypass_rights_on_media_dialog(**attachment_data)
-        ):
-            attachment = IrAttachment.sudo().create(attachment_data)
-            # When portal users upload an attachment with the wysiwyg widget,
-            # the access token is needed to use the image in the editor. If
-            # the attachment is not public, the user won't be able to generate
-            # the token, so we need to generate it using sudo
-            if not attachment_data['public']:
-                attachment.sudo().generate_access_token()
-
-            if request.env.user.share:
-                max_portal_file_size = int(request.env["ir.config_parameter"].sudo().get_int(
-                    "html_editor.max_portal_file_size",
-                    100_000_000,
-                ))
-                if not (attachment.mimetype or '').startswith('image/'):
-                    raise AccessError(request.env._("Non-internal users can only upload image."))
-                if attachment.file_size >= max_portal_file_size:
-                    raise AccessError(request.env._("Non-internal users can't upload large files."))
-        else:
-            attachment = get_existing_attachment(IrAttachment, attachment_data) \
-                or IrAttachment.create(attachment_data)
-
-        return attachment
-
     @route(['/web_editor/get_image_info', '/html_editor/get_image_info'], type='jsonrpc', auth='user', website=True)
     def get_image_info(self, src='', href_base=''):
         """This route is used to determine the information of an attachment so that
@@ -449,13 +448,13 @@ class HTML_Editor(Controller):
                 return {'error': e.args[0]}
 
         self._clean_context()
-        attachment = self._attachment_create(name=name, data=data, res_id=res_id, res_model=res_model)
+        attachment = attachment_create(request.env['ir.attachment'], name=name, data=data, res_id=res_id, res_model=res_model)
         return attachment._get_media_info()
 
     @route(['/web_editor/attachment/add_url', '/html_editor/attachment/add_url'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def add_url(self, url, res_id=False, res_model='ir.ui.view', **kwargs):
         self._clean_context()
-        attachment = self._attachment_create(url=url, res_id=res_id, res_model=res_model)
+        attachment = attachment_create(request.env['ir.attachment'], url=url, res_id=res_id, res_model=res_model)
         return attachment._get_media_info()
 
     @route(['/web_editor/modify_image/<model("ir.attachment"):attachment>', '/html_editor/modify_image/<model("ir.attachment"):attachment>'], type="jsonrpc", auth="user", website=True)

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -113,7 +113,7 @@ export class ChannelMember extends Record {
     registerTypingTimeout() {
         this.typingTimeoutId = browser.setTimeout(
             () => (this.isTyping = false),
-            Store.OTHER_LONG_TYPING
+            this.typingTimeoutDuration
         );
     }
     channelAsTyping = fields.One("discuss.channel", {
@@ -128,6 +128,10 @@ export class ChannelMember extends Record {
     /** @type {number} */
     typingTimeoutId;
     unpin_dt = fields.Datetime();
+
+    get typingTimeoutDuration() {
+        return Store.OTHER_LONG_TYPING;
+    }
 
     get canRemoveAdmin() {
         return (

--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -7,7 +7,6 @@ import werkzeug.utils
 from werkzeug.urls import url_encode
 
 from odoo import http, modules, _
-from odoo.http import request
 from odoo.tools.image import image_process
 from odoo.tools.mimetypes import guess_mimetype
 
@@ -15,12 +14,15 @@ from odoo.addons.html_editor.controllers.main import HTML_Editor
 
 logger = logging.getLogger(__name__)
 
+UNSPLASH_APP_ID_ICP = 'unsplash.app_id'
+UNSPLASH_ACCESS_KEY_ICP = 'unsplash.access_key'
+
 
 class Web_Unsplash(http.Controller):
 
     def _get_access_key(self):
         """ Use this method to get the key, needed for internal reason """
-        return request.env['ir.config_parameter'].sudo().get_str('unsplash.access_key')
+        return self.env['ir.config_parameter'].sudo().get_str(UNSPLASH_ACCESS_KEY_ICP)
 
     def _notify_download(self, url):
         ''' Notifies Unsplash from an image download. (API requirement)
@@ -126,29 +128,16 @@ class Web_Unsplash(http.Controller):
 
     @http.route("/web_unsplash/fetch_images", type='jsonrpc', auth="user")
     def fetch_unsplash_images(self, **post):
-        access_key = self._get_access_key()
-        app_id = self.get_unsplash_app_id()
-        if not access_key or not app_id:
-            if not request.env.user._can_manage_unsplash_settings():
-                return {'error': 'no_access'}
-            return {'error': 'key_not_found'}
-        post['client_id'] = access_key
-        response = requests.get('https://api.unsplash.com/search/photos/', params=url_encode(post))
-        if response.status_code == requests.codes.ok:
-            return response.json()
-        else:
-            if not request.env.user._can_manage_unsplash_settings():
-                return {'error': 'no_access'}
-            return {'error': response.status_code}
+        return self.env['ir.attachment']._fetch_unsplash_images(**post)
 
     @http.route("/web_unsplash/get_app_id", type='jsonrpc', auth="public")
     def get_unsplash_app_id(self, **post):
-        return request.env['ir.config_parameter'].sudo().get_str('unsplash.app_id')
+        return self.env['ir.config_parameter'].sudo().get_str(UNSPLASH_APP_ID_ICP)
 
     @http.route("/web_unsplash/save_unsplash", type='jsonrpc', auth="user")
     def save_unsplash(self, **post):
-        if request.env.user._can_manage_unsplash_settings():
-            request.env['ir.config_parameter'].sudo().set_str('unsplash.app_id', post.get('appId'))
-            request.env['ir.config_parameter'].sudo().set_str('unsplash.access_key', post.get('key'))
+        if self.env.user._can_manage_unsplash_settings():
+            self.env['ir.config_parameter'].sudo().set_str(UNSPLASH_APP_ID_ICP, post.get('appId'))
+            self.env['ir.config_parameter'].sudo().set_str(UNSPLASH_ACCESS_KEY_ICP, post.get('key'))
             return True
         raise werkzeug.exceptions.NotFound()

--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -10,7 +10,7 @@ from odoo import http, modules, _
 from odoo.tools.image import image_process
 from odoo.tools.mimetypes import guess_mimetype
 
-from odoo.addons.html_editor.controllers.main import HTML_Editor
+from odoo.addons.html_editor.controllers.main import attachment_create
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ class Web_Unsplash(http.Controller):
                 'res_id': res_id,
                 'res_model': res_model,
             }
-            attachment = HTML_Editor._attachment_create(self, **attachment_data)
+            attachment = attachment_create(self.env['ir.attachment'], **attachment_data)
             if value.get('description'):
                 attachment.description = value.get('description')
             attachment.generate_access_token()

--- a/addons/web_unsplash/models/ir_attachment.py
+++ b/addons/web_unsplash/models/ir_attachment.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import requests
+
 from odoo import api, models
 from odoo.exceptions import ValidationError
+
+from odoo.addons.web_unsplash.controllers.main import (
+    UNSPLASH_ACCESS_KEY_ICP,
+    UNSPLASH_APP_ID_ICP,
+)
 
 
 class IrAttachment(models.Model):
@@ -21,3 +28,32 @@ class IrAttachment(models.Model):
         if forbidden and attachment_data['url'].startswith('/unsplash/'):
             return True
         return super()._can_bypass_rights_on_media_dialog(**attachment_data)
+
+    @api.model
+    def _fetch_unsplash_images(self, **post):
+        IrConfigParameter = self.env["ir.config_parameter"].sudo()
+        access_key = IrConfigParameter.get_str(UNSPLASH_ACCESS_KEY_ICP)
+        app_id = IrConfigParameter.get_str(UNSPLASH_APP_ID_ICP)
+
+        if not access_key or not app_id:
+            if not self.env.user._can_manage_unsplash_settings():
+                return {'error': 'no_access'}
+            return {'error': 'key_not_found'}
+
+        allowed_keys = {'query', 'page', 'per_page', 'orientation'}
+        payload = {key: value for key, value in post.items() if key in allowed_keys}
+        headers = {'Authorization': f'Client-ID {access_key}'}
+
+        response = requests.get(
+            'https://api.unsplash.com/search/photos/',
+            params=payload,
+            headers=headers,
+            timeout=10,
+        )
+
+        if response.status_code == requests.codes.ok:
+            return response.json()
+
+        if not self.env.user._can_manage_unsplash_settings():
+            return {'error': 'no_access'}
+        return {'error': response.status_code}

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -58,9 +58,11 @@ export const setupWebsiteBuilderOeId = 539;
 export const invisibleEl =
     '<div class="s_invisible_el o_snippet_invisible" data-name="Invisible Element" data-invisible="1"></div>';
 
-export function defineWebsiteModels() {
+export function defineWebsiteModels({ includeMailModels = true } = {}) {
     describe.current.tags("desktop");
-    defineMailModels();
+    if (includeMailModels) {
+        defineMailModels();
+    }
     defineModels([Website, IrUiView]);
     onRpc("/website/theme_customize_data_get", () => []);
     onRpc("website", "web_search_read", () => ({


### PR DESCRIPTION
Few tweaks for the AI Website Builder assistant enterprise PR: odoo/enterprise#106196

## [IMP] web_unsplash: take Unsplash request out of the controller

In `ai_website`, we need to make an Unsplash request from inside an
agent tool. However we can't call a controller method from a model.

__Fix__
- Extract `_fetch_unsplash_images` into `ir.attachment` to make it
  callable from other models.
- Make the `requests.get` call safer by adding a timeout, filtering the
  payload keys and putting the access key in `Authorization` header.
- Replace the useless `request` variable uses with `self`
- Add some constant for the Unsplash ICP keys

## [IMP] website: make `defineMailModels` optional in `defineWebsiteModels`

In some case, we need to use `defineWebsiteModels` without defining the
mail models at the same time.

For example, in `ai_website` we call `defineAIModels` which is
defining the mail model `DiscussChannel` differently.

__Fix__
A new parameter (i.e.`includeMailModels`) is added to be able to prevent
the call to `defineMailModels` when needed.

## [IMP] html_editor, *: make `attachment_create` usable in models

*: web_unsplash

__Before commit__
`_attachment_create` was a private method in the `HTML_Editor`
controller that can only be called within a controller context as it
uses the `request` variable.

__After commit__
Make `attachment_create` a standalone function that can be imported and
used from a model such as AI tools in `ai_website`.