### PR TITLE
[FIX] html_editor: revert fix of button's popover style initialization

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -99,14 +99,6 @@ export class LinkPopover extends Component {
 
         const computedStyle = this.props.document.defaultView.getComputedStyle(linkElement);
         const currentRelValues = linkElement.rel.split(" ");
-        const hasButtonSizeOrShapeOrCustom = this.props.linkElement.className.match(
-            /btn-(lg|sm|xs|custom)|rounded-circle|(?:^|\\s)(outline|fill|flat)(?:\\s|$)/
-        );
-        const buttonType = hasButtonSizeOrShapeOrCustom
-            ? "custom"
-            : this.props.linkElement.className
-                  .match(/btn(-[a-z0-9_-]*)(primary|secondary)/)
-                  ?.pop() || "";
         this.state = useState({
             editing: this.props.LinkPopoverState.editing,
             // `.getAttribute("href")` instead of `.href` to keep relative url
@@ -121,7 +113,10 @@ export class LinkPopover extends Component {
             urlDescription: "",
             linkPreviewName: "",
             imgSrc: "",
-            type: this.props.type || buttonType,
+            type:
+                this.props.type ||
+                linkElement.className.match(/btn(-[a-z0-9_-]*)(primary|secondary|custom)/)?.pop() ||
+                "",
             linkTarget: linkElement.target === "_blank" ? "_blank" : "",
             directDownload: true,
             isDocument: false,

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -318,22 +318,6 @@ describe("Custom button style", () => {
             '<p><a href="https://test.com/" class="rounded-circle btn btn-fill-custom" style="color: rgb(0, 0, 0); background-color: rgb(166, 227, 226); border-width: 1px; border-color: rgb(0, 143, 140); border-style: dashed; ">link[]Label</a></p>'
         );
     });
-
-    test("button with size classes should be detected as custom type", async () => {
-        // Setup: Editor with a button link containing size class (btn-lg) + primary class
-        await setupEditor(
-            '<p><a href="https://test.com/" class="btn btn-lg btn-primary">link[]Label</a></p>',
-            allowCustomOpt
-        );
-
-        // Wait for popover and click edit
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await animationFrame();
-
-        // The button type should be detected as "custom" because it has btn-lg
-        expect(queryOne('select[name="link_type"]').selectedOptions[0].value).toBe("custom");
-    });
 });
 
 describe("button edit", () => {


### PR DESCRIPTION
This reverts commit 6eaf2afcbb4be84b1e986ef43eb7cf9b62a4cd95.

After 19.0, the custom button style is introduced again. The previous fix causes another problem by setting the button style as custom in normal editor. Thus it should be fixed differently.

task-6061443


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
