### PR TITLE
[IMP] mrp_account: changing price unit to value

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -13,7 +13,7 @@ class StockMove(models.Model):
         self.ensure_one()
         if not self.production_id:
             return super()._get_value_from_production(quantity, at_date)
-        value = quantity * self.price_unit
+        value = self.value
         return {
             'value': value,
             'quantity': quantity,


### PR DESCRIPTION
Current behavior:
--
The function _get_value_from_production is using the deprecated "price_unit" instead of the value "field". The should be changed to value now as users are able to change stock.move values manually in 19

Changes:
--
value = quantity * self.price_unit
is changed to
value = self.value

opw-61098406
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
