### PR TITLE
[I18N] event_sms: fix corrupted Catalan translation in SMS reminder template

### DIFF
--- a/addons/event_sms/i18n/ca.po
+++ b/addons/event_sms/i18n/ca.po
@@ -55,8 +55,8 @@ msgid ""
 "Ready for \"{{ object.event_id.name }}\" {{ object.get_date_range_str(object.partner_id.lang) }}?\n"
 "{{ 'It starts at %s' % format_time(time=object.event_begin_date, tz=object.event_id.date_tz, time_format='short', lang_code=object.partner_id.lang) + (', at %s' % object.event_id.address_inline if object.event_id.address_inline else '') + '.\\nSee you there!' if object.event_id.address_inline or 'website_published' not in object.event_id._fields else 'Join us on %s/event/%i !' % (object.get_base_url(), object.event_id.id) }}"
 msgstr ""
-"Preparat per a \"{{ object.eventid.name }}\" {{ object.getdaterangestr(object.partnerid.lang) }}?\n"
-"{{ 'S'inicia a %s' % formattime(time=objecte.eventbegindate, tz=objecte.eventid.datetz, format de temps='curt', langcode=objecte.partnerid.lang) + (', a %s' % objecte.eventid.addressinline else '') + '.\\nVegeu-ho allà!' si object.eventid.addressinline o 'websitepublished' no és a object.eventid.fields altrament 'Uneix-vos a %s/event/%i !' % (object.getbaseurl(), object.eventid.id) }}"
+"Preparat per a \"{{ object.event_id.name }}\" {{ object.get_date_range_str(object.partner_id.lang) }}?\n"
+"{{ 'Comença a les %s' % format_time(time=object.event_begin_date, tz=object.event_id.date_tz, time_format='short', lang_code=object.partner_id.lang) + (', a %s' % object.event_id.address_inline if object.event_id.address_inline else '') + '.\\nEns veiem allà!' if object.event_id.address_inline or 'website_published' not in object.event_id._fields else 'Uneix-vos a %s/event/%i !' % (object.get_base_url(), object.event_id.id) }}"
 
 #. module: event_sms
 #: model:ir.model,name:event_sms.model_event_mail_registration


### PR DESCRIPTION
**Catalan SMS reminder template crashes for users with Catalan language**

Impacted versions:

 - 16.0

Steps to reproduce:

 1. Set a user's language to Catalan (ca)
 2. Create an event with SMS reminders enabled
 3. Wait for the SMS reminder to trigger (or trigger it manually)

Current behavior:

 - Server error: the Jinja template fails to render because Python code in the translation was corrupted — field names lost underscores, function names were translated, Python keywords were translated into Catalan

Expected behavior:

 - SMS reminder is sent correctly with the event name, date and location in Catalan

The Catalan translation of `sms_template_data_event_reminder` has corrupted Jinja expressions:

 - `object.event_id` → `object.eventid`
 - `object.partner_id` → `object.partnerid`
 - `format_time()` → `formattime()`
 - `get_base_url()` → `getbaseurl()`
 - `get_date_range_str()` → `getdaterangestr()`
 - `object` → `objecte` (variable name translated)
 - `if`/`else`/`not in` → `si`/`altrament`/`no és a` (Python keywords translated)

Note: We are aware that 16.0 is not accepting PRs and that translations should go through the translation platform, but the Transifex organization is inactive and Weblate has no 16.0 project, so there is no other channel to submit this fix.