### PR TITLE
[FIX] website: make BuilderList lazy-load robust on fast scroll

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "@web/owl2/utils";
+import { useRef, useState } from "@web/owl2/utils";
 import { BuilderComponent } from "@html_builder/core/building_blocks/builder_component";
 import { BuilderListDialog } from "@html_builder/core/building_blocks/builder_list_dialog";
 import {
@@ -12,6 +12,7 @@ import { _t } from "@web/core/l10n/translation";
 import { SelectMenu } from "@web/core/select_menu/select_menu";
 import { useSortable } from "@web/core/utils/sortable_owl";
 import { useService } from "@web/core/utils/hooks";
+import { useThrottleForAnimation } from "@web/core/utils/timing";
 
 export class BuilderList extends Component {
     static template = "html_builder.BuilderList";
@@ -72,34 +73,11 @@ export class BuilderList extends Component {
         this.commit = commit;
         this.preview = preview;
         this.allRecords = this.formatRawValue(this.props.records);
+        this.tableRef = useRef("table");
         this.visibilityState = useState({
             limit: this.props.limit,
         });
-        this.tableRef = useRef("table");
-        this.sentinelRef = useRef("sentinel");
-        useLayoutEffect(
-            () => {
-                const sentinelEl = this.sentinelRef.el;
-                if (!sentinelEl) {
-                    return;
-                }
-                const observer = new IntersectionObserver(
-                    ([entry]) => {
-                        if (entry.isIntersecting && this.hasMoreItems) {
-                            this.visibilityState.limit += this.props.limit;
-                        }
-                    },
-                    {
-                        root: this.tableRef.el.parentElement,
-                        threshold: 1.0,
-                        rootMargin: "100px",
-                    }
-                );
-                observer.observe(sentinelEl);
-                return () => observer.disconnect();
-            },
-            () => []
-        );
+        this.onTableScroll = useThrottleForAnimation(this._onTableScroll);
 
         onWillUpdateProps((props) => {
             this.allRecords = this.formatRawValue(props.records);
@@ -127,6 +105,25 @@ export class BuilderList extends Component {
 
     get hasMoreItems() {
         return this.cappedItems.length < this.getIncludedRecords().length;
+    }
+
+    loadMoreItems() {
+        if (!this.hasMoreItems) {
+            return;
+        }
+        this.visibilityState.limit = Math.min(
+            this.visibilityState.limit + this.props.limit,
+            this.getIncludedRecords().length
+        );
+    }
+
+    _onTableScroll(ev) {
+        const tableWrapperEl = ev.currentTarget;
+        const distanceToBottom =
+            tableWrapperEl.scrollHeight - (tableWrapperEl.scrollTop + tableWrapperEl.clientHeight);
+        if (distanceToBottom <= 100) {
+            this.loadMoreItems();
+        }
     }
 
     validateProps() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -6,7 +6,7 @@
         <div class="w-100 p-2 py-0">
             <t t-set="isMany2X" t-value="this.allRecords and this.allRecords.length"/>
             <t t-if="this.state.value?.length > 2">
-                <div class="o_we_table_wrapper">
+                <div class="o_we_table_wrapper" t-on-scroll="this.onTableScroll">
                     <table t-custom-ref="table">
                         <t t-set="items" t-value="this.cappedItems"/>
                         <t t-foreach="items" t-as="item" t-key="item._id">
@@ -52,9 +52,6 @@
                                 </td>
                             </tr>
                         </t>
-                        <tr t-custom-ref="sentinel" t-if="this.hasMoreItems">
-                            <td colspan="99"/>
-                        </tr>
                     </table>
                 </div>
             </t>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -5,7 +5,7 @@ import {
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
-import { expect, test, describe, animationFrame } from "@odoo/hoot";
+import { expect, test, describe } from "@odoo/hoot";
 import { onError, xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import { press } from "@odoo/hoot-dom";
@@ -486,12 +486,8 @@ test("loads more items when the last row intersects", async () => {
     await setupHTMLBuilder(`<div class="test-options-target">content</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".we-bg-options-container .o_row_draggable").toHaveCount(50);
-
     await contains(".we-bg-options-container .o_we_table_wrapper").scroll({ top: 9999 });
-    await animationFrame();
     expect(".we-bg-options-container .o_row_draggable").toHaveCount(100);
-
     await contains(".we-bg-options-container .o_we_table_wrapper").scroll({ top: 9999 });
-    await animationFrame();
     expect(".we-bg-options-container .o_row_draggable").toHaveCount(150);
 });


### PR DESCRIPTION
Problem:
`BuilderList` could get stuck at 50 items when users scrolled quickly.
The previous lazy-load logic relied on IntersectionObserver, which
could miss the trigger during fast scroll jumps.

This commit aims to replace that behavior with a simple scroll event
listener on the list container. When the user reaches the near-bottom
threshold, the next batch loads immediately until all items are
displayed.

runbot-242473