### PR TITLE
[FIX] stock: do not save when toggling tracking

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -203,6 +203,7 @@
                 <xpath expr="//field[@name='is_storable']" position="attributes">
                     <attribute name="groups">!stock.group_production_lot</attribute>
                     <attribute name="widget">boolean_toggle</attribute>
+                    <attribute name="options">{'autosave': False}</attribute>
                     <attribute name="invisible">type != 'consu'</attribute>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="inside">


### PR DESCRIPTION
The widget 'boolean_toggle' has a default websave. This causes issues when creating new products.
On the basic form view, the new product is saved but the toggle is back to its initial position.
On quick create&edit view, you think you have enabled tracking but it was saved as consu.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
