### PR TITLE
[FIX] hr: add 'active_model' to plan wizard context

### DIFF
--- a/addons/hr/views/mail_activity_plan_views.xml
+++ b/addons/hr/views/mail_activity_plan_views.xml
@@ -100,7 +100,7 @@
             <field name="name">Launch Plan</field>
             <field name="res_model">mail.activity.schedule</field>
             <field name="view_mode">form</field>
-            <field name="context">{'plan_mode': True}</field>
+            <field name="context">{'plan_mode': True, 'active_model': 'hr.employee'}</field>
             <field name="target">new</field>
         </record>
     </data>


### PR DESCRIPTION
Steps to reproduce:
1- Install Employees app
2- Open the app and select any employee
3- In the chatter, click the onboarding plan link

Issue:
Starting from version 18.4 and onwards, clicking the link opens the 'Launch Plan' wizard without the Offboarding/Onboarding plans

Expected behavior:
The wizard should contain the plan Badges just like in previous versions or when clicking the 'Activity' button in the chatter

Why this happens:
One of the changes in the commit ef34950 was removing the following line: `context.params = state`
The `state` included the `active_model` value which was passed in the url.
As a result, `res_model` attribute in the model 'mail_activity_schedule' is `false`.
The `_compute_plan_available_ids` will then return an empty list. So the consequent call which gets the available plans to display as a Badge will not be made.

opw-6074918