### PR TITLE
Bump pyopenssl version to fix CVE-2026-27459

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ psycopg2==2.9.5 ; python_version == '3.11'
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
 pyopenssl==21.0.0 ; python_version < '3.12'
-pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
+pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
 PyPDF2==1.26.0 ; python_version <= '3.10'
 PyPDF2==2.12.1 ; python_version > '3.10' and python_version < '3.13' # (Noble and below)
 PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cbor2==5.6.2 ; python_version >= '3.12'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)
 chardet==5.2.0 ; python_version >= '3.11'
 cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
-cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
+cryptography==46.0.7 ; python_version >= '3.12'  # (Noble) min 41.0.7
 docutils==0.17 ; python_version < '3.11'  # (Jammy)
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.1.0 ; python_version < '3.11'  # (Jammy)
@@ -58,7 +58,7 @@ psycopg2==2.9.5 ; python_version == '3.11'
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
 pyopenssl==21.0.0 ; python_version < '3.12'
-pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
+pyopenssl==26.0.0 ; python_version >= '3.12' # (Noble) min 23.2.0
 PyPDF2==1.26.0 ; python_version <= '3.10'
 PyPDF2==2.12.1 ; python_version > '3.10' and python_version < '3.13' # (Noble and below)
 PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

pyopenssl >=22.0.0 and <26.0.0 is affected by CVE-2026-27459. 

If a user provided callback to set_cookie_generate_callback returned a cookie value greater than 256 bytes, pyOpenSSL would overflow an OpenSSL provided buffer.

Updating pyopenssl version to fix this vulnerability 

Desired behavior after PR is merged:

Fixed pyopenssl version is installed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
