### PR TITLE
[FIX] mrp: recursively update bom from mo update

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1634,7 +1634,7 @@ class MrpProduction(models.Model):
 
         ignored_mo_ids = self.env.context.get('ignore_mo_ids', [])
         move_raws_to_adjust._adjust_procure_method()
-        moves_to_confirm._action_confirm(merge=False, create_proc=not self.env.context.get('no_procurement'))
+        moves_to_confirm._action_confirm(merge=False)
         workorder_to_confirm._action_confirm()
         workorder_to_confirm._set_cost_mode()
         # run scheduler for moves forecasted to not have enough in stock

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1632,7 +1632,7 @@ class MrpProduction(models.Model):
 
         ignored_mo_ids = self.env.context.get('ignore_mo_ids', [])
         move_raws_to_adjust._adjust_procure_method()
-        moves_to_confirm._action_confirm(merge=False, create_proc=not self.env.context.get('no_procurement'))
+        moves_to_confirm._action_confirm(merge=False)
         workorder_to_confirm._action_confirm()
         workorder_to_confirm._set_cost_mode()
         # run scheduler for moves forecasted to not have enough in stock

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -266,6 +266,31 @@ class TestProcurement(TestMrpCommon):
         self.assertAlmostEqual(mo.move_raw_ids.date, mo.date_start, delta=timedelta(seconds=1))
         self.assertAlmostEqual(mo.move_finished_ids.date, mo.date_finished, delta=timedelta(seconds=1))
 
+    def test_add_component_multi_level_bom(self):
+        mto_route = self.warehouse_1.mto_pull_id.route_id
+        mto_route.action_unarchive()
+        self.product_5.bom_ids.type = 'normal'
+        (self.product_5 | self.product_4).write({'route_ids': [Command.link(mto_route.id)]})
+        component = self.product_5
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_8.id,
+            'product_qty': 1,
+        })
+        mo.action_confirm()
+        mo_form = Form(mo)
+        with mo_form.move_raw_ids.new() as raw_move:
+            raw_move.product_id = component
+            raw_move.product_uom_qty = 1.0
+        mo = mo_form.save()
+        child_mo = mo._get_children()
+        grand_child_mo = child_mo._get_children()
+
+        self.assertRecordValues(mo.move_raw_ids, [{'product_id': component.id, 'product_qty': 1}])
+        self.assertEqual(child_mo.product_id, component)
+        self.assertRecordValues(child_mo.move_raw_ids, [{'product_id': self.product_4.id, 'product_qty': 2}, {'product_id': self.product_3.id, 'product_qty': 3}])
+        self.assertEqual(grand_child_mo.product_id, self.product_4)
+        self.assertRecordValues(grand_child_mo.move_raw_ids, [{'product_id': self.product_2.id, 'product_qty': 12}, {'product_id': self.product_1.id, 'product_qty': 24}])
+
     def test_finished_move_cancellation(self):
         """Check state of finished move on cancellation of raw moves. """
         product_bottle = self.env['product.product'].create({


### PR DESCRIPTION
When updating a mo, if the new component has a multilvl bom, it will only create a mo for the direct child and not the next

Steps to reproduce:
-------------------
* Create a products "Main", "Final", "Semi", "Raw"
* Create a Bom for "Final" with "Semi" as component
* Create a Bom for "Semi" with "Raw as component
* Add MTO on Final and Semi
* Create a MO for Main with no components and confirm it
* Add "Final" to the mo as component as save. -> The MO for "Final" is correctly created with "Semi" as component but there is no MO for "Semi" with "Raw" as component.

Observation:
-------------

When updating de MO, it will write the new SM (Final) to the production, and we will call ```_autoconfirm_production``` with ```no_procurement```: https://github.com/odoo/odoo/blob/6fb69b5640743d3bc7bb52c73cb27da428f2451c/addons/mrp/models/mrp_production.py#L1051 Where we will directly confirm the sm (```_action_confirm```).

From the SM ```_action_confirm``` we will create and run a procurement (manufacture in our case).
From the manufacture we will create the new move line for Semi and go through ```action_confirm``` on the manufacturing order:
https://github.com/odoo/odoo/blob/9ef76a4d6010191ab7ab1a0d1085972901280dda/addons/mrp/models/stock_rule.py#L116-L118
In the MO ```action_confirm```, we will confirm the move and should create new procurement for the moves that need them, but, since in our case we have ```no_procurement``` in the context, we will set ```create_proc``` to false:
https://github.com/odoo/odoo/blob/9ef76a4d6010191ab7ab1a0d1085972901280dda/addons/mrp/models/mrp_production.py#L1635
Since ```create_proc``` is false we will not create a procurement for those move lines:
https://github.com/odoo/odoo/blob/6fb69b5640743d3bc7bb52c73cb27da428f2451c/addons/stock/models/stock_move.py#L1557-L1558
https://github.com/odoo/odoo/blob/6fb69b5640743d3bc7bb52c73cb27da428f2451c/addons/stock/models/stock_move.py#L1571-L1580

opw-6005675