### PR TITLE
non-secure contexts

### DIFF
--- a/addons/web/static/src/core/errors/non_secure_context_error.js
+++ b/addons/web/static/src/core/errors/non_secure_context_error.js
@@ -1,0 +1,25 @@
+import { registry } from "../registry";
+
+const errorHandlerRegistry = registry.category("error_handlers");
+
+export class NonSecureContextError extends Error {
+    name = "NonSecureContextError";
+}
+
+/**
+ * @param {OdooEnv} env
+ * @param {UncaughError} _error
+ * @param {Error} originalError
+ * @returns {boolean}
+ */
+export function NonSecureContextErrorHandler(env, _error, originalError) {
+    if (originalError instanceof NonSecureContextError) {
+        env.services.notification.add(originalError.message, { type: "danger", sticky: true });
+
+        return true;
+    }
+}
+
+errorHandlerRegistry.add("NonSecureContextErrorHandler", NonSecureContextErrorHandler, {
+    sequence: 98,
+});

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -8,8 +8,26 @@ import { session } from "@web/session";
 import { hashCode } from "../utils/strings";
 import { Crypto, CRYPTO_ALGO } from "../crypto";
 import { normalize } from "../l10n/utils";
+import { NonSecureContextError } from "../errors/non_secure_context_error";
+import { _t } from "../l10n/translation";
 
 const IS_READY = Symbol("ready");
+
+class FakeIndexedDB {
+    // used in non secure context to disable the offline features as data can't be encrypted
+    invalidate() {}
+    read() {
+        return Promise.resolve({});
+    }
+    write() {}
+    delete() {}
+    getAllKeys() {
+        return Promise.resolve([]);
+    }
+    getAllEntries() {
+        return Promise.resolve([]);
+    }
+}
 
 class OfflineManager extends Reactive {
     static VISITED_UI_TABLE_NAME = "visited-ui-items";
@@ -24,8 +42,13 @@ class OfflineManager extends Reactive {
 
         this.env = env;
         this.orm = orm;
-        this._idb = markRaw(new IndexedDB("offline", session.registry_hash + CRYPTO_ALGO));
-        this._crypto = session.browser_cache_secret && new Crypto(session.browser_cache_secret);
+        this._idb = window.isSecureContext
+            ? markRaw(new IndexedDB("offline", session.registry_hash + CRYPTO_ALGO))
+            : new FakeIndexedDB();
+        this._crypto =
+            window.isSecureContext &&
+            session.browser_cache_secret &&
+            new Crypto(session.browser_cache_secret);
         this._visitedUITable = this.env.debug
             ? OfflineManager.VISITED_UI_TABLE_NAME_DEBUG
             : OfflineManager.VISITED_UI_TABLE_NAME;
@@ -228,6 +251,11 @@ class OfflineManager extends Reactive {
     // -------------------------------------------------------------------------
 
     scheduleORM(model, method, args, kwargs, options) {
+        if (!window.isSecureContext) {
+            throw new NonSecureContextError(
+                _t("Offline features not available in a non-secure context")
+            );
+        }
         const value = { model, method, args, kwargs, extras: options.extras };
         const key = options.id ?? hashCode(JSON.stringify(value));
         this._ormToSync[key] = { key, value };
@@ -387,7 +415,12 @@ class OfflineManager extends Reactive {
     // -------------------------------------------------------------------------
 
     async _syncORM() {
+        if (!window.isSecureContext) {
+            return;
+        }
+
         // Only one tab can execute this block at a time
+        // This can only be done in a secure context
         await navigator.locks.request("db-sync", async () => {
             this._syncingORM = true;
             await this._updateScheduledORMList();

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -6,6 +6,7 @@ import { user } from "@web/core/user";
 import { Component, whenReady } from "@odoo/owl";
 import { rpc } from "./core/network/rpc";
 import { RPCCache } from "./core/network/rpc_cache";
+import { _t } from "./core/l10n/translation";
 
 // Chrome iOS wraps some text nodes (like measures, email...)
 // with a `<chrome_annotation>` tag, which breaks OWL rendering.
@@ -40,6 +41,14 @@ export async function startWebClient(Webclient) {
     const app = await mountComponent(Webclient, document.body, { name: "Odoo Web Client" });
     const { env } = app;
     Component.env = env;
+
+    if (!window.isSecureContext) {
+        console.error(
+            _t(
+                "You are currently using a non-secure context. As a result, some Odoo features may be unavailable or function improperly. For more information, please visit: https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts"
+            )
+        );
+    }
 
     const classList = document.body.classList;
     if (localization.direction === "rtl") {


### PR DESCRIPTION
[FIX] web: prevent errors in non-secure contexts

Multiple browser APIs are restricted in non-secure contexts. This commit
protects the offline service to prevent it from throwing errors when
running without HTTPS.

Note that most offline service functionalities will not work in a
non-secure context. This is because we cannot encrypt the IndexedDB caches
without a secure context; consequently, offline navigation will be
unavailable.

Part-of-task-6075066

---

[IMP] web: notify user in non-secure contexts

This commit adds a console error to alert the user when they are connected
via a non-secure context (HTTP). It specifies that certain Odoo
functionalities may not work correctly and that errors may occur due to
browser API restrictions.

Part-of-task-6075066