### PR TITLE
[FIX] marketing_card: malformed xml

### DIFF
--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -296,7 +296,7 @@ class CardCampaign(models.Model):
 
 <div class="s_text_block o_mail_snippet_general pt24 pb24" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
     <div class="container s_allow_columns">
-        <p">{_("Hello everyone")}</p>
+        <p>{_("Hello everyone")}</p>
         <p>{_("Here's the link to advertise your participation.")}
         <br>{_("Your help with this promotion would be greatly appreciated!")}</p>
         <p>{_("Many thanks")}</p>


### PR DESCRIPTION
This commit fixes a malformed HTML/XML tag in CardCampaign.

Note: before libxml2 v2.14.0, this issue was automagically cleaned up, but not anymore.
