### PR TITLE
[FIX] account_peppol: handle new peppol_move_state for sending condition

### DIFF
--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -22,11 +22,12 @@ class AccountMove(models.Model):
         string='PEPPOL status',
         copy=False,
     )
+    peppol_is_sent = fields.Boolean(compute='_compute_peppol_is_sent')
 
     def action_cancel_peppol_documents(self):
-        # if the peppol_move_state is processing/done
+        # if the peppol_move_state is processing/done/has been replied to
         # then it means it has been already sent to peppol proxy and we can't cancel
-        if any(move.peppol_move_state in {'processing', 'done'} for move in self):
+        if any(move.peppol_is_sent for move in self):
             raise UserError(_("Cannot cancel an entry that has already been sent to PEPPOL"))
         self.peppol_move_state = False
         self.sending_data = False
@@ -46,11 +47,16 @@ class AccountMove(models.Model):
             elif (
                 move.state == 'draft'
                 and move.is_sale_document(include_receipts=True)
-                and move.peppol_move_state not in ('processing', 'done')
+                and not move.peppol_is_sent
             ):
                 move.peppol_move_state = False
             else:
                 move.peppol_move_state = move.peppol_move_state
+
+    @api.depends('peppol_move_state')
+    def _compute_peppol_is_sent(self):
+        for move in self:
+            move.peppol_is_sent = move.peppol_move_state not in {False, 'ready', 'to_send', 'error'}
 
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
                                                    force_email_company=False, force_email_lang=False):
@@ -66,7 +72,7 @@ class AccountMove(models.Model):
         if company_on_peppol and company_country in PEPPOL_MAILING_COUNTRIES and invoice_country in PEPPOL_MAILING_COUNTRIES:
             render_context['peppol_info'] = {
                 'peppol_country': invoice_country,
-                'is_peppol_sent': invoice.peppol_move_state in ('processing', 'done'),
+                'is_peppol_sent': invoice.peppol_is_sent,
                 'partner_on_peppol': invoice.commercial_partner_id.peppol_verification_state in ('valid', 'not_valid_format'),
             }
         return render_context

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -67,7 +67,7 @@ class AccountMoveSend(models.AbstractModel):
         }
         info_always_on_countries = {'BE', 'FI', 'LU', 'LV', 'NL', 'NO', 'SE'}
         can_send = self.env['account_edi_proxy_client.user']._get_can_send_domain()
-        any_moves_not_sent_peppol = any(move.peppol_move_state not in ('processing', 'done') for move in moves)
+        any_moves_not_sent_peppol = any(not move.peppol_is_sent for move in moves)
         always_on_companies = moves.company_id.filtered(
             lambda c: c.country_code in info_always_on_countries and c.account_peppol_proxy_state not in can_send
         )
@@ -137,8 +137,7 @@ class AccountMoveSend(models.AbstractModel):
                 self._is_applicable_to_company(method, move.company_id),
                 self.env['res.partner']._get_peppol_verification_state(partner.peppol_endpoint, partner.peppol_eas, invoice_edi_format) == 'valid',
                 move.company_id.account_peppol_proxy_state != 'rejected',
-                move._need_ubl_cii_xml(invoice_edi_format)
-                or move.ubl_cii_xml_id and move.peppol_move_state not in ('processing', 'done'),
+                move._need_ubl_cii_xml(invoice_edi_format) or move.ubl_cii_xml_id and not move.peppol_is_sent,
             ])
         else:
             return super()._is_applicable_to_move(method, move, **move_data)
@@ -189,7 +188,7 @@ class AccountMoveSend(models.AbstractModel):
                 if invoice_data.get('ubl_cii_xml_attachment_values'):
                     xml_file = invoice_data['ubl_cii_xml_attachment_values']['raw']
                     filename = invoice_data['ubl_cii_xml_attachment_values']['name']
-                elif invoice.ubl_cii_xml_id and invoice.peppol_move_state not in ('processing', 'done'):
+                elif invoice.ubl_cii_xml_id and not invoice.peppol_is_sent:
                     xml_file = invoice.ubl_cii_xml_id.raw
                     filename = invoice.ubl_cii_xml_id.name
                 else:


### PR DESCRIPTION
With the addition of new peppol_move_state for the Application Responses in Peppol, some checks to know wether the move was sent through Peppol were not updated. This commit does that by adding a common field for it.

This is usefull as we might add some extra peppol_move_state values in the near future (Peppol supports more response types than we currently offer to our users).