### PR TITLE
[FIX] stock: only enforce serial lot uniqueness

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -102,13 +102,24 @@ class StockLot(models.Model):
 
     @api.constrains('name', 'product_id', 'company_id')
     def _check_unique_lot(self):
-        domain = [('product_id', 'in', self.product_id.ids),
-                  ('name', 'in', self.mapped('name'))]
+        """Ensure uniqueness only for serial-number tracked products.
+
+        Lots for products tracked "by lots" are allowed to reuse the same
+        lot name across multiple records/shipments.
+        """
+        serial_lots = self.filtered(lambda lot: lot.product_id.tracking == 'serial')
+        if not serial_lots:
+            return
+
+        domain = [
+            ('product_id', 'in', serial_lots.product_id.ids),
+            ('name', 'in', serial_lots.mapped('name')),
+        ]
         groupby = ['company_id', 'product_id', 'name']
-        if any(not lot.company_id for lot in self):
+        if any(not lot.company_id for lot in serial_lots):
             # We need to check across other companies to not have duplicates between 'no-company' and a company.
-            self = self.sudo()
-        records = self.with_context(skip_preprocess_gs1=True)._read_group(domain, groupby, ['__count'], order='company_id DESC')
+            serial_lots = serial_lots.sudo()
+        records = serial_lots.with_context(skip_preprocess_gs1=True)._read_group(domain, groupby, ['__count'], order='company_id DESC')
         error_message_lines = set()
         cross_lots = {}
         for company, product, name, count in records:

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -117,7 +117,10 @@ class TestLotSerial(TestStockCommon):
         self.assertFalse(move.move_line_ids.lot_id.company_id)
 
     def test_lot_uniqueness(self):
-        """ Checks that the same lot name cannot be inserted twice for the same company or 'no-company'.
+        """Checks that the same name cannot be reused for serial numbers.
+
+        The uniqueness constraint must still apply for products tracked by
+        unique serial number.
         """
         lot_1 = self.env['stock.lot'].create({
             'name': 'unique',
@@ -160,6 +163,32 @@ class TestLotSerial(TestStockCommon):
                 'product_id': self.productB.id,
                 'company_id': self.env.company.id,
             })
+
+    def test_lot_reuse_for_lot_tracked_product(self):
+        """Lots with the same name are allowed for lot-tracked products.
+
+        For products tracked "by lots", suppliers can reuse the same lot
+        identifier across multiple receipts of the same product. The
+        uniqueness constraint must therefore not block duplicated lot names
+        for such products.
+        """
+        self.assertEqual(self.productA.tracking, 'lot')
+
+        lot_1 = self.env['stock.lot'].create({
+            'name': 'LOT-001',
+            'product_id': self.productA.id,
+            'company_id': False,
+        })
+        self.assertTrue(lot_1)
+
+        # Creating another lot with the same name for the same product and
+        # company (or no company) must not raise a ValidationError.
+        lot_2 = self.env['stock.lot'].create({
+            'name': 'LOT-001',
+            'product_id': self.productA.id,
+            'company_id': False,
+        })
+        self.assertTrue(lot_2)
 
     def test_bypass_reservation(self):
         """

--- a/doc/cla/individual/AbhinavJD7.md
+++ b/doc/cla/individual/AbhinavJD7.md
@@ -1,0 +1,11 @@
+India, 2026-04-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Abhinav Rai abhinavrai966@gmail.com https://github.com/AbhinavJD7

--- a/doc/cla/individual/abhinavjd7.md
+++ b/doc/cla/individual/abhinavjd7.md
@@ -1,0 +1,11 @@
+India, 2026-04-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Abhinav Rai abhinavrai966@gmail.com https://github.com/AbhinavJD7


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- _check_unique_lot on stock.lot was enforcing uniqueness for both lot- and serial-tracked products.
- This prevented reusing the same lot name across multiple records/shipments for products tracked by lots, which contradicts the documentation and common use cases.

Current behavior before PR:
- Creating multiple stock.lot records with the same name for a product tracked by lots raises a ValidationError.
- The uniqueness constraint effectively treats lot-tracked products the same as serial-tracked ones.

Desired behavior after PR is merged:
- Uniqueness is enforced only for products tracked by unique serial number (tracking = 'serial').
- Products tracked by lots (tracking = 'lot') can reuse the same lot name across multiple lots/shipments.
- Existing serial-number uniqueness behavior (including cross-company checks between no-company and specific-company lots) is preserved.

Description of the solution:
- Scope _check_unique_lot to only consider lots whose product has tracking = 'serial'.
- Keep the existing _read_group-based aggregation and cross-company logic, but restrict it to serial-tracked lots only.

Tests:
- Clarified the intention of test_lot_uniqueness to validate serial-number uniqueness.
- Added test_lot_reuse_for_lot_tracked_product to ensure that reusing a lot name for a lot-tracked product no longer raises a ValidationError.

Related issue:
- Fixes #257790