### PR TITLE
[FIX] mrp,stock: consider kit variants in available quantity computation

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -113,6 +113,38 @@ class ProductTemplate(models.Model):
     def _get_backend_root_menu_ids(self):
         return super()._get_backend_root_menu_ids() + [self.env.ref('mrp.menu_mrp_root').id]
 
+    def _get_available_variant_quantities_dict(self):
+        if not any(variant.is_kits for variant in self.product_variant_ids._origin):
+            return super()._get_available_variant_quantities_dict()
+        variants_kit = self.product_variant_ids._origin.filtered(lambda v: v.is_kits)
+        variants_regular = self.product_variant_ids._origin - variants_kit
+        res = {
+            p['id']: p for p in variants_regular.read(['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty'])
+        }
+        kit_boms = self.bom_ids.filtered(lambda bom: bom.type == "phantom")
+        component_availability = {
+            comp.id: comp.qty_available
+            for comp in kit_boms.bom_line_ids.mapped('product_id')
+        }
+        for variant in self.product_variant_ids._origin.filtered(lambda var: var.is_kits):
+            var_boms = kit_boms.filtered(lambda bom: bom.product_id == variant)
+            max_var_qty = 0
+            for bom in var_boms:
+                max_bom_qty = min(
+                    (component_availability[line.product_id.id] / line.product_qty for line in bom.bom_line_ids),
+                    default=variant.qty_available
+                )
+                for line in bom.bom_line_ids:
+                    component_availability[line.product_id.id] -= (max_bom_qty * line.product_qty)
+                max_var_qty += max_bom_qty
+            vals = variant.read(['incoming_qty', 'outgoing_qty'])[0]
+            vals.update({
+                'qty_available': max_var_qty,
+                'virtual_available': max_var_qty
+            })
+            res[variant.id] = vals
+        return res
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -870,10 +870,13 @@ class ProductTemplate(models.Model):
             template.incoming_qty = res[template.id]['incoming_qty']
             template.outgoing_qty = res[template.id]['outgoing_qty']
 
-    def _compute_quantities_dict(self):
-        variants_available = {
+    def _get_available_variant_quantities_dict(self):
+        return {
             p['id']: p for p in self.product_variant_ids._origin.read(['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty'])
         }
+
+    def _compute_quantities_dict(self):
+        variants_available = self._get_available_variant_quantities_dict()
         prod_available = {}
         for template in self:
             qty_available = 0


### PR DESCRIPTION
Issue
-----
For a product.template with kit variants, the total available quantity shown on the template's view is the sum of all individual variants' available quantity. This poses problem when variant boms share components, because producing all variants individually could consume more of the components than available.

Steps to reproduce
-----
- Enable variants
- Create a product "Kit prod" with 2 variants: "Blue" and "Red"
- Create 2 stored components
	- "Comp A" with 10 in stock
	- "Comp B" with 8 in stock
- Create a bom for "Kit prod: Blue"
	- kit
	- uses 1 unit of "Comp A" per kit
- Create a bom for "Kit prod: Red"
	- kit
	- uses 1 unit of "Comp A" per kit
	- uses 1 unit of "Comp B" per kit
- Go to Products > Kit prod

> The displayed available quantity is 18

Cause
-----
`_compute_quantities_dict` simply sums the available quantities of all the variants, disregarding the availability of components.

https://github.com/odoo/odoo/blob/9c11e3e34e3b30b2abe9b445c775348e11474b2e/addons/stock/models/product.py#L873-L894

-----
Ticket:
opw-5935088