### PR TITLE
[FIX] stock: use the move UoM when generating lots

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1084,7 +1084,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             vals_list.append({**default_vals,
                              **lot,
                              'location_dest_id': putaway_loc_dest.id,
-                             'product_uom_id': product.uom_id.id,
+                             'product_uom_id': default_vals.get('uom_id', product.uom_id.id),
                             })
         if default_vals.get('picking_type_id'):
             picking_type = self.env['stock.picking.type'].browse(default_vals['picking_type_id'])

--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -71,6 +71,7 @@ export class GenerateDialog extends Component {
                 default_location_id: this.props.move.data.location_id.id,
                 default_tracking: this.props.move.data.has_tracking,
                 default_quantity: qtyToProcess,
+                default_uom_id: this.props.move.data.has_tracking === 'lot' ? this.props.move.data.product_uom?.id : undefined,
             },
             this.props.mode,
             this.nextSerial.el?.value,


### PR DESCRIPTION
Steps to reproduce the issue:
- Enable "Units of Measure" and "Lots & Serial Numbers" in the inventory settings

- Create a storable product "P1":
    - Tracking: Lot
    - UoM: Unit
    - Sales tab: Packagings > Pack of 6

- Create a receipt with 3 packs of 6 of P1
- Mark it as "To Do"
- Open the detailed operations and click on the "Generate Serials/Lots" button:
    - First lot: Lot 1
    - Quantity per Lot: 3 packs of 6
    - Quantity received: 3 packs of 6
    - Click on "Generate"

Problem:
A stock move line is created with 3 units instead of 3 packs of 6, because the UoM is not passed from the JavaScript side to the Python side. As a result, the default product UoM (Unit) is used.

opw-5933277
