### PR TITLE
[FIX] portal : Show non-internal messages regardless subtype

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -82,18 +82,18 @@ class PortalChatter(http.Controller):
         # extract domain from the 'website_message_ids' field
         model = request.env[thread_model]
         field = model._fields['website_message_ids']
+        Message = request.env['mail.message']
         domain = expression.AND([
             self._setup_portal_message_fetch_extra_domain(kw),
             field.get_domain_list(model),
             self._get_non_empty_message_domain(),
             [
                 ("res_id", "=", thread_id),
-                ("subtype_id", "=", request.env.ref("mail.mt_comment").id),
+                ("subtype_id", "in", Message._get_allowed_message_subtypes()),
             ],
         ])
 
         # Check access
-        Message = request.env['mail.message']
         if kw.get('token'):
             access_as_sudo = request.env[thread_model]._get_thread_with_access(
                 thread_id, token=kw.get("token")

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -168,3 +168,6 @@ class MailMessage(models.Model):
             if partner and self.author_id == partner:
                 return True
         return False
+
+    def _get_allowed_message_subtypes(self):
+        return [self.env.ref("mail.mt_comment").id]


### PR DESCRIPTION
### Steps to reproduce:
	- Create a helpdesk ticket from the backend
	- Create another ticket through an email from the customer
	- Send some message in both tickets
	- Merge both tickets
	- Go to the ticket through portal view
	- Notice the mail that the customer sent to open the second ticket is not shown

### Cause:
When fetching the message that will be shown in portal chatter we are only showing the messages with subtype  which is flagged as discussion.

### Fix:
Add the subtype of the ticket creation to the domain where we fetch the messages for portal


opw-6031571