### PR TITLE
[FIX] event: copy ticket translations from template to event

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -642,6 +642,7 @@ class EventEvent(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         events = super(EventEvent, self).create(vals_list)
+        events._copy_event_type_ticket_translations()
         for res in events:
             if res.organizer_id:
                 res.message_subscribe([res.organizer_id.id])
@@ -649,13 +650,36 @@ class EventEvent(models.Model):
         return events
 
     def write(self, vals):
+        existing_ticket_ids = {
+            event.id: set(event.event_ticket_ids.ids)
+            for event in self
+        } if 'event_type_id' in vals else {}
         if 'stage_id' in vals and 'kanban_state' not in vals:
             # reset kanban state when changing stage
             vals['kanban_state'] = 'normal'
         res = super(EventEvent, self).write(vals)
+        if 'event_type_id' in vals:
+            self._copy_event_type_ticket_translations(existing_ticket_ids)
         if vals.get('organizer_id'):
             self.message_subscribe([vals['organizer_id']])
         return res
+
+    def _copy_event_type_ticket_translations(self, existing_ticket_ids=None):
+        """Copy all template ticket translations onto the newly generated event tickets."""
+        existing_ticket_ids = existing_ticket_ids or {}
+        for event in self.filtered('event_type_id'):
+            template_tickets = event.event_type_id.event_type_ticket_ids
+            if not template_tickets:
+                continue
+
+            new_tickets = event.event_ticket_ids.filtered(
+                lambda ticket: ticket.id not in existing_ticket_ids.get(event.id, set())
+            )
+            if len(new_tickets) != len(template_tickets):
+                continue
+
+            for template_ticket, event_ticket in zip(template_tickets, new_tickets):
+                template_ticket.copy_translations(event_ticket)
 
     @api.depends('event_registrations_sold_out', 'seats_limited', 'seats_max', 'seats_available')
     @api.depends_context('name_with_seats_availability')

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -642,6 +642,7 @@ class EventEvent(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         events = super(EventEvent, self).create(vals_list)
+        events._copy_event_type_ticket_translations()
         for res in events:
             if res.organizer_id:
                 res.message_subscribe([res.organizer_id.id])
@@ -649,13 +650,38 @@ class EventEvent(models.Model):
         return events
 
     def write(self, vals):
+        existing_ticket_ids = {
+            event.id: set(event.event_ticket_ids.ids)
+            for event in self
+        } if 'event_type_id' in vals else {}
         if 'stage_id' in vals and 'kanban_state' not in vals:
             # reset kanban state when changing stage
             vals['kanban_state'] = 'normal'
         res = super(EventEvent, self).write(vals)
+        if 'event_type_id' in vals:
+            self._copy_event_type_ticket_translations(existing_ticket_ids)
         if vals.get('organizer_id'):
             self.message_subscribe([vals['organizer_id']])
         return res
+
+    def _copy_event_type_ticket_translations(self, existing_ticket_ids=None):
+        """Copy all template ticket translations onto the newly generated event tickets."""
+        if len(self.env['res.lang'].get_installed()) <= 1:
+            return
+        existing_ticket_ids = existing_ticket_ids or {}
+        for event in self.filtered('event_type_id'):
+            template_tickets = event.event_type_id.event_type_ticket_ids
+            if not template_tickets:
+                continue
+
+            new_tickets = event.event_ticket_ids.filtered(
+                lambda ticket: ticket.id not in existing_ticket_ids.get(event.id, set())
+            )
+            if len(new_tickets) != len(template_tickets):
+                continue
+
+            for template_ticket, event_ticket in zip(template_tickets, new_tickets):
+                template_ticket.copy_translations(event_ticket)
 
     @api.depends('event_registrations_sold_out', 'seats_limited', 'seats_max', 'seats_available')
     @api.depends_context('name_with_seats_availability')

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -408,6 +408,30 @@ class TestEventData(TestEventInternalsCommon):
         )
 
     @users('user_eventmanager')
+    def test_event_configuration_ticket_translations_from_type(self):
+        self.env['res.lang'].sudo()._activate_lang('fr_FR')
+        event_type = self.env['event.type'].create({
+            'name': 'Type Tickets',
+            'event_type_ticket_ids': [Command.create({
+                'name': 'Default Ticket',
+            })],
+        })
+        template_ticket = event_type.event_type_ticket_ids
+        template_ticket.with_context(lang='fr_FR').name = 'French name'
+        event_create = self.env['event.event'].create({
+            'name': 'Event',
+            'event_type_id': event_type.id,
+        })
+        self.event_0.write({'event_type_id': event_type.id})
+
+        # Ensure ticket translations are copied from the template on both create and write.
+        for event in (event_create, self.event_0):
+            self.assertEqual(
+                event.event_ticket_ids._fields['name']._get_stored_translations(event.event_ticket_ids),
+                template_ticket._fields['name']._get_stored_translations(template_ticket),
+            )
+
+    @users('user_eventmanager')
     def test_event_mail_default_config(self):
         event = self.env['event.event'].create({
             'name': 'Event Update Type',


### PR DESCRIPTION
Steps to reproduce:
1. Install event
2. Install multiple languages
3. Create an event template from configuration in events
4. Add tickets to it.
5. Click on the name field of the ticket and then the `EN` button
6. Add translations for multiople language for the name in tickets
7. Now Create an event and set the template to the template we just created.
 8. Click on the 'EN' button of ticket's name field

Issue:
- Only the value of the current user language is copied to the event ticket. Other translations are lost.

Cause:
- When tickets are generated from the template in `_compute_event_ticket_ids`, they are created with `Command.create`, which only propagates the current language value and does not copy stored translations.

Solution:
- After event tickets are created from the template, explicitly copy the translations from `event.type.ticket` to the corresponding `event.event.ticket` records during create/write flows.

opw-6088184

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
