### PR TITLE
[FIX] web: malformed xml in test

### DIFF
--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -99,7 +99,7 @@ class TestReports(odoo.tests.HttpCase):
             'key': 'base.test_report',
             'arch': '''
                 <main>
-                    <div">
+                    <div>
                         <p>TEST</p>
                     </div>
                 </main>


### PR DESCRIPTION
This commit fixes a malformed HTML/XML tag in TestReports.

Note: before libxml2 v2.14.0, this issue was automagically cleaned up, but not anymore.
