### PR TITLE
[FIX] purchase: display section subtotal in PO report

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -745,3 +745,23 @@ class PurchaseOrderLine(models.Model):
             return self.parent_id.parent_id
 
         return self.parent_id
+
+    def _get_section_subtotal(self):
+        section_lines = self._get_section_lines()
+        return sum(section_lines.mapped('price_subtotal'))
+
+    def _get_section_lines(self):
+        self.ensure_one()
+        return self.order_id.order_line.filtered(self._is_line_in_section)
+
+    def _is_line_in_section(self, line):
+        """Return whether the line is a direct or indirect child of the section."""
+        self.ensure_one()
+        is_direct_child = line.parent_id == self and not line.display_type
+        is_indirect_child = (
+            self.display_type == 'line_section'
+            and line.parent_id
+            and line.parent_id.display_type == 'line_subsection'
+            and line.parent_id.parent_id == self
+        )
+        return is_direct_child or is_indirect_child

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -97,8 +97,12 @@
                                 </td>
                             </t>
                             <t t-if="line.display_type in ('line_section', 'line_subsection')">
+                                <t t-set="section_subtotal" t-value="line._get_section_subtotal()"/>
                                 <td colspan="99" id="section">
                                     <span t-field="line.name"/>
+                                </td>
+                                 <td colspan="1" class="text-end o_price_total">
+                                    <span t-out="section_subtotal" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                 </td>
                                 <t t-set="current_section" t-value="line"/>
                                 <t t-set="current_subtotal" t-value="0"/>
@@ -109,17 +113,6 @@
                                 </td>
                             </t>
                         </tr>
-                        <t t-if="current_section and (line_last or o.order_line[line_index+1].display_type in ('line_section', 'line_subsection'))">
-                            <tr class="is-subtotal text-end">
-                                <td colspan="99" id="subtotal">
-                                    <strong class="mr16">Subtotal</strong>
-                                    <span
-                                        t-out="current_subtotal"
-                                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                    />
-                                </td>
-                            </tr>
-                        </t>
                     </t>
                 </tbody>
             </table>


### PR DESCRIPTION
Steps to reproduce:
1- Install Purchase app
2- Create a new purchase order
3- Add a section with two subsections, and add a product in each subsection
4- Confirm the PO and print

Issue:
The section subtotal is equal to 0

Expected behavior:
Section subtotal should be equal to the sum of all subsections

Why this happens:
After introducing sections and subsections in this commit bc6592a, the subtotal calculation in Purchase does not follow the same logic as in Sales and Invoicing which work properly. The code relied on `current_subtotal` for calculation, which would reset after each subsection and section. By the time we display the section subtotal, the attribute value would be 0.

Fix:
Implemented the same logic used in the other apps.

opw-6086465