### PR TITLE
[FIX] orm: revalidate cached Domain field

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -964,7 +964,7 @@ class DomainCondition(Domain):
     def _field(self, model: BaseModel) -> Field:
         """Cached Field instance for the expression."""
         field = self._field_instance  # type: ignore[arg-type]
-        if field is None or field.model_name != model._name:
+        if field is None or field is not model._fields[field.name]:
             field, _ = self.__get_field(model)
         return field
 


### PR DESCRIPTION
A domain may be stored for some time and the registry could be re-setup after it has been optimized. The re-setup model will have new instances of fields that we should return instead of just checking the model name.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
