### PR TITLE
[IMP] iot_drivers: upgrade iot boxes to saas-19.2

### DIFF
--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -23,7 +23,7 @@ def get_last_stable_odoo_version():
     To be changed whenever a new stable Odoo version is released and
     we are sure that this version is compatible with all db versions.
     """
-    return "saas-19.1"
+    return "saas-19.2"
 
 
 @toggleable


### PR DESCRIPTION
This PR updates the current version of the iot boxes to saas-19.2. This only applies to the iot boxes currently in saas-19.1

This will lead to the iot boxes updating to the next version 2 weeks after this PR is merged

task-5949470
