### PR TITLE
[IMP] mail, im_livechat: improve discuss command palette

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_command_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_command_patch.js
@@ -1,0 +1,11 @@
+import { DiscussCommand } from "@mail/discuss/core/public_web/discuss_command_palette";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {DiscussCommand} */
+const discussCommandComponentPatch = {
+    get email() {
+        return this.props.channel?.livechatVisitorMember?.persona.email ?? super.email;
+    },
+};
+patch(DiscussCommand.prototype, discussCommandComponentPatch);

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -507,6 +507,12 @@ export class DiscussChannel extends Record {
             this.onPinStateUpdated();
         },
     });
+    storeAsFavoriteChannels = fields.One("Store", {
+        compute() {
+            return this.self_member_id?.is_favorite ? this.store : null;
+        },
+        inverse: "favoriteChannels",
+    });
     thread = fields.One("mail.thread", {
         compute() {
             return { id: this.id, model: "discuss.channel" };

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -1,4 +1,5 @@
 import { Store } from "@mail/core/common/store_service";
+import { fields } from "@mail/model/misc";
 import { compareDatetime } from "@mail/utils/common/misc";
 
 import { patch } from "@web/core/utils/patch";
@@ -22,6 +23,9 @@ const storeServicePatch = {
             () => this.env.services.bus_service.forceUpdateChannels(),
             0
         );
+        this.favoriteChannels = fields.Many("discuss.channel", {
+            inverse: "storeAsFavoriteChannels",
+        });
     },
     /**
      * @param {Object} param0

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -1,56 +1,20 @@
-import { useState } from "@web/owl2/utils";
 import { cleanTerm } from "@mail/utils/common/format";
+import { useState } from "@web/owl2/utils";
 
 import { Component } from "@odoo/owl";
 
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
+import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { Dialog } from "@web/core/dialog/dialog";
-import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
-import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
+import { highlightText } from "@web/core/utils/html";
 
 const commandSetupRegistry = registry.category("command_setup");
 const commandProviderRegistry = registry.category("command_provider");
 
 const NEW_CHANNEL = "NEW_CHANNEL";
-const NEW_GROUP_CHAT = "NEW_GROUP_CHAT";
-
-class CreateChatDialog extends Component {
-    static components = { ChannelInvitation, Dialog };
-    static props = ["close", "name?"];
-    static template = "mail.CreateChatDialog";
-
-    setup() {
-        super.setup();
-        this.store = useService("mail.store");
-        this.invitePeopleState = useState({
-            selectablePartners: [],
-            selectedPartners: [],
-            searchStr: this.props.name,
-        });
-    }
-
-    get createText() {
-        if (this.invitePeopleState.selectedPartners.length === 1) {
-            return _t("Open Chat");
-        }
-        return _t("Create Group Chat");
-    }
-
-    onClickConfirm() {
-        const selectedPartnersId = this.invitePeopleState.selectedPartners.map((p) => p.id);
-        const partners_to = [
-            ...new Set([this.store.self_user?.partner_id.id, ...selectedPartnersId]),
-        ];
-        if (partners_to.length === 1) {
-            this.store.createGroupChat({ partners_to });
-        } else {
-            this.store.startChat(partners_to);
-        }
-        this.props.close();
-    }
-}
+const VIEW_HIDDEN = "VIEW_HIDDEN";
 
 class CreateChannelDialog extends Component {
     static components = { Dialog };
@@ -90,7 +54,7 @@ class CreateChannelDialog extends Component {
     }
 }
 
-class DiscussCommand extends Component {
+export class DiscussCommand extends Component {
     static components = { DiscussAvatar };
     static template = "mail.DiscussCommand";
     static props = {
@@ -110,6 +74,14 @@ class DiscussCommand extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
     }
+
+    get formattedEmail() {
+        return highlightText(this.props.searchValue, this.email, "fw-bolder text-primary");
+    }
+
+    get email() {
+        return this.props.persona?.email;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -119,7 +91,7 @@ commandSetupRegistry.add("@", {
     debounceDelay: 200,
     emptyMessage: _t("No conversation found"),
     name: _t("conversations"),
-    placeholder: _t("Search a conversation"),
+    placeholder: _t("Search conversations"),
 });
 
 /**
@@ -168,7 +140,8 @@ export class DiscussCommandPalette {
             partners = Object.values(this.store["res.partner"].records).filter(
                 (partner) =>
                     partner.main_user_id?.share === false &&
-                    cleanTerm(partner.displayName).includes(this.cleanedTerm) &&
+                    (cleanTerm(partner.displayName).includes(this.cleanedTerm) ||
+                        cleanTerm(partner.email).includes(this.cleanedTerm)) &&
                     (!filtered || !filtered.has(partner))
             );
             partners = this.suggestion
@@ -274,29 +247,24 @@ export class DiscussCommandPalette {
         if (channelOrPersona === NEW_CHANNEL) {
             return {
                 Component: DiscussCommand,
-                action: async () => {
-                    const name = this.options.searchValue.trim();
-                    if (name) {
-                        await makeNewChannel(name, this.store);
-                    } else {
-                        this.dialog.add(CreateChannelDialog);
-                    }
+                action: () => {
+                    this.dialog.add(CreateChannelDialog, {
+                        name: this.options.searchValue?.trim(),
+                    });
                 },
                 name: _t("Create Channel"),
                 className: "o-mail-DiscussCommand-createChannel d-flex",
                 props: { action: { icon: "fa fa-fw fa-hashtag", searchValueSuffix: true } },
             };
         }
-        if (channelOrPersona === NEW_GROUP_CHAT) {
-            const name = this.options.searchValue.trim();
+        if (channelOrPersona === VIEW_HIDDEN) {
             return {
                 Component: DiscussCommand,
+                name: _t("View hidden conversations"),
+                props: { action: {} },
                 action: () => {
-                    this.dialog.add(CreateChatDialog, { name });
+                    this.env.services.action.doAction("mail.discuss_my_conversations_action");
                 },
-                name: _t("Create Chat"),
-                className: "d-flex",
-                props: { action: { icon: "oi fa-fw oi-users" } },
             };
         }
         throw new Error(`Unsupported use of makeDiscussCommand("${channelOrPersona}")`);
@@ -311,15 +279,11 @@ commandProviderRegistry.add("find_or_start_conversation", {
         palette.buildResults();
         palette.commands.slice(0, 8);
         if (!palette.store.inPublicPage) {
-            palette.commands.push(palette.makeDiscussCommand(NEW_CHANNEL));
-            palette.commands.push(palette.makeDiscussCommand(NEW_GROUP_CHAT));
+            if (palette.cleanedTerm) {
+                palette.commands.push(palette.makeDiscussCommand(NEW_CHANNEL));
+            }
             if (palette.store.has_unpinned_channels) {
-                palette.commands.push({
-                    name: _t("View hidden conversations"),
-                    action: () => {
-                        env.services.action.doAction("mail.discuss_my_conversations_action");
-                    },
-                });
+                palette.commands.push(palette.makeDiscussCommand(VIEW_HIDDEN));
             }
         }
         return palette.commands;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -3,17 +3,18 @@
 
     <t t-name="mail.DiscussCommand">
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': this.ui.isSmall }">
-            <i t-if="this.props.channel" class="fa-fw opacity-75 text-muted me-2" t-att-class="this.props.channel.parent_channel_id ? 'fa fa-comments-o' : this.props.channel.discussAppCategory?.icon ?? 'oi oi-user opacity-0'"/>
-            <i t-elif="this.props.persona" class="oi fa-fw oi-user opacity-75 text-muted me-2"/>
             <DiscussAvatar t-if="this.props.channel or this.props.persona" channel="this.props.channel" persona="this.props.persona" size="this.ui.isSmall ? 32 : 26" className="'me-2'"/>
             <span class="o-mail-DiscussCommand-nameContainer pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': this.props.action }">
                 <t t-if="this.props.channel?.parent_channel_id">
-                    <span class="text-truncate flex-shrink-0 opacity-75 mw-50 small" t-out="this.props.channel?.parent_channel_id.displayName"/>
+                    <span class="text-truncate flex-shrink-0 opacity-75 mw-75 small" t-out="this.props.channel?.parent_channel_id.displayName"/>
                     <i class="oi oi-chevron-right o-xsmaller mx-1"/>
                 </t>
                 <t t-slot="name" />
             </span>
-            <span t-if="this.props.persona and this.props.persona.email" class="text-truncate text-muted smaller opacity-75" t-out="'- ' + this.props.persona.email" t-att-title="this.props.persona.email"/>
+            <span t-if="this.email" class="text-truncate text-muted smaller opacity-75" t-att-title="this.email">
+                <span class="pe-1">-</span>
+                <t t-out="this.formattedEmail"/>
+            </span>
             <i t-if="this.props.action?.icon" class="o-mail-DiscussCommand-actionIcon fa fa-fw opacity-75 o-action" t-attf-class="{{ this.props.action.icon }}"/>
             <span t-if="this.props.action?.searchValueSuffix" class="o-action fw-bold" t-out="this.props.searchValue"/>
             <span class="flex-grow-1"/>
@@ -40,20 +41,5 @@
             </t>
         </Dialog>
     </t>
-
-<t t-name="mail.CreateChatDialog">
-    <Dialog size="'md'" title.translate="Make Chat" contentClass="'o-mail-CreateChatDialog'" bodyClass="'py-0'">
-        <div class="d-flex flex-column flex-grow-1 bg-inherit w-100">
-            <div class="d-flex align-items-center px-0 mb-1 gap-1">
-                <span class="ms-2 my-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="oi oi-user-plus"/> Invite people</span>
-            </div>
-            <ChannelInvitation state="this.invitePeopleState"/>
-        </div>
-        <t t-set-slot="footer">
-            <button class="btn btn-primary me-2" t-on-click="this.onClickConfirm" t-out="this.createText"/>
-            <button class="btn btn-secondary me-2" t-on-click="this.props.close">Discard</button>
-        </t>
-    </Dialog>
-</t>
 
 </templates>

--- a/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
@@ -18,6 +18,7 @@ patch(DiscussCommandPalette.prototype, {
         const recentChannels = this.store.getSelfRecentChannels();
         const mentionedSet = new Set();
         const recentSet = new Set();
+        const favoriteSet = new Set();
         const CATEGORY_LIMIT = 3;
         if (!this.cleanedTerm) {
             const limitedMentioned = importantChannels.slice(0, CATEGORY_LIMIT);
@@ -44,7 +45,14 @@ patch(DiscussCommandPalette.prototype, {
                     recentSet.add(channel);
                 }
             }
+            const limitedFavorites = this.store.favoriteChannels.filter(
+                (c) => !mentionedSet.has(c) && !recentSet.has(c)
+            );
+            for (const channel of limitedFavorites) {
+                this.commands.push(this.makeDiscussCommand(channel));
+                favoriteSet.add(channel);
+            }
         }
-        super.buildResults(new Set([...mentionedSet, ...recentSet]));
+        super.buildResults(new Set([...mentionedSet, ...recentSet, ...favoriteSet]));
     },
 });

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -36,6 +36,12 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             tooltipPosition: "right",
         },
         {
+            trigger: ".o-mail-CreateChannelDialog .btn-primary",
+            content: markup(_t("<p>Create a public or private channel.</p>")),
+            run: "click",
+            tooltipPosition: "bottom",
+        },
+        {
             trigger: ".o-mail-Composer-input",
             content: markup(
                 _t(

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -48,9 +48,14 @@ test("No duplicated chat bubbles", async () => {
     // Make bubble of "John" chat
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button:text('New Message')");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "John");
     await contains(".o_command_name", { count: 3 });
+    await contains(".o_command:eq(0):text(John)");
+    await contains(".o_command:eq(1):text(OdooBot)");
+    await contains(".o_command:eq(2):text(Mitchell Admin)");
+    await insertText(".o_command_palette_search input[placeholder='Search conversations']", "John");
+    await contains(".o_command_name", { count: 2 });
+    await contains(".o_command:eq(0):text(John)");
+    await contains(".o_command:eq(1):has(:text(Create Channel))");
     await click(".o_command_name:text('John')");
     await contains(".o-mail-ChatWindow:text('John')");
     await contains(
@@ -61,9 +66,11 @@ test("No duplicated chat bubbles", async () => {
     // Make bubble of "John" chat again
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button:text('New Message')");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "John");
     await contains(".o_command_name", { count: 3 });
+    await insertText(".o_command_palette_search input[placeholder='Search conversations']", "John");
+    await contains(".o_command_name", { count: 2 });
+    await contains(".o_command:eq(0):text(John)");
+    await contains(".o_command:eq(1):has(:text(Create Channel))");
     await click(".o_command_name:text('John')");
     await contains(".o-mail-ChatBubble[name='John']", { count: 0 });
     await contains(".o-mail-ChatWindow .o-mail-ChatWindow-header:has(:text('John'))");

--- a/addons/mail/static/tests/core/common/message.test.js
+++ b/addons/mail/static/tests/core/common/message.test.js
@@ -33,8 +33,9 @@ test("following internal link from chatter does not open chat window", async () 
     await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button:text('New Message')");
-    await insertText("input[placeholder='Search a conversation']", "abc");
+    await insertText(".o_command_palette_search input[placeholder='Search conversations']", "abc");
     await click("a:has(:text('Create Channel'))");
+    await click("button:text(Create Channel)");
     await contains(".o-mail-ChatWindow-header:text('abc')");
     await contains(".o-mail-ChatWindow", { count: 1 });
 });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -11,10 +11,10 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { Settings } from "@mail/core/common/settings_model";
-import { makeRecordFieldLocalId } from "@mail/model/misc";
-import { toRawValue } from "@mail/utils/common/local_storage";
 import { pttExtensionServiceInternal } from "@mail/discuss/call/common/ptt_extension_service";
 import { PTT_RELEASE_DURATION } from "@mail/discuss/call/common/rtc_service";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { toRawValue } from "@mail/utils/common/local_storage";
 import { advanceTime, freezeTime, keyDown, mockTouch, mockUserAgent, test } from "@odoo/hoot";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
@@ -29,9 +29,12 @@ test("no auto-call on joining chat", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "mario");
     await contains(".o_command_name", { count: 3 });
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "mario"
+    );
+    await contains(".o_command_name", { count: 2 });
     await click(".o_command_name:text('Mario')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mario')");
     await contains(".o-mail-Message", { count: 0 });
@@ -49,9 +52,10 @@ test("no auto-call on joining group chat", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
-    await click("a:text('Create Chat')");
-    await click("li:text('Mario')");
-    await click("li:text('Luigi')");
+    await click(".o_command_name:text(Mario)");
+    await contains(".o-mail-DiscussContent-threadName[title='Mario']");
+    await click("[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable:has(:text(Luigi))");
     await click("button:text('Create Group Chat')");
     await contains(".o-mail-DiscussSidebar-item:contains('Mario, and Luigi')");
     await contains(".o-mail-Message", { count: 0 });

--- a/addons/mail/static/tests/discuss/core/bus_subscription.test.js
+++ b/addons/mail/static/tests/discuss/core/bus_subscription.test.js
@@ -87,7 +87,10 @@ test("bus subscription is refreshed when channel is joined", async () => {
     await openDiscuss();
     await expect.waitForSteps([]);
     await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "new channel");
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "new channel"
+    );
     await expect.waitForSteps(["subscribe"]);
 });
 

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -10,6 +10,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -21,8 +22,11 @@ test("can open DM from @username in command palette", async () => {
     await start();
     triggerHotkey("control+k");
     await insertText(".o_command_palette_search input", "@");
-    await insertText("input[placeholder='Search a conversation']", "Mario");
-    await click(".o_command.focused:has(.oi-user):text('Mario')");
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "Mario"
+    );
+    await click(".o_command.focused:has(:text('Mario')");
     await contains(".o-mail-ChatWindow:text('Mario')");
 });
 
@@ -49,14 +53,12 @@ test("can open channel from @channel_name in command palette", async () => {
     await start();
     triggerHotkey("control+k");
     await insertText(".o_command_palette_search input", "@");
-    await contains(".o_command", { count: 6 });
-    await contains(".o_command:eq(0):has(.fa-hashtag):text('project')");
-    await contains(".o_command:eq(1):has(.fa-hashtag):text('general')");
-    await contains(".o_command:has(.oi-user):text('OdooBot')");
-    await contains(".o_command:has(.oi-user):text('Mitchell Admin')"); // self-conversation
-    await contains(".o_command:text('Create Channel')");
-    await contains(".o_command:text('Create Chat')");
-    await click(".o_command.focused:has(.fa-hashtag):text('project')");
+    await contains(".o_command", { count: 4 });
+    await contains(".o_command:eq(0):text('project')");
+    await contains(".o_command:eq(1):text('general')");
+    await contains(".o_command:eq(2):text('OdooBot')");
+    await contains(".o_command:eq(3):text('Mitchell Admin')"); // self-conversation
+    await click(".o_command.focused:text('project')");
     await contains(".o-mail-ChatWindow:text('project')");
 });
 
@@ -121,12 +123,10 @@ test("only partners with dedicated users will be displayed in command palette", 
     await start();
     triggerHotkey("control+k");
     await insertText(".o_command_palette_search input", "@");
-    await contains(".o_command_name", { count: 5 });
+    await contains(".o_command_name", { count: 3 });
     await contains(".o_command_name:text('Demo')");
     await contains(".o_command_name:text('OdooBot')");
     await contains(".o_command_name:text('Mitchell Admin')"); // self-conversation
-    await contains(".o_command_name:text('Create Channel')");
-    await contains(".o_command_name:text('Create Chat')");
     await contains(".o_command_name:text('Portal')", { count: 0 });
 });
 
@@ -161,11 +161,34 @@ test("Ctrl-K opens @ command palette in discuss app", async () => {
     await contains(".o_command_palette_search:text('@')");
 });
 
-test("Can create group chat from ctrl-k without any user selected", async () => {
+test("Favorite channels come first in default command palette category", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create([
+        ...range(10).map((n) => ({ name: `channel_${n}` })),
+        {
+            name: "favorite_1",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId, is_favorite: true }),
+            ],
+        },
+        {
+            name: "favorite_2",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId, is_favorite: true }),
+            ],
+        },
+        ...range(10, 20).map((n) => ({ name: `channel_${n}` })),
+    ]);
     await start();
-    await openDiscuss();
     triggerHotkey("control+k");
-    await click(".o_command_name:text('Create Chat')");
-    await click(".modal-footer > .btn:text('Create Group Chat')");
-    await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')");
+    await insertText(".o_command_palette_search input", "@", { replace: true });
+    await contains(".o_command_category:has(:text(Recent)) .o_command:eq(0):text(channel_19)");
+    await contains(".o_command_category:has(:text(Recent)) .o_command:eq(1):text(channel_18)");
+    await contains(".o_command_category:has(:text(Recent)) .o_command:eq(2):text(channel_17)");
+    await contains(
+        ".o_command_category:not(:has(:text(Recent))) .o_command:eq(0):text(favorite_1)"
+    );
+    await contains(
+        ".o_command_category:not(:has(:text(Recent))) .o_command:eq(1):text(favorite_2)"
+    );
 });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -50,12 +50,13 @@ test("can create a new channel", async () => {
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('abc')", { count: 0 });
     await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "abc");
+    await insertText(".o_command_palette_search input[placeholder='Search conversations']", "abc");
     await expect.waitForSteps([
         `/discuss/search - {"term":""}`,
         `/discuss/search - {"term":"abc"}`,
     ]);
     await click(".o-mail-DiscussCommand-nameContainer:text('Create Channel')");
+    await click("button:text(Create Channel)");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('abc')");
     await contains(".o-mail-Message", { count: 0 });
     const [channelId] = pyEnv["discuss.channel"].search([["name", "=", "abc"]]);
@@ -89,10 +90,9 @@ test("can create a read-only channel", async () => {
     const pyEnv = await startServer();
     await start();
     await openDiscuss();
-    await contains(".o-mail-Discuss");
     await click("input[placeholder='Search conversations']");
-    await click("a:text('Create Channel')");
-    await insertText("input[placeholder='Channel name']", "abc");
+    await insertText(".o_command_palette input", "abc");
+    await click("a:text('Create Channel abc')");
     await click("input[type='checkbox'][name='readonly']");
     await triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('abc')");
@@ -133,9 +133,12 @@ test("can make a DM chat", async () => {
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mario')", { count: 0 });
     await click("input[placeholder='Search conversations']");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "mario");
     await contains(".o_command_name", { count: 3 });
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "mario"
+    );
+    await contains(".o_command_name", { count: 2 });
     await click(".o_command_name:text('Mario')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mario')");
     await contains(".o-mail-Message", { count: 0 });
@@ -164,10 +167,11 @@ test("can create a group chat conversation", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
-    await click("a:text('Create Chat')");
-    await click("li:text('Mario')");
-    await click("li:text('Luigi')");
-    await click(".btn:text('Create Group Chat')");
+    await click(".o_command_name:text(Mario)");
+    await contains(".o-mail-DiscussContent-threadName[title='Mario']");
+    await click("[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable:has(:text(Luigi))");
+    await click("button:text('Create Group Chat')");
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-Message", { count: 0 });
 });
@@ -190,9 +194,12 @@ test("Chat is pinned on other tabs when joined", async () => {
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
     await click(`${env1.selector} input[placeholder='Search conversations']`);
-    await contains(`${env1.selector} .o_command_name`, { count: 5 });
-    await insertText(`${env1.selector} input[placeholder='Search a conversation']`, "Jer");
     await contains(`${env1.selector} .o_command_name`, { count: 3 });
+    await insertText(
+        `${env1.selector} .o_command_palette_search input[placeholder='Search conversations']`,
+        "Jer"
+    );
+    await contains(`${env1.selector} .o_command_name`, { count: 2 });
     await click(`${env1.selector} .o_command_name:text('Jerry Golay')`);
     await contains(`${env1.selector} .o-mail-DiscussSidebarChannel-itemName:text('Jerry Golay')`);
     await contains(`${env2.selector} .o-mail-DiscussSidebarChannel-itemName:text('Jerry Golay')`);
@@ -260,8 +267,12 @@ test("Preserve letter case and accents when creating channel from sidebar", asyn
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "Crème brûlée Fan Club");
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "Crème brûlée Fan Club"
+    );
     await click(".o-mail-DiscussCommand-nameContainer:text('Create Channel')");
+    await click("button:text(Create Channel)");
     await contains(".o-mail-DiscussContent-threadName", { value: "Crème brûlée Fan Club" });
 });
 
@@ -269,8 +280,9 @@ test("Create channel must have a name", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
+    await insertText(".o_command_palette input", "abc");
     await click(".o-mail-DiscussCommand-nameContainer:text('Create Channel')");
-    await click("input[placeholder='Channel name']");
+    await insertText("input[placeholder='Channel name']:value(abc)", "", { replace: true });
     await triggerHotkey("Enter");
     await contains(".invalid-feedback:text('Channel must have a name.')");
 });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -35,9 +35,12 @@ test("can make DM chat in mobile", async () => {
     await contains("button.active:text('Notifications')");
     await click("button:text('Chats')");
     await click(".o-mail-DiscussSearch-inputContainer");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "Gandalf");
     await contains(".o_command_name", { count: 3 });
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "Gandalf"
+    );
+    await contains(".o_command_name", { count: 2 });
     await click(".o_command_name:text('Gandalf')");
     await contains(".o-mail-ChatWindow:text('Gandalf')");
 });
@@ -51,9 +54,12 @@ test("can search channel in mobile", async () => {
     await contains("button.active:text('Notifications')");
     await click("button:text('Channels')");
     await click(".o-mail-DiscussSearch-inputContainer");
-    await contains(".o_command_name", { count: 5 });
-    await insertText("input[placeholder='Search a conversation']", "Gryff");
     await contains(".o_command_name", { count: 3 });
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "Gryff"
+    );
+    await contains(".o_command_name", { count: 2 });
     await click(".o_command_name:text('Gryffindors')");
     await contains(".o-mail-ChatWindow div[title='Gryffindors']");
 });
@@ -65,8 +71,9 @@ test("can make new channel in mobile", async () => {
     await contains("button.active:text('Notifications')");
     await click("button:text('Channels')");
     await click(".o-mail-DiscussSearch-inputContainer");
-    await insertText("input[placeholder='Search a conversation']", "slytherins");
+    await insertText(".o_command_palette input", "slytherins");
     await click(".o-mail-DiscussCommand-nameContainer:text('Create Channel')");
+    await click("button:text(Create Channel)");
     await contains(".o-mail-ChatWindow:text('slytherins')");
 });
 
@@ -75,7 +82,7 @@ test("new message opens the @ command palette", async () => {
     await click(".o_menu_systray .dropdown-toggle i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button:text('New Message')");
     await contains(".o_command_palette_search .o_namespace:text('@')");
-    await contains(".o_command_palette input[placeholder='Search a conversation']");
+    await contains(".o_command_palette input[placeholder='Search conversations']");
 });
 
 test("channel preview show deleted messages", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2543,9 +2543,9 @@ test("Newly created chat is at the top of the DM list", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Search conversations']");
-    await contains(".o_command_name", { count: 6 });
-    await insertText("input[placeholder='Search a conversation']", "Jer");
-    await contains(".o_command_name", { count: 3 });
+    await contains(".o_command_name", { count: 4 });
+    await insertText(".o_command_palette_search input[placeholder='Search conversations']", "Jer");
+    await contains(".o_command_name", { count: 2 });
     await click(".o_command_name:text('Jerry Golay')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Jerry Golay')", {
         before: [".o-mail-DiscussSidebarChannel-itemName:text('Albert')"],

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -921,12 +921,18 @@ test("opening a hidden channel re-pins it", async () => {
     await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')", { count: 0 });
     await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "Mitchell Admin");
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "Mitchell Admin"
+    );
     await click(".o-mail-DiscussCommand-nameContainer:text('Mitchell Admin')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')");
     await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
     await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "General");
+    await insertText(
+        ".o_command_palette_search input[placeholder='Search conversations']",
+        "General"
+    );
     await click(".o-mail-DiscussCommand-nameContainer:text('General')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')");
     await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))", {

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -35,8 +35,7 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
             run: "fill @",
         },
         {
-            trigger:
-                ".o-mail-DiscussCommand:not(:has(.fa-user)):has(.fa-hashtag):text(Test channel)",
+            trigger: ".o-mail-DiscussCommand:text(Test channel)",
         },
     ],
 });


### PR DESCRIPTION
The command palette allows to quickly find recent discussions. This commit improves the palette:
- Allow searching by email: results were already fetched but not properly displayed and the email is not highlighted like for name matches.
- Remove distracting icons.
- Only show create channel option when a value is entered, thus removing the need for the channel creation modal.
- Display emails for live chats when available.
- Avoid name truncation when there is enough space to display it.
- Display favorite channels first.

part of task-5867464

enterprise: https://github.com/odoo/enterprise/pull/113490
