### PR TITLE
[PERF] website_sale: make has_published_products stored

### DIFF
--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -295,7 +295,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 43  # To increase this number you must ask the permission to al
+        query_count = 42  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
             'website': 1,
@@ -303,7 +303,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             'product_pricelist': 4,
             'product_template': 3,
             'product_tag': 1,
-            'product_public_category': 2,
+            'product_public_category': 1,
             'product_product': 1,
             'product_template_attribute_line': 2,
             'res_users': 1,

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -2,7 +2,6 @@
 
 from odoo import api, fields, models
 from odoo.fields import Domain
-from odoo.tools.sql import SQL
 from odoo.tools.translate import html_translate
 
 from odoo.addons.website_sale.const import SHOP_PATH
@@ -60,8 +59,8 @@ class ProductPublicCategory(models.Model):
     )
     has_published_products = fields.Boolean(
         compute="_compute_has_published_products",
-        search="_search_has_published_products",
-        compute_sudo=True,
+        store=True,
+        recursive=True,
     )
 
     website_description = fields.Html(
@@ -138,37 +137,13 @@ class ProductPublicCategory(models.Model):
                     category
                 )
 
-    @api.depends_context("company", "website_id")
+    @api.depends("product_tmpl_ids.is_published", "child_id.has_published_products")
     def _compute_has_published_products(self):
-        has_published_products = self.search(
-            # See also :meth:`_search_has_published_products`
-            Domain([("has_published_products", "=", True), ("id", "in", self.ids)]),
-            order="id",
-        )
-        has_published_products.has_published_products = True
-        (self - has_published_products).has_published_products = False
-
-    # === SEARCH METHODS === #
-
-    @api.model
-    def _search_has_published_products(self, operator, value):
-        if not (operator == "in" and True in value):
-            return NotImplemented
-
-        published_products_domain = (
-            Domain([("active", "=", True), ("is_published", "=", True)])
-            & self.env["website"].sale_product_domain()
-        )
-        # Bypass access rules in the subquery to avoid adding `has_published_products = True` twice.
-        subquery = self._search(
-            Domain("product_tmpl_ids", "any", published_products_domain), bypass_access=True
-        )
-        parents_and_self_have_published_products = SQL(
-            "SELECT unnest(string_to_array(left(c.parent_path, -1), '/'))::integer FROM %s c",
-            subquery.subselect(subquery.table.parent_path),
-        )
-
-        return Domain("id", "any", parents_and_self_have_published_products)
+        for category in self:
+            category.has_published_products = (
+                any(p.is_published for p in category.product_tmpl_ids.with_context(prefetch_fields=False))
+                or any(c.has_published_products for c in category.child_id)
+            )
 
     # === BUSINESS METHODS === #
 


### PR DESCRIPTION
`has_published_products` is read on every render of the /shop page, to determine if each category is displayed to the public user. However, computing it presents a bottleneck when querying databases with a large `product_public_category_product_template_rel` table.

Given the read-heavy nature of the field, it should be stored to improve the performance while rendering /shop.

Benchmark opening /shop with 250,000 products
|Render time before|Render time after|Total before|Total after|
|------------------|-----------------|------------|-----------|
|1.52s             |0.52s            |3.82s       |2.80s      |

opw-5969878