### PR TITLE
[FIX] account_peppol: use correct error method

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -381,7 +381,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                     # "Peppol request not ready" error:
                     # thrown when the IAP is still processing the message
                     continue
-                error_message = self.get_peppol_error_message(self.env, error_vals)
+                error_message = get_peppol_error_message(self.env, error_vals)
                 move._message_log(body=error_message)
                 move.peppol_move_state = 'error'
                 processed_message_uuids.append(uuid)


### PR DESCRIPTION
Correction in a typo from the last commit

opw-6102471
