### PR TITLE
[FIX] website_sale: Filter categories by current website on product page

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -799,7 +799,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
         original_category = category
-        category = category or product.public_categ_ids[:1]
+        category = category or product.public_categ_ids.filtered(
+            lambda c: c.can_access_from_current_website()
+        )[:1]
         if category:
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -513,3 +513,41 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
                 category=public_category,
             )
         self.assertIn('/category', values['keep'].path)
+
+    def test_product_page_category_respects_current_website(self):
+        """When two categories share the same name but belong to different websites, the product
+        page breadcrumb should show the category accessible from the current website, not the one
+        from another website.
+        """
+        second_website = self.env['website'].create({'name': 'Second Website'})
+
+        categ_website_1 = self.env['product.public.category'].create({
+            'name': 'My Category',
+            'website_id': self.website.id,
+        })
+        categ_website_2 = self.env['product.public.category'].create({
+            'name': 'My Category',
+            'website_id': second_website.id,
+        })
+
+        product_tmpl = self.env['product.template'].create({
+            'name': 'Multi Website Product',
+            'website_published': True,
+            'public_categ_ids': [Command.set([categ_website_1.id, categ_website_2.id])],
+        })
+
+        # On website 1, the category from website 1 should be selected.
+        with MockRequest(self.env, website=self.website):
+            values = self.pc_controller._prepare_product_values(
+                product_tmpl,
+                category=None,
+            )
+        self.assertEqual(values['category'], categ_website_1)
+
+        # On website 2, the category from website 2 should be selected.
+        with MockRequest(self.env, website=second_website):
+            values = self.pc_controller._prepare_product_values(
+                product_tmpl,
+                category=None,
+            )
+        self.assertEqual(values['category'], categ_website_2)


### PR DESCRIPTION
An issue is observed when two categories share the same name but are assigned to different websites, and a product is linked to both categories.

Steps to Reproduce:
====================
1. Create two Ecommerce categories with the same name, one assigned to Website 1 and the other to Website 2.
2. Create a product and assign both categories to it.
3. On Website 1, navigate to the product page and click the category breadcrumb → works correctly
4. On Website 2, navigate to the same product page and click the category breadcrumb → **404 error**

Cause:
======
In `_prepare_product_values`, when no category is passed in the URL, the fallback was:
https://github.com/odoo/odoo/blob/a253cff9039fcf729a9922b119acad5ec7c7a0bd/addons/website_sale/controllers/main.py#L802

This blindly picks the **first** category from the product's public categories without checking which website it belongs to. If the first category (by ID order) belongs to Website 1, it gets used even when the user is browsing Website 2.
The breadcrumb then generates a slug pointing to Website 1's category. When clicked on Website 2, `can_access_from_current_website()` fails for that category, resulting in a 404.

Solution:
=========
Filter `public_categ_ids` through `can_access_from_current_website()` before selecting the first one.

opw-6070191

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
