### PR TITLE
[FIX] stock_account: valuation report crash

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -43,7 +43,7 @@
         <StockValuationReportLine
             label.translate="Initial Balance"
             level="0"
-            onClickMethod.bind="this.data.initial_balance.lines.length ? openAccountMoves.bind(this) : undefined"
+            onClickMethod="this.data.initial_balance.lines.length ? this.openAccountMoves.bind(this) : undefined"
             sublines="this.data.initial_balance.lines"
             value="this.data.initial_balance.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
@@ -63,7 +63,7 @@
         <StockValuationReportLine
             label.translate="Ending Stock"
             level="0"
-            onClickMethod.bind="this.data.ending_stock.lines.length ? openStockReport.bind(this) : undefined"
+            onClickMethod="this.data.ending_stock.lines.length ? this.openStockReport.bind(this) : undefined"
             sublines="this.data.ending_stock.lines"
             value="this.data.ending_stock.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>


### PR DESCRIPTION
It was an error during the forward port after the owl3 merge. Now, we need to call this before reaching a props of the component.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
