### PR TITLE
[FIX] account,purchase: ignore empty origin refs

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4093,7 +4093,7 @@ class AccountMove(models.Model):
 
     def _link_bill_origin_to_purchase_orders(self, timeout=10):
         for move in self.filtered(lambda m: m.move_type in self.get_purchase_types()):
-            references = [ref.strip() for ref in move.invoice_origin.split(',')] if move.invoice_origin else []
+            references = re.findall(r"[^,\s]+", move.invoice_origin or "")
             move._find_and_set_purchase_orders(references, move.partner_id.id, move.amount_total, timeout=timeout)
         return self
 

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -1096,3 +1096,14 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         self.assertTrue(bill.id in po.invoice_ids.ids)
         self.assertTrue(bill.id in po_2.invoice_ids.ids)
         self.assertEqual(bill.amount_total, po.amount_total + po_2.amount_total)
+
+    def test_link_bill_origin_skips_whitespace(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order])
+        po.partner_ref = ''  # don't matching on empty reference
+
+        bill = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order, self.service_order])
+        bill.invoice_origin = ' '
+
+        bill._link_bill_origin_to_purchase_orders()
+
+        self.assertFalse(po.invoice_ids)


### PR DESCRIPTION
`invoice_origin` is parsed to build the references passed to `_match_purchase_orders()`.

Since odoo/odoo#223398, we split this field on commas so values like `"P00001, P00002"` correctly become `["P00001", "P00002"]`.

That still leaves a bad case: blank or whitespace-only content still produces empty refs. For example, `","` becomes `['', '']`, and since https://github.com/odoo/odoo/pull/225294 on 18.4+ during foward port it's gotten even worse: " commission" becomes `['', 'commission']`

This problematic because `invoice_origin` does not always contain real PO refs. Since odoo/odoo#207037, XML imports can also fill it with concatenated line descriptions which contains arbitrary text. We recently hit this on odoo.com with a Peppol bill where this led to parsed refs including `''`.

Once `['']` is passed to `_match_purchase_orders()`, POs with an empty `partner_ref` can enter the candidate set. From there, the normal amount or line matching can link the bill to a wrong PO (which will always happen with the number of POs and PO lines we have on prod)
