### PR TITLE
[FIX] web: fix round duration

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -220,6 +220,16 @@ function formatDuration(value, options = {}) {
         seconds: showSeconds ? Math.round(seconds % 60) : 0,
     };
 
+    if (duration.seconds === 60) {
+        duration.minutes += 1;
+        duration.seconds = 0;
+    }
+
+    if (duration.minutes === 60) {
+        duration.hours += 1;
+        duration.minutes = 0;
+    }
+
     let durationParts = new Intl.DurationFormat(l10n.locale, {
         style: options.numeric ? "digital" : "narrow",
         hoursDisplay: unit === "hours" || options.numeric ? "always" : "auto",

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -64,6 +64,8 @@ test("formatFloatTime", () => {
     expect(formatFloatTime(0.25 + 45 / 3600, { showSeconds: true })).toBe("0h 15m 45s");
     expect(formatFloatTime(56 / 3600, { showSeconds: true })).toBe("0h 0m 56s");
     expect(formatFloatTime(-0.5)).toBe("-0h 30m");
+    expect(formatFloatTime(1799.999, { unit: "minutes" })).toBe("30h 0m");
+    expect(formatFloatTime(1799.999, { unit: "minutes", showSeconds: true })).toBe("30h 0m 0s");
 
     const options = { numeric: true };
     expect(formatFloatTime(2, options)).toBe("2:00");


### PR DESCRIPTION
Before this commit, when the minutes of a duration go
through Math.round, it can return 60 minutes in the duration
instead of 1h. The same issue go for the seconds too.

Now, the formatDuration check if this cases happen and and ajust
the result of the rounding if necessary.

TASK-6107266


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
