### PR TITLE
[FIX] account: use sudo() when reading reconciled_payment_ids on portal invoice list

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6628,7 +6628,7 @@ class AccountMove(models.Model):
                 self.company_id,
                 payment.date
             )
-            for payment in self.reconciled_payment_ids.filtered(
+            for payment in self.sudo().reconciled_payment_ids.filtered(
                 lambda p: (
                     not p.is_reconciled
                     and not p.is_matched

--- a/addons/account/tests/test_portal_invoice.py
+++ b/addons/account/tests/test_portal_invoice.py
@@ -41,6 +41,24 @@ class TestPortalInvoice(AccountTestInvoicingHttpCommon):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.content, invoice_with_pdf.invoice_pdf_report_id.raw)
 
+    def test_portal_my_invoices_with_matched_payment(self):
+        """Portal users must be able to list their invoices even when a payment
+        is linked via matched_payment_ids. Reading reconciled_payment_ids (which
+        internally reads matched_payment_ids -> account.payment) was done without
+        sudo, causing a 403 for portal users who have no read access on account.payment."""
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.portal_partner.id,
+            'invoice_line_ids': [Command.create({'price_unit': 100})],
+        })
+        invoice.action_post()
+        self.env['account.payment.register'].with_context(
+            active_model='account.move', active_ids=invoice.ids,
+        ).create({})._create_payments()
+        self.authenticate(self.user_portal.login, self.user_portal.login)
+        res = self.url_open('/my/invoices')
+        self.assertEqual(res.status_code, 200)
+
     def test_portal_my_invoice_detail_download_proforma(self):
         invoice_no_pdf = self.env['account.move'].create({
             'move_type': 'out_invoice',


### PR DESCRIPTION
Steps to reproduce
1. Create a portal user linked to a partner.
2. Create a customer invoice for that partner and confirm it.
3. Log in as the portal user and visit /my/invoices.
4. The page returns a 403 / raises an access error.

Issue
When rendering the portal invoice list, the code iterates over `self.reconciled_payment_ids`, which internally reads records on `account.payment`. Portal users have no read access on `account.payment`, so the ORM raises an access error as soon as the field is accessed on any visible invoice, even when no payment is linked.

opw-6104847