### PR TITLE
[FIX] point_of_sale: prevent crashes on duplicate order synchronization

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -92,27 +92,29 @@ class PosOrder(models.Model):
         else:
             pos_order = existing_order
 
-            # If the order is belonging to another session, it must be moved to the current session first
             if order.get('session_id') and order['session_id'] != pos_order.session_id.id:
                 pos_order.write({'session_id': order['session_id']})
 
-            # Save lines and payments before to avoid exception if a line is deleted
-            # when vals change the state to 'paid'
+            # Process lines and payments separately before the main write.
+            # We use `order[field] = []` to clear them from the `order` dict so they aren't
+            # written twice. We must explicitly set them to `[]` (not `.pop()`) because
+            # downstream overrides like `pos_event` rely on `order.get('lines')` returning an iterable.
             for field in ['lines', 'payment_ids']:
-                if order.get(field):
-                    existing_ids = set(pos_order[field].ids)
-                    pos_order.write({field: order[field]})
-                    added_ids = set(pos_order[field].ids) - existing_ids
-                    if added_ids:
-                        _logger.info("Added %s %s to pos.order #%s", field, list(added_ids), pos_order.id)
+                commands = order.get(field, [])
+                if commands:
+                    self._write_order_field(pos_order, field, commands)
+                if field in order:
                     order[field] = []
 
-            del order['uuid']
-            del order['access_token']
+            order.pop('uuid', None)
+            order.pop('access_token', None)
+
+            # The "paid" state is assigned later by `_process_saved_order`.
             if order.get('state') == 'paid':
-                # The "paid" state will be assigned later by `_process_saved_order`
                 order['state'] = pos_order.state
-            pos_order.write(order)
+
+            if order:
+                pos_order.write(order)
 
         for model_name, mapping in record_uuid_mapping.items():
             owner_records = self.env[model_name].search([('uuid', 'in', mapping.keys())])
@@ -129,6 +131,24 @@ class PosOrder(models.Model):
         self = self.with_company(pos_order.company_id)
         self._process_payment_lines(order, pos_order, pos_session, draft)
         return pos_order._process_saved_order(draft)
+
+    def _write_order_field(self, pos_order, field, commands):
+        """Write lines or payments to an existing order, handling duplicate UUIDs.
+
+        During a duplicate sync (e.g. network retry), the frontend may resend
+        create commands for records that already exist. This method converts
+        those into update commands to avoid unique constraint violations.
+        """
+        existing_by_uuid = {r.uuid: r.id for r in pos_order[field] if r.uuid}
+        updated_commands = []
+        for op, rec_id, vals in commands:
+            existing_id = existing_by_uuid.get(vals.get('uuid'))
+            if op == 0 and existing_id:
+                updated_commands.append((1, existing_id, vals))
+            else:
+                updated_commands.append((op, rec_id, vals))
+
+        pos_order.write({field: updated_commands})
 
     def _process_saved_order(self, draft):
         self.ensure_one()

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -25,3 +25,4 @@ from . import test_report_session
 from . import test_res_config_settings
 from . import test_pos_product_variants
 from . import test_generic_localization
+from . import test_pos_duplicate_sync

--- a/addons/point_of_sale/tests/test_pos_duplicate_sync.py
+++ b/addons/point_of_sale/tests/test_pos_duplicate_sync.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPosDuplicateSync(TestPoSCommon):
+
+    def test_duplicate_sync(self):
+        """Syncing the same draft order twice must not raise a UniqueViolation on line/payment UUIDs."""
+        self.config = self.basic_config
+        self.open_new_session()
+        product = self.create_product('Test Product', self.categ_basic, 10.0)
+
+        order_uuid = 'test-order-uuid-unique-1'
+        line_uuid = 'test-line-uuid-unique-1'
+        order_data = self.create_ui_order_data([(product, 1)], uuid=order_uuid)
+        order_data['lines'][0][2]['uuid'] = line_uuid
+        # Keep the order in draft so the second sync actually re-processes lines.
+        order_data['payment_ids'] = []
+        order_data['amount_paid'] = 0
+
+        # First sync: creates the order.
+        self.env['pos.order'].sync_from_ui([order_data])
+        order = self.env['pos.order'].search([('uuid', '=', order_uuid)])
+        self.assertTrue(order)
+        self.assertEqual(len(order.lines), 1)
+        self.assertEqual(order.lines.uuid, line_uuid)
+
+        # Second sync with identical data: must update, not duplicate.
+        self.env['pos.order'].sync_from_ui([order_data])
+        self.assertEqual(len(order.lines), 1)


### PR DESCRIPTION
The Point of Sale frontend generates UUIDs for order lines and payments to manage offline creation. During synchronization, if a network timeout occurs, the frontend retries the request.

Before this commit, a retry would attempt to re-insert the same UUIDs, leading to a "duplicate key value violates unique constraint" error (e.g., pos_order_line_unique_uuid) because the lines had already been created during the first (timed out) attempt.

This fix checks for existing UUIDs in the backend. If a 'create' command is received for a UUID already present in the database, it is automatically converted into an 'update' command. This ensures that retries are handled gracefully without duplication or server crashes.

Steps to reproduce:
- Create a POS order with lines.
- Simulate a network timeout during the sync request.
- Observe the server error on the retry due to UUID uniqueness.

Now, the server correctly identifies the existing lines and updates them instead of crashing.

runbot-error: 242433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
