### PR TITLE
[PERF] mrp/stock: fix OOM and slow product quantity filters in Inventory report

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -405,20 +405,113 @@ class ProductProduct(models.Model):
 
     def _search_qty_available_new(self, operator, value, lot_id=False, owner_id=False, package_id=False):
         '''extending the method in stock.product to take into account kits'''
-        product_ids = super(ProductProduct, self)._search_qty_available_new(operator, value, lot_id, owner_id, package_id)
-        kit_boms = self.env['mrp.bom'].search([('type', "=", 'phantom')])
-        kit_products = self.env['product.product']
-        for kit in kit_boms:
-            if kit.product_id:
-                kit_products |= kit.product_id
+        product_ids = super()._search_qty_available_new(
+            operator, value, lot_id, owner_id, package_id
+        )
+        kit_boms_data = self.env['mrp.bom'].search_fetch(
+            [('type', '=', 'phantom')],
+            ['product_id', 'product_tmpl_id', 'product_qty'],
+        )
+        if not kit_boms_data:
+            return list(set(product_ids))
+
+        bom_by_kit_product = {}
+        tmpl_boms = {}
+        for bom in kit_boms_data:
+            if bom.product_id:
+                pid = bom.product_id.id
+                if pid not in bom_by_kit_product:
+                    bom_by_kit_product[pid] = bom
             else:
-                kit_products |= kit.product_tmpl_id.product_variant_ids
-        for product in kit_products:
-            if OPERATORS[operator](product.qty_available, value):
-                product_ids.append(product.id)
-            elif product.id in product_ids:
-                product_ids.pop(product_ids.index(product.id))
-        return list(set(product_ids))
+                tmpl_id = bom.product_tmpl_id.id
+                if tmpl_id not in tmpl_boms:
+                    tmpl_boms[tmpl_id] = bom
+
+        if tmpl_boms:
+            for tmpl in self.env['product.template'].browse(list(tmpl_boms.keys())):
+                bom = tmpl_boms[tmpl.id]
+                for variant in tmpl.product_variant_ids:
+                    if variant.id not in bom_by_kit_product:
+                        bom_by_kit_product[variant.id] = bom
+        kit_product_id_set = set(bom_by_kit_product.keys())
+
+        bom_lines_data = self.env['mrp.bom.line'].search_fetch(
+            [('bom_id', 'in', list({bom.id for bom in bom_by_kit_product.values()}))],
+            ['bom_id', 'product_id', 'product_qty', 'product_uom_id',
+             'bom_product_template_attribute_value_ids'],
+        )
+
+        kit_pids_by_bom_id = collections.defaultdict(set)
+        for pid, bom in bom_by_kit_product.items():
+            kit_pids_by_bom_id[bom.id].add(pid)
+
+        slowpath_kit_ids = set()
+        for line in bom_lines_data:
+            if (line.product_id.id in kit_product_id_set
+                    or line.bom_product_template_attribute_value_ids):
+                slowpath_kit_ids |= kit_pids_by_bom_id[line.bom_id.id]
+        fastpath_bom_id_set = {
+            bom.id for pid, bom in bom_by_kit_product.items()
+            if pid not in slowpath_kit_ids
+        }
+        fastpath_lines = [
+            line for line in bom_lines_data
+            if line.bom_id.id in fastpath_bom_id_set
+        ]
+
+        comp_ids = list({line.product_id.id for line in fastpath_lines})
+
+        domain_quant = self._get_domain_locations()[0]
+        if lot_id:
+            domain_quant.append(('lot_id', '=', lot_id))
+        if owner_id:
+            domain_quant.append(('owner_id', '=', owner_id))
+        if package_id:
+            domain_quant.append(('package_id', '=', package_id))
+        domain_quant.append(('product_id', 'in', comp_ids))
+        comp_qty_available = {
+            p.id: qty
+            for p, qty in self.env['stock.quant']._read_group(
+                domain_quant, ['product_id'], ['quantity:sum'],
+            )
+        }
+
+        lines_by_bom = collections.defaultdict(list)
+        for line in fastpath_lines:
+            lines_by_bom[line.bom_id.id].append(line)
+
+        product_ids_set = set(product_ids)
+        for kit_pid in kit_product_id_set - slowpath_kit_ids:
+            bom = bom_by_kit_product[kit_pid]
+            ratios = []
+            for line in lines_by_bom.get(bom.id, []):
+                comp = line.product_id
+                if not comp.is_storable:
+                    continue
+                line_factor = line.product_uom_id.factor
+                base_factor = comp.uom_id.factor
+                if not line_factor or not base_factor:
+                    continue
+                qty_per_kit = line.product_qty / line_factor * base_factor
+                if not qty_per_kit:
+                    continue
+                ratios.append(comp_qty_available.get(comp.id, 0.0) / qty_per_kit)
+            kit_qty = (min(ratios) * bom.product_qty) // 1 if ratios else 0.0
+            if OPERATORS[operator](kit_qty, value):
+                product_ids_set.add(kit_pid)
+            else:
+                product_ids_set.discard(kit_pid)
+
+        if slowpath_kit_ids:
+            slowpath_products = self.env['product.product'].browse(slowpath_kit_ids)
+            slow_qty = slowpath_products._compute_quantities_dict(lot_id, owner_id, package_id)
+            for product in slowpath_products:
+                if OPERATORS[operator](slow_qty[product.id]['qty_available'], value):
+                    product_ids_set.add(product.id)
+                else:
+                    product_ids_set.discard(product.id)
+
+        return list(product_ids_set)
 
     def action_archive(self):
         filtered_products = self.env['mrp.bom.line'].search([('product_id', 'in', self.ids), ('bom_id.active', '=', True)]).product_id.mapped('display_name')

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -396,20 +396,113 @@ class ProductProduct(models.Model):
 
     def _search_qty_available_new(self, operator, value, lot_id=False, owner_id=False, package_id=False):
         '''extending the method in stock.product to take into account kits'''
-        product_ids = super(ProductProduct, self)._search_qty_available_new(operator, value, lot_id, owner_id, package_id)
-        kit_boms = self.env['mrp.bom'].search([('type', "=", 'phantom')])
-        kit_products = self.env['product.product']
-        for kit in kit_boms:
-            if kit.product_id:
-                kit_products |= kit.product_id
+        product_ids = super()._search_qty_available_new(
+            operator, value, lot_id, owner_id, package_id
+        )
+        kit_boms_data = self.env['mrp.bom'].search_fetch(
+            [('type', '=', 'phantom')],
+            ['product_id', 'product_tmpl_id', 'product_qty'],
+        )
+        if not kit_boms_data:
+            return list(set(product_ids))
+
+        bom_by_kit_product = {}
+        tmpl_boms = {}
+        for bom in kit_boms_data:
+            if bom.product_id:
+                pid = bom.product_id.id
+                if pid not in bom_by_kit_product:
+                    bom_by_kit_product[pid] = bom
             else:
-                kit_products |= kit.product_tmpl_id.product_variant_ids
-        for product in kit_products:
-            if OPERATORS[operator](product.qty_available, value):
-                product_ids.append(product.id)
-            elif product.id in product_ids:
-                product_ids.pop(product_ids.index(product.id))
-        return list(set(product_ids))
+                tmpl_id = bom.product_tmpl_id.id
+                if tmpl_id not in tmpl_boms:
+                    tmpl_boms[tmpl_id] = bom
+
+        if tmpl_boms:
+            for tmpl in self.env['product.template'].browse(list(tmpl_boms.keys())):
+                bom = tmpl_boms[tmpl.id]
+                for variant in tmpl.product_variant_ids:
+                    if variant.id not in bom_by_kit_product:
+                        bom_by_kit_product[variant.id] = bom
+        kit_product_id_set = set(bom_by_kit_product.keys())
+
+        bom_lines_data = self.env['mrp.bom.line'].search_fetch(
+            [('bom_id', 'in', list({bom.id for bom in bom_by_kit_product.values()}))],
+            ['bom_id', 'product_id', 'product_qty', 'product_uom_id',
+             'bom_product_template_attribute_value_ids'],
+        )
+
+        kit_pids_by_bom_id = collections.defaultdict(set)
+        for pid, bom in bom_by_kit_product.items():
+            kit_pids_by_bom_id[bom.id].add(pid)
+
+        slowpath_kit_ids = set()
+        for line in bom_lines_data:
+            if (line.product_id.id in kit_product_id_set
+                    or line.bom_product_template_attribute_value_ids):
+                slowpath_kit_ids |= kit_pids_by_bom_id[line.bom_id.id]
+        fastpath_bom_id_set = {
+            bom.id for pid, bom in bom_by_kit_product.items()
+            if pid not in slowpath_kit_ids
+        }
+        fastpath_lines = [
+            line for line in bom_lines_data
+            if line.bom_id.id in fastpath_bom_id_set
+        ]
+
+        comp_ids = list({line.product_id.id for line in fastpath_lines})
+
+        domain_quant = self._get_domain_locations()[0]
+        if lot_id:
+            domain_quant.append(('lot_id', '=', lot_id))
+        if owner_id:
+            domain_quant.append(('owner_id', '=', owner_id))
+        if package_id:
+            domain_quant.append(('package_id', '=', package_id))
+        domain_quant.append(('product_id', 'in', comp_ids))
+        comp_qty_available = {
+            p.id: qty
+            for p, qty in self.env['stock.quant']._read_group(
+                domain_quant, ['product_id'], ['quantity:sum'],
+            )
+        }
+
+        lines_by_bom = collections.defaultdict(list)
+        for line in fastpath_lines:
+            lines_by_bom[line.bom_id.id].append(line)
+
+        product_ids_set = set(product_ids)
+        for kit_pid in kit_product_id_set - slowpath_kit_ids:
+            bom = bom_by_kit_product[kit_pid]
+            ratios = []
+            for line in lines_by_bom.get(bom.id, []):
+                comp = line.product_id
+                if not comp.is_storable:
+                    continue
+                line_factor = line.product_uom_id.factor
+                base_factor = comp.uom_id.factor
+                if not line_factor or not base_factor:
+                    continue
+                qty_per_kit = line.product_qty / line_factor * base_factor
+                if not qty_per_kit:
+                    continue
+                ratios.append(comp_qty_available.get(comp.id, 0.0) / qty_per_kit)
+            kit_qty = (min(ratios) * bom.product_qty) // 1 if ratios else 0.0
+            if OPERATORS[operator](kit_qty, value):
+                product_ids_set.add(kit_pid)
+            else:
+                product_ids_set.discard(kit_pid)
+
+        if slowpath_kit_ids:
+            slowpath_products = self.env['product.product'].browse(slowpath_kit_ids)
+            slow_qty = slowpath_products._compute_quantities_dict(lot_id, owner_id, package_id)
+            for product in slowpath_products:
+                if OPERATORS[operator](slow_qty[product.id]['qty_available'], value):
+                    product_ids_set.add(product.id)
+                else:
+                    product_ids_set.discard(product.id)
+
+        return list(product_ids_set)
 
     def action_archive(self):
         filtered_products = self.env['mrp.bom.line'].search([('product_id', 'in', self.ids), ('bom_id.active', '=', True)]).product_id.mapped('display_name')

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -474,6 +474,13 @@ class TestKitPicking(common.TestMrpCommon):
             component_g: 6
         }
 
+    def _apply_component_quants(self, location_id):
+        self.env['stock.quant'].create([{
+            'product_id': product.id,
+            'inventory_quantity': qty,
+            'location_id': location_id,
+        } for product, qty in self.expected_quantities.items()]).action_apply_inventory()
+
     def test_kit_immediate_transfer(self):
         """ Make sure a kit is split in the corrects quantity by components in case of an
         immediate transfer.
@@ -729,11 +736,7 @@ class TestKitPicking(common.TestMrpCommon):
         self.assertEqual(delivery.move_ids.move_line_ids.product_packaging_qty, 12)
 
     def test_search_kit_on_quantity(self):
-        self.env['stock.quant'].create([{
-            'product_id': product.id,
-            'inventory_quantity': qty,
-            'location_id': self.test_supplier.id,
-        } for product, qty in self.expected_quantities.items()]).action_apply_inventory()
+        self._apply_component_quants(self.stock_location)
 
         products = self.env['product.product'].search([
             '&', ('qty_available', '>', 3), ('qty_available', '<', 9),
@@ -741,6 +744,53 @@ class TestKitPicking(common.TestMrpCommon):
         self.assertNotIn(self.kit_1, products)  # 12
         self.assertIn(self.kit_2, products)     # 6
         self.assertNotIn(self.kit_3, products)  # 3
+
+    def test_search_kit_on_quantity_operators(self):
+        """Search on qty_available for kit BoMs with no nested kit components
+        and no variant-specific lines."""
+        self._apply_component_quants(self.stock_location)
+
+        # kit_1.id=12, kit_2.id=6, kit_3.id=3
+        def search(domain):
+            return self.env['product.product'].search(
+                domain + [('id', 'in', (self.kit_1 | self.kit_2 | self.kit_3).ids)]
+            )
+        self.assertEqual(search([('qty_available', '<=', 6)]), self.kit_2 | self.kit_3)
+        self.assertEqual(search([('qty_available', '>=', 6)]), self.kit_1 | self.kit_2)
+        self.assertEqual(search([('qty_available', '=', 6)]), self.kit_2)
+        self.assertEqual(search([('qty_available', '!=', 6)]), self.kit_1 | self.kit_3)
+
+    def test_search_kit_on_quantity_multi_uom(self):
+        """Search on qty_available for a kit BoM with no nested kit components,
+        where the BOM line is in dozens and the component quant is in units."""
+        uom_dozen = self.env.ref('uom.product_uom_dozen')
+
+        comp = self.env['product.product'].create({'name': 'Comp UoM', 'is_storable': True})
+        kit = self.env['product.product'].create({'name': 'Kit UoM', 'is_storable': True})
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+        })
+        self.env['mrp.bom.line'].create({
+            'bom_id': bom.id,
+            'product_id': comp.id,
+            'product_qty': 1.0,
+            'product_uom_id': uom_dozen.id,
+        })
+        self.env['stock.quant'].create({
+            'product_id': comp.id,
+            'location_id': self.stock_location,
+            'quantity': 24.0,
+        })
+        result = self.env['product.product'].search([
+            ('qty_available', '>=', 2), ('id', '=', kit.id),
+        ])
+        self.assertEqual(result, kit)
+        result = self.env['product.product'].search([
+            ('qty_available', '>=', 3), ('id', '=', kit.id),
+        ])
+        self.assertNotIn(kit, result)
 
     def test_scrap_change_product(self):
         """ Ensure a scrap order automatically updates the BoM when its product is changed,

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -474,6 +474,13 @@ class TestKitPicking(common.TestMrpCommon):
             component_g: 6
         }
 
+    def _apply_component_quants(self, location_id):
+        self.env['stock.quant'].create([{
+            'product_id': product.id,
+            'inventory_quantity': qty,
+            'location_id': location_id,
+        } for product, qty in self.expected_quantities.items()]).action_apply_inventory()
+
     def test_kit_immediate_transfer(self):
         """ Make sure a kit is split in the corrects quantity by components in case of an
         immediate transfer.
@@ -724,11 +731,7 @@ class TestKitPicking(common.TestMrpCommon):
         self.assertEqual(delivery.move_ids.move_line_ids.product_packaging_qty, 12)
 
     def test_search_kit_on_quantity(self):
-        self.env['stock.quant'].create([{
-            'product_id': product.id,
-            'inventory_quantity': qty,
-            'location_id': self.test_supplier.id,
-        } for product, qty in self.expected_quantities.items()]).action_apply_inventory()
+        self._apply_component_quants(self.stock_location)
 
         products = self.env['product.product'].search([
             '&', ('qty_available', '>', 3), ('qty_available', '<', 9),
@@ -736,6 +739,53 @@ class TestKitPicking(common.TestMrpCommon):
         self.assertNotIn(self.kit_1, products)  # 12
         self.assertIn(self.kit_2, products)     # 6
         self.assertNotIn(self.kit_3, products)  # 3
+
+    def test_search_kit_on_quantity_operators(self):
+        """Search on qty_available for kit BoMs with no nested kit components
+        and no variant-specific lines."""
+        self._apply_component_quants(self.stock_location)
+
+        # kit_1.id=12, kit_2.id=6, kit_3.id=3
+        def search(domain):
+            return self.env['product.product'].search(
+                domain + [('id', 'in', (self.kit_1 | self.kit_2 | self.kit_3).ids)]
+            )
+        self.assertEqual(search([('qty_available', '<=', 6)]), self.kit_2 | self.kit_3)
+        self.assertEqual(search([('qty_available', '>=', 6)]), self.kit_1 | self.kit_2)
+        self.assertEqual(search([('qty_available', '=', 6)]), self.kit_2)
+        self.assertEqual(search([('qty_available', '!=', 6)]), self.kit_1 | self.kit_3)
+
+    def test_search_kit_on_quantity_multi_uom(self):
+        """Search on qty_available for a kit BoM with no nested kit components,
+        where the BOM line is in dozens and the component quant is in units."""
+        uom_dozen = self.env.ref('uom.product_uom_dozen')
+
+        comp = self.env['product.product'].create({'name': 'Comp UoM', 'is_storable': True})
+        kit = self.env['product.product'].create({'name': 'Kit UoM', 'is_storable': True})
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+        })
+        self.env['mrp.bom.line'].create({
+            'bom_id': bom.id,
+            'product_id': comp.id,
+            'product_qty': 1.0,
+            'product_uom_id': uom_dozen.id,
+        })
+        self.env['stock.quant'].create({
+            'product_id': comp.id,
+            'location_id': self.stock_location,
+            'quantity': 24.0,
+        })
+        result = self.env['product.product'].search([
+            ('qty_available', '>=', 2), ('id', '=', kit.id),
+        ])
+        self.assertEqual(result, kit)
+        result = self.env['product.product'].search([
+            ('qty_available', '>=', 3), ('id', '=', kit.id),
+        ])
+        self.assertNotIn(kit, result)
 
     def test_scrap_change_product(self):
         """ Ensure a scrap order automatically updates the BoM when its product is changed,

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -389,14 +389,139 @@ class Product(models.Model):
         if not isinstance(value, (float, int)):
             raise UserError(_("Invalid domain right operand '%s'. It must be of type Integer/Float", value))
 
-        # TODO: Still optimization possible when searching virtual quantities
-        ids = []
-        # Order the search on `id` to prevent the default order on the product name which slows
-        # down the search because of the join on the translation table to get the translated names.
-        for product in self.with_context(prefetch_fields=False).search([], order='id'):
-            if OPERATORS[operator](product[field], value):
-                ids.append(product.id)
-        return [('id', 'in', ids)]
+        domain_quant_loc, domain_move_in_loc, domain_move_out_loc = self._get_domain_locations()
+        from_date = fields.Datetime.to_datetime(self.env.context.get('from_date'))
+        to_date = fields.Datetime.to_datetime(self.env.context.get('to_date'))
+        dates_in_the_past = to_date and to_date < fields.Datetime.now()
+        lot_id = self.env.context.get('lot_id')
+        owner_id = self.env.context.get('owner_id')
+        package_id = self.env.context.get('package_id')
+
+        needs_quants = field in ('qty_available', 'virtual_available', 'free_qty')
+        needs_in = field in ('incoming_qty', 'virtual_available')
+        needs_out = field in ('outgoing_qty', 'virtual_available')
+
+        Move = self.env['stock.move'].with_context(active_test=False)
+        Quant = self.env['stock.quant'].with_context(active_test=False)
+        pending_states = ('waiting', 'confirmed', 'assigned', 'partially_available')
+
+        domain_quant_loc = list(domain_quant_loc)
+        domain_move_in_loc = list(domain_move_in_loc)
+        domain_move_out_loc = list(domain_move_out_loc)
+        if lot_id is not None:
+            domain_quant_loc += [('lot_id', '=', lot_id)]
+        if owner_id is not None:
+            domain_quant_loc += [('owner_id', '=', owner_id)]
+            domain_move_in_loc += [('restrict_partner_id', '=', owner_id)]
+            domain_move_out_loc += [('restrict_partner_id', '=', owner_id)]
+        if package_id is not None:
+            domain_quant_loc += [('package_id', '=', package_id)]
+
+        quants_res = {}
+        moves_in_res = {}
+        moves_out_res = {}
+        moves_in_res_past = defaultdict(float)
+        moves_out_res_past = defaultdict(float)
+
+        if needs_quants:
+            quants_res = {
+                p.id: (qty, reserved)
+                for p, qty, reserved in Quant._read_group(
+                    domain_quant_loc, ['product_id'],
+                    ['quantity:sum', 'reserved_quantity:sum'],
+                )
+            }
+
+        domain_move_in = list(domain_move_in_loc)
+        domain_move_out = list(domain_move_out_loc)
+        if from_date:
+            domain_move_in.append(('date', '>=', from_date))
+            domain_move_out.append(('date', '>=', from_date))
+        if to_date:
+            domain_move_in.append(('date', '<=', to_date))
+            domain_move_out.append(('date', '<=', to_date))
+
+        if needs_in:
+            moves_in_res = {
+                p.id: qty
+                for p, qty in Move._read_group(
+                    [('state', 'in', pending_states)] + domain_move_in,
+                    ['product_id'], ['product_qty:sum'],
+                )
+            }
+        if needs_out:
+            moves_out_res = {
+                p.id: qty
+                for p, qty in Move._read_group(
+                    [('state', 'in', pending_states)] + domain_move_out,
+                    ['product_id'], ['product_qty:sum'],
+                )
+            }
+
+        if dates_in_the_past and needs_quants:
+            domain_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + list(domain_move_in_loc)
+            domain_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + list(domain_move_out_loc)
+            for product, uom, quantity in Move._read_group(domain_in_done, ['product_id', 'product_uom'], ['quantity:sum']):
+                moves_in_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
+            for product, uom, quantity in Move._read_group(domain_out_done, ['product_id', 'product_uom'], ['quantity:sum']):
+                moves_out_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
+
+        all_product_ids = (
+            set(quants_res)
+            | set(moves_in_res)
+            | set(moves_out_res)
+            | set(moves_in_res_past)
+            | set(moves_out_res_past)
+        )
+
+        product_rounding = {
+            p.id: p.uom_id.rounding
+            for p in self.env['product.product'].search_fetch(
+                [('id', 'in', list(all_product_ids))], ['uom_id'],
+            )
+        }
+
+        def compute_qty(pid):
+            qty_avail, reserved = quants_res.get(pid, (0.0, 0.0))
+            if dates_in_the_past:
+                qty_avail = (
+                    qty_avail
+                    - moves_in_res_past.get(pid, 0.0)
+                    + moves_out_res_past.get(pid, 0.0)
+                )
+            in_qty = moves_in_res.get(pid, 0.0)
+            out_qty = moves_out_res.get(pid, 0.0)
+            rounding = product_rounding.get(pid, 0.01)
+            if field == 'qty_available':
+                return float_round(qty_avail, precision_rounding=rounding)
+            elif field == 'free_qty':
+                return float_round(qty_avail - reserved, precision_rounding=rounding)
+            elif field == 'incoming_qty':
+                return float_round(in_qty, precision_rounding=rounding)
+            elif field == 'outgoing_qty':
+                return float_round(out_qty, precision_rounding=rounding)
+            else:
+                return float_round(qty_avail + in_qty - out_qty, precision_rounding=rounding)
+
+        include_zero = (
+            value < 0.0 and operator in ('>', '>=')
+            or value > 0.0 and operator in ('<', '<=')
+            or value == 0.0 and operator in ('>=', '<=', '=')
+        )
+
+        product_ids = set()
+        for pid in all_product_ids:
+            if OPERATORS[operator](compute_qty(pid), value):
+                product_ids.add(pid)
+
+        if include_zero:
+            products_with_zero = self.env['product.product'].search(
+                [('id', 'not in', list(all_product_ids))], order='id'
+            )
+            if OPERATORS[operator](0.0, value):
+                product_ids |= set(products_with_zero.ids)
+
+        return [('id', 'in', list(product_ids))]
 
     def _search_qty_available_new(self, operator, value, lot_id=False, owner_id=False, package_id=False):
         ''' Optimized method which doesn't search on stock.moves, only on stock.quants. '''

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -217,6 +217,88 @@ class TestVirtualAvailable(TestStockCommon):
         ])
         self.assertEqual(product, result)
 
+    def test_search_product_quantity_fields(self):
+        """Test domain search on non-stored quantity fields via _search_product_quantity."""
+        self.picking_out.action_confirm()
+        self.picking_out.action_assign()
+        self.picking_out_2.action_confirm()
+        self.picking_out_2.action_assign()
+
+        pid = self.product_3.ids
+
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('virtual_available', '<', 40), ('id', 'in', pid),
+        ])
+        self.assertEqual(result, self.product_3)
+
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('outgoing_qty', '>', 0), ('id', 'in', pid),
+        ])
+        self.assertEqual(result, self.product_3)
+
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('free_qty', '<', 40), ('id', 'in', pid),
+        ])
+        self.assertEqual(result, self.product_3)
+
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('incoming_qty', '=', 0), ('id', 'in', pid),
+        ])
+        self.assertIn(self.product_3, result)
+
+        result = self.env['product.product'].with_context(
+            to_date='2099-01-01', owner_id=self.user_stock_user.partner_id.id,
+        ).search([('virtual_available', '<', 10), ('id', 'in', pid)])
+        self.assertEqual(result, self.product_3)
+
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('virtual_available', '<', 10), ('id', 'in', pid),
+        ])
+        self.assertNotIn(self.product_3, result)
+
+        lot_product = self.env['product.product'].create({
+            'name': 'Lot Product', 'is_storable': True, 'tracking': 'lot',
+        })
+        stock_loc = self.env.ref('stock.stock_location_stock')
+        lot_a = self.env['stock.lot'].create({'name': 'LOT-A', 'product_id': lot_product.id})
+        lot_b = self.env['stock.lot'].create({'name': 'LOT-B', 'product_id': lot_product.id})
+        self.env['stock.quant'].create([
+            {'product_id': lot_product.id, 'location_id': stock_loc.id,
+             'lot_id': lot_a.id, 'quantity': 7.0},
+            {'product_id': lot_product.id, 'location_id': stock_loc.id,
+             'lot_id': lot_b.id, 'quantity': 20.0},
+        ])
+        lot_pid = lot_product.ids
+
+        result = self.env['product.product'].with_context(
+            to_date='2099-01-01', lot_id=lot_a.id,
+        ).search([('qty_available', '<', 10), ('id', 'in', lot_pid)])
+        self.assertEqual(result, lot_product)
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('qty_available', '<', 10), ('id', 'in', lot_pid),
+        ])
+        self.assertNotIn(lot_product, result)
+
+        pkg_product = self.env['product.product'].create({
+            'name': 'Package Product', 'is_storable': True,
+        })
+        package = self.env['stock.quant.package'].create({'name': 'PKG-001'})
+        self.env['stock.quant'].create([
+            {'product_id': pkg_product.id, 'location_id': stock_loc.id,
+             'package_id': package.id, 'quantity': 5.0},
+            {'product_id': pkg_product.id, 'location_id': stock_loc.id,
+             'quantity': 50.0},
+        ])
+        pkg_pid = pkg_product.ids
+        result = self.env['product.product'].with_context(
+            to_date='2099-01-01', package_id=package.id,
+        ).search([('qty_available', '<', 10), ('id', 'in', pkg_pid)])
+        self.assertEqual(result, pkg_product)
+        result = self.env['product.product'].with_context(to_date='2099-01-01').search([
+            ('qty_available', '<', 10), ('id', 'in', pkg_pid),
+        ])
+        self.assertNotIn(pkg_product, result)
+
     def test_search_product_template(self):
         """
         Suppose a variant V01 that can not be deleted because it is used by a


### PR DESCRIPTION
On a customer database with 109k products and 83k phantom BoMs, the
"Quantity on Hand <= 0" and "Negative Forecasted Quantity" filters in
the Inventory report killed the worker before returning results.

Root cause: `_search_product_quantity` looped over all products calling
`product[field]` per singleton, triggering `_compute_quantities` on
each. Quant and move records accumulated in the ORM field cache across
109k iterations without eviction, exhausting the 2 GiB worker limit.
The mrp override compounded this with an O(n²) recordset build over
83k BoMs using `|=` in a loop.

Fix: replace both per-product loops with bulk `_read_group` aggregation.
Quantities are computed in Python from plain dicts — no ORM records
loaded, no field cache growth. Also adds `lot_id`/`owner_id`/
`package_id` context support and `float_round` to align with
`_compute_quantities_dict`. Kit components with nested phantom BoMs or
variant-specific lines fall back to `_compute_quantities_dict`.

| Filter                  | Before          | After         |
|-------------------------|-----------------|---------------|
| `qty_available <= 0`    | OOM ~5min       | ~21s, 219 MB  |
| `virtual_available < 0` | OOM             | ~0.5s, 1.6 MB |

opw-6073689