### PR TITLE
[IMP] payment, payment_mollie: add Apple Pay & Google Pay support

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -317,6 +317,28 @@
         />
     </record>
 
+    <record id="payment_method_apple_pay" model="payment.method">
+        <field name="name">Apple Pay</field>
+        <field name="code">apple_pay</field>
+        <field name="sequence">1000</field>
+        <field name="active">False</field>
+        <field name="image" type="bytes" file="payment/static/img/apple_pay.png"/>
+        <field name="support_tokenization">False</field>
+        <field name="support_express_checkout">True</field>
+        <field name="support_refund">partial</field>
+    </record>
+
+    <record id="payment_method_google_pay" model="payment.method">
+        <field name="name">Google Pay</field>
+        <field name="code">google_pay</field>
+        <field name="sequence">1000</field>
+        <field name="active">False</field>
+        <field name="image" type="bytes" file="payment/static/img/google_pay.png"/>
+        <field name="support_tokenization">False</field>
+        <field name="support_express_checkout">True</field>
+        <field name="support_refund">partial</field>
+    </record>
+
     <record id="payment_method_astropay" model="payment.method">
         <field name="name">Astropay TEF</field>
         <field name="code">astropay</field>

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -284,12 +284,14 @@
         <!-- https://www.mollie.com/en/payments -->
         <field name="payment_method_ids"
                eval="[Command.set([
+                         ref('payment.payment_method_apple_pay'),
                          ref('payment.payment_method_bancontact'),
                          ref('payment.payment_method_bank_transfer'),
                          ref('payment.payment_method_belfius'),
                          ref('payment.payment_method_blik'),
                          ref('payment.payment_method_card'),
                          ref('payment.payment_method_eps'),
+                         ref('payment.payment_method_google_pay'),
                          ref('payment.payment_method_ideal'),
                          ref('payment.payment_method_in3'),
                          ref('payment.payment_method_kbc_cbc'),

--- a/addons/payment/static/src/interactions/payment_form.js
+++ b/addons/payment/static/src/interactions/payment_form.js
@@ -28,6 +28,7 @@ export class PaymentForm extends Interaction {
     }
 
     async willStart() {
+        this._checkAppleGooglePaySupport();
         // Expand the payment form of the selected payment option if there is only one.
         const checkedRadio = document.querySelector('input[name="o_payment_radio"]:checked');
         if (checkedRadio) {
@@ -147,6 +148,61 @@ export class PaymentForm extends Interaction {
     }
 
     // #=== DOM MANIPULATION ===#
+    /**
+     * Check if Apple Pay and Google Pay are supported by the browser and device.
+     * Reveals the option if supported, completely hides and disables it if not.
+     *
+     * @private
+     * @return {void}
+     */
+    async _checkAppleGooglePaySupport() {
+        const applePayInput = this.el.querySelector('input[data-payment-method-code="apple_pay"]');
+        if (applePayInput) {
+            const isApplePaySupported = window.ApplePaySession && window.ApplePaySession.canMakePayments();
+            const optionContainer = applePayInput.closest('[name="o_payment_option"]');
+
+            if (optionContainer) {
+                if (isApplePaySupported) {
+                    optionContainer.classList.remove('d-none');
+                }
+            }
+        }
+
+        const googlePayInput = this.el.querySelector('input[data-payment-method-code="google_pay"]');
+        if (googlePayInput) {
+            const optionContainer = googlePayInput.closest('[name="o_payment_option"]');
+
+            if (optionContainer && window.google && window.google.payments) {
+                try {
+                    const paymentsClient = new window.google.payments.api.PaymentsClient(
+                        { environment: 'PRODUCTION' }
+                    );
+
+                    const isReadyToPayRequest = {
+                        apiVersion: 2,
+                        apiVersionMinor: 0,
+                        allowedPaymentMethods: [
+                            {
+                                type: 'CARD',
+                                parameters: {
+                                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                                    allowedCardNetworks: ['MASTERCARD', 'VISA']
+                                }
+                            }
+                        ]
+                    };
+
+                    const response = await paymentsClient.isReadyToPay(isReadyToPayRequest);
+
+                    if (response.result) {
+                        optionContainer.classList.remove('d-none');
+                    }
+                } catch (err) {
+                    console.error("Google Pay Error:", err);
+                }
+            }
+        }
+    }
 
     /**
      * Check if the submit button can be enabled and do it if so.

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -97,7 +97,8 @@
                     <ul class="list-group">
                         <t t-foreach="payment_methods_sudo" t-as="pm_sudo">
                             <li name="o_payment_option"
-                                class="list-group-item d-flex flex-column gap-2 py-3 o_outline"
+                                t-att-class="'list-group-item d-flex flex-column gap-2 py-3 o_outline'
+                                    + (' d-none' if pm_sudo.code in ['apple_pay', 'google_pay'] else '')"
                             >
                                 <t t-call="payment.method_form" is_selected="pm_sudo.id == selected_method_id"/>
                             </li>
@@ -123,6 +124,12 @@
             <t t-call="payment.availability_report"/>
         </form>
         <t t-else="" t-call="payment.no_pms_available_warning"/>
+    </template>
+
+    <template id="google_pay_script_assets" inherit_id="web.layout">
+        <xpath expr="//head" position="inside">
+            <script src="https://pay.google.com/gp/p/js/pay.js"></script>
+        </xpath>
     </template>
 
     <template id="payment.token_form" name="Payment Token Form">

--- a/addons/payment_mollie/const.py
+++ b/addons/payment_mollie/const.py
@@ -77,6 +77,7 @@ DEFAULT_PAYMENT_METHOD_CODES = {
 PAYMENT_METHODS_MAPPING = {
     "apple_pay": "applepay",
     "card": "creditcard",
+    "google_pay": "creditcard",
     "bank_transfer": "banktransfer",
     "kbc_cbc": "kbc",
     "p24": "przelewy24",


### PR DESCRIPTION
Integrate Apple Pay and Google Pay with the Mollie provider. Show payment buttons at checkout only when available.

task-6060862