### PR TITLE
[FIX] hr_holidays: fix department filtering in employee leave report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -59,7 +59,7 @@ class HrLeaveEmployeeTypeReport(models.Model):
 						employee.active as active_employee,
 						allocation.number_of_days as number_of_days,
 						allocation.number_of_hours_display as number_of_hours,
-						allocation.department_id as department_id,
+						v.department_id as department_id,
 						allocation.holiday_status_id as leave_type,
 						allocation.state as state,
 						allocation.date_from as date_from,
@@ -81,6 +81,7 @@ class HrLeaveEmployeeTypeReport(models.Model):
 						) as cumulative_allocated_hours
                     FROM hr_leave_allocation allocation
                     JOIN hr_employee employee ON (allocation.employee_id = employee.id)
+                    LEFT JOIN hr_version v ON v.id = employee.current_version_id
                     WHERE allocation.state = 'validate'
                 ),
 
@@ -162,7 +163,7 @@ class HrLeaveEmployeeTypeReport(models.Model):
 						employee.active as active_employee,
 						request.number_of_days as number_of_days,
 						request.number_of_hours as number_of_hours,
-						request.department_id as department_id,
+						v.department_id as department_id,
 						request.holiday_status_id as leave_type,
 						request.state as state,
 						request.date_from as date_from,
@@ -174,6 +175,7 @@ class HrLeaveEmployeeTypeReport(models.Model):
 						request.employee_company_id as company_id
                     FROM hr_leave as request
                     JOIN hr_employee as employee ON (request.employee_id = employee.id)
+                    LEFT JOIN hr_version v ON v.id = employee.current_version_id
                     WHERE request.state IN ('confirm', 'validate', 'validate1')
                 ) leaves
             );


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install the Time Off module.
2. Go to Time Off > Management > Allocations, create an allocation for an employee, and approve it.
3. Go to Reporting > Balance and apply the filter Department > Employee.
4. Change the employee’s department.
5. Create an allocation for the same employee and approve.
6. Apply the Department > Employee filter again.

Observed behaviour:
----------------------------
After a department change:
* Existing allocations keep the old department
* New allocations use the new department

As a result, duplicate employee entries appear in the report

Cause:
----------
It is using allocation.department_id.
Allocations store the department at creation time, which may differ from the employee’s current department, causing an incorrect report filtering.

Solution:
------------
Fetch department_id from hr_version instead of hr_leave_allocation in the hr_leave_employee_type_report.

This ensures:
* Leave balances always follow the employee’s current department
* Correct aggregation when grouping by Department → Employee

opw-5220577

Before:
<img width="1238" height="857" alt="image" src="https://github.com/user-attachments/assets/15e1293b-dc50-4067-a12f-079c046c2074" />

After:
<img width="1247" height="824" alt="image" src="https://github.com/user-attachments/assets/feea32de-0d9c-4eef-9ae5-639f4658560c" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
