### PR TITLE
[FIX] base: cron always progressing but failing

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -538,6 +538,18 @@ class IrCron(models.Model):
                     count=MIN_FAILURE_COUNT_BEFORE_DEACTIVATION,
                     time=now,
                 ))
+            elif (
+                # XXX too much notifications like this
+                failure_count >= MIN_FAILURE_COUNT_BEFORE_DEACTIVATION // 2
+                and first_failure_date + MIN_DELTA_BEFORE_DEACTIVATION / 2 < now
+            ):
+                self._notify_admin(self.env._(
+                    "Cron job %(name)s (%(id)s) is failing and will be deactivated if you don't take action. "
+                    "More information can be found in the server logs around %(time)s.",
+                    name=repr(job['cron_name']),
+                    id=job['id'],
+                    time=now,
+                ))
         else:
             failure_count = 0
             first_failure_date = None

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -439,6 +439,7 @@ class IrCron(models.Model):
             cron = env[cls._name].browse(job['id'])
 
             status = None
+            error_per_run = []
             loop_count = 0
             _logger.info('Job %r (%s) starting', job['cron_name'], job['id'])
 
@@ -454,7 +455,8 @@ class IrCron(models.Model):
                 try:
                     # signaling check and commit is done inside `_callback`
                     cron._callback(job['cron_name'], job['ir_actions_server_id'])
-                except Exception:  # noqa: BLE001
+                except Exception as error:  # noqa: BLE001
+                    error_per_run.append(error)
                     _logger.exception('Job %r (%s) server action #%s failed',
                         job['cron_name'], job['id'], job['ir_actions_server_id'])
                     if progress.done and progress.remaining:
@@ -464,6 +466,7 @@ class IrCron(models.Model):
                     else:
                         status = CompletionStatus.FAILED
                 else:
+                    error_per_run.append(None)
                     if not progress.remaining:
                         # assume the server action doesn't use the progress API
                         # and that there is nothing left to process
@@ -488,6 +491,10 @@ class IrCron(models.Model):
                 if status in (CompletionStatus.FULLY_DONE, CompletionStatus.FAILED):
                     break
 
+            if status == CompletionStatus.PARTIALLY_DONE and all(error_per_run) and set(map(type, error_per_run)) == 1:
+                # When a cron job always finished in a partially done state with
+                # the same error, it will probably continue doing so.
+                status = CompletionStatus.FAILED
             _logger.info(
                 'Job %r (%s) %s (#loop %s; done %s; remaining %s; duration %.2fs)',
                 job['cron_name'], job['id'], status,


### PR DESCRIPTION
When the issue is always the same, we should not hope that progress is going well. If we fail every time with the same exception type and make some progress, we still should consider the run as failed.

The problem solved: cron that do some action for the same set of records like 'time-based automation' cron can have one of the actions fail. If it's not the first, some progress is made resulting in a retry and a PARTIALLY_DONE state. This retrigers the cron asap resulting in a loop.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
