### PR TITLE
[FIX] hr: employee type visibility

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -352,11 +352,6 @@ class HrEmployee(models.Model):
         'A user cannot be linked to multiple employees in the same company.',
     )
 
-    has_country_employee_type = fields.Boolean(
-        compute='_compute_has_country_employee_type',
-        groups="hr.group_hr_user",
-    )
-
     @api.model
     def _get_current_day_location_field(self):
         return DAYS[fields.Date.today().weekday()]
@@ -718,18 +713,6 @@ class HrEmployee(models.Model):
             # To not trigger computed properties if still the same version
             if employee.current_version_id != new_current_version:
                 employee.current_version_id = new_current_version
-
-    @api.depends('company_country_id')
-    def _compute_has_country_employee_type(self):
-        count_contract_type_by_country = dict(self.env['hr.employee.type']._read_group(
-            domain=[],
-            groupby=['country_id'],
-            aggregates=['__count']
-        ))
-        for employee in self:
-            employee.has_country_employee_type = bool(
-                count_contract_type_by_country.get(employee.company_country_id)
-            )
 
     def _cron_update_current_version_id(self):
         self.search([])._compute_current_version_id()

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -358,7 +358,7 @@
                                                 nolabel="1"/>
                                             </div>
                                         <field name="employee_type_id" string="Employee Type" placeholder="Select employee type"
-                                                invisible="not has_country_employee_type" domain="[('country_id', 'in', [company_country_id, False])]"
+                                                domain="[('country_id', '=', company_country_id)]"
                                                 required="contract_date_start"/>
                                         <label for="contract_date_start" string="Contract"/>
                                         <div class="o_row" name="contract_dates">


### PR DESCRIPTION
Ensure the Employee Type field is always visible on the Payroll tab so users can create/select a type even when no country-specific types exist. Remove the unused has_country_employee_type logic

task-6106861

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
