### PR TITLE
[FIX] hr_recruitment: Use lambda domain for interviewer_ids field

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -26,7 +26,10 @@ class HrJob(models.Model):
     user_id = fields.Many2one(
         "res.users",
         "Recruiter",
-        domain="[('share', '=', False), ('company_ids', '=?', company_id)]",
+        domain=lambda self: [
+            ('share', '=', False),
+            ('company_ids', '=?', self.company_id.id if self.company_id else None)
+        ],
         default=lambda self: self.env.user,
         groups="hr.group_hr_user",
         tracking=True,

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -63,7 +63,10 @@ class HrJob(models.Model):
     favorite_user_ids = fields.Many2many('res.users', 'job_favorite_user_rel', 'job_id', 'user_id', default=_get_default_favorite_user_ids)
     interviewer_ids = fields.Many2many(
         "res.users",
-        domain="[('share', '=', False), ('company_ids', '=?', company_id)]",
+        domain=lambda self: [
+            ('share', '=', False),
+            ('company_ids', '=?', self.company_id.id if self.company_id else None)
+        ],
         string="Interviewers",
         groups="hr_recruitment.group_hr_recruitment_interviewer",
         help="The Interviewers set on the job position can see all Applicants in it. They have access to the information, the attachments, the meeting management and they can refuse him. You don't need to have Recruitment rights to be set as an interviewer.",


### PR DESCRIPTION
**Steps to Reproduce:**
1. Ensure hr_payroll module is NOT installed
2. Open a Job Position in hr_recruitment app
3. Click on "Assign Recruiter" button for a position without a recruiter
4. Observe error: "Name 'company_id' is not defined"

**Bug Cause:**
The interviewer_ids field used a string-based domain that referenced 'company_id' as a variable which is evaluation in client-side lacking  access to Python record context, causing it to fail when hr_payroll module is not installed.

**Solution:**
Replace the string domain with a lambda function that evaluates server-side, providing access to self.company_id context.

**Task:** 6106143
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
