### PR TITLE
[FIX] website: solve failing hoot test of age verification popup

### DIFF
--- a/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
+++ b/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
@@ -1,10 +1,12 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, tick } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
-import { contains } from "@web/../tests/web_test_helpers";
+import { contains, defineStyle } from "@web/../tests/web_test_helpers";
 
 setupInteractionWhiteList("website.age_verification_popup");
+beforeEach(() => defineStyle(/* css */ `* { transition: none !important; }`));
+
 describe.current.tags("interaction_dev");
 
 const modalSelector = "#sAgeVerificationPopup .modal";


### PR DESCRIPTION
### Issue:
`age_verification_popup` tests were failing non-deterministically on
Runbot, caused by a timing mismatch related to Bootstrap's use of CSS
transitions. The modal hide logic relies on the `transitionend` event,
which can cause test assertions to run before the transition has fully
completed, leading to inconsistent results.

### Fix:
Disabled CSS transitions to make the tests deterministic and avoid race
conditions, ensuring that DOM updates are applied immediately and the
assertions run reliably.

runbot-[242448](https://runbot.odoo.com/odoo/runbot.build.error/242448)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
