### PR TITLE
[FIX] survey: show questions triggered by answers of skipped questions

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -558,7 +558,11 @@ class Survey(http.Controller):
             return correct_answers, self._prepare_question_html(survey_sudo, answer_sudo, **post)
         elif 'next_skipped_page_or_question' in post:
             answer_sudo.last_displayed_page_id = page_or_question_id
-            return correct_answers, self._prepare_question_html(survey_sudo, answer_sudo, next_skipped_page=True)
+            next_skipped_page = answer_sudo._get_next_skipped_page_or_question()
+            if not next_skipped_page:
+                answer_sudo._mark_done()
+            else:
+                return correct_answers, self._prepare_question_html(survey_sudo, answer_sudo, next_skipped_page=True)
         else:
             if not answer_sudo.is_session_answer:
                 page_or_question = request.env['survey.question'].sudo().browse(page_or_question_id)

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -615,6 +615,14 @@ class SurveyUserInput(models.Model):
         It loops to the first skipped question or page if 'last_displayed_page_id' is the last
         skipped question or page."""
         self.ensure_one()
+
+        # Conditional questions management
+        # Questions that are triggered by a selected answer in the last answered skipped question
+        _, triggered_questions_by_answers, selected_answers = self._get_conditional_values()
+        for answer in self.last_displayed_page_id.suggested_answer_ids:
+            if answer in selected_answers and answer in triggered_questions_by_answers:
+                return self.survey_id._get_next_page_or_question(self, self.last_displayed_page_id.id)
+        
         skipped_mandatory_answer_ids = self.user_input_line_ids.filtered(
             lambda answer: answer.skipped and answer.question_id.constr_mandatory)
 
@@ -655,8 +663,15 @@ class SurveyUserInput(models.Model):
         skipped = self._get_skipped_questions()
         if not skipped:
             return True
-        if self.survey_id.questions_layout == 'page_per_section':
+        __, triggered_questions_by_answer, __ = self._get_conditional_values()
+        if self.survey_id.questions_layout == 'page_per_question':
+            if any(answer in triggered_questions_by_answer for answer in page_or_question.suggested_answer_ids):
+                return False
+        elif self.survey_id.questions_layout == 'page_per_section':
             skipped = skipped.page_id
+            for question in page_or_question.question_ids:
+                if any(answer in triggered_questions_by_answer for answer in question.suggested_answer_ids):
+                    return False
         return skipped == page_or_question
 
     # ------------------------------------------------------------


### PR DESCRIPTION
Problem:
In a survey that allows roaming, when a user skips a question with conditional questions triggered by its answers, submits the survey and then answers the question, the triggered questions are not displayed next. The survey either gets submitted or displays the next skipped mandatory question.

Steps to reproduce:
1. Create a survey with roaming allowed and at least 2 questions.
2. Make the first question mandatory and add an answer that triggers the display of the second question.
3. Start the survey, skip the first question and submit the survey.
4. After skipping the first question and trying to submit, answer the first question with the answer that should trigger the second question.
5. Notice how the second question is not displayed and the survey is submitted or the next skipped mandatory question is displayed instead.

Cause:
When looking for the next question to display, the survey only checks for skipped mandatory questions. It doesn't check if there are any triggered questions that should be displayed before the next skipped mandatory question.

opw-5917891