### PR TITLE
[I18N] purchase,repair,stock_picking_batch: translate "New" records

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -71,7 +71,7 @@ class PurchaseOrder(models.Model):
             order.invoice_ids = invoices
             order.invoice_count = len(invoices)
 
-    name = fields.Char('Order Reference', required=True, index='trigram', copy=False, default='New')
+    name = fields.Char('Order Reference', required=True, index='trigram', copy=False, default=lambda self: _('New'))
     priority = fields.Selection(
         [('0', 'Normal'), ('1', 'Urgent')], 'Priority', default='0', index=True)
     origin = fields.Char('Source Document', copy=False,
@@ -279,7 +279,7 @@ class PurchaseOrder(models.Model):
             company_id = vals.get('company_id', self.default_get(['company_id'])['company_id'])
             # Ensures default picking type and currency are taken from the right company.
             self_comp = self.with_company(company_id)
-            if vals.get('name', 'New') == 'New':
+            if vals.get('name', _('New')) == _('New'):
                 seq_date = None
                 if 'date_order' in vals:
                     seq_date = fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(vals['date_order']))

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -32,7 +32,7 @@ class Repair(models.Model):
     # Common Fields
     name = fields.Char(
         'Repair Reference',
-        default='New', index='trigram',
+        default=lambda self: _('New'), index='trigram',
         copy=False, required=True,
         readonly=True)
     company_id = fields.Many2one(
@@ -383,7 +383,7 @@ class Repair(models.Model):
             )
             if 'picking_type_id' not in vals:
                 vals['picking_type_id'] = picking_type.id
-            if not vals.get('name', False) or vals['name'] == 'New':
+            if not vals.get('name', False) or vals['name'] == _('New'):
                 vals['name'] = picking_type.sequence_id.next_by_id()
             if not vals.get('procurement_group_id'):
                 vals['procurement_group_id'] = self.env["procurement.group"].create({'name': vals['name']}).id

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -15,7 +15,7 @@ class StockPickingBatch(models.Model):
     _order = "name desc"
 
     name = fields.Char(
-        string='Batch Transfer', default='New',
+        string='Batch Transfer', default=lambda self: _('New'),
         copy=False, required=True, readonly=True)
     description = fields.Char('Description')
     user_id = fields.Many2one(


### PR DESCRIPTION
New POs, repairs, and batch pickings always showed "New" in English
for the name of a new (not saved) record. We now make it match the SO
logic to show up as translated so as to not confuse users (even though
it will automatically change to another name once saved)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
