### PR TITLE
[FIX] website_sale: fix pavs when no products are available

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -514,7 +514,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 order="attribute_id",
                 aggregates=["id:recordset"],
             )
-            pavs_per_attribute = dict(grouped_pavs)
+            pavs_per_attribute.update(grouped_pavs)
             # Return attributes as recordset of `product.attribute`
             attributes = ProductAttribute.union(pavs_per_attribute.keys())
         else:

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -2,6 +2,7 @@
 
 import itertools
 import json
+from collections import defaultdict
 from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -238,12 +239,17 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     def _shop_lookup_products(self, options, post, search, website):
         # No limit because attributes are obtained from complete product list
-        product_count, details, fuzzy_search_term = website._search_with_fuzzy("product_template", search,
-                                                                               offset=0,
-                                                                               limit=None,
-                                                                               order=self._get_search_order(post),
-                                                                               options=options)
-        search_result = details[0].get("results", request.env["product.template"]).with_context(bin_size=True)
+        product_count, details, fuzzy_search_term = website._search_with_fuzzy(
+            "product_template",
+            search,
+            offset=0,
+            limit=None,
+            order=self._get_search_order(post),
+            options=options,
+        )
+        search_result = (
+            details[0].get("results", request.env["product.template"]).with_context(bin_size=True)
+        )
 
         return fuzzy_search_term, product_count, search_result
 
@@ -492,13 +498,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
         )
 
         ProductAttribute = request.env["product.attribute"]
-        pavs_per_attribute = {}
+        ProductAttributeValue = request.env["product.attribute.value"]
+        pavs_per_attribute = defaultdict(lambda: ProductAttributeValue)
         if products:
             search_term = fuzzy_search_term if fuzzy_search_term else search
             product_query = request.env["product.template"]._search(
                 self._get_shop_domain(search_term, category, attribute_value_dict)
             )
-            grouped_pavs = request.env["product.attribute.value"]._read_group(
+            grouped_pavs = ProductAttributeValue._read_group(
                 domain=[
                     ("pav_attribute_line_ids.product_tmpl_id", "in", product_query),
                     ("attribute_id.visibility", "=", "visible"),

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -828,11 +828,6 @@
             method="get"
             t-att-action="keep(attribute_values=0, tags=0)"
         >
-            <t
-                t-set="visible_attributes"
-                t-value="len([a for a in attributes if pavs_per_attribute[a] and len(pavs_per_attribute[a]) &gt; 1])"
-            />
-
             <t t-foreach="attributes" t-as="a">
                 <t t-set="_status" t-value="'inactive'"/>
                 <t t-set="current_attribute_pavs" t-value="pavs_per_attribute[a]" />
@@ -843,9 +838,12 @@
                     t-set="_status"
                     t-value="'active'"
                 />
-                <t t-set="_expand_attributes" t-value="_status == 'active' or visible_attributes &lt; 4"/>
+                <t
+                    t-set="_expand_attributes"
+                    t-value="_status == 'active' or len(attributes) &lt; 4"
+                />
                 <div
-                    t-if="current_attribute_pavs and len(current_attribute_pavs) &gt; 1"
+                    t-if="current_attribute_pavs"
                     t-attf-class="accordion-item {{('border-top-0 ' + ('order-1' if _status == 'active' else 'order-2')) if isMobile else 'nav-item mb-1 rounded-0'}}"
                 >
                     <h2

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -1461,8 +1461,9 @@
     <template id="website_sale.filter_products_price" name="Filter by Prices">
         <t t-set="is_disabled" t-value="available_min_price == available_max_price"/>
         <div
+            t-if="not is_disabled"
             id="o_wsale_price_range_option"
-            t-attf-class="position-relative {{_classes}} {{is_disabled and 'opacity-75 pe-none user-select-none'}}"
+            t-attf-class="position-relative {{_classes}}"
         >
             <t t-if="is_sidebar_collapsible">
                 <div class="accordion-item">


### PR DESCRIPTION
follow up of task-4423954 , commit eb00160d52f7a26381f5f2b4dd1405f7d1a97748
1. Add a defaultdict value for pavs if page has no products.
2. Don't hide attributes if pavs are only 1 anymore.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
