### PR TITLE
[IMP] hr_*: rename work entry types to time type

### DIFF
--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -13,7 +13,7 @@ Manage time off requests and allocations
 
 This application controls the time off schedule of your company. It allows employees to request time off. Then, managers can review requests for time off and approve or reject them. This way you can control the overall time off planning for the company or department.
 
-You can configure several kinds of time off (sickness, paid days, ...) and allocate time off to an employee or department quickly using time off allocation. An employee can also make a request for more days off by making a new time off allocation. It will increase the total of available days for that time off type (if the request is accepted).
+You can configure several kinds of time off (sickness, paid days, ...) and allocate time off to an employee or department quickly using time off allocation. An employee can also make a request for more days off by making a new time off allocation. It will increase the total of available days for that time type (if the request is accepted).
 
 You can keep track of time off in different ways by following reports:
 

--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -13,7 +13,7 @@
         <field name="implied_ids" eval="[(4, ref('hr_holidays.group_hr_holidays_manager'))]"/>
     </record>
 
-    <!--Time Off Type-->
+    <!--Time Type-->
     <record id="hr_work_entry.hr_work_entry_type_dv" model="hr.work.entry.type">
         <field name="requires_allocation">yes</field>
         <field name="employee_requests">False</field>

--- a/addons/hr_holidays/data/mail_template_data.xml
+++ b/addons/hr_holidays/data/mail_template_data.xml
@@ -14,7 +14,7 @@
                     <br/><br/>
                     <p>I'm requesting a Time Off. I would appreciate if you could approve it whenever possible!</p>
                     <ul>
-                        <li>Time Off Type: <t t-out="object.work_entry_type_id.name"/></li>
+                        <li>Time Type: <t t-out="object.work_entry_type_id.name"/></li>
                         <li><t t-out="object.request_date_from"/> → <t t-out="object.request_date_to"/> (<t t-out="object.duration_display"/>)</li>
                         <li t-if="object.name">Reason: <t t-out="object.name"/></li>
                     </ul>

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -22,7 +22,7 @@ class HrEmployee(models.Model):
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
         help='Select the user responsible for approving "Time Off" of this employee.\n'
              'If empty, the approval is done by an Administrator or Approver (determined in settings/users).')
-    current_work_entry_type_id = fields.Many2one('hr.work.entry.type', compute='_compute_current_work_entry_type_id', string="Current Work Entry Type",
+    current_work_entry_type_id = fields.Many2one('hr.work.entry.type', compute='_compute_current_work_entry_type_id', string="Current Time Type",
                                        groups="hr.group_hr_user")
     current_leave_state = fields.Selection(compute='_compute_leave_status', string="Current Time Off Status",
         selection=[

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -135,7 +135,7 @@ class HrLeave(models.Model):
     # leave type configuration
     work_entry_type_id = fields.Many2one(
         "hr.work.entry.type", compute='_compute_work_entry_type_id',
-        store=True, string="Time Off Type",
+        store=True, string="Time Type",
         required=True, readonly=False,
         domain="""[
             '|',
@@ -187,7 +187,7 @@ class HrLeave(models.Model):
         help='This area is automatically filled by the user who validate the time off')
     second_approver_id = fields.Many2one(
         'hr.employee', string='Second Approval', readonly=True, copy=False,
-        help='This area is automatically filled by the user who validate the time off with second level (If time off type need second validation)')
+        help='This area is automatically filled by the user who validate the time off with second level (If time type need second validation)')
 
     can_approve = fields.Boolean(compute='_compute_can_approve', export_string_translation=False)
     can_validate = fields.Boolean(compute='_compute_can_validate', export_string_translation=False)
@@ -813,7 +813,7 @@ class HrLeave(models.Model):
                         if self.env.context.get('multi_leave_request', False):
                             employees_without_allocation |= employee
                         else:
-                            raise ValidationError(self.env._("You do not have any allocation for this time off type.\n"
+                            raise ValidationError(self.env._("You do not have any allocation for this time type.\n"
                                                              "Please request an allocation before submitting your time off request."))
                     if leave_data[employee] and leave_data[employee][0][1]['virtual_remaining_leaves'] < -max_excess:
                         if self.env.context.get('multi_leave_request', False):
@@ -832,7 +832,7 @@ class HrLeave(models.Model):
                     if self.env.context.get('multi_leave_request', False):
                         employees_without_allocation |= employee
                     else:
-                        raise ValidationError(self.env._("You do not have any allocation for this time off type.\n"
+                        raise ValidationError(self.env._("You do not have any allocation for this time type.\n"
                                                          "Please request an allocation before submitting your time off request."))
                 if not previous_emp_data and not emp_data:
                     continue

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -25,7 +25,7 @@ class HrLeaveAccrualPlan(models.Model):
     show_transition_mode = fields.Boolean(compute='_compute_show_transition_mode', export_string_translation=False)
     is_based_on_worked_time = fields.Boolean(compute="_compute_is_based_on_worked_time", store=True, readonly=False,
         export_string_translation=False,
-        help="Only excludes requests where the time off type is set as unpaid kind of.")
+        help="Only excludes requests where the time type is set as unpaid kind of.")
     accrued_gain_time = fields.Selection([
         ("start", "At the start of the accrual period"),
         ("end", "At the end of the accrual period")],

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -66,7 +66,7 @@ class HrLeaveAllocation(models.Model):
         tracking=True, required=True)
     date_to = fields.Date('End Date', copy=False, tracking=True)
     work_entry_type_id = fields.Many2one(
-        "hr.work.entry.type", compute='_compute_work_entry_type_id', store=True, string="Time Off Type", required=True, readonly=False,
+        "hr.work.entry.type", compute='_compute_work_entry_type_id', store=True, string="Time Type", required=True, readonly=False,
         domain=_domain_work_entry_type_id,
         default=_default_work_entry_type_id)
     employee_id = fields.Many2one(
@@ -95,7 +95,7 @@ class HrLeaveAllocation(models.Model):
         help='This area is automatically filled by the user who validates the allocation')
     second_approver_id = fields.Many2one(
         'hr.employee', string='Second Approval', readonly=True, copy=False,
-        help='This area is automatically filled by the user who validates the allocation with second level (If time off type need second validation)')
+        help='This area is automatically filled by the user who validates the allocation with second level (If time type need second validation)')
     validation_type = fields.Selection(string='Validation Type', related='work_entry_type_id.allocation_validation_type', readonly=True)
     can_approve = fields.Boolean('Can Approve', compute='_compute_can_approve')
     can_validate = fields.Boolean('Can Validate', compute='_compute_can_validate')
@@ -276,7 +276,7 @@ class HrLeaveAllocation(models.Model):
             if allocation.number_of_days >= 0:
                 continue
             if not allocation.work_entry_type_id.allows_negative:
-                raise ValidationError(self.env._("Negative allocations are not allowed for this time off type."))
+                raise ValidationError(self.env._("Negative allocations are not allowed for this time type."))
             allocation_unit = allocation.type_request_unit
             if allocation_unit != 'hour' and abs(allocation.number_of_days_display) > allocation.work_entry_type_id.max_allowed_negative:
                 raise ValidationError(self.env._("The negative allocation cannot exceed the maximum allowed negative value of %(max)s day(s).",

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -39,7 +39,7 @@ class HrWorkEntryType(models.Model):
         return -1 * work_entry_type.sequence, not work_entry_type.employee_requests and remaining, work_entry_type.employee_requests and remaining, taken
 
     create_calendar_meeting = fields.Boolean(string="Display Time Off in Calendar", default=True)
-    color = fields.Integer(string='Color', help="The color selected here will be used in every screen with the time off type.")
+    color = fields.Integer(string='Color', help="The color selected here will be used in every screen with the time type.")
     hide_on_dashboard = fields.Boolean(default=False, string="Hide On Dashboard", help="Non-visible allocations can still be selected when taking a leave, but will simply not be displayed on the leave dashboard.")
 
     # employee specific computed data
@@ -87,7 +87,7 @@ class HrWorkEntryType(models.Model):
         ('hour', 'Custom Hours')], default='day', string='Duration Type', required=True,
         help="""Define the minimum time off duration in which an employee can take when requesting a leave""")
     unit_of_measure = fields.Selection([('hour', 'Hours'), ('day', 'Days')], default="hour", string="Unit of measure", required=True,
-                                       help="Define if the time off type will be allocated/accrued in hours or days")
+                                       help="Define if the time type will be allocated/accrued in hours or days")
     unpaid = fields.Boolean('Is Unpaid', default=False)
     include_public_holidays_in_duration = fields.Boolean('Ignore Public Holidays', default=False, help="Public holidays should be counted in the leave duration when applying for leaves")
     leave_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Time Off Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave', raise_if_not_found=False))
@@ -96,7 +96,7 @@ class HrWorkEntryType(models.Model):
     allow_request_on_top = fields.Boolean(string='Allow Request on Top', default=False,
         help="If checked, users can request another leave on top of the ones of this type.")
     elligible_for_accrual_rate = fields.Boolean(string='Eligible for Accrual Rate', compute="_compute_eligible_for_accrual_rate", store=True, readonly=False,
-        help="If checked, this time off type will be taken into account for accruals computation.")
+        help="If checked, this time type will be taken into account for accruals computation.")
     # negative time off
     allows_negative = fields.Boolean(string='Allow Negative',
         help="If checked, users request can exceed the allocated days and balance can go in negative.")
@@ -185,7 +185,7 @@ class HrWorkEntryType(models.Model):
 
                 if leave_from_date <= public_holiday_to_date and leave_to_date >= public_holiday_from_date:
                     raise ValidationError(_("You cannot modify the 'Public Holiday Included' setting since one or more leaves for that \
-                        time off type are overlapping with public holidays, meaning that the balance of those employees would be affected by this change."))
+                        time type are overlapping with public holidays, meaning that the balance of those employees would be affected by this change."))
 
     def get_work_entry_types_with_valid_allocations(self, date_from, date_to, employee_id):
         allocation_by_work_entry_type = dict(self.env['hr.leave.allocation']._read_group(
@@ -232,7 +232,7 @@ class HrWorkEntryType(models.Model):
     @api.constrains('requires_allocation')
     def check_allocation_requirement_edit_validity(self):
         if not self.env.context.get('install_mode') and self.env['hr.leave'].search_count([('work_entry_type_id', 'in', self.ids)], limit=1):
-            raise UserError(_("The allocation requirement of a time off type cannot be changed once leaves of that type have been taken. You should create a new time off type instead."))
+            raise UserError(_("The allocation requirement of a time type cannot be changed once leaves of that type have been taken. You should create a new time type instead."))
 
     def _search_max_leaves(self, operator, value):
         op = PY_OPERATORS.get(operator)

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -15,7 +15,7 @@ class ResourceCalendarLeaves(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Time Off Request')
     elligible_for_accrual_rate = fields.Boolean(string='Eligible for Accrual Rate', default=False,
-        help="If checked, this time off type will be taken into account for accruals computation.")
+        help="If checked, this time type will be taken into account for accruals computation.")
 
     @api.constrains('date_from', 'date_to', 'calendar_id')
     def _check_compare_dates(self):

--- a/addons/hr_holidays/report/hr_holidays_templates.xml
+++ b/addons/hr_holidays/report/hr_holidays_templates.xml
@@ -63,7 +63,7 @@
                         <thead>
                             <tr>
                                 <th class="col-1">Color</th>
-                                <th class="text-center">Time Off Type</th>
+                                <th class="text-center">Time Type</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/addons/hr_holidays/report/hr_leave_employee_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_report.py
@@ -23,7 +23,7 @@ class HrLeaveEmployeeReport(models.Model):
     number_of_days = fields.Float(compute='_compute_leave_duration', readonly=True, store=True)
     number_of_hours = fields.Float(compute='_compute_leave_duration', readonly=True, store=True)
     description = fields.Char()
-    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Off Type")
+    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Type")
     state = fields.Selection([
         ('confirm', 'To Approve'),
         ('refuse', 'Refused'),

--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -15,7 +15,7 @@ class HrLeaveEmployeeTypeReport(models.Model):
     number_of_days = fields.Float('Number of Days', readonly=True, aggregator="sum")
     number_of_hours = fields.Float('Number of Hours', readonly=True, aggregator="sum")
     department_id = fields.Many2one('hr.department', string='Department', readonly=True)
-    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Off Type", readonly=True)
+    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Type", readonly=True)
     holiday_status = fields.Selection([
         ('taken', 'Taken'), #taken = validated
         ('left', 'Left'),

--- a/addons/hr_holidays/report/hr_leave_employee_type_report.xml
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.xml
@@ -30,7 +30,7 @@
     </record>
 
     <record id="action_hr_holidays_by_employee_and_type_report" model="ir.actions.server">
-        <field name="name">Time off Analysis by Employee and Time Off Type</field>
+        <field name="name">Time off Analysis by Employee and Time Type</field>
         <field name="model_id" ref="hr_holidays.model_hr_leave_employee_type_report"/>
         <field name="state">code</field>
         <field name="code">

--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -19,7 +19,7 @@ class HrLeaveReport(models.Model):
         ('request', 'Time Off')
         ], string='Request Type', readonly=True)
     department_id = fields.Many2one('hr.department', string='Department', readonly=True)
-    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Off Type", readonly=True)
+    work_entry_type_id = fields.Many2one("hr.work.entry.type", string="Time Type", readonly=True)
     state = fields.Selection([
         ('cancel', 'Cancelled'),
         ('confirm', 'To Approve'),

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -31,7 +31,7 @@ class HrLeaveReportCalendar(models.Model):
         ('validate', 'Approved')
     ], readonly=True)
     description = fields.Char("Description", readonly=True, groups='hr_holidays.group_hr_holidays_user')
-    work_entry_type_id = fields.Many2one('hr.work.entry.type', readonly=True, string="Time Off Type",
+    work_entry_type_id = fields.Many2one('hr.work.entry.type', readonly=True, string="Time Type",
         groups='hr_holidays.group_hr_holidays_user')
 
     is_hatched = fields.Boolean('Hatched', readonly=True)
@@ -98,7 +98,7 @@ class HrLeaveReportCalendar(models.Model):
         for leave in self:
             leave.name = leave.employee_id.name
             if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
-                # Include the time off type name
+                # Include the time type name
                 leave.name += f" {leave.leave_id.work_entry_type_id.display_code or leave.leave_id.work_entry_type_id.name}"
             # Include the time off duration.
             leave.name += f": {leave.sudo().leave_id.duration_display}"

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -104,7 +104,7 @@
                 <filter name="exclude_refused_leaves" string="Exclude Refused" domain="[('state', '!=', 'refuse')]"/>
                 <filter string="Waiting for Approval" name="approve" domain="[('state','in',('confirm','validate1'))]"/>
                 <filter name="groupby_job_id" string="Job Position" context="{'group_by': 'job_id'}"/>
-                <filter name="groupby_time_off_type" string="Time Off Type" context="{'group_by': 'work_entry_type_id'}"/>
+                <filter name="groupby_time_off_type" string="Time Type" context="{'group_by': 'work_entry_type_id'}"/>
                 <filter name="groupby_company_id" string="Company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                 <filter name="groupby_department_id" context="{'group_by': 'department_id'}"/>
             </search>

--- a/addons/hr_holidays/views/hr_holidays_views.xml
+++ b/addons/hr_holidays/views/hr_holidays_views.xml
@@ -96,7 +96,7 @@
     <menuitem
         id="hr_holidays_status_menu_configuration"
         action="open_view_work_entry_type"
-        name="Time Off Types"
+        name="Time Types"
         parent="menu_hr_holidays_configuration"
         groups="hr_holidays.group_hr_holidays_manager"
         sequence="1"/>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -117,7 +117,7 @@
                     <div class="oe_button_box" name="button_box"/>
                     <div id="title" class="oe_title">
                         <h2><field name="name" class="w-100"
-                            placeholder="e.g. Time Off type (From validity start to validity end / no limit)"
+                            placeholder="e.g. Time type (From validity start to validity end / no limit)"
                             invisible="state != 'confirm'" readonly="True" force_save="True"/>
                         <field name="name_validity" invisible="state == 'confirm'"/></h2>
                     </div>
@@ -196,7 +196,7 @@
                 <div class="oe_title">
                     <h2>
                         <field name="name"
-                            placeholder="e.g. Time Off type (From validity start to validity end / no limit)"
+                            placeholder="e.g. Time Type (From validity start to validity end / no limit)"
                             required="1" readonly="state == 'refuse'"/>
                     </h2>
                 </div>

--- a/addons/hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/hr_holidays/views/hr_work_entry_type_views.xml
@@ -5,8 +5,8 @@
         <field name="name">hr.work.entry.type.filter</field>
         <field name="model">hr.work.entry.type</field>
         <field name="arch" type="xml">
-            <search string="Search Time Off Type">
-                <field name="name" string="Time Off Types"/>
+            <search string="Search Time Type">
+                <field name="name" string="Time Types"/>
                 <field name="create_calendar_meeting"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
@@ -26,7 +26,7 @@
                         name="action_see_days_allocated"
                         icon="fa-calendar"
                         invisible="not requires_allocation or not id"
-                        help="Count of allocations for this time off type (approved or waiting for approbation) with a validity period starting this year.">
+                        help="Count of allocations for this time type (approved or waiting for approbation) with a validity period starting this year.">
                     <div class="o_stat_info">
                         <field name="allocation_count" class="o_stat_value"/>
                         <span class="o_stat_text">Allocations</span>
@@ -37,7 +37,7 @@
                         name="action_see_group_leaves"
                         icon="fa-calendar"
                         invisible="not id"
-                        help="Count of time off requests for this time off type (approved or waiting for approbation) with a start date in the current year.">
+                        help="Count of time off requests for this time type (approved or waiting for approbation) with a start date in the current year.">
                     <div class="o_stat_info">
                         <field name="group_days_leave" class="o_stat_value"/>
                         <span class="o_stat_text">Time Off</span>
@@ -121,12 +121,12 @@
         <field name="name">hr.work.entry.type.normal.list</field>
         <field name="model">hr.work.entry.type</field>
         <field name="arch" type="xml">
-            <list string="Time Off Type" multi_edit="1">
+            <list string="Time Type" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name"/>
                 <field name="unit_of_measure" optional="hide"/>
                 <field name="request_unit" optional="hide"/>
-                <field name="leave_validation_type" optional="hide" string="Time Off Approval"/>
+                <field name="leave_validation_type" optional="hide" string="Time Type Approval"/>
                 <field name="requires_allocation" optional="hide"/>
                 <field name="allocation_validation_type" string="Allocation Approval"/>
                 <field name="employee_requests" optional="hide"/>
@@ -137,7 +137,7 @@
     </record>
 
     <record id="open_view_work_entry_type" model="ir.actions.act_window">
-        <field name="name">Time Off Types</field>
+        <field name="name">Time Types</field>
         <field name="res_model">hr.work.entry.type</field>
         <field name="view_mode">list,kanban,form</field>
     </record>

--- a/addons/hr_holidays/wizard/hr_holidays_summary_employees.py
+++ b/addons/hr_holidays/wizard/hr_holidays_summary_employees.py
@@ -16,7 +16,7 @@ class HrHolidaysSummaryEmployee(models.TransientModel):
         ('Approved', 'Approved'),
         ('Confirmed', 'Confirmed'),
         ('both', 'Both Approved and Confirmed')
-    ], string='Select Time Off Type', required=True, default='Approved')
+    ], string='Select Time Type', required=True, default='Approved')
 
     def print_report(self):
         self.ensure_one()

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -31,7 +31,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
     name = fields.Char("Description", compute="_compute_name", store=True, readonly=False)
     duration = fields.Float(string="Allocation")
     work_entry_type_id = fields.Many2one(
-        "hr.work.entry.type", string="Time Off Type", required=True,
+        "hr.work.entry.type", string="Time Type", required=True,
         domain=_domain_work_entry_type_id)
     unit_of_measure = fields.Selection(related="work_entry_type_id.unit_of_measure")
     employee_ids = fields.Many2many('hr.employee', string='Employees', domain=lambda self: self._get_employee_domain())

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -25,7 +25,7 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
 
     name = fields.Char("Description")
     work_entry_type_id = fields.Many2one(
-        "hr.work.entry.type", string="Time Off Type", required=True, domain="[('id', 'in', valid_work_entry_type_ids)]")
+        "hr.work.entry.type", string="Time Type", required=True, domain="[('id', 'in', valid_work_entry_type_ids)]")
     employee_ids = fields.Many2many('hr.employee', string='Employees', domain=lambda self: self._get_employee_domain())
     company_id = fields.Many2one('res.company', default=lambda self: self.env.company, required=True)
     date_from = fields.Date('Start Date', required=True, default=lambda self: fields.Date.today())

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -16,7 +16,7 @@ class HrLeaveAllocation(models.Model):
         if 'work_entry_type_id' in fields and self.env.context.get('deduct_extra_hours'):
             domain = Domain('overtime_deductible', '=', True) & Domain('requires_allocation', '=', True)
             if self.env.context.get('deduct_extra_hours_employee_request', False):
-                # Prevent loading manager allocated time off type in self request contexts
+                # Prevent loading manager allocated time type in self request contexts
                 domain &= Domain('employee_requests', '=', True)
             work_entry_type = self.env['hr.work.entry.type'].search(domain, limit=1)
             res['work_entry_type_id'] = work_entry_type.id

--- a/addons/hr_holidays_attendance/report/hr_leave_attendance_report.py
+++ b/addons/hr_holidays_attendance/report/hr_leave_attendance_report.py
@@ -26,7 +26,7 @@ class HrLeaveAttendanceReport(models.Model):
     leave_hours = fields.Float("Approved Time Off")
     difference_hours = fields.Float("Difference", help="Worked Hours - Expected Hours + Approved Time Off")
 
-    work_entry_type_names = fields.Char("Time Off Types", compute="_compute_leave_attendance_fields")
+    work_entry_type_names = fields.Char("Time Types", compute="_compute_leave_attendance_fields")
     leave_ids = fields.Many2many("hr.leave", string="Time Offs", compute="_compute_leave_attendance_fields")
     attendance_ids = fields.Many2many("hr.attendance", string="Attendances", compute="_compute_leave_attendance_fields")
 

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -26,7 +26,7 @@ class ResCompany(models.Model):
     internal_project_id = fields.Many2one(
         "project.project", string="Internal Project",
         domain=[("is_template", "=", False)],
-        help="Default project value for timesheet generated from time off type.",
+        help="Default project value for timesheet generated from time type.",
     )
 
     @api.constrains('internal_project_id')

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -20,7 +20,7 @@ class HrWorkEntryType(models.Model):
     sequence = fields.Integer(default=25)
     active = fields.Boolean(
         'Active', default=True,
-        help="If the active field is set to false, it will allow you to hide the work entry type without removing it.")
+        help="If the active field is set to false, it will allow you to hide the time type without removing it.")
     country_id = fields.Many2one(
         'res.country',
         string="Country",
@@ -52,7 +52,7 @@ class HrWorkEntryType(models.Model):
         for code, country_id in grouped_duplicates:
             if len(grouped_duplicates[code, country_id]) > 1:
                 raise UserError(self.env._(
-                    'You cannot create more than one work entry type of code "%(code)s" for the same country (%(country)s)',
+                    'You cannot create more than one time type of code "%(code)s" for the same country (%(country)s)',
                     code=code, country=(country_id.name if country_id else self.env._("All")),
                 ))
 
@@ -71,7 +71,7 @@ class HrWorkEntryType(models.Model):
                 raise UserError(self.env._(
                     """
 Cannot insert "%(insert_name)s":
-Work entry type "%(name)s" of code "%(code)s" already exists for country "%(country)s".
+Time type "%(name)s" of code "%(code)s" already exists for country "%(country)s".
                     """,
                     insert_name=we_type.name,
                     name=duplicate.name,
@@ -81,7 +81,7 @@ Work entry type "%(name)s" of code "%(code)s" already exists for country "%(coun
             raise UserError(self.env._(
                     """
 Cannot insert "%(insert_name)s":
-Work entry type "%(name)s" of code "%(code)s", with no country assigned, already exists.
+Time type "%(name)s" of code "%(code)s", with no country assigned, already exists.
                     """,
                 insert_name=we_type.name,
                 name=duplicate.name,

--- a/addons/hr_work_entry/models/resource_calendar_attendance.py
+++ b/addons/hr_work_entry/models/resource_calendar_attendance.py
@@ -6,7 +6,7 @@ from odoo import api, models, fields
 class ResourceCalendarAttendance(models.Model):
     _inherit = 'resource.calendar.attendance'
 
-    work_entry_type_id = fields.Many2one('hr.work.entry.type', 'Work Entry Type', store=True,
+    work_entry_type_id = fields.Many2one('hr.work.entry.type', 'Time Type', store=True,
         compute='_compute_work_entry_type_id', groups="hr.group_hr_user", readonly=False)
 
     @api.depends('calendar_id.country_id')

--- a/addons/hr_work_entry/models/resource_calendar_leaves.py
+++ b/addons/hr_work_entry/models/resource_calendar_leaves.py
@@ -7,7 +7,7 @@ class ResourceCalendarLeaves(models.Model):
     _inherit = 'resource.calendar.leaves'
 
     work_entry_type_id = fields.Many2one(
-        'hr.work.entry.type', 'Work Entry Type',
+        'hr.work.entry.type', 'TimeType',
         groups="hr.group_hr_user")
 
     def _copy_leave_vals(self):

--- a/addons/hr_work_entry/views/hr_work_entry_type_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_type_views.xml
@@ -4,7 +4,7 @@
         <field name="name">hr.work.entry.type.view.search</field>
         <field name="model">hr.work.entry.type</field>
         <field name="arch" type="xml">
-            <search string="Search Work Entry Type">
+            <search string="Search Time Type">
                 <field name="name" filter_domain="['|', ('name', 'ilike', self), ('code', 'ilike', self)]"/>
                 <separator/>
                 <filter name="working_time" string="Working Time" domain="[('count_as', '=', 'working_time')]"/>
@@ -19,13 +19,13 @@
     </record>
 
     <record id="hr_work_entry_type_action" model="ir.actions.act_window">
-        <field name="name">Work Entry Types</field>
+        <field name="name">Time Types</field>
         <field name="res_model">hr.work.entry.type</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="search_view_id" ref="hr_work_entry_type_view_search"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                Create a new work entry type
+                Create a new Time type
             </p>
         </field>
     </record>
@@ -51,13 +51,13 @@
         <field name="name">hr.work.entry.type.form</field>
         <field name="model">hr.work.entry.type</field>
         <field name="arch" type="xml">
-            <form string="Work Entry Type" >
+            <form string="Time Type" >
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="oe_title">
                         <h1>
-                            <field name="name" placeholder="Work Entry Type Name"/>
+                            <field name="name" placeholder="Time Type Name"/>
                         </h1>
                     </div>
                     <group name="main_group">
@@ -93,7 +93,7 @@
                             </group>
 
                             <separator string="Description" />
-                            <field rows="5" nolabel="1" name="description" placeholder="Provide a description of the Work Entry Type, in which case should it be used"/>
+                            <field rows="5" nolabel="1" name="description" placeholder="Provide a description of the Time Type, in which case should it be used"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/hr_work_entry/views/menuitems.xml
+++ b/addons/hr_work_entry/views/menuitems.xml
@@ -17,7 +17,7 @@
     <!-- Work entries Configuration -->
     <menuitem
         id="menu_hr_work_entry_configuration"
-        name="Work Entries"
+        name="Time"
         parent="menu_hr_payroll_configuration"
         sequence="50"
     />

--- a/addons/hr_work_entry/views/resource_calendar_views.xml
+++ b/addons/hr_work_entry/views/resource_calendar_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <filter name="resource" position="after">
                 <field name="work_entry_type_id" groups="hr.group_hr_user"/>
-                <filter name="work_entry" string="Work Entry Type" context="{'group_by':'work_entry_type_id'}" groups="hr.group_hr_user"/>
+                <filter name="work_entry" string="TimeType" context="{'group_by':'work_entry_type_id'}" groups="hr.group_hr_user"/>
             </filter>
         </field>
     </record>

--- a/addons/l10n_fr_hr_holidays/models/res_company.py
+++ b/addons/l10n_fr_hr_holidays/models/res_company.py
@@ -10,10 +10,10 @@ class ResCompany(models.Model):
 
     l10n_fr_reference_work_entry_type = fields.Many2one(
         'hr.work.entry.type',
-        string='Company Paid Time Off Type')
+        string='Company Paid Time Type')
 
     def _get_fr_reference_work_entry_type(self):
         self.ensure_one()
         if not self.l10n_fr_reference_work_entry_type:
-            raise ValidationError(_("You must first define a reference time off type for the company."))
+            raise ValidationError(_("You must first define a reference time type for the company."))
         return self.l10n_fr_reference_work_entry_type

--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -9,7 +9,7 @@
             <block name="work_organization_setting_container" position="after">
                 <field name="company_country_code" invisible="1"/>
                 <block title="French Time Off Localization" invisible="company_country_code != 'FR'">
-                    <setting company_dependent="1" help="Set the time off type used as the company Paid Time Off to compute part-timers leave duration">
+                    <setting company_dependent="1" help="Set the time type used as the company Paid Time Off to compute part-timers leave duration">
                         <field name="l10n_fr_reference_work_entry_type"
                             class="o_light_label"
                             required="company_country_code == 'FR'"/>

--- a/addons/l10n_in_hr_holidays/__manifest__.py
+++ b/addons/l10n_in_hr_holidays/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'India - Time Off',
     'category': 'Human Resources/Time Off',
     'summary': 'Leave Management of Indian Localization',
-    'description': 'The Indian Time Off module provides additional features to the application. With it, you\'ll be able to define Sandwich Leaves on your time off type, including weekends or holidays in the duration of the employee leave\'s request.',
+    'description': 'The Indian Time Off module provides additional features to the application. With it, you\'ll be able to define Sandwich Leaves on your time type, including weekends or holidays in the duration of the employee leave\'s request.',
     'countries': ['in'],
     'depends': ['hr_holidays'],
     'auto_install': ['hr_holidays'],

--- a/addons/project_timesheet_holidays/models/project_task.py
+++ b/addons/project_timesheet_holidays/models/project_task.py
@@ -8,7 +8,7 @@ from odoo.tools import OrderedSet
 class ProjectTask(models.Model):
     _inherit = 'project.task'
 
-    leave_types_count = fields.Integer(compute='_compute_leave_types_count', string="Time Off Types Count")
+    leave_types_count = fields.Integer(compute='_compute_leave_types_count', string="Time Types Count")
     is_timeoff_task = fields.Boolean("Is Time off Task", compute="_compute_is_timeoff_task", search="_search_is_timeoff_task", export_string_translation=False, groups="hr_timesheet.group_hr_timesheet_user")
 
     def _compute_leave_types_count(self):

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -11,12 +11,12 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.internal_project_id', required=True, string="Internal Project",
         domain="[('company_id', '=', company_id), ('is_template', '=', False)]", readonly=False,
         help="The default project used when automatically generating timesheets via time off requests."
-             " You can specify another project on each time off type individually.")
+             " You can specify another project on each time type individually.")
     leave_timesheet_task_id = fields.Many2one(
         related='company_id.leave_timesheet_task_id', string="Time Off Task", readonly=False,
         domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id), ('has_template_ancestor', '=', False)]",
         help="The default task used when automatically generating timesheets via time off requests."
-             " You can specify another task on each time off type individually.")
+             " You can specify another task on each time type individually.")
 
     @api.onchange('internal_project_id')
     def _onchange_timesheet_project_id(self):


### PR DESCRIPTION
Previously, time off types were generating hr.leave.request records while still being exposed as work entry types, leading to inconsistencies across the system.

In this commit, renaming:

work entry type -> time type
time off type -> time type

Task-5976238