### PR TITLE
[IMP] account: two-way exchange rate on invoices

### DIFF
--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
@@ -1,4 +1,4 @@
-import { Component, signal } from "@odoo/owl";
+import { Component, signal, proxy, props, types as t } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
 import { useService } from "@web/core/utils/hooks";
@@ -37,8 +37,74 @@ export class AccountPickCurrencyDate extends Component {
     }
 }
 
+export class AccountCurrencyExchangeRate extends Component {
+    static template = "account.AccountCurrencyExchangeRate";
+    props = props({
+        readonly: t.boolean(),
+        record: t.object(),
+        rateField: t.string(),
+    });
+
+    setup() {
+        this._swapKey = "account.currency_exchange_rate.swapped";
+        this.state = proxy({
+            swapped: localStorage.getItem(this._swapKey) === "true" 
+        });
+    }
+
+    get rate() {
+        return this.props.record.data[this.props.rateField];
+    }
+
+    get fromCurrency() {
+        return this.state.swapped
+            ? this.props.record.data.currency_id
+            : this.props.record.data.company_currency_id;
+    }
+
+    get toCurrency() {
+        return this.state.swapped
+            ? this.props.record.data.company_currency_id
+            : this.props.record.data.currency_id;
+    }
+
+    get displayRate() {
+        if (!this.rate) {
+            return "0.000000";
+        }
+        return (this.state.swapped ? 1 / this.rate : this.rate).toFixed(6);
+    }
+
+    get isEditable() {
+        return !this.props.readonly;
+    }
+
+    onSwap() {
+        this.state.swapped = !this.state.swapped;
+        localStorage.setItem(this._swapKey, this.state.swapped);
+    }
+
+    async onRateInput(ev) {
+        const parsed = parseFloat(ev.target.value.replace(",", "."));
+        if (isNaN(parsed) || parsed <= 0) {
+            ev.target.value = this.displayRate;
+            return;
+        }
+        const newRate = this.state.swapped ? 1 / parsed : parsed;
+        await this.props.record.update({ [this.props.rateField]: newRate });
+    }
+}
+
 export const accountPickCurrencyDate = {
     component: AccountPickCurrencyDate,
+}
+
+export const accountCurrencyExchangeRate = {
+    component: AccountCurrencyExchangeRate,
+    extractProps: ({ options }) => ({
+        rateField: options.rate_field,
+    }),
 };
 
-registry.category("view_widgets").add("account_pick_currency_date", accountPickCurrencyDate);
+registry.category("view_widgets").add("account_pick_currency_date",  accountPickCurrencyDate);
+registry.category("view_widgets").add("account_currency_exchange_rate", accountCurrencyExchangeRate);

--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
 import { useService } from "@web/core/utils/hooks";
@@ -37,8 +37,69 @@ export class AccountPickCurrencyDate extends Component {
     }
 }
 
+export class AccountCurrencyExchangeRate extends Component {
+    static template = "account.AccountCurrencyExchangeRate";
+    static props = {
+        ...standardWidgetProps,
+        rateField: { type: String },
+    };
+
+    setup() {
+        this.state = useState({ swapped: false });
+    }
+
+    get rate() {
+        return this.props.record.data[this.props.rateField];
+    }
+
+    get fromCurrency() {
+        return this.state.swapped
+            ? this.props.record.data.currency_id
+            : this.props.record.data.company_currency_id;
+    }
+
+    get toCurrency() {
+        return this.state.swapped
+            ? this.props.record.data.company_currency_id
+            : this.props.record.data.currency_id;
+    }
+
+    get displayRate() {
+        if (!this.rate) {
+            return "0.000000";
+        }
+        return (this.state.swapped ? 1 / this.rate : this.rate).toFixed(6);
+    }
+
+    get isEditable() {
+        return !this.props.readonly;
+    }
+
+    onSwap() {
+        this.state.swapped = !this.state.swapped;
+    }
+
+    async onRateInput(ev) {
+        const parsed = parseFloat(ev.target.value.replace(",", "."));
+        if (isNaN(parsed) || parsed <= 0) {
+            ev.target.value = this.displayRate;
+            return;
+        }
+        const newRate = this.state.swapped ? 1 / parsed : parsed;
+        await this.props.record.update({ [this.props.rateField]: newRate });
+    }
+}
+
 export const accountPickCurrencyDate = {
     component: AccountPickCurrencyDate,
 }
 
+export const accountCurrencyExchangeRate = {
+    component: AccountCurrencyExchangeRate,
+    extractProps: ({ options }) => ({
+        rateField: options.rate_field,
+    }),
+};
+
 registry.category("view_widgets").add("account_pick_currency_date",  accountPickCurrencyDate);
+registry.category("view_widgets").add("account_currency_exchange_rate", accountCurrencyExchangeRate);

--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
@@ -12,4 +12,20 @@
         </button>
     </t>
 
+    <t t-name="account.AccountCurrencyExchangeRate">
+        <div class="d-flex gap-1 align-items-center flex-nowrap text-muted">
+            <span>1</span>
+            <span class="w-auto" t-out="this.fromCurrency and this.fromCurrency.display_name or ''"/>
+            <button type="button" t-on-click.prevent="this.onSwap"
+                    class="btn btn-link text-dark p-0 mx-1"
+                    title="Click to swap currencies">
+                <i class="fa fa-exchange"/>
+            </button>
+            <input t-if="this.isEditable" type="text" class="o_input"
+                   style="max-width: 21ch;"
+                   t-att-value="this.displayRate" t-on-change="this.onRateInput"/>
+            <span t-else="" t-out="this.displayRate"/>
+            <span class="w-auto" t-out="this.toCurrency and this.toCurrency.display_name or ''"/>
+        </div>
+    </t>
 </template>

--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
@@ -12,4 +12,20 @@
         </button>
     </t>
 
+    <t t-name="account.AccountCurrencyExchangeRate">
+        <div class="d-flex gap-1 align-items-center flex-nowrap text-muted">
+            <span>1</span>
+            <span class="w-auto" t-esc="fromCurrency and fromCurrency.display_name or ''"/>
+            <button type="button" t-on-click.prevent="onSwap"
+                    class="btn btn-link text-dark p-0 mx-1"
+                    title="Click to swap currencies">
+                <i class="fa fa-exchange"/>
+            </button>
+            <input t-if="isEditable" type="text" class="o_input"
+                   style="max-width: 21ch;"
+                   t-att-value="displayRate" t-on-change="onRateInput"/>
+            <span t-else="" t-esc="displayRate"/>
+            <span class="w-auto" t-esc="toCurrency and toCurrency.display_name or ''"/>
+        </div>
+    </t>
 </template>

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4822,14 +4822,14 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
         # Test invoice_currency_rate with 0 value
         with self.assertRaises(ValidationError):
-            with Form(invoice) as move_form:
-                move_form.invoice_currency_rate = 0
+            invoice.invoice_currency_rate = 0
+
         self.assertEqual(invoice.invoice_currency_rate, 2.0)
 
         # Test invoice_currency_rate with negative value
         with self.assertRaises(ValidationError):
-            with Form(invoice) as move_form:
-                move_form.invoice_currency_rate = -420
+            invoice.invoice_currency_rate = -420
+
         self.assertEqual(invoice.invoice_currency_rate, 2.0)
 
     def test_invoice_currency_rate_manually_changed(self):

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4769,14 +4769,14 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
         # Test invoice_currency_rate with 0 value
         with self.assertRaises(ValidationError):
-            with Form(invoice) as move_form:
-                move_form.invoice_currency_rate = 0
+            invoice.invoice_currency_rate = 0
+
         self.assertEqual(invoice.invoice_currency_rate, 2.0)
 
         # Test invoice_currency_rate with negative value
         with self.assertRaises(ValidationError):
-            with Form(invoice) as move_form:
-                move_form.invoice_currency_rate = -420
+            invoice.invoice_currency_rate = -420
+
         self.assertEqual(invoice.invoice_currency_rate, 2.0)
 
     def test_invoice_currency_rate_manually_changed(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1237,11 +1237,9 @@
                                         <div name="currency_conversion_div"
                                              class="d-flex gap-1 text-muted"
                                              invisible="currency_id == company_currency_id">
-                                            <span>1</span>
-                                            <field name="company_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
-                                            <span>=</span>
-                                            <field name="invoice_currency_rate" digits="[12,6]" readonly="state != 'draft'" style="max-width: 21ch;"/>
-                                            <field name="currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                                            <field name="company_currency_id" invisible="1"/>
+                                            <field name="invoice_currency_rate" invisible="1"/>
+                                            <widget name="account_currency_exchange_rate" readonly="state != 'draft'" options="{'rate_field': 'invoice_currency_rate'}"/>
                                             <div
                                              invisible="show_journal or state != 'draft' or invoice_currency_rate == expected_currency_rate">
                                             <button type="object"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1199,11 +1199,9 @@
                                         <div name="currency_conversion_div"
                                              class="d-flex gap-1 text-muted"
                                              invisible="currency_id == company_currency_id">
-                                            <span>1</span>
-                                            <field name="company_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
-                                            <span>=</span>
-                                            <field name="invoice_currency_rate" digits="[12,6]" readonly="state != 'draft'" style="max-width: 21ch;"/>
-                                            <field name="currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                                            <field name="company_currency_id" invisible="1"/>
+                                            <field name="invoice_currency_rate" invisible="1"/>
+                                            <widget name="account_currency_exchange_rate" readonly="state != 'draft'" options="{'rate_field': 'invoice_currency_rate'}"/>
                                             <div
                                              invisible="show_journal or state != 'draft' or invoice_currency_rate == expected_currency_rate">
                                             <button type="object"

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -89,7 +89,6 @@ class AccountPaymentRegister(models.TransientModel):
         readonly=True,
         store=False
     )
-    exchange_rate_currency_code = fields.Char(compute="_compute_exchange_rate")
 
     # == Fields given through the context ==
     line_ids = fields.Many2many('account.move.line', 'account_payment_register_move_line_rel', 'wizard_id', 'line_id',
@@ -970,10 +969,8 @@ class AccountPaymentRegister(models.TransientModel):
                     company=wizard.company_id,
                     date=wizard.payment_date,
                 )
-                wizard.exchange_rate_currency_code = target_currency.name
             else:
                 wizard.exchange_rate = 1.0
-                wizard.exchange_rate_currency_code = wizard.company_currency_id.name
 
     def _fetch_duplicate_reference(self, matching_states=('draft', 'posted')):
         """ Retrieve move ids for possible duplicates of payments. Duplicates moves:

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -88,7 +88,6 @@ class AccountPaymentRegister(models.TransientModel):
         readonly=True,
         store=False
     )
-    exchange_rate_currency_code = fields.Char(compute="_compute_exchange_rate")
 
     # == Fields given through the context ==
     line_ids = fields.Many2many('account.move.line', 'account_payment_register_move_line_rel', 'wizard_id', 'line_id',
@@ -969,10 +968,8 @@ class AccountPaymentRegister(models.TransientModel):
                     company=wizard.company_id,
                     date=wizard.payment_date,
                 )
-                wizard.exchange_rate_currency_code = target_currency.name
             else:
                 wizard.exchange_rate = 1.0
-                wizard.exchange_rate_currency_code = wizard.company_currency_id.name
 
     def _fetch_duplicate_reference(self, matching_states=('draft', 'posted')):
         """ Retrieve move ids for possible duplicates of payments. Duplicates moves:

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -119,11 +119,9 @@
                                            groups="base.group_multi_currency"/>
                                 </div>
                                 <div name="currency_conversion_div" class="d-flex gap-1 text-muted" invisible="company_currency_id == (currency_id if currency_id != company_currency_id else (source_currency_id or company_currency_id))">
-                                    <span>1</span>
-                                    <field name="company_currency_id" readonly="1" options="{'no_open': True}"/>
-                                    <span>=</span>
-                                    <field name="exchange_rate" readonly="True"/>
-                                    <field name="exchange_rate_currency_code" readonly="True"/>
+                                    <field name="company_currency_id" invisible="1"/>
+                                    <field name="exchange_rate" invisible="1"/>
+                                    <widget name="account_currency_exchange_rate" readonly="1" options="{'rate_field': 'exchange_rate'}"/>
                                 </div>
                             </div>
                             <field

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -118,11 +118,9 @@
                                            groups="base.group_multi_currency"/>
                                 </div>
                                 <div name="currency_conversion_div" class="d-flex gap-1 text-muted" invisible="currency_id == company_currency_id == source_currency_id">
-                                    <span>1</span>
-                                    <field name="company_currency_id" readonly="1" options="{'no_open': True}"/>
-                                    <span>=</span>
-                                    <field name="exchange_rate" readonly="True"/>
-                                    <field name="exchange_rate_currency_code" readonly="True"/>
+                                    <field name="company_currency_id" invisible="1"/>
+                                    <field name="exchange_rate" invisible="1"/>
+                                    <widget name="account_currency_exchange_rate" readonly="1" options="{'rate_field': 'exchange_rate'}"/>
                                 </div>
                             </div>
                             <field


### PR DESCRIPTION
Add a reusable exchange rate widget that displays the conversion
between two currencies with swap and inline edit support. The rate
field is configurable via the rate_field option.

Used on invoice and payment register form views when a foreign
currency is involved.

Upgrade PR: https://github.com/odoo/upgrade/pull/9989
task-6060587