### PR TITLE
[IMP] base: Use badges_selection widget instead of radio

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -239,7 +239,12 @@
                                 <form string="Contact / Address">
                                     <sheet>
                                         <field name="parent_id" invisible="1"/>  <!-- Used for partner_autocomplete -->
-                                        <field name="type" required="1" widget="radio" options="{'horizontal': true}"/>
+                                        <field name="type" required="1" widget="badges_selection"
+                                            options="{ 'icon_mapping': {
+                                                'contact': 'fa-user', 'invoice': 'fa-file',
+                                                'delivery': 'fa-truck', 'other': 'fa-cube'
+                                            }}"
+                                        />
                                         <div class="d-flex flex-column flex-md-row align-items-center gap-3">
                                             <field name="image_1920" widget="contact_image" nolabel="1" options="{'preview_image': 'avatar_128', 'size': [100,100], 'img_class': 'rounded border'}"/>
                                             <group class="w-100">


### PR DESCRIPTION
When adding new related contact from a contact, the selection of type of contact is now displayed using a `badges_selection` instead of a `radio` widget for having a better ux on tablet and smartphone.

task-6027020

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
