### PR TITLE
[FIX] l10n_dk: consider accounts without code

### DIFF
--- a/addons/l10n_dk/migrations/1.4/end-migrate.py
+++ b/addons/l10n_dk/migrations/1.4/end-migrate.py
@@ -99,7 +99,7 @@ def migrate(cr, version):
 
     for account in env['account.account'].with_context(active_test=False).search([('company_id', 'in', dk_companies.ids)]):
         # Adapt existing codes to use 6 digits.
-        if len(account.code) < 6:
+        if account.code and len(account.code) < 6:
             account.code = account.code.ljust(6, '0')
         # Deprecate removed accounts.
         if account.id in deprecated_account_ids:


### PR DESCRIPTION
From https://github.com/odoo/odoo/pull/256541.

```yml
  File "/home/.../odoo/addons/l10n_dk/migrations/1.4/end-migrate.py", line 102, in migrate
    if len(account.code) < 6:
TypeError: object of type 'bool' has no len()
```




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr