### PR TITLE
[FIX] {mrp, stock}_account: avoid traceback after kit explosion

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -7,7 +7,7 @@ from odoo.addons.mrp_account.tests.common import TestBomPriceCommon, TestBomPric
 from odoo.tests import Form
 from odoo.tests.common import new_test_user
 from odoo.tools import float_compare, float_round
-from odoo import fields
+from odoo import Command, fields
 
 
 class TestMrpAccount(TestBomPriceCommon):
@@ -158,6 +158,45 @@ class TestMrpAccount(TestBomPriceCommon):
         ])
         self.assertEqual(productB_debit_line.account_id, self.account_stock_valuation)
         self.assertEqual(productB_credit_line.account_id, self.account_production)
+
+    def test_delivery_validate_after_product_converted_to_kit(self):
+        """
+        Create a delivery for a product, make the product a kit then
+        validate it.
+        """
+        self.env['stock.quant']._update_available_quantity(self.dining_table, self.stock_location, 1)
+        self.screw.categ_id = self.category_avco_auto
+        self.stock_location.valuation_account_id = self.account_production
+        delivery = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            'move_ids': [Command.create({
+                'product_id': self.dining_table.id,
+                'product_uom_qty': 1,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+            })],
+        })
+        delivery.action_confirm()
+        self.bom_1.bom_line_ids = self.bom_1.bom_line_ids[1]
+        self.bom_1.type = 'phantom'
+        self.dining_table.invalidate_recordset()
+        delivery.button_validate()
+        self.assertEqual(delivery.move_ids.product_id, self.bom_1.bom_line_ids.product_id)
+        self.assertEqual(delivery.state, 'assigned')
+        # Needs to validate the delivery twice
+        delivery.move_ids.quantity = 5
+        delivery.button_validate()
+        self.assertEqual(delivery.move_ids.product_id, self.bom_1.bom_line_ids.product_id)
+        self.assertEqual(delivery.state, 'done')
+        product_aml = self.env['account.move.line'].search([('product_id', '=', self.dining_table.id)])
+        comp_aml = self.env['account.move.line'].search([('product_id', '=', self.screw.id)], order='debit')
+        self.assertEqual(len(product_aml), 0)
+        self.assertRecordValues(comp_aml, [
+            {'debit':  0.0, 'credit':  50.0},
+            {'debit':  50.0, 'credit':  0.0},
+        ])
 
     def test_mo_overview_comp_different_uom(self):
         """ Test that the overview takes into account the uom of the component in the price computation

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -172,6 +172,7 @@ class StockMove(models.Model):
         moves_out = self.filtered(lambda m: m._is_out())
         moves_out._set_value()
         moves = super()._action_done(cancel_backorder=cancel_backorder)
+        moves_out = moves_out.exists()
         moves_in = moves.filtered(lambda m: m.is_in or m.is_dropship)
         moves_in._set_value()
         moves._create_account_move()


### PR DESCRIPTION
**Issue**:
Making a product a kit could prevent confirming deliveries.

**Steps to reproduce**:
- Make sure the account application is installed
- Create a product P without kit
- Create a SO and confirm it
- Make the product P a kit
- Validate the delivery associated to the SO
-> A traceback occurs: the record does not exist anymore

**Cause**:
While confirming the delivery:
https://github.com/odoo/odoo/blob/a253cff9039fcf729a9922b119acad5ec7c7a0bd/addons/stock_account/models/stock_move.py#L168 It first filters which moves are out (`moves_out`). On the move associated with product P, since the kit is not exploded yet: https://github.com/odoo/odoo/blob/a253cff9039fcf729a9922b119acad5ec7c7a0bd/addons/stock_account/models/stock_move.py#L172 Then explodes the kit:
https://github.com/odoo/odoo/blob/a253cff9039fcf729a9922b119acad5ec7c7a0bd/addons/stock_account/models/stock_move.py#L174 https://github.com/odoo/odoo/blob/ea18f34a48d61350f80c79894bef66bf02840bfc/addons/mrp/models/stock_move.py#L357-L361 By doing so, the original move associated to the product P are deleted: https://github.com/odoo/odoo/blob/ea18f34a48d61350f80c79894bef66bf02840bfc/addons/mrp/models/stock_move.py#L399 Thus, `moves_out` contains moves that no longer exist, and eventually, and eventually while accessing `product_id`: https://github.com/odoo/odoo/blob/a253cff9039fcf729a9922b119acad5ec7c7a0bd/addons/stock_account/models/stock_move.py#L179 A traceback is thrown

**Aditionnal information**
Validating a delivery of a kit product whose moves were not exploded will trigger their explosion and require a second validation.
Therefore, no stock valuation errors will be created.

opw-6063602