### PR TITLE
[FIX] account: allow picking today's currency rate with date picker

### DIFF
--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
@@ -2,7 +2,6 @@ import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
 import { useService } from "@web/core/utils/hooks";
-import { today } from "@web/core/l10n/dates";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 
@@ -30,7 +29,6 @@ export class AccountPickCurrencyDate extends Component {
             get pickerProps() {
                 return {
                     type: 'date',
-                    value: today(),
                 };
             },
         });


### PR DESCRIPTION
On an invoice, using the date picker to choose the currency rate did not allow picking today's date.

Steps to reproduce:
- Activate a currency
- Add currency rate for today, yesterday and tomorrow
- Create a new invoice
- Select the newly activated currency
- Pick yesterday's date
- Pick today's date

Current behavior:
   picking today's date close the date picker without doing anything

Expected behavior:
   picking today's date close the date picker and apply today's currency rate
   (or latest if today's doesn't exist)

Cause:
The date picker was opened with today's date selected, preventing selecting it again.

Opening the date picker with the right date selected isn't possible as we don't save the currency rate date. It would require doing a reverse search among the currency rate date which might be wrong as the currency rate can be customized.

opw-6046169