### PR TITLE
[FIX] web: tree_editor: format numbers according to localization

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -216,10 +216,22 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "float":
         case "monetary": {
             const formatType = type === "integer" ? "integer" : "float";
+            const typeFormatter = formatters.get(formatType, null);
+            const formatter = (value) => {
+                let v = value;
+                if (typeFormatter) {
+                    try {
+                        v = typeFormatter(value);
+                    } catch {
+                        /* do nothing */
+                    }
+                }
+                return String(v);
+            };
             return {
                 component: Input,
                 extractProps: ({ value, update }) => ({
-                    value: String(value),
+                    value: formatter(value),
                     update: (value) => update(parseValue(formatType, value)),
                     startEmpty: params.startEmpty,
                 }),

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2551,3 +2551,29 @@ test("hide within operators when allowExpressions = False", async () => {
         "is not set",
     ]);
 });
+
+test("number formatting", async () => {
+    defineParams({
+        lang_parameters: {
+            decimal_point: "$",
+            thousands_sep: "~",
+        },
+    });
+
+    Partner._fields.number = fields.Float();
+    let expr;
+    await makeDomainSelector({
+        update: (e) => {
+            expr = e;
+        },
+        domain: `[("number", "=", 1989.45)]`,
+    });
+    expect(".o_tree_editor_editor input").toHaveValue("1~989$45");
+    await contains(".o_tree_editor_editor input").edit("1~989$46");
+    expect(".o_tree_editor_editor input").toHaveValue("1~989$46");
+    expect(expr).toEqual('[("number", "=", 1989.46)]');
+
+    await contains(".o_tree_editor_editor input").edit("1989.47");
+    expect(".o_tree_editor_editor input").toHaveValue("1~989$47");
+    expect(expr).toEqual('[("number", "=", 1989.47)]');
+});


### PR DESCRIPTION
Before this commit, the domain selector (and expression editor) did not format numbers according to the localization parameters (decimal and thousands separators), while the parsing step did.

After this commit, the value is displayed in the correct format to the user, while the expression remains unchanged.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
