### PR TITLE
[FIX] l10n_es_edi_facturae: XML structure and rounding fixes

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -312,6 +312,43 @@ class AccountMove(models.Model):
             items.append(invoice_line_values)
             taxes += taxes_output
             taxes_withheld += tax_withheld_output
+        # Aggregate subtotals and recalculate taxes for these subtotals to avoid rounding mismatches
+        subtotals_taxes = {}
+        for item in taxes:
+            key = (item['tax_record'].l10n_es_edi_facturae_tax_type, item['TaxRate'])
+            if key in subtotals_taxes:
+                subtotals_taxes[key]['TaxableBase']['TotalAmount'] += item['TaxableBase']['TotalAmount']
+                subtotals_taxes[key]['TaxableBase']['EquivalentInEuros'] += item['TaxableBase']['EquivalentInEuros']
+                subtotals_taxes[key]['TaxAmount']['TotalAmount'] += item['TaxAmount']['TotalAmount']
+                subtotals_taxes[key]['TaxAmount']['EquivalentInEuros'] += item['TaxAmount']['EquivalentInEuros']
+            else:
+                subtotals_taxes[key] = item.copy()
+                subtotals_taxes[key]['TaxableBase'] = subtotals_taxes[key]['TaxableBase'].copy()
+                subtotals_taxes[key]['TaxAmount'] = subtotals_taxes[key]['TaxAmount'].copy()
+        for key, value in subtotals_taxes.items():
+            value['TaxAmount']['TotalAmount'] = value['tax_record']._compute_amount(
+                value['TaxableBase']['TotalAmount'], value['TaxableBase']['TotalAmount'])
+            value['TaxAmount']['EquivalentInEuros'] = value['tax_record']._compute_amount(
+                value['TaxableBase']['EquivalentInEuros'], value['TaxableBase']['EquivalentInEuros'])
+        taxes = subtotals_taxes.values()
+        subtotals_taxes_withheld = {}
+        for item in taxes_withheld:
+            key = (item['tax_record'].l10n_es_edi_facturae_tax_type, item['TaxRate'])
+            if key in subtotals_taxes_withheld:
+                subtotals_taxes_withheld[key]['TaxableBase']['TotalAmount'] += item['TaxableBase']['TotalAmount']
+                subtotals_taxes_withheld[key]['TaxableBase']['EquivalentInEuros'] += item['TaxableBase']['EquivalentInEuros']
+                subtotals_taxes_withheld[key]['TaxAmount']['TotalAmount'] += item['TaxAmount']['TotalAmount']
+                subtotals_taxes_withheld[key]['TaxAmount']['EquivalentInEuros'] += item['TaxAmount']['EquivalentInEuros']
+            else:
+                subtotals_taxes_withheld[key] = item.copy()
+                subtotals_taxes_withheld[key]['TaxableBase'] = subtotals_taxes_withheld[key]['TaxableBase'].copy()
+                subtotals_taxes_withheld[key]['TaxAmount'] = subtotals_taxes_withheld[key]['TaxAmount'].copy()
+        for key, value in subtotals_taxes_withheld.items():
+            value['TaxAmount']['TotalAmount'] = value['tax_record']._compute_amount(
+                value['TaxableBase']['TotalAmount'], value['TaxableBase']['TotalAmount'])
+            value['TaxAmount']['EquivalentInEuros'] = value['tax_record']._compute_amount(
+                value['TaxableBase']['EquivalentInEuros'], value['TaxableBase']['EquivalentInEuros'])
+        taxes_withheld = subtotals_taxes_withheld.values()
         return items, taxes, taxes_withheld, totals
 
     def _l10n_es_edi_facturae_export_facturae(self):

--- a/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
@@ -74,50 +74,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
+            <TotalAmount>2400.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>200.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>42.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>900.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>189.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>1100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>231.00</TotalAmount>
+            <TotalAmount>504.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml
@@ -8,53 +8,53 @@
             <BatchIdentifier>INV/2023/00001</BatchIdentifier>
             <InvoicesCount>1</InvoicesCount>
             <TotalInvoicesAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.81</TotalAmount>
             </TotalInvoicesAmount>
             <TotalOutstandingAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.81</TotalAmount>
             </TotalOutstandingAmount>
             <TotalExecutableAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.81</TotalAmount>
             </TotalExecutableAmount>
             <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
         </Batch>
     </FileHeader>
     <Parties>
-        <SellerParty>
-            <TaxIdentification>
-                <PersonTypeCode>J</PersonTypeCode>
-                <ResidenceTypeCode>R</ResidenceTypeCode>
-                <TaxIdentificationNumber>ES59962470K</TaxIdentificationNumber>
-            </TaxIdentification>
-             <LegalEntity>
-        <CorporateName>company_1_data</CorporateName>
-        <TradeName>company_1_data</TradeName>
-        <AddressInSpain>
-          <Address>C. de Embajadores, 68-116</Address>
-          <PostCode>12345</PostCode>
-          <Town>Madrid</Town>
-          <Province>Madrid</Province>
-          <CountryCode>ESP</CountryCode>
-        </AddressInSpain>
-      </LegalEntity>
-    </SellerParty>
-    <BuyerParty>
-      <TaxIdentification>
-        <PersonTypeCode>F</PersonTypeCode>
-        <ResidenceTypeCode>U</ResidenceTypeCode>
-        <TaxIdentificationNumber>BE0477472701</TaxIdentificationNumber>
-      </TaxIdentification>
-      <Individual>
-        <Name>UNKNOWN</Name>
-        <FirstSurname>UNKNOWN</FirstSurname>
-        <OverseasAddress>
-          <Address>Rue de Bruxelles, 15000</Address>
-          <PostCodeAndTown>5000 Namur</PostCodeAndTown>
-          <Province>Belgium</Province>
-          <CountryCode>BEL</CountryCode>
-        </OverseasAddress>
-      </Individual>
-    </BuyerParty>
+      <SellerParty>
+        <TaxIdentification>
+            <PersonTypeCode>J</PersonTypeCode>
+            <ResidenceTypeCode>R</ResidenceTypeCode>
+            <TaxIdentificationNumber>ES59962470K</TaxIdentificationNumber>
+        </TaxIdentification>
+        <LegalEntity>
+          <CorporateName>company_1_data</CorporateName>
+          <TradeName>company_1_data</TradeName>
+          <AddressInSpain>
+            <Address>C. de Embajadores, 68-116</Address>
+            <PostCode>12345</PostCode>
+            <Town>Madrid</Town>
+            <Province>Madrid</Province>
+            <CountryCode>ESP</CountryCode>
+          </AddressInSpain>
+        </LegalEntity>
+      </SellerParty>
+      <BuyerParty>
+        <TaxIdentification>
+          <PersonTypeCode>F</PersonTypeCode>
+          <ResidenceTypeCode>U</ResidenceTypeCode>
+          <TaxIdentificationNumber>BE0477472701</TaxIdentificationNumber>
+        </TaxIdentification>
+        <Individual>
+          <Name>UNKNOWN</Name>
+          <FirstSurname>UNKNOWN</FirstSurname>
+          <OverseasAddress>
+            <Address>Rue de Bruxelles, 15000</Address>
+            <PostCodeAndTown>5000 Namur</PostCodeAndTown>
+            <Province>Belgium</Province>
+            <CountryCode>BEL</CountryCode>
+          </OverseasAddress>
+        </Individual>
+      </BuyerParty>
     </Parties>
     <Invoices>
         <Invoice>
@@ -74,40 +74,40 @@
                     <TaxTypeCode>01</TaxTypeCode>
                     <TaxRate>21.000</TaxRate>
                     <TaxableBase>
-                        <TotalAmount>339.18</TotalAmount>
+                        <TotalAmount>5028.77</TotalAmount>
                     </TaxableBase>
                     <TaxAmount>
-                        <TotalAmount>71.23</TotalAmount>
+                        <TotalAmount>1056.04</TotalAmount>
                     </TaxAmount>
                 </Tax>
             </TaxesOutputs>
             <InvoiceTotals>
-                <TotalGrossAmount>339.18</TotalGrossAmount>
-                <TotalGrossAmountBeforeTaxes>339.18</TotalGrossAmountBeforeTaxes>
-                <TotalTaxOutputs>71.23</TotalTaxOutputs>
+                <TotalGrossAmount>5028.77</TotalGrossAmount>
+                <TotalGrossAmountBeforeTaxes>5028.77</TotalGrossAmountBeforeTaxes>
+                <TotalTaxOutputs>1056.04</TotalTaxOutputs>
                 <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
-                <InvoiceTotal>410.41</InvoiceTotal>
-                <TotalOutstandingAmount>410.41</TotalOutstandingAmount>
-                <TotalExecutableAmount>410.41</TotalExecutableAmount>
+                <InvoiceTotal>6084.81</InvoiceTotal>
+                <TotalOutstandingAmount>6084.81</TotalOutstandingAmount>
+                <TotalExecutableAmount>6084.81</TotalExecutableAmount>
             </InvoiceTotals>
             <Items>
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>25.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>2.0200</UnitPriceWithoutTax>
-                    <TotalCost>50.50</TotalCost>
-                    <GrossAmount>50.50</GrossAmount>
+                    <UnitPriceWithoutTax>2478.14</UnitPriceWithoutTax>
+                    <TotalCost>2478.14</TotalCost>
+                    <GrossAmount>2478.14</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>50.50</TotalAmount>
+                                <TotalAmount>2478.14</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>10.61</TotalAmount>
+                                <TotalAmount>520.41</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -115,20 +115,20 @@
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>2.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>7.2900</UnitPriceWithoutTax>
-                    <TotalCost>14.58</TotalCost>
-                    <GrossAmount>14.58</GrossAmount>
+                    <UnitPriceWithoutTax>1062.50</UnitPriceWithoutTax>
+                    <TotalCost>1062.50</TotalCost>
+                    <GrossAmount>1062.50</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>14.58</TotalAmount>
+                                <TotalAmount>1062.50</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>3.06</TotalAmount>
+                                <TotalAmount>223.13</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -136,41 +136,20 @@
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>5.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>7.3200</UnitPriceWithoutTax>
-                    <TotalCost>36.60</TotalCost>
-                    <GrossAmount>36.60</GrossAmount>
+                    <UnitPriceWithoutTax>1488.13</UnitPriceWithoutTax>
+                    <TotalCost>1488.13</TotalCost>
+                    <GrossAmount>1488.13</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>36.60</TotalAmount>
+                                <TotalAmount>1488.13</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>7.69</TotalAmount>
-                            </TaxAmount>
-                        </Tax>
-                    </TaxesOutputs>
-                </InvoiceLine>
-                <InvoiceLine>
-                    <FileDate>2023-01-01</FileDate>
-                    <ItemDescription>product_a</ItemDescription>
-                    <Quantity>25.0</Quantity>
-                    <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>9.5000</UnitPriceWithoutTax>
-                    <TotalCost>237.50</TotalCost>
-                    <GrossAmount>237.50</GrossAmount>
-                    <TaxesOutputs>
-                        <Tax>
-                            <TaxTypeCode>01</TaxTypeCode>
-                            <TaxRate>21.000</TaxRate>
-                            <TaxableBase>
-                                <TotalAmount>237.50</TotalAmount>
-                            </TaxableBase>
-                            <TaxAmount>
-                                <TotalAmount>49.88</TotalAmount>
+                                <TotalAmount>312.51</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -179,7 +158,7 @@
             <PaymentDetails>
                 <Installment>
                     <InstallmentDueDate>2023-01-01</InstallmentDueDate>
-                    <InstallmentAmount>410.41</InstallmentAmount>
+                    <InstallmentAmount>6084.81</InstallmentAmount>
                     <PaymentMeans>04</PaymentMeans>
                     <AccountToBeCredited>
                         <IBAN>ES9121000418450200051332</IBAN>
@@ -246,7 +225,7 @@
                 </xades:SigPolicyId>
                 <xades:SigPolicyHash>
                   <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-                  <ds:DigestValue>Ohixl6upD6av8N7pEvDABhEL6hM=</ds:DigestValue>
+                  <ds:DigestValue>___ignore___</ds:DigestValue>
                 </xades:SigPolicyHash>
                 <xades:SigPolicyQualifiers>
                   <xades:SigPolicyQualifier>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -88,20 +88,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
+            <TotalAmount>-200.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>-21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>-21.00</TotalAmount>
+            <TotalAmount>-42.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -74,50 +74,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
+            <TotalAmount>2400.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>200.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>42.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>900.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>189.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>1100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>231.00</TotalAmount>
+            <TotalAmount>504.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>
@@ -273,7 +233,7 @@
         <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
       </ds:Transforms>
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-      <ds:DigestValue>+v+AUxz9tkW0fW3AllOweXyOER14IgfGTNUFE0dCilM=</ds:DigestValue>
+      <ds:DigestValue>SUrA8zME0VHzKa3H0Jq35MoFgpLG1NNV8vPg+S/zN/g=</ds:DigestValue>
     </ds:Reference>
     <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignatureProperties-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
@@ -284,11 +244,11 @@
       <ds:DigestValue>ARCif8tQIKagVfeHX4Fit5ZfK3mXQCPclQISywh7h44=</ds:DigestValue>
     </ds:Reference>
   </ds:SignedInfo>
-  <ds:SignatureValue>jEfah4l5JQHNK39X9Vytkn2mGLNWLpEnGHeh5mSZL0dqSBcWcL93SOkiMbNeSMl1r1hKrNlsTirj
-X2WdTNRY19u3YhOc/ZEa1hmi5vKdq5QvsQvGNhu72GIybnh4LpYwfK/MwOBr9gAMGnJYAiOjG7YZ
-bHzi8Nn3ViUApPmaYPAtkhWYHmTQBLChCMkGTHRy+i99NDSlL7SYcgztA6OQHlwNv4WyT4fXtZoa
-gmmRAFR4B3ccUYv28XtHMmz50HE1RxOn+AH4Z8AAdgQmCnbY0tyGOJPNTsShV4nisALqcmx8Tdqb
-4MhISi8x4ehjACvNSGNo9gMgsRdVZVQc7U7Qaw==
+  <ds:SignatureValue>YbGWhczIMv9tf69fkepQQ3av/YgHuLJK3Kw3GZjV4GdQ2GK5DCgsh+rG+tHW1UEJpsMP0ZM7P0Nh
+ETb56VMHXwbJk/kkTx0s76T7AIo/i+6lyPOpiwugwQ1882LxwHfoxSBBW2LyQNA5N6hTnnNxrW3k
+1PdOl3ijXCmevc3AuMuHU8FByIePF4BIdf+QrPUKuBm0QPvqt1HtrvAidu4ny+p6EDnVjtfLyDYm
+n9ZHch2SuVb2fv98PIf+NnQ9V3kPf+gSHK78/CPfQVOmCDC82PIOD9HRXSFdNax7cul8hJCQQzIn
+o3oaBhz0iifLuwRtdpHSyP2lLAJbVhcB6xOLaA==
 </ds:SignatureValue>
   <ds:KeyInfo Id="KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
     <ds:X509Data>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -400,3 +400,25 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             with file_open("l10n_es_edi_facturae/tests/data/expected_simplified_document.xml", "rt") as f:
                 expected_xml = lxml.etree.fromstring(f.read().encode())
             self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)
+
+    def test_out_invoice_rounding_2(self):
+        company = self.company_data['company']
+        company.tax_calculation_rounding_method = 'round_globally'
+        with freeze_time(datetime(2023, 1, 1)):
+            invoice = self.create_invoice(
+                partner_id=self.partner_a.id,
+                move_type='out_invoice',
+                invoice_line_ids=[
+                    {'product_id': self.product_a.id, 'price_unit': 2478.1355, 'quantity': 1.0, 'tax_ids': [self.tax.id]},
+                    {'product_id': self.product_a.id, 'price_unit': 1062.50, 'quantity': 1.0, 'tax_ids': [self.tax.id]},
+                    {'product_id': self.product_a.id, 'price_unit': 1488.125, 'quantity': 1.0, 'tax_ids': [self.tax.id]},
+                ],
+            )
+            invoice.action_post()
+            generated_file, errors = invoice._l10n_es_edi_facturae_render_facturae()
+            self.assertFalse(errors)
+            self.assertTrue(generated_file)
+
+            with file_open("l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml", "rt") as f:
+                expected_xml = lxml.etree.fromstring(f.read().encode())
+            self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)


### PR DESCRIPTION
Adjusting invoice-level <TaxesOutputs> nodes to be generated per tax rather than per line
Enabling rounding for invoice-level tax data aggregation
Adding a second rounding test derived from bug ticket
Backport of odoo-253305
task-6009108

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
