### PR TITLE
[FIX] website(_sale): remove static id from dynamic carousel snippet

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -24,7 +24,7 @@
             <!-- Content -->
             <t t-set="rowIndexGenerator" t-value="Array(this.rowPerSlide)"/>
             <t t-set="colIndexGenerator" t-value="Array(rowSize)"/>
-            <div id="s_dynamic_snippet_carousel" class="carousel-inner w-100 mx-auto" role="listbox"
+            <div class="carousel-inner w-100 mx-auto" role="listbox"
                  aria-label="Carousel">
                 <t t-foreach="slideIndexGenerator" t-as="slideIndex" t-key="slideIndex_index">
                     <t t-set="slideOffset" t-value="slideIndex_index * slideSize"/>

--- a/addons/website_sale/static/src/interactions/product/product_variant_preview.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview.js
@@ -2,7 +2,7 @@ import { Interaction } from '@web/public/interaction';
 import { registry } from '@web/core/registry';
 
 export class ProductVariantPreview extends Interaction {
-    static selector = "#o_wsale_products_grid, .s_dynamic_snippet_products #s_dynamic_snippet_carousel";
+    static selector = "#o_wsale_products_grid, .s_dynamic_snippet_products .carousel-inner";
 
     dynamicContent = {
         _window: {


### PR DESCRIPTION
Issue:
- A static id (`s_dynamic_snippet_carousel`) was introduced in https://github.com/odoo/odoo/commit/f427f795c24ee37ee02302642b77bfc314a9ea43 to target the dynamic carousel in interaction. Since snippets can be added multiple times on the same page, this leads to duplicate ids, resulting in invalid HTML and potentially unexpected behavior.

Fix:
- Remove the static id and rely on class based selectors instead. The existing structure (`.s_dynamic_snippet_products .carousel-inner`) is specific enough for targeting the carousel in interactions.
