### PR TITLE
[FIX] html_editor: proper cursor update when normalizing list item

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -501,7 +501,7 @@ export class ListPlugin extends Plugin {
             baseContainerNodeName: this.dependencies.baseContainer.getDefaultNodeName(),
             cursors,
         });
-        callbacksForCursorUpdate.unwrap(element);
+        cursors.update(callbacksForCursorUpdate.unwrap(element));
         unwrapContents(element);
         cursors.restore();
     }


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR is a fixup to [[1]](https://github.com/odoo/odoo/commit/77cbdc0120f7ae7d5c777eb946ad568f2caf05d7) where cursor was not updated properly before unwrapping the element.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
