### PR TITLE
[FIX] html_editor: prevent premature font-size correction while typing

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -180,6 +180,7 @@ export class FontPlugin extends Plugin {
                     getItems: () => this.fontSizeItems,
                     getDisplay: () => this.fontSize,
                     onFontSizeInput: (size) => {
+                        this.isTypingFontSize = true;
                         const resolvedSize = this.resolveFontSize(parseFloat(size));
                         if (resolvedSize === null) {
                             // Desired size matches the inherited value
@@ -192,7 +193,6 @@ export class FontPlugin extends Plugin {
                                 applyStyle: true,
                             });
                         }
-                        this.updateFontSizeSelectorParams();
                     },
                     onSelected: (item) => {
                         this.dependencies.format.formatSelection("setFontSizeClassName", {
@@ -201,7 +201,11 @@ export class FontPlugin extends Plugin {
                         });
                         this.updateFontSizeSelectorParams();
                     },
-                    onBlur: () => this.dependencies.selection.focusEditable(),
+                    onBlur: () => {
+                        this.isTypingFontSize = false;
+                        this.updateFontSizeSelectorParams();
+                        this.dependencies.selection.focusEditable();
+                    },
                     document: this.document,
                 },
                 isAvailable: isHtmlContentSupported,
@@ -336,6 +340,7 @@ export class FontPlugin extends Plugin {
     setup() {
         this.fontSize = reactive({ displayName: "" });
         this.font = reactive({ displayName: "" });
+        this.isTypingFontSize = false;
         this.blockFormatIsAvailableMemoized = weakMemoize(
             (selection) => isHtmlContentSupported(selection) && this.dependencies.dom.canSetBlock()
         );
@@ -638,6 +643,9 @@ export class FontPlugin extends Plugin {
     }
 
     updateFontSizeSelectorParams() {
+        if (this.isTypingFontSize) {
+            return;
+        }
         this.fontSize.displayName = this.fontSizeName;
     }
 

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -32,7 +32,7 @@ export class FontSizeSelector extends Component {
         this.menuRef = useChildRef();
         useDropdownAutoVisibility(this.env.overlayState, this.menuRef);
         this.iframeContentRef = useRef("iframeContent");
-        this.debouncedCustomFontSizeInput = useDebounced(this.onCustomFontSizeInput, 1000);
+        this.debouncedCustomFontSizeInput = useDebounced(this.onCustomFontSizeInput, 200);
 
         onMounted(() => {
             const iframeEl = this.iframeContentRef.el;
@@ -46,6 +46,9 @@ export class FontSizeSelector extends Component {
                 }
 
                 this.fontSizeInput = iframeDoc.createElement("input");
+                this.fontSizeInput.addEventListener("blur", () => {
+                    this.props.onBlur?.();
+                });
                 const isDarkMode = cookie.get("color_scheme") === "dark";
                 const htmlStyle = getHtmlStyle(document);
                 const backgroundColor = getCSSVariableValue(

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -622,6 +622,7 @@ test("toolbar works: display correct font size on select all", async () => {
     expect(inputEl).toHaveValue(`${h1Size}`);
 });
 
+test.tags("desktop");
 test("toolbar works: displays correct font size on input", async () => {
     const { el } = await setupEditor("<p>test</p>");
     setContent(el, "<p>[test]</p>");
@@ -638,10 +639,12 @@ test("toolbar works: displays correct font size on input", async () => {
     expect(getContent(el)).toBe(`<p>[test]</p>`);
     expect(inputEl).toBeFocused();
 
-    await press("8");
-    expect(inputEl).toHaveValue("8");
-    await advanceTime(1000);
+    await press("5");
+    await advanceTime(200);
+    expect(inputEl).toHaveValue("5");
     expectElementCount(".o_font_size_selector_menu", 1);
+    inputEl.blur();
+    await animationFrame();
     // Responsive font-size: check for o_rfs class and clamp() value
     const rfsSpan = el.querySelector("span.o_rfs");
     expect(rfsSpan !== null).toBe(true);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Steps to reproduce:

1. Select some text.
2. In the font size dropdown, write 57 but very slowly.
3. If you let one second pass between writing 5 and 7, the 5 will be replaced by 8 and you will end up writing 87.

This is because of the new minimum value of 8. The system thinks the user wrote 5 and corrects it to 8, but the user wanted to write 57.

This PR revert to 200ms delay, and the reactive value of font-size is updated on blur of font size input box.

task-6106076

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
