### PR TITLE
[PERF] website: speed up search on website translated fields

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2217,7 +2217,7 @@ class Website(models.Model):
             where_clauses = []
             for field_name in fields:
                 field = model._fields[field_name]
-                if field.translate:
+                if field.translate and field.index == 'trigram':
                     alias = model._table
                     if field.related and not field.store:
                         _, field, alias = model._traverse_related_sql(model._table, field, subquery)


### PR DESCRIPTION
The `_trigram_enumerate_words` method generates a WHERE clause using `jsonb_path_query_array(col, '$.*')::text` to allow PostgreSQL to use a GiST trigram index via the `<%` operator. This optimisation only works when the field actually has `index='trigram'`. Without it, no GiST index exists and the expression becomes an expensive scan that extracts and concatenates every language translation from the JSONB blob for every row.

`arch_db` on `ir.ui.view` (used by `website.page` search) is a large translated field with no trigram index. The condition `if field.translate:` check was causing it to take the costly `jsonb_path_query_array` path, making website search slow on databases with many pages or large page content.

Restrict the check to only fields that carry a trigram index. Other fields fall through to the plain `search <% field` condition, which still filters rows via the `pg_trgm.word_similarity_threshold` but avoids the unnecessary JSONB extraction overhead.

Adding `index='trigram'` to `arch_db` was considered but not viable, in this specific case, the trigram representation of HTML page content exceeds PostgreSQL's index entry size limit.

Related issue:
opw-6066306

Benchmark:

| Search term | Before | After |
|-------------|--------|-------|
| circularity | 16.39s | 2.09s |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
