### PR TITLE
[REF] web: rename `onPageChangeScroll` in kanban and list controllers

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -195,9 +195,8 @@ export class KanbanController extends Component {
                     total: count,
                     onUpdate: async ({ offset, limit }, hasNavigated) => {
                         await this.model.root.load({ offset, limit });
-                        await this.onUpdatedPager();
                         if (hasNavigated) {
-                            this.onPageChangeScroll();
+                            this.onPageChange();
                         }
                     },
                     updateTotal: hasLimitedCount ? () => root.fetchCount() : undefined,
@@ -510,7 +509,7 @@ export class KanbanController extends Component {
         }
     }
 
-    onPageChangeScroll() {
+    onPageChange() {
         if (this.rootRef && this.rootRef.el) {
             if (this.env.isSmall) {
                 this.rootRef.el.scrollTop = 0;
@@ -523,8 +522,6 @@ export class KanbanController extends Component {
     async beforeExecuteActionButton(clickParams) {}
 
     async afterExecuteActionButton(clickParams) {}
-
-    async onUpdatedPager() {}
 
     scrollTop() {
         this.rootRef.el.querySelector(".o_content").scrollTo({ top: 0 });

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -171,7 +171,7 @@ export class ListController extends Component {
                     }
                     await this.model.root.load({ limit, offset });
                     if (hasNavigated) {
-                        this.onPageChangeScroll();
+                        this.onPageChange();
                     }
                 },
                 updateTotal:
@@ -419,7 +419,7 @@ export class ListController extends Component {
         );
     }
 
-    onPageChangeScroll() {
+    onPageChange() {
         if (this.rootRef && this.rootRef.el) {
             if (this.env.isSmall) {
                 this.rootRef.el.scrollTop = 0;

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1389,49 +1389,6 @@ test("pager, ungrouped, deleting all records from last page", async () => {
     expect(getPagerLimit()).toBe(3);
 });
 
-test.tags("desktop");
-test("pager, update calls onUpdatedPager", async () => {
-    class TestKanbanController extends KanbanController {
-        setup() {
-            super.setup();
-            onWillRender(() => {
-                expect.step("render");
-            });
-        }
-
-        async onUpdatedPager() {
-            expect.step("onUpdatedPager");
-        }
-    }
-
-    viewRegistry.add("test_kanban_view", {
-        ...kanbanView,
-        Controller: TestKanbanController,
-    });
-    after(() => viewRegistry.remove("test_kanban_view"));
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban js_class="test_kanban_view">
-                <templates>
-                    <t t-name="card">
-                        <field name="foo"/>
-                    </t>
-                </templates>
-            </kanban>`,
-        limit: 3,
-    });
-
-    expect(getPagerValue()).toEqual([1, 3]);
-    expect(getPagerLimit()).toBe(4);
-    expect.step("next page");
-    await contains(".o_pager_next").click();
-    expect(getPagerValue()).toEqual([4, 4]);
-    expect.verifySteps(["render", "render", "next page", "render", "onUpdatedPager"]);
-});
-
 test("click on a button type='delete' to delete a record in a column", async () => {
     await mountView({
         type: "kanban",
@@ -6019,8 +5976,8 @@ test(`kanban should ask to scroll to top on page changes`, async () => {
         Partner._records.push({ id: i, foo: "foo" });
     }
     patchWithCleanup(KanbanController.prototype, {
-        onPageChangeScroll() {
-            super.onPageChangeScroll(...arguments);
+        onPageChange() {
+            super.onPageChange(...arguments);
             expect.step("scroll");
         },
     });
@@ -6069,8 +6026,8 @@ test(`kanban should ask to scroll to top on page changes (mobile)`, async () => 
         Partner._records.push({ id: i, foo: "foo" });
     }
     patchWithCleanup(KanbanController.prototype, {
-        onPageChangeScroll() {
-            super.onPageChangeScroll(...arguments);
+        onPageChange() {
+            super.onPageChange(...arguments);
             expect.step("scroll");
         },
     });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -13472,8 +13472,8 @@ test(`list should ask to scroll to top on page changes`, async () => {
         Foo._records.push({ id: i, foo: "foo" });
     }
     patchWithCleanup(ListController.prototype, {
-        onPageChangeScroll() {
-            super.onPageChangeScroll(...arguments);
+        onPageChange() {
+            super.onPageChange(...arguments);
             expect.step("scroll");
         },
     });


### PR DESCRIPTION
This commit renames `onPageChangeScroll` in kanban and list view controllers to 'onPageChange'. The new name is more descriptive of what the method does as it will be used for more than scrolling.

task-6070904