### PR TITLE
[FIX] base: prevent non-stored fields in related field definitions

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -655,8 +655,10 @@ class IrModelFields(models.Model):
         names = self.related.split(".")
         last = len(names) - 1
         model_name = self.model or self.model_id.model
+        Model = self.env[model_name]
         for index, name in enumerate(names):
             field = self._get(model_name, name)
+            fields = Model._fields[name]
             if not field:
                 raise UserError(_(
                     'Unknown field name "%(field_name)s" in related field "%(related_field)s"',
@@ -670,7 +672,7 @@ class IrModelFields(models.Model):
                     field_name=name,
                     related_field=self.related,
                 ))
-            if not field.store:
+            if not fields._description_searchable:
                 raise ValidationError(_(
                     'Field "%(field_name)s" in related path "%(related_field)s" is not stored. '
                     'Non-stored fields cannot be used in related fields.',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -670,6 +670,13 @@ class IrModelFields(models.Model):
                     field_name=name,
                     related_field=self.related,
                 ))
+            if not field.store:
+                raise ValidationError(_(
+                    'Field "%(field_name)s" in related path "%(related_field)s" is not stored. '
+                    'Non-stored fields cannot be used in related fields.',
+                    field_name=name,
+                    related_field=self.related,
+                ))
         return field
 
     @api.constrains('related')


### PR DESCRIPTION
**Steps to Reproduce:**
- Create a new database.
- Install any module (for example, Sale).
- Go to Settings → Technical → Database Structure → Fields.
- Create a new field using Studio or manually.
- Set the field as a related field using a path that includes a non-stored field (e.g., product_variant_id.active where product_variant_id is non-stored). Save the field.

**Issue:**
- Odoo allows defining related fields that depend on non-stored (non-searchable) fields in the dependency chain.

- This leads to runtime issues such as:
    - Cannot convert field to SQL because it is not stored
    - Failures in search, domains, and reporting
    - Inconsistent behavior depending on usage context

- Currently, no validation prevents users from configuring such invalid related fields.

**Solution:**
- Add validation in the related field resolution logic to ensure that all fields In the related path are stored.

- Raise a ValidationError when a non-stored field is encountered in the related path, clearly indicating the offending field and model.

This prevents invalid related field configurations at creation time and ensures data consistency and predictable behavior across ORM operations.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
