### PR TITLE
[FIX] account_peppol: prevent error when Peppol: update message status cron runs

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -381,7 +381,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                     # "Peppol request not ready" error:
                     # thrown when the IAP is still processing the message
                     continue
-                error_message = self.get_peppol_error_message(self.env, error_vals)
+                error_message = get_peppol_error_message(self.env, error_vals)
                 move._message_log(body=error_message)
                 move.peppol_move_state = 'error'
                 processed_message_uuids.append(uuid)


### PR DESCRIPTION
Currently, an error occurs when the Peppol: update message status scheduled action is executed.

**Error:**
`AttributeError: 'account_edi_proxy_client.user' object has no attribute 'get_peppol_error_message'.`

**Cause:**
When the scheduled action runs, it attempts to update message statuses and retrieve the processing 
state of previously sent invoices using their message UUIDs [1].
If a message is in an error state, the system tries to convert the error dictionary into a readable, 
translated message based on the error code and details [2]. And, this raises an error because account_edi_proxy_client.user does not have the method get_peppol_error_message when retrieving 
the error message [3], as it is defined in an exception file.

This commit ensures the correct usage of get_peppol_error_message, as it is already imported, instead 
of calling it on account_edi_proxy_client.user.

[1]: https://github.com/odoo/odoo/blob/f7c309cdac754ead9e00b3443a2fe764efec819c/addons/account_peppol/models/account_edi_proxy_user.py#L351

[2]: https://github.com/odoo/odoo/blob/f7c309cdac754ead9e00b3443a2fe764efec819c/addons/account_peppol/models/account_edi_proxy_user.py#L379

[3]: https://github.com/odoo/odoo/blob/f7c309cdac754ead9e00b3443a2fe764efec819c/addons/account_peppol/models/account_edi_proxy_user.py#L384

sentry-7395549907

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
