### PR TITLE
[FIX] account_edi_ubl_cii: remove recompute eas for BE on validity check

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -492,17 +492,6 @@ class ResPartner(models.Model):
             edi_identification = f'{self.peppol_eas}:{self.peppol_endpoint}'.lower()
             self.account_peppol_validity_last_check = fields.Date.context_today(self)
             self.account_peppol_is_endpoint_valid = bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format))
-
-            if (
-                not self.account_peppol_is_endpoint_valid
-                and self.peppol_eas in ('0208', '9925')
-            ):
-                inverse_eas = '9925' if self.peppol_eas == '0208' else '0208'
-                inverse_endpoint = f'BE{self.peppol_endpoint}' if self.peppol_eas == '0208' else self.peppol_endpoint[2:]
-                if self._check_peppol_participant_exists(f'{inverse_eas}:{inverse_endpoint}', ubl_cii_format=self.ubl_cii_format):
-                    self.peppol_eas = inverse_eas
-                    self.peppol_endpoint = inverse_endpoint
-                    self.account_peppol_is_endpoint_valid = True
         return False
 
     def _get_partners_to_skip_peppol_computation(self):


### PR DESCRIPTION
When adding peppol, we didn't know if we needed to use the 9925:BE or 0208.
 Therefore, we switched between them if the endpoint was not found. 
This has no more use today as we use 0208.

opw-5976574

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
