### PR TITLE
[FIX] point_of_sale: chrome is synced

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -282,10 +282,16 @@ export function checkButtonDisabled(text) {
 }
 
 export function isSynced() {
-    return {
-        content: "Check if the request is proceeded",
-        trigger: negate(".fa-spin", ".status-buttons"),
-    };
+    return [
+        {
+            content: "Check fa-spin is here before check it's not here",
+            trigger: ".status-buttons:has(.fa-spin)",
+        },
+        {
+            content: "Check if the request is proceeded",
+            trigger: negate(".fa-spin", ".status-buttons"),
+        },
+    ];
 }
 
 export function clickOnScanButton() {


### PR DESCRIPTION
With this fix, we ensure fa-spin is in .status-buttons before to check that it's not there. If we don't add this previous step, the check is trivial ... always true.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
