### PR TITLE
[FIX] stock: allow opening records in forecasted report

### DIFF
--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -122,10 +122,14 @@ export class StockForecasted extends Component {
     }
 
     async openView(resModel, view, resId=false, domain = false) {
+        const views = [[false, view]];
+        if (view !== "form") {
+            views.push([false, "form"]);
+        }
         const action = {
             type: "ir.actions.act_window",
             res_model: resModel,
-            views: [[false, view]],
+            views,
             view_mode: view,
             res_id:  resId,
             domain: domain,


### PR DESCRIPTION
Steps to reproduce
==================

- Install sale_stock
- Go to Products
- Open the "Acoustic Bloc Screens" record
- Click on the Forecasted smart button
- Click on "three quotations"
- Click on a record

=> Nothing happens

opw-6095229