### PR TITLE
[FIX] mrp_subcontracting: don't leak serial to backorder MO on partial receipt

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -131,19 +131,11 @@ class MrpProduction(models.Model):
                 quantity_to_process = min(quantity, ml.quantity)
                 quantity -= quantity_to_process
 
-                # on which lot of finished product
-                if float_compare(quantity_to_process, ml.quantity, precision_rounding=rounding) >= 0:
-                    ml.write({
-                        'quantity': quantity_to_process,
-                        'picked': True,
-                        'lot_id': self.lot_producing_id and self.lot_producing_id.id,
-                    })
-                else:
-                    ml.write({
-                        'quantity': quantity_to_process,
-                        'picked': True,
-                        'lot_id': self.lot_producing_id and self.lot_producing_id.id,
-                    })
+                ml.with_context(skip_subcontract_lot_propagation=True).write({
+                    'quantity': quantity_to_process,
+                    'picked': True,
+                    'lot_id': self.lot_producing_id and self.lot_producing_id.id,
+                })
 
             if float_compare(quantity, 0, precision_rounding=self.product_uom_id.rounding) > 0:
                 self.env['stock.move.line'].create({

--- a/addons/mrp_subcontracting/models/stock_move_line.py
+++ b/addons/mrp_subcontracting/models/stock_move_line.py
@@ -20,6 +20,8 @@ class StockMoveLine(models.Model):
         return res
 
     def write(self, vals):
+        if self.env.context.get('skip_subcontract_lot_propagation'):
+            return super().write(vals)
         for move_line in self:
             if vals.get('lot_id') and move_line.move_id.is_subcontract and move_line.location_id.is_subcontracting_location:
                 # Update related subcontracted production to keep consistency between production and reception.

--- a/addons/mrp_subcontracting/models/stock_move_line.py
+++ b/addons/mrp_subcontracting/models/stock_move_line.py
@@ -21,7 +21,7 @@ class StockMoveLine(models.Model):
 
     def write(self, vals):
         for move_line in self:
-            if vals.get('lot_id') and move_line.move_id.is_subcontract and move_line.location_id.is_subcontracting_location:
+            if vals.get('lot_id') and move_line.lot_id and move_line.move_id.is_subcontract and move_line.location_id.is_subcontracting_location:
                 # Update related subcontracted production to keep consistency between production and reception.
                 subcontracted_production = move_line.move_id._get_subcontract_production().filtered(lambda p: p.state not in ('done', 'cancel') and p.lot_producing_id == move_line.lot_id)
                 if subcontracted_production:

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -900,6 +900,39 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         subcontracted = move._get_subcontract_production().filtered(lambda p: p.state == 'done')
         self.assertEqual(sum(subcontracted.mapped('qty_produced')), quantities[-1])
 
+    def test_subcontracting_set_quantity_serial_preserves_backorder_serial(self):
+        """ Setting a partial quantity on a serial-tracked subcontract move splits
+        the MO into one MO per unit plus a remainder backorder. The recorded MOs
+        must each get a distinct serial, and the untouched backorder MO must keep
+        `lot_producing_id` empty so the next reception can generate a fresh one.
+        """
+        self.finished.tracking = 'serial'
+        self.bom.consumption = 'flexible'
+
+        picking_receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'partner_id': self.subcontractor_partner1.id,
+            'move_ids': [Command.create({
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_uom_qty': 5,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.warehouse.lot_stock_id.id,
+            })],
+        })
+        picking_receipt.action_confirm()
+
+        move = picking_receipt.move_ids_without_package
+        move.quantity = 3
+
+        productions = move._get_subcontract_production()
+        recorded = productions.filtered('subcontracting_has_been_recorded')
+        backorder = productions - recorded
+        self.assertEqual(len(recorded), 3)
+        self.assertEqual(len(recorded.lot_producing_id), 3)
+        self.assertEqual(len(backorder), 1)
+        self.assertFalse(backorder.lot_producing_id)
+
     def test_change_reception_serial(self):
         self.env.ref('base.group_user').write({'implied_ids': [(4, self.env.ref('stock.group_production_lot').id)]})
         self.finished.tracking = 'serial'

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -900,6 +900,39 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         subcontracted = move._get_subcontract_production().filtered(lambda p: p.state == 'done')
         self.assertEqual(sum(subcontracted.mapped('qty_produced')), quantities[-1])
 
+    def test_subcontracting_set_quantity_serial_preserves_backorder_lot(self):
+        """ Setting a partial quantity on a serial-tracked subcontract move splits
+        the MO into one MO per unit plus a remainder backorder. The recorded MOs
+        must each get a distinct serial, and the untouched backorder MO must keep
+        `lot_producing_id` empty so the next reception can generate a fresh one.
+        """
+        self.finished.tracking = 'serial'
+        self.bom.consumption = 'flexible'
+
+        picking_receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'partner_id': self.subcontractor_partner1.id,
+            'move_ids': [Command.create({
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_uom_qty': 5,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.warehouse.lot_stock_id.id,
+            })],
+        })
+        picking_receipt.action_confirm()
+
+        move = picking_receipt.move_ids_without_package
+        move.quantity = 3
+
+        productions = move._get_subcontract_production()
+        recorded = productions.filtered('subcontracting_has_been_recorded')
+        backorder = productions - recorded
+        self.assertEqual(len(recorded), 3)
+        self.assertEqual(len(recorded.lot_producing_id), 3)
+        self.assertEqual(len(backorder), 1)
+        self.assertFalse(backorder.lot_producing_id)
+
     def test_change_reception_serial(self):
         self.env.ref('base.group_user').write({'implied_ids': [(4, self.env.ref('stock.group_production_lot').id)]})
         self.finished.tracking = 'serial'


### PR DESCRIPTION
Steps to reproduce
1. Create a serial-tracked product with a subcontract BoM.
2. Create a receipt from the subcontractor for e.g. 5 units and confirm it.
3. Change the quantity to 3 and validate the receipt and click "Create Backorder" in the wizard.

Issue
Clicking "Create Backorder" raises "The serial number has already been
assigned" because the remainder backorder MO was silently assigned the
same serial as one of the recorded MOs, causing a quant uniqueness
violation.

When validating a serial-tracked subcontract receipt, `_auto_record_components`
splits the original MO into one MO per unit plus a remainder backorder MO,
and assigns a fresh serial to each recorded MO. It then calls
`subcontracting_record_component` which writes `lot_id` on reserved
`stock.move.line` records via `_update_finished_move`. The write override in
`stock.move.line` is meant to sync the matching MO's `lot_producing_id` when
a user changes a serial from A to B on a move line. Its filter at

https://github.com/odoo/odoo/blob/f251139ab668651cbd359fdae73befaf1683085b/addons/mrp_subcontracting/models/stock_move_line.py#L26

  p.lot_producing_id == move_line.lot_id

degenerates when the move line's previous `lot_id` is `False` (a freshly
reserved line with no prior lot) into "any open MO with no lot yet", which
matches the untouched remainder backorder MO and writes the just-assigned
serial onto it. All recorded MOs end up sharing the same serial number from
the contaminated backorder, triggering the duplicate quant error.

Solution
Guard the sync with `move_line.lot_id` at

https://github.com/odoo/odoo/blob/f251139ab668651cbd359fdae73befaf1683085b/addons/mrp_subcontracting/models/stock_move_line.py#L24

so it only runs when the move line already had a lot — i.e. the user is
replacing an existing serial — and not when one is being assigned for the
first time.

opw-6018243