### PR TITLE
[FIX] mail: no longpress trigger while scrolling in inbox mobile

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -21,6 +21,12 @@ import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
+/**
+ * @param {() => HTMLElement} target
+ * @param {string} eventName
+ * @param {Function} handler
+ * @param {boolean|AddEventListenerOptions} [eventParams]
+ */
 export function useLazyExternalListener(target, eventName, handler, eventParams) {
     const boundHandler = handler.bind(useComponent());
     let t;
@@ -634,11 +640,15 @@ export function useLongPress(refName, { action, predicate = () => true } = {}) {
         clearTimeout(timer);
         timer = null;
     }
+    /** @param {TouchEvent} ev */
+    function isTouchTargetInside(ev) {
+        return ref.el?.contains(ev.target);
+    }
     useLazyExternalListener(
-        () => ref.el,
+        () => window,
         "touchstart",
         (ev) => {
-            if (!predicate()) {
+            if (!isTouchTargetInside(ev) || !predicate()) {
                 return;
             }
             const touch = ev.touches[0];
@@ -648,13 +658,14 @@ export function useLongPress(refName, { action, predicate = () => true } = {}) {
                 action();
                 reset();
             }, LONG_PRESS_DELAY);
-        }
+        },
+        true
     );
     useLazyExternalListener(
-        () => ref.el,
+        () => window,
         "touchmove",
         (ev) => {
-            if (!timer) {
+            if (!isTouchTargetInside(ev) || !timer) {
                 return;
             }
             const touch = ev.touches[0];
@@ -663,10 +674,29 @@ export function useLongPress(refName, { action, predicate = () => true } = {}) {
             if (Math.hypot(dx, dy) > MOVE_TRESHOLD) {
                 reset();
             }
-        }
+        },
+        true
     );
-    useLazyExternalListener(() => ref.el, "touchend", reset);
-    useLazyExternalListener(() => ref.el, "touchcancel", reset);
+    useLazyExternalListener(
+        () => window,
+        "touchend",
+        (ev) => {
+            if (isTouchTargetInside(ev)) {
+                reset();
+            }
+        },
+        true
+    );
+    useLazyExternalListener(
+        () => window,
+        "touchcancel",
+        (ev) => {
+            if (isTouchTargetInside(ev)) {
+                reset();
+            }
+        },
+        true
+    );
 }
 
 export const inDiscussCallViewProps = ["isPip?"];


### PR DESCRIPTION
Before this commit, when in inbox mobile and scrolling & swiping on inbox notifications, the message actions was displayed at the same time.

Steps to reproduce:
- have Admin with "Handle in Odoo" Notification preferences
- have some messages in Inbox (e.g. receive @ mentions from chatter)
- open Inbox in Discuss app in mobile, and scroll up / swipe horizontally on each message

=> this opens message actions in bottom sheet

This happens because when scrolling up/down or swiping left/right on a message, this is triggering a longpress. The longpress has some dedicated code to detect that there's no scrolling or swipe at the same time, however since 1 the action swiper was changed and made this regression. This happens because 1 introduced some
`ev.stopPropagation()` on touch event, which are crucial for the hook useLongPress() to determine whether a scroll or swipe is occuring. Because the events have been stopped, the useLongPress() wrongly assumes the user triggers a long press.

One could think we could use capture in useLongPress(), which is generally the way to prevent this issue. However, ActionSwiper is stopping propagation at the capture mode, therefore giving no chance for useLongPress() to detect the touch events.

Thankfully the capture event listener target is the `ActionSwiper` itself, so one solution is to register in capture mode in a broader scope like `window`. This commit fixes the issue by registering on `capture` of the touch event on `window` for `useLongPress()`.

Task-6008171

Scroll up in inbox, Before / After:
![before](https://github.com/user-attachments/assets/14453752-e6bb-41ed-8947-969680222588)
![after](https://github.com/user-attachments/assets/5bc5ce81-4088-4b37-bb37-c18ffd2d5da7)
