### PR TITLE
[FIX] account_edi_ubl_cii: fix rounding issue

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -292,8 +292,10 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             amount_total = invoice.amount_total_signed * -invoice.direction_sign
             amount_residual = invoice.amount_residual_signed * -invoice.direction_sign
 
+        payable_rounding_amount = (node['cbc:PayableRoundingAmount'] or {}).get('_text') or 0.0
         node['cbc:PayableAmount']['_text'] = FloatFmt(
-            amount_residual,
+            amount_residual +
+            payable_rounding_amount,
             min_dp=currency.decimal_places,
         )
         node['cbc:PrepaidAmount']['_text'] = FloatFmt(


### PR DESCRIPTION
With l10n_be:
- Create the following sales order: Lines 1: qty: 25, Price: 23.90, Tax: 6%
Line 2: qty: 25, Price: 17.00, Tax: 21%
- Create a dowpayment for this SO at 50%
- Generate the peppol xml, you get the following error (link to the validator: https://peppol-ap.test.odoo.com/filevalidator/validate):

Peppol Error [code=106]: Schematron Validation Error The XML document did not pass the Schematron validation. Schematron Validation failed with error: Fatal: [BR-CO-16]-Amount due for payment (BT-115) = Invoice total amount with VAT (BT-112) -Paid amount (BT-113) +Rounding amount (BT-114).

In the override of _ubl_add_legal_monetary_total_payable_rounding_amount_node, the payable_rounding_amount was not added to the PayableAmount node like in the original method.

opw-6067736

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
