### PR TITLE
[IMP] l10n_ar_stock: support batch remito generation

### DIFF
--- a/addons/l10n_ar_stock/__manifest__.py
+++ b/addons/l10n_ar_stock/__manifest__.py
@@ -5,6 +5,8 @@
     'depends': ['l10n_ar', 'stock_account'],
     'data': [
         # data
+        'data/ir_actions_server_data.xml',
+        'data/ir_cron_data.xml',
         'data/mail_template_data.xml',
         # Views
         'views/stock_picking_type_views.xml',

--- a/addons/l10n_ar_stock/data/ir_actions_server_data.xml
+++ b/addons/l10n_ar_stock/data/ir_actions_server_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_generate_delivery_guide" model="ir.actions.server">
+        <field name="name">Generate Delivery Guide</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.l10n_ar_action_create_delivery_guide()</field>
+    </record>
+    <record id="action_send_delivery_guide" model="ir.actions.server">
+        <field name="name">Send Delivery Guide</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.l10n_ar_action_send_delivery_guide(do_async=True)</field>
+    </record>
+</odoo>

--- a/addons/l10n_ar_stock/data/ir_cron_data.xml
+++ b/addons/l10n_ar_stock/data/ir_cron_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_l10n_ar_send_delivery_guide" model="ir.cron">
+            <field name="name">Argentina: Send queued delivery guides</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="model_id" ref="stock.model_stock_picking"/>
+            <field name="code">model._cron_l10n_ar_send_delivery_guide()</field>
+            <field name="state">code</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_ar_stock/models/stock_picking.py
+++ b/addons/l10n_ar_stock/models/stock_picking.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -16,6 +16,11 @@ class StockPicking(models.Model):
     )
     l10n_ar_allow_send_delivery_guide = fields.Boolean(
         compute="_compute_l10n_ar_delivery_guide_flags",
+    )
+    l10n_ar_delivery_guide_cron_user_id = fields.Many2one(
+        comodel_name="res.users",
+        readonly=True,
+        copy=False,
     )
 
     # === COMPUTE METHODS === #
@@ -38,18 +43,34 @@ class StockPicking(models.Model):
 
     def l10n_ar_action_create_delivery_guide(self):
         """
-        Create the delivery guide number and store CAI data for the stock picking.
+        Create the delivery guide number and store CAI data for the selected stock pickings.
         """
-        self.ensure_one()
+        already_generated = not_done = no_doc_type = self.env['stock.picking']
+        for picking in self:
+            if picking.l10n_ar_delivery_guide_number:
+                already_generated += picking
+            elif picking.state != 'done':
+                not_done += picking
+            elif not picking.picking_type_id.l10n_ar_document_type_id:
+                no_doc_type += picking
+        errors = []
+        if already_generated:
+            errors.append(self.env._("- %(names)s already have a delivery guide.", names=already_generated.mapped('name')))
+        if not_done:
+            errors.append(self.env._("- %(names)s must be validated before generating a delivery guide.", names=not_done.mapped('name')))
+        if no_doc_type:
+            errors.append(self.env._("- The operation types on the deliveries are not configured for delivery guides: %(names)s.", names=no_doc_type.mapped('name')))
+        if errors:
+            raise UserError(self.env._("Cannot generate delivery guides for the following transfers:\n%(transfers)s", transfers="\n".join(errors)))
 
-        if not self.l10n_ar_delivery_guide_number:
-            picking_type = self.picking_type_id
+        for picking in self:
+            picking_type = picking.picking_type_id
             new_sequence_number = picking_type.l10n_ar_next_delivery_number
             delivery_guide_number = picking_type.l10n_ar_sequence_id.next_by_id()
             if not int(picking_type.l10n_ar_sequence_number_start) <= new_sequence_number <= int(picking_type.l10n_ar_sequence_number_end):
-                raise UserError(_("The delivery guide number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range.", delivery_guide_number))
-            self.l10n_ar_delivery_guide_number = delivery_guide_number
-            self.l10n_ar_cai_data = {
+                raise UserError(self.env._("The delivery guide number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range.", delivery_guide_number))
+            picking.l10n_ar_delivery_guide_number = delivery_guide_number
+            picking.l10n_ar_cai_data = {
                 'document_type_id': picking_type.l10n_ar_document_type_id.id,
                 'cai_authorization_code': picking_type.l10n_ar_cai_authorization_code,
                 'cai_expiration_date': picking_type.l10n_ar_cai_expiration_date.strftime('%Y-%m-%d'),
@@ -57,35 +78,189 @@ class StockPicking(models.Model):
                 'sequence_number_end': picking_type.l10n_ar_sequence_number_end,
             }
 
-    def l10n_ar_action_send_delivery_guide(self):
+    def l10n_ar_action_send_delivery_guide(self, do_async=False):
+        """ Send the delivery guide to the proper partners.
+            :param do_async: If True, queue the sending via cron instead of sending immediately."""
+        self._l10n_ar_validate_send_delivery_guide()
+        if not do_async:
+            self._l10n_ar_send_delivery_guide(force_send=True)
+            return None
+        self.l10n_ar_delivery_guide_cron_user_id = self.env.user
+        self.env.ref('l10n_ar_stock.ir_cron_l10n_ar_send_delivery_guide')._trigger()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'info',
+                'title': self.env._('Processing Delivery Guides'),
+                'message': self.env._('Delivery guides are being sent in the background.'),
+                'next': {'type': 'ir.actions.act_window_close'},
+            },
+        }
+
+    def _l10n_ar_validate_send_delivery_guide(self, do_async=False):
+        """ Validate that all pickings in self are eligible for sending delivery guides. """
+        no_doc_type = no_number = no_email = already_queued = self.env['stock.picking']
+        for picking in self:
+            if not picking.picking_type_id.l10n_ar_document_type_id:
+                no_doc_type += picking
+            elif not picking.l10n_ar_delivery_guide_number:
+                no_number += picking
+            elif not picking.partner_id.email:
+                no_email += picking
+            elif picking.l10n_ar_delivery_guide_cron_user_id:
+                already_queued += picking
+        if do_async:
+            # We don't care about already_queued as this is call during the queued cron.
+            return {
+                'no_doc_type': no_doc_type,
+                'no_number': no_number,
+                'no_email': no_email,
+                'all_errors': no_doc_type + no_number + no_email,
+            }
+        errors = []
+        if no_doc_type:
+            errors.append(self.env._("- The operation types on the deliveries are not configured for delivery guides: %(names)s.", names=no_doc_type.mapped('name')))
+        if no_number:
+            errors.append(self.env._("- No delivery guide has been generated yet for the following deliveries: %(names)s.", names=no_number.mapped('name')))
+        if no_email:
+            errors.append(self.env._("- The contacts on the following deliveries have no email address: %(names)s.", names=no_email.mapped('name')))
+        if already_queued:
+            errors.append(self.env._("- The following deliveries are already queued for sending: %(names)s.", names=already_queued.mapped('name')))
+        if errors:
+            raise UserError(self.env._("Cannot send delivery guides for the following transfers:\n%(transfers)s", transfers="\n".join(errors)))
+        return {}
+
+    def _l10n_ar_send_delivery_guide(self, force_send=False):
+        """ Send the delivery guide email for each picking in self.
+
+        PDFs are rendered in a single wkhtmltopdf call and split per record,
+        which is dramatically faster than per-record rendering for batches.
         """
-        Send the delivery guide to the partner.
-        """
-        self.ensure_one()
-        if not self.partner_id.email:
-            raise UserError(_("The partner does not have an email address."))
         template = self.env.ref('l10n_ar_stock.email_template_ar_remitos_delivery_guide')
         pdf_action = self.env.ref('l10n_ar_stock.action_delivery_guide_report_pdf')
-        pdf_content, __ = self.env['ir.actions.report'].sudo()._render_qweb_pdf(pdf_action, self.id)
-        pdf_attachment = self.env['ir.attachment'].create({
-            'name': f'Remito - {self.l10n_ar_delivery_guide_number}.pdf',
+
+        pdf_contents = self._l10n_ar_render_delivery_guide_pdfs(pdf_action)
+
+        attachment_vals = [{
+            'name': f'Remito - {picking.l10n_ar_delivery_guide_number}.pdf',
             'type': 'binary',
-            'raw': pdf_content,
+            'raw': pdf_contents[picking.id],
             'res_model': self._name,
-            'res_id': self.id,
+            'res_id': picking.id,
             'mimetype': 'application/pdf',
-        })
-        composer = self.env['mail.compose.message'].with_context(
-            default_model='stock.picking',
-            active_model='stock.picking',
-            active_id=self.id,
-            default_res_ids=self.ids,
-            default_use_template=True,
-            default_template_id=template.id,
-            default_composition_mode='comment',
-            default_email_layout_xmlid='mail.mail_notification_layout_with_responsible_signature',
-            force_email=True,
-        ).create({
-            'attachment_ids': pdf_attachment.ids,
-        })
-        composer._action_send_mail()
+        } for picking in self]
+        attachments = self.env['ir.attachment'].create(attachment_vals)
+
+        for picking, attachment in zip(self, attachments):
+            picking.with_context(
+                mail_notify_force_send=force_send,
+            ).message_post_with_source(
+                template,
+                subtype_xmlid='mail.mt_comment',
+                email_layout_xmlid='mail.mail_notification_layout_with_responsible_signature',
+                attachment_ids=attachment.ids,
+            )
+
+    def _l10n_ar_render_delivery_guide_pdfs(self, pdf_action):
+        """ Batch-render delivery guide PDFs, returning {picking_id: pdf_bytes}.
+
+        Falls back to per-record rendering if the batched merge step fails
+        (wkhtmltopdf can refuse to merge multiple documents on unpatched QT,
+        and the merge helper raises UserError when pypdf can't stitch the
+        intermediate PDFs together).
+        """
+        report_sudo = self.env['ir.actions.report'].sudo()
+        try:
+            collected_streams, report_type = report_sudo._pre_render_qweb_pdf(pdf_action, self.ids)
+            if report_type != 'pdf':
+                # In test environments _pre_render_qweb_pdf falls back to
+                # _render_qweb_html which returns raw bytes, not a stream dict.
+                return {picking.id: collected_streams for picking in self}
+            return {
+                res_id: stream_data['stream'].getvalue()
+                for res_id, stream_data in collected_streams.items()
+                if stream_data.get('stream')
+            }
+        except UserError:
+            pdf_contents = {}
+            for picking in self:
+                pdf_content, _unused = report_sudo._render_qweb_pdf(pdf_action, picking.id)
+                pdf_contents[picking.id] = pdf_content
+            return pdf_contents
+
+    def _l10n_ar_handle_cron_failures(self, errors):
+        """ Dequeue failed records: log in chatter, notify users, clear cron field. """
+        failed = errors['all_errors']
+        error_messages = {
+            'no_doc_type': self.env._("Delivery guide could not be sent: the operation type is not configured for delivery guides."),
+            'no_number': self.env._("Delivery guide could not be sent: no delivery guide number has been generated."),
+            'no_email': self.env._("Delivery guide could not be sent: the contact has no email address."),
+        }
+        for error_key, message in error_messages.items():
+            for picking in errors.get(error_key, self.env['stock.picking']):
+                picking.message_post(body=message, message_type='notification')
+        for user, user_pickings in failed.grouped('l10n_ar_delivery_guide_cron_user_id').items():
+            user._bus_send(
+                'account_notification',
+                {
+                    'type': 'warning',
+                    'title': self.env._('Delivery Guide Send Failed'),
+                    'message': self.env._(
+                        'The following Delivery Guides could not be sent due to validation errors:\n%(errors)s',
+                        errors="\n".join(user_pickings.mapped('name')),
+                    ),
+                    'action_button': {
+                        'name': self.env._('Open'),
+                        'action_name': self.env._('Failed Delivery Guides'),
+                        'model': 'stock.picking',
+                        'res_ids': user_pickings.ids,
+                    },
+                },
+            )
+        failed.write({'l10n_ar_delivery_guide_cron_user_id': False})
+
+    def _cron_l10n_ar_send_delivery_guide(self, batch_size=50):
+        """ Cron method: process queued delivery guide sends in batches. """
+        domain = [
+            ('l10n_ar_delivery_guide_cron_user_id', '!=', False),
+        ]
+        records = self.search(domain, order='id asc', limit=batch_size).try_lock_for_update()
+        records_len = len(records)
+        if not records:
+            return
+
+        # Re-validate: fields may have changed since queueing.
+        errors = records._l10n_ar_validate_send_delivery_guide(do_async=True)
+        if errors.get('all_errors'):
+            self._l10n_ar_handle_cron_failures(errors)
+            records -= errors['all_errors']
+
+        if not records:
+            remaining = self.search_count(domain)
+            self.env['ir.cron']._commit_progress(records_len, remaining=remaining)
+            return
+
+        pickings_by_user = records.grouped('l10n_ar_delivery_guide_cron_user_id')
+        for user, user_pickings in pickings_by_user.items():
+            user_pickings.with_user(user)._l10n_ar_send_delivery_guide()
+
+        for user, user_pickings in pickings_by_user.items():
+            user._bus_send(
+                'account_notification',
+                {
+                    'type': 'success',
+                    'title': self.env._('Delivery Guides Sent'),
+                    'message': self.env._('The following Delivery Guide emails have been sent successfully.'),
+                    'action_button': {
+                        'name': self.env._('Open'),
+                        'action_name': self.env._('Sent Delivery Guides'),
+                        'model': 'stock.picking',
+                        'res_ids': user_pickings.ids,
+                    },
+                },
+            )
+        records.write({'l10n_ar_delivery_guide_cron_user_id': False})
+
+        remaining = self.search_count(domain)
+        self.env['ir.cron']._commit_progress(records_len, remaining=remaining)

--- a/addons/l10n_ar_stock/tests/__init__.py
+++ b/addons/l10n_ar_stock/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_l10n_ar_delivery_guide
+from . import test_l10n_ar_delivery_guide_batch

--- a/addons/l10n_ar_stock/tests/test_l10n_ar_delivery_guide.py
+++ b/addons/l10n_ar_stock/tests/test_l10n_ar_delivery_guide.py
@@ -55,11 +55,15 @@ class TestArDeliveryGuide(TestArCommon, MailCommon):
         }
 
     def get_stock_picking(self, stock_picking_args=None, move_lines_args=None):
-        """Create and validate a stock picking."""
+        """Helper method to create and validate a single stock picking."""
+        return self.get_stock_pickings(stock_picking_args=stock_picking_args, move_lines_args=move_lines_args, count=1)
+
+    def get_stock_pickings(self, stock_picking_args=None, move_lines_args=None, count=3):
+        """Create and validate multiple stock pickings."""
         stock_picking_vals = self._get_stock_picking_vals(move_lines_args)
         if stock_picking_args:
             stock_picking_vals.update(stock_picking_args)
-        stock_picking = self.env['stock.picking'].create(stock_picking_vals)
+        stock_picking = self.env['stock.picking'].create([dict(stock_picking_vals) for _ in range(count)])
         stock_picking.action_confirm()
         stock_picking.button_validate()
         return stock_picking

--- a/addons/l10n_ar_stock/tests/test_l10n_ar_delivery_guide_batch.py
+++ b/addons/l10n_ar_stock/tests/test_l10n_ar_delivery_guide_batch.py
@@ -1,0 +1,192 @@
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ar_stock.tests.test_l10n_ar_delivery_guide import (
+    TestArDeliveryGuide,
+)
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestArDeliveryGuideBatch(TestArDeliveryGuide):
+    """ Tests for the multi-record / batch delivery guide."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cron = cls.env.ref('l10n_ar_stock.ir_cron_l10n_ar_send_delivery_guide')
+
+    @staticmethod
+    def _stub_render(recordset, _pdf_action):
+        """ Patch target for `_l10n_ar_render_delivery_guide_pdfs` so cron tests
+        don't shell out to wkhtmltopdf. Bound to the recordset via `patch.object`. """
+        return {p.id: b'%PDF-stub' for p in recordset}
+
+    # === l10n_ar_action_create_delivery_guide (multi) === #
+
+    def test_create_delivery_guide_multi(self):
+        """ Generating delivery guides on a recordset assigns a unique number to each picking. """
+        pickings = self.get_stock_pickings(count=3)
+        pickings.l10n_ar_action_create_delivery_guide()
+
+        numbers = pickings.mapped('l10n_ar_delivery_guide_number')
+        self.assertEqual(len(set(numbers)), 3, "Each picking should get a distinct delivery guide number.")
+        self.assertTrue(all(numbers), "All pickings should have a delivery guide number.")
+        for picking in pickings:
+            self.assertTrue(picking.l10n_ar_cai_data, "CAI data should be stored on each picking.")
+
+    def test_create_delivery_guide_collects_errors(self):
+        """ When some pickings are ineligible the error message lists each offender; no number is assigned. """
+        ok_picking = self.get_stock_picking()
+        already_done = self.get_stock_picking()
+        already_done.l10n_ar_action_create_delivery_guide()
+        existing_number = already_done.l10n_ar_delivery_guide_number
+
+        with self.assertRaisesRegex(UserError, rf"{already_done.name}.*already have a delivery guide"):
+            (ok_picking | already_done).l10n_ar_action_create_delivery_guide()
+
+        self.assertFalse(
+            ok_picking.l10n_ar_delivery_guide_number,
+            "When validation fails, no picking in the batch should be mutated.",
+        )
+        self.assertEqual(
+            already_done.l10n_ar_delivery_guide_number, existing_number,
+            "An already-generated number must not be overwritten.",
+        )
+
+    # === l10n_ar_action_send_delivery_guide_batch === #
+
+    def test_send_batch_queues_records(self):
+        """ The batch send action queues records on the cron and returns a notification. """
+        pickings = self.get_stock_pickings(count=3)
+        pickings.l10n_ar_action_create_delivery_guide()
+
+        action = pickings.l10n_ar_action_send_delivery_guide(do_async=True)
+
+        self.assertEqual(action['tag'], 'display_notification')
+        for picking in pickings:
+            self.assertEqual(picking.l10n_ar_delivery_guide_cron_user_id, self.env.user)
+
+    def test_send_batch_validation_errors(self):
+        """ Validation collects per-picking failures (no number, no email, already queued). """
+        no_number = self.get_stock_picking()  # done but no guide number generated yet
+        no_email_partner = self.env['res.partner'].create({'name': 'No Email Co'})
+        no_email = self.get_stock_picking(stock_picking_args={'partner_id': no_email_partner.id})
+        no_email.l10n_ar_action_create_delivery_guide()
+
+        with self.assertRaisesRegex(UserError, "No delivery guide has been generated yet"):
+            (no_number | no_email).l10n_ar_action_send_delivery_guide(do_async=True)
+
+    def test_send_batch_already_queued(self):
+        """ A picking already queued for sending cannot be re-queued. """
+        picking = self.get_stock_picking()
+        picking.l10n_ar_action_create_delivery_guide()
+        picking.l10n_ar_action_send_delivery_guide(do_async=True)
+
+        with self.assertRaisesRegex(UserError, "already queued"):
+            picking.l10n_ar_action_send_delivery_guide(do_async=True)
+
+    # === Cron processing === #
+
+    def test_cron_sends_grouped_per_user(self):
+        """ The cron sends queued guides, marks them processed, and clears state per user. """
+        pickings = self.get_stock_pickings(count=2)
+        pickings.l10n_ar_action_create_delivery_guide()
+        pickings.l10n_ar_action_send_delivery_guide(do_async=True)
+
+        StockPicking = self.env.registry['stock.picking']
+        with patch.object(
+            StockPicking, '_l10n_ar_render_delivery_guide_pdfs', self._stub_render,
+        ), self.mock_mail_gateway(), self.enter_registry_test_mode():
+            self.cron.method_direct_trigger()
+
+        # One mail per picking
+        self.assertEqual(len(self._new_mails), 2)
+        # State cleared once the user has no more pending records
+        for picking in pickings:
+            self.assertFalse(picking.l10n_ar_delivery_guide_cron_user_id)
+
+    def test_cron_respects_batch_size(self):
+        """ The cron only processes `batch_size` records per call; the rest stay queued. """
+        pickings = self.get_stock_pickings(count=3)
+        pickings.l10n_ar_action_create_delivery_guide()
+        pickings.l10n_ar_action_send_delivery_guide(do_async=True)
+
+        StockPicking = self.env.registry['stock.picking']
+        IrCron = self.env.registry['ir.cron']
+        # method_direct_trigger doesn't accept kwargs, so call the cron method
+        # directly. That bypasses the registry-test-mode cursor swap, so stub
+        # _commit_progress to avoid its forbidden cr.commit().
+        with patch.object(
+            StockPicking, '_l10n_ar_render_delivery_guide_pdfs', self._stub_render,
+        ), patch.object(IrCron, '_commit_progress'), self.mock_mail_gateway():
+            self.env['stock.picking']._cron_l10n_ar_send_delivery_guide(batch_size=2)
+
+        remaining = pickings.filtered('l10n_ar_delivery_guide_cron_user_id')
+        self.assertEqual(len(remaining), 1)
+
+    def test_cron_noop_when_queue_empty(self):
+        """ Cron is a no-op when nothing is queued. """
+        # Should not raise nor send anything.
+        with self.mock_mail_gateway(), self.enter_registry_test_mode():
+            self.cron.method_direct_trigger()
+        self.assertFalse(self._new_mails)
+
+    def test_cron_dequeues_invalid_records(self):
+        """ When a queued picking becomes invalid before the cron fires, it is
+        dequeued (cron user cleared, chatter note logged) while valid ones are still sent. """
+        no_email_partner = self.env['res.partner'].create({'name': 'Will Lose Email', 'email': 'temp@test.com'})
+        valid = self.get_stock_picking()
+        invalid = self.get_stock_picking(stock_picking_args={'partner_id': no_email_partner.id})
+        (valid | invalid).l10n_ar_action_create_delivery_guide()
+        (valid | invalid).l10n_ar_action_send_delivery_guide(do_async=True)
+
+        # Simulate field change after queueing: remove email from the partner.
+        no_email_partner.email = False
+
+        StockPicking = self.env.registry['stock.picking']
+        with patch.object(
+            StockPicking, '_l10n_ar_render_delivery_guide_pdfs', self._stub_render,
+        ), self.mock_mail_gateway(), self.enter_registry_test_mode():
+            self.cron.method_direct_trigger()
+
+        # Valid picking: sent and dequeued.
+        self.assertEqual(len(self._new_mails), 1)
+        self.assertFalse(valid.l10n_ar_delivery_guide_cron_user_id)
+
+        # Invalid picking: dequeued with chatter note, no mail sent.
+        self.assertFalse(invalid.l10n_ar_delivery_guide_cron_user_id)
+        chatter_messages = invalid.message_ids.filtered(
+            lambda m: 'no email address' in (m.body or ''),
+        )
+        self.assertTrue(chatter_messages, "A chatter note should explain why the record was dequeued.")
+
+    def test_render_fallback_on_batch_failure(self):
+        """ If batched PDF rendering fails, the helper falls back to per-record rendering. """
+        pickings = self.get_stock_pickings(count=2)
+        pickings.l10n_ar_action_create_delivery_guide()
+
+        report_action = self.env.ref('l10n_ar_stock.action_delivery_guide_report_pdf')
+        IrActionsReport = self.env.registry['ir.actions.report']
+
+        call_counter = {'pre': 0, 'render': 0}
+
+        boom_msg = "simulated batch failure"
+
+        def boom_pre(*_args, **_kwargs):
+            call_counter['pre'] += 1
+            raise UserError(boom_msg)
+
+        def fake_render(*_args, **_kwargs):
+            call_counter['render'] += 1
+            return (b'%PDF-fallback', 'pdf')
+
+        with patch.object(IrActionsReport, '_pre_render_qweb_pdf', boom_pre), \
+             patch.object(IrActionsReport, '_render_qweb_pdf', fake_render):
+            result = pickings._l10n_ar_render_delivery_guide_pdfs(report_action)
+
+        self.assertEqual(call_counter['pre'], 1)
+        self.assertEqual(call_counter['render'], 2)
+        self.assertEqual(set(result.keys()), set(pickings.ids))
+        self.assertTrue(all(v == b'%PDF-fallback' for v in result.values()))

--- a/addons/l10n_ar_stock_batch/__init__.py
+++ b/addons/l10n_ar_stock_batch/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_ar_stock_batch/__manifest__.py
+++ b/addons/l10n_ar_stock_batch/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Argentinean Stock - Batch Transfers',
+    'description': """Bridge module for Argentine delivery guides on batch transfers.""",
+    'category': 'Accounting/Localizations',
+    'depends': ['l10n_ar_stock', 'stock_picking_batch'],
+    'data': [
+        'data/ir_actions_server_data.xml',
+        'views/stock_picking_batch_views.xml',
+    ],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ar_stock_batch/data/ir_actions_server_data.xml
+++ b/addons/l10n_ar_stock_batch/data/ir_actions_server_data.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_generate_delivery_guide" model="ir.actions.server">
+        <field name="name">Generate Delivery Guides</field>
+        <field name="model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
+        <field name="binding_model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.l10n_ar_action_create_delivery_guide()</field>
+    </record>
+    <record id="action_send_delivery_guide" model="ir.actions.server">
+        <field name="name">Send Delivery Guides</field>
+        <field name="model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
+        <field name="binding_model_id" ref="stock_picking_batch.model_stock_picking_batch"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.l10n_ar_action_send_delivery_guide()</field>
+    </record>
+</odoo>
+

--- a/addons/l10n_ar_stock_batch/models/__init__.py
+++ b/addons/l10n_ar_stock_batch/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_batch

--- a/addons/l10n_ar_stock_batch/models/stock_picking_batch.py
+++ b/addons/l10n_ar_stock_batch/models/stock_picking_batch.py
@@ -1,0 +1,34 @@
+from odoo import api, fields, models
+
+
+class StockPickingBatch(models.Model):
+    _inherit = 'stock.picking.batch'
+
+    l10n_ar_show_generate_delivery_guide = fields.Boolean(
+        compute="_compute_l10n_ar_delivery_guide_buttons",
+    )
+    l10n_ar_show_send_delivery_guide = fields.Boolean(
+        compute="_compute_l10n_ar_delivery_guide_buttons",
+    )
+
+    @api.depends(
+        'picking_type_id.l10n_ar_document_type_id',
+        'picking_ids.l10n_ar_allow_generate_delivery_guide',
+        'picking_ids.l10n_ar_allow_send_delivery_guide',
+    )
+    def _compute_l10n_ar_delivery_guide_buttons(self):
+        for batch in self:
+            is_done = batch.state == 'done'
+            has_doc_type = bool(batch.picking_type_id.l10n_ar_document_type_id)
+            batch.l10n_ar_show_generate_delivery_guide = (
+                has_doc_type and is_done and any(batch.picking_ids.mapped('l10n_ar_allow_generate_delivery_guide'))
+            )
+            batch.l10n_ar_show_send_delivery_guide = (
+                has_doc_type and is_done and any(batch.picking_ids.mapped('l10n_ar_allow_send_delivery_guide'))
+            )
+
+    def l10n_ar_action_create_delivery_guide(self):
+        self.picking_ids.filtered('l10n_ar_allow_generate_delivery_guide').l10n_ar_action_create_delivery_guide()
+
+    def l10n_ar_action_send_delivery_guide(self):
+        self.picking_ids.filtered('l10n_ar_allow_send_delivery_guide').l10n_ar_action_send_delivery_guide(do_async=True)

--- a/addons/l10n_ar_stock_batch/tests/__init__.py
+++ b/addons/l10n_ar_stock_batch/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_ar_stock_batch

--- a/addons/l10n_ar_stock_batch/tests/test_l10n_ar_stock_batch.py
+++ b/addons/l10n_ar_stock_batch/tests/test_l10n_ar_stock_batch.py
@@ -1,0 +1,75 @@
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ar_stock.tests.test_l10n_ar_delivery_guide import (
+    TestArDeliveryGuide,
+)
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestArStockBatch(TestArDeliveryGuide):
+    """Tests for the l10n_ar_stock_batch bridge module."""
+
+    def _create_batch_with_pickings(self, count=2, validate=True):
+        """Create pickings inside a batch. Pickings must be added before
+        validation because the batch sanity check forbids done pickings."""
+        vals = self._get_stock_picking_vals()
+        pickings = self.env["stock.picking"].create([dict(vals) for _ in range(count)])
+        pickings.action_confirm()
+
+        batch = self.env["stock.picking.batch"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "picking_ids": [(4, p.id) for p in pickings],
+            },
+        )
+        if validate:
+            pickings.button_validate()
+        return batch, pickings
+
+    # --- Computed button visibility --- #
+
+    def test_show_generate_button_on_done_batch(self):
+        """Done batch with eligible pickings shows the generate button."""
+        batch, _ = self._create_batch_with_pickings()
+
+        self.assertTrue(batch.l10n_ar_show_generate_delivery_guide)
+        self.assertFalse(batch.l10n_ar_show_send_delivery_guide)
+
+    def test_hide_buttons_when_batch_not_done(self):
+        """Buttons are hidden when the batch pickings are not yet done."""
+        batch, _ = self._create_batch_with_pickings(validate=False)
+
+        self.assertFalse(batch.l10n_ar_show_generate_delivery_guide)
+        self.assertFalse(batch.l10n_ar_show_send_delivery_guide)
+
+    def test_show_send_button_after_generation(self):
+        """After generating guides, send button appears and generate hides."""
+        batch, pickings = self._create_batch_with_pickings()
+        pickings.l10n_ar_action_create_delivery_guide()
+
+        self.assertFalse(batch.l10n_ar_show_generate_delivery_guide)
+        self.assertTrue(batch.l10n_ar_show_send_delivery_guide)
+
+    # --- Delegation methods --- #
+
+    def test_create_delivery_guide_delegates_to_eligible(self):
+        """Only pickings without a guide number get one when called via batch."""
+        batch, pickings = self._create_batch_with_pickings()
+        # Pre-generate a guide on the first picking
+        pickings[0].l10n_ar_action_create_delivery_guide()
+        existing_number = pickings[0].l10n_ar_delivery_guide_number
+
+        batch.l10n_ar_action_create_delivery_guide()
+
+        self.assertEqual(pickings[0].l10n_ar_delivery_guide_number, existing_number)
+        self.assertTrue(pickings[1].l10n_ar_delivery_guide_number)
+
+    def test_send_delivery_guide_delegates_async(self):
+        """Batch send queues eligible pickings for async delivery."""
+        batch, pickings = self._create_batch_with_pickings()
+        pickings.l10n_ar_action_create_delivery_guide()
+
+        batch.l10n_ar_action_send_delivery_guide()
+
+        for picking in pickings:
+            self.assertEqual(picking.l10n_ar_delivery_guide_cron_user_id, self.env.user)

--- a/addons/l10n_ar_stock_batch/views/stock_picking_batch_views.xml
+++ b/addons/l10n_ar_stock_batch/views/stock_picking_batch_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_picking_batch_form_inherit_l10n_ar" model="ir.ui.view">
+        <field name="name">stock.picking.batch.form.inherit.l10n_ar</field>
+        <field name="model">stock.picking.batch</field>
+        <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header//button[@name='action_cancel']" position="after">
+                <button name="l10n_ar_action_create_delivery_guide"
+                    type="object"
+                    string="Generate Delivery Guides"
+                    invisible="not l10n_ar_show_generate_delivery_guide"/>
+                <button name="l10n_ar_action_send_delivery_guide"
+                    type="object"
+                    class="btn-primary"
+                    string="Send Delivery Guides"
+                    invisible="not l10n_ar_show_send_delivery_guide"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Argentine companies must issue a Remito (delivery guide) for every goods transfer. Until now, this had to be done one delivery at a time, which is unworkable for distributors handling dozens or hundreds of deliveries per day.

Add mass actions on stock.picking to generate and send Delivery Guides for multiple deliveries at once from the list view, and expose the same actions on stock.picking.batch so a whole batch can be processed without drilling into each picking.

task-6046241
