### PR TITLE
[FIX] setup: fix shell rc config in code.local

### DIFF
--- a/setup/sandboxing/firejail/code.local
+++ b/setup/sandboxing/firejail/code.local
@@ -14,16 +14,14 @@ whitelist ${HOME}/.cursor
 
 # Allow access to shell configuration for the integrated terminal to work properly.
 # Needs to be defined as whitelist and read-only.
-whitelist ${HOME}/.zshrc
-whitelist ${HOME}/.bashrc
-whitelist ${HOME}/.oh-my-zsh
-whitelist ${HOME}/.config/fish
-whitelist ${HOME}/.profile
-read-only ${HOME}/.zshrc
-read-only ${HOME}/.bashrc
-read-only ${HOME}/.oh-my-zsh
-read-only ${HOME}/.config/fish
-read-only ${HOME}/.profile
+whitelist-ro ${HOME}/.profile
+whitelist-ro ${HOME}/.bashrc
+whitelist-ro ${HOME}/.zshrc
+whitelist-ro ${HOME}/.oh-my-zsh
+whitelist-ro ${HOME}/.config/fish
+
+# Do not copy shell configuration from /etc/skel but keep the one found in $HOME.
+keep-shell-rc
 
 # IBus input method: the daemon's Unix socket lives at ~/.cache/ibus/dbus-*
 # (see IBUS_ADDRESS in firejail --debug output). Whitelist mode hides it,


### PR DESCRIPTION
Use whitelist-ro instead of separate whitelist + read-only directives for shell config files. The two-step approach causes single files to not appear in the sandbox at all.

Also add keep-shell-rc to prevent firejail from copying the profile from /etc/skel, which would shadow the user's actual configuration.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
