### PR TITLE
[FIX] html_editor: ensure table menu updates on target change

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUpdateProps, useExternalListener, useRef } from "@odoo/owl";
+import { Component, onMounted, useEffect, useExternalListener, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -25,25 +25,27 @@ export class TableMenu extends Component {
 
     setup() {
         this.dropdownRef = useRef("dropdown");
-        if (this.props.type === "column") {
-            this.isFirst = this.props.target.cellIndex === 0;
-            this.isLast = !this.props.target.nextElementSibling;
-        } else {
-            const tr = this.props.target.parentElement;
-            this.isFirst = !tr.previousElementSibling;
-            this.isLast = !tr.nextElementSibling;
-        }
-        this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
-        onWillUpdateProps((newProps) => {
-            this.updatePosition(newProps);
-        });
         onMounted(() => {
             this.overlayEl = this.dropdownRef.el;
-            this.updatePosition(this.props);
         });
+        useEffect(
+            () => {
+                if (this.props.type === "column") {
+                    this.isFirst = this.props.target.cellIndex === 0;
+                    this.isLast = !this.props.target.nextElementSibling;
+                } else {
+                    const tr = this.props.target.parentElement;
+                    this.isFirst = !tr.previousElementSibling;
+                    this.isLast = !tr.nextElementSibling;
+                }
+                this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
+                this.updatePosition();
+            },
+            () => [this.props.target]
+        );
         if (this.props.document.defaultView.frameElement) {
             useExternalListener(this.props.document, "scroll", () => {
-                this.updatePosition(this.props);
+                this.updatePosition();
             });
             useExternalListener(this.props.document, "pointerdown", (ev) => {
                 if (!this.overlayEl.contains(ev.target)) {
@@ -61,7 +63,8 @@ export class TableMenu extends Component {
         );
     }
 
-    updatePosition({ target, type, direction }) {
+    updatePosition() {
+        const { target, type, direction } = this.props;
         if (!this.overlayEl || !target) {
             return;
         }

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -224,6 +224,70 @@ test("list of table commands in last column", async () => {
     ]);
 });
 
+test("list of commands updates when hovering different table columns", async () => {
+    const { el } = await setupEditor(`
+        <p><br></p>
+        <table>
+            <tbody>
+            <tr><td class="a">1[]</td><td class="b">2</td><td class="c">3</td></tr>
+            </tbody>
+        </table>`);
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // check list of commands on first column
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await hover(el);
+    await animationFrame();
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(0);
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        // no move left
+        "move_right",
+        "insert_left",
+        "insert_right",
+        "delete",
+    ]);
+    // Close menu
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+
+    // check list of commands on second column
+    await hover(el.querySelector("td.b"));
+    await animationFrame();
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "move_left",
+        "move_right",
+        "insert_left",
+        "insert_right",
+        "delete",
+    ]);
+    // Close menu
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+
+    // check list of commands on last column
+    await hover(el.querySelector("td.c"));
+    await animationFrame();
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "move_left",
+        // no move right
+        "insert_left",
+        "insert_right",
+        "delete",
+    ]);
+});
+
 test("list of table commands in first row", async () => {
     const { el } = await setupEditor(`
         <table>
@@ -295,6 +359,71 @@ test("list of table commands in last row", async () => {
     // check list of commands on last row
     await hover(el.querySelector("td.c"));
     await waitFor(".o-we-table-menu");
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "move_up",
+        // no move down
+        "insert_above",
+        "insert_below",
+        "delete",
+    ]);
+});
+
+test("list of commands updates when hovering different table rows", async () => {
+    const { el } = await setupEditor(`
+        <table>
+            <tbody>
+            <tr><td class="a">1[]</td></tr>
+            <tr><td class="b">2</td></tr>
+            <tr><td class="c">3</td></tr>
+            </tbody>
+        </table>`);
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // check list of commands on first row
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await hover(el);
+    await animationFrame();
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(0);
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        // no move up
+        "move_down",
+        "insert_above",
+        "insert_below",
+        "delete",
+    ]);
+    // Close menu
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+
+    // check list of commands on second row
+    await hover(el.querySelector("td.b"));
+    await animationFrame();
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "move_up",
+        "move_down",
+        "insert_above",
+        "insert_below",
+        "delete",
+    ]);
+    // Close menu
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+
+    // check list of commands on last row
+    await hover(el.querySelector("td.c"));
+    await animationFrame();
     expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
     await click("[data-type='row'].o-we-table-menu");
     await waitFor(".dropdown-menu");


### PR DESCRIPTION
After this commit [1], setup is executed only on the initial mount of the table menu and not on subsequent target cell changes.

As a result, colItems, rowItems, and other values found in setup become stale, causing the menu to display options that do not reflect the current target cell.

This commit moves the necessary values from setup into useEffect so they update correctly when the target cell changes.

task-6111986

[1]: https://github.com/odoo/odoo/commit/7d523d6402c9bff3c2e4bcd0329f486a2d0f45ec

Backport of Commit https://github.com/odoo/odoo/commit/729c45ddf3d1e377507d93997c5ca45984d64d75

