### PR TITLE
[FIX] hr: consistent unavailability of employees

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -8,6 +8,7 @@ from string import digits
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
+from dateutil.rrule import rrule, DAILY
 from markupsafe import Markup
 
 from odoo import _, api, fields, models, tools
@@ -1983,7 +1984,13 @@ class HrEmployee(models.Model):
         :param string field: the field mapped over the periods. Returns the versions if left empty
         :param boolean check_contract: true means that we restrict valid versions only to contract periods
         """
-        if field and field not in self:
+        if isinstance(field, list):
+            if any(f not in self for f in field):
+                raise UserError(self.env._(
+                    "Some of these fields %(field_name)s don't exist on this model (hr.version).",
+                    field_name=field,
+                ))
+        elif field and field not in self:
             raise UserError(self.env._(
                 "This field %(field_name)s doesn't exist on this model (hr.version).",
                 field_name=field,
@@ -2004,9 +2011,14 @@ class HrEmployee(models.Model):
             if date_end < start or date_start > stop or date_start > date_end:
                 # not overlapping, this can happen if we check contract versions
                 continue
-            version_periods_by_employee[version.employee_id].append(
-                (date_start, date_end, version[field] if field else version),
-            )
+            if isinstance(field, list):
+                version_periods_by_employee[version.employee_id].append(
+                    (date_start, date_end, tuple(version[f] for f in field)),
+                )
+            else:
+                version_periods_by_employee[version.employee_id].append(
+                    (date_start, date_end, version[field] if field else version),
+                )
         return version_periods_by_employee
 
     def _get_calendar_periods(self, start, stop, check_contract=True):
@@ -2017,6 +2029,91 @@ class HrEmployee(models.Model):
         """
         return self.sudo()._get_version_periods(start, stop, 'resource_calendar_id', check_contract)
 
+    def _adjust_leaves(self, leave_intervals):
+        return leave_intervals
+
+    def _get_flexible_reference_calendar(self, date=fields.Date.today()):
+        self.ensure_one()
+        return self.company_id.resource_calendar_id
+
+    def _get_employee_unavailable_intervals(self, start, stop):
+        """ returns a dict {employee_id: [{start, stop}]} for the unavailability intervals of each employee which is used for _gantt_unavailability """
+
+        unavailability_mapping = defaultdict(list)
+        start_dt = start.astimezone(UTC)
+        stop_dt = stop.astimezone(UTC)
+        full_interval = Intervals([(start_dt, stop_dt, self.env['resource.calendar.attendance'])])
+        calendar_tz_periods_per_employee = self.sudo()._get_version_periods(
+            (start_dt - relativedelta(days=1)).date(),
+            (stop_dt + relativedelta(days=1)).date(),
+            ['resource_calendar_id', 'tz'],
+            check_contract=True,
+        )
+
+        work_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        attendance_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        leave_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        for employee, calendar_periods in calendar_tz_periods_per_employee.items():
+            for period_start, period_stop, (calendar, tz) in calendar_periods:
+                if calendar:
+                    if any(calendar.attendance_ids.mapped('duration_based')):
+                        attendance_resources_per_calendar[calendar, tz] += employee.resource_id
+                        leave_resources_per_calendar[calendar, tz] += employee.resource_id
+                    else:
+                        work_resources_per_calendar[calendar, tz] += employee.resource_id
+                else:
+                    leave_resources_per_calendar[employee._get_flexible_reference_calendar(period_start), tz] += employee.resource_id
+
+        work_intervals_per_calendar = defaultdict()
+        attendance_intervals_per_calendar = defaultdict()
+        leave_intervals_per_calendar = defaultdict()
+        # Standard Calendars
+        for (calendar, tz), resources in work_resources_per_calendar.items():
+            work_intervals_per_calendar[calendar, tz] = calendar._work_intervals_batch(start_dt, stop_dt, resources_per_tz={ZoneInfo(tz): resources})
+
+        # Duration Based Calendars
+        for (calendar, tz), resources in attendance_resources_per_calendar.items():
+            attendance_intervals_per_calendar[calendar, tz] = calendar._attendance_intervals_batch(start_dt, stop_dt, resources_per_tz={ZoneInfo(tz): resources})
+            for resource_id, work_intervals in attendance_intervals_per_calendar[calendar, tz].items():
+                extended_intervals = Intervals([])
+                for att_start, att_end, attendance in work_intervals:
+                    if not attendance.duration_based:
+                        extended_intervals |= Intervals([(att_start, att_end, attendance)])
+                        continue
+                    extended_start = datetime.combine(att_start.date(), time.min, ZoneInfo(tz))
+                    extended_end = datetime.combine(att_end.date() + timedelta(days=1), time.min, ZoneInfo(tz))
+                    extended_intervals |= Intervals([(extended_start, extended_end, attendance)])
+                attendance_intervals_per_calendar[calendar, tz][resource_id] = extended_intervals
+
+        # Flexible and Fully Flexible Calendars
+        for (calendar, tz), resources in leave_resources_per_calendar.items():
+            leave_intervals_per_calendar[calendar, tz] = calendar._leave_intervals_batch(start_dt, stop_dt, resources_per_tz={ZoneInfo(tz): resources})
+
+        for employee, calendar_periods in calendar_tz_periods_per_employee.items():
+            employee_work_intervals = []
+            for period_start, period_stop, (calendar, tz) in calendar_periods:
+                period_start_dt = datetime.combine(period_start, time.min).replace(tzinfo=ZoneInfo(tz))
+                period_stop_dt = datetime.combine(period_stop + timedelta(days=1), time.min).replace(tzinfo=ZoneInfo(tz))
+                period_interval = Intervals([(period_start_dt, period_stop_dt, calendar)])
+                if calendar:
+                    if any(calendar.attendance_ids.mapped('duration_based')):
+                        employee_work_intervals += period_interval & attendance_intervals_per_calendar[calendar, tz][employee.resource_id.id] \
+                                                - employee._adjust_leaves(leave_intervals_per_calendar[calendar, tz][employee.resource_id.id])
+                    else:
+                        employee_work_intervals += period_interval & work_intervals_per_calendar[calendar, tz][employee.resource_id.id]
+                else:
+                    employee_work_intervals += period_interval - leave_intervals_per_calendar[employee._get_flexible_reference_calendar(calendar), tz][employee.resource_id.id]
+            unavailability_mapping[employee.resource_id.id] = full_interval - employee_work_intervals
+
+        result = {}
+        for employee in self:
+            if employee not in calendar_tz_periods_per_employee:
+                result[employee.id] = [{'start': start_dt, 'stop': stop_dt}]
+                continue
+            result[employee.id] = [{'start': interval[0].astimezone(UTC), 'stop': interval[1].astimezone(UTC)} for interval in unavailability_mapping.get(employee.resource_id.id, [])]
+
+        return result
+
     @api.model
     def _get_all_versions_with_contract_overlap_with_period(self, date_from, date_to):
         """
@@ -2026,6 +2123,14 @@ class HrEmployee(models.Model):
         return self.search([])._get_versions_with_contract_overlap_with_period(date_from, date_to)
 
     def _get_unusual_days(self, date_from, date_to=None):
+        def _generate_unusual_days(date_from, date_to):
+            return {
+                day.strftime('%Y-%m-%d'): True
+                for day in rrule(DAILY, date_from, until=date_to - relativedelta(days=1))
+            }
+
+        if self:
+            self.ensure_one()
         date_from_date = datetime.strptime(date_from, '%Y-%m-%d %H:%M:%S').date()
         date_to_date = datetime.strptime(date_to, '%Y-%m-%d %H:%M:%S').date() if date_to else None
         employee_versions = self.env['hr.version'].sudo().search([
@@ -2034,23 +2139,24 @@ class HrEmployee(models.Model):
         ]).filtered(
             lambda v: v._is_overlapping_period(date_from_date, date_to_date))
         if not employee_versions:
-            # Checking the calendar directly allows to not grey out the leaves taken
-            # by the employee or fallback to the company calendar
-            return (self.resource_calendar_id or self.env.company.resource_calendar_id)._get_unusual_days(
-                datetime.combine(fields.Date.from_string(date_from), time.min, tzinfo=UTC),
-                datetime.combine(fields.Date.from_string(date_to), time.max, tzinfo=UTC),
-                self.company_id,
-            )
+            return _generate_unusual_days(date_from_date, date_to_date + timedelta(days=1))
         unusual_days = {}
+        next_date_to_generate = date_from_date
         for version in employee_versions:
-            tmp_date_from = max(date_from_date, version.date_start)
+            tmp_date_from = max(date_from_date, version.date_version)
             tmp_date_to = min(date_to_date, version.date_end) if version.date_end else date_to_date
+            if tmp_date_from > next_date_to_generate:
+                unusual_days.update(_generate_unusual_days(next_date_to_generate, tmp_date_from))
             unusual_days.update(version.resource_calendar_id.sudo(False)._get_unusual_days(
-                datetime.combine(fields.Date.from_string(tmp_date_from), time.min, tzinfo=UTC),
-                datetime.combine(fields.Date.from_string(tmp_date_to), time.max, tzinfo=UTC),
+                datetime.combine(tmp_date_from, time.min, tzinfo=UTC),
+                datetime.combine(tmp_date_to, time.max, tzinfo=UTC),
                 self.company_id,
                 self.resource_id,
             ))
+            next_date_to_generate = tmp_date_to + timedelta(days=1)
+
+        if date_to_date and next_date_to_generate <= date_to_date:
+            unusual_days.update(_generate_unusual_days(next_date_to_generate, date_to_date + timedelta(days=1)))
         return unusual_days
 
     def formatted_employee_attendance_intervals(self, start, stop):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1966,6 +1966,103 @@ class HrEmployee(models.Model):
         """
         return self.sudo()._get_version_periods(start, stop, 'resource_calendar_id', check_contract)
 
+    def _get_employee_unavailable_intervals(self, start, stop):
+        """ returns a dict {employee_id: [{start, stop}]} for the unavailability intervals of each employee which is used for _gantt_unavailability """
+        def _adjust_leaves(leave_intervals):
+            adjusted_leaves = Intervals([])
+            for (start, stop, leave) in leave_intervals:
+                tz = start.tzinfo
+                holiday = leave.holiday_id
+                if holiday.work_entry_type_request_unit == 'half_day':
+                    if holiday.request_date_from_period == 'am' and holiday.request_date_from == start.date():
+                        leave_start = datetime.combine(start.date(), time.min, tz)
+                    if holiday.request_date_from_period == 'pm' and holiday.request_date_from == start.date():
+                        leave_start = datetime.combine(start.date(), time(12), tz)
+                    if holiday.request_date_to_period == 'am' and holiday.request_date_to == stop.date():
+                        leave_stop = datetime.combine(stop.date(), time(12), tz)
+                    if holiday.request_date_to_period == 'pm' and holiday.request_date_to == stop.date():
+                        leave_stop = datetime.combine(stop.date() + timedelta(days=1), time.min, tz)
+                elif holiday.work_entry_type_request_unit == 'day':
+                    leave_start = datetime.combine(start.date(), time.min, tz)
+                    leave_stop = datetime.combine(stop.date() + timedelta(days=1), time.min, tz)
+                else:
+                    leave_start = leave.date_from.astimezone(tz)
+                    leave_stop = leave.date_to.astimezone(tz)
+                adjusted_leaves |= Intervals([(leave_start, leave_stop, leave)])
+            return adjusted_leaves
+
+        unavailability_mapping = defaultdict(list)
+        start_dt = start.astimezone(UTC)
+        stop_dt = stop.astimezone(UTC)
+        full_interval = Intervals([(start_dt, stop_dt, self.env['resource.calendar.attendance'])])
+        calendar_periods_per_employee = self._get_calendar_periods((start_dt - relativedelta(days=1)).date(), (stop_dt + relativedelta(days=1)).date())
+
+        work_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        attendance_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        leave_resources_per_calendar = defaultdict(lambda: self.env['resource.resource'])
+        for employee, calendar_periods in calendar_periods_per_employee.items():
+            for _start, _stop, calendar in calendar_periods:
+                if calendar:
+                    if any(calendar.attendance_ids.mapped('duration_based')):
+                        attendance_resources_per_calendar[calendar] += employee.resource_id
+                        leave_resources_per_calendar[calendar] += employee.resource_id
+                    else:
+                        work_resources_per_calendar[calendar] += employee.resource_id
+                else:
+                    leave_resources_per_calendar[employee.company_id.resource_calendar_id] += employee.resource_id
+
+        work_intervals_per_calendar = defaultdict()
+        attendance_intervals_per_calendar = defaultdict()
+        leave_intervals_per_calendar = defaultdict()
+        # Standard Calendars
+        for calendar, resources in work_resources_per_calendar.items():
+            work_intervals_per_calendar[calendar] = calendar._work_intervals_batch(start_dt, stop_dt, resources_per_tz=resources._get_resources_per_tz())
+
+        # Duration Based Calendars
+        for calendar, resources in attendance_resources_per_calendar.items():
+            attendance_intervals_per_calendar[calendar] = calendar._attendance_intervals_batch(start_dt, stop_dt, resources_per_tz=resources._get_resources_per_tz())
+            for resource_id, work_intervals in attendance_intervals_per_calendar[calendar].items():
+                extended_intervals = Intervals([])
+                for att_start, att_end, attendance in work_intervals:
+                    if not attendance.duration_based:
+                        extended_intervals |= Intervals([(att_start, att_end, attendance)])
+                        continue
+                    tz = att_start.tzinfo
+                    extended_start = datetime.combine(att_start.date(), time.min, tz)
+                    extended_end = datetime.combine(att_end.date() + timedelta(days=1), time.min, tz)
+                    extended_intervals |= Intervals([(extended_start, extended_end, attendance)])
+                attendance_intervals_per_calendar[calendar][resource_id] = extended_intervals
+
+        # Flexible and Fully Flexible Calendars
+        for calendar, resources in leave_resources_per_calendar.items():
+            reference_calendar = calendar or employee.company_id.resource_calendar_id
+            leave_intervals_per_calendar[reference_calendar] = reference_calendar._leave_intervals_batch(start_dt, stop_dt, resources_per_tz=resources._get_resources_per_tz())
+
+        for employee, calendar_periods in calendar_periods_per_employee.items():
+            employee_work_intervals = []
+            for calendar_period in calendar_periods:
+                period_start_dt = datetime.combine(calendar_period[0], time.min).astimezone(UTC)
+                period_stop_dt = datetime.combine(calendar_period[1], time.min).astimezone(UTC)
+                period_interval = Intervals([(period_start_dt, period_stop_dt, calendar_period[2])])
+                if calendar_period[2]:
+                    if any(calendar_period[2].attendance_ids.mapped('duration_based')):
+                        employee_work_intervals += period_interval & attendance_intervals_per_calendar[calendar_period[2]][employee.resource_id.id] \
+                                                - _adjust_leaves(leave_intervals_per_calendar[calendar_period[2]][employee.resource_id.id])
+                    else:
+                        employee_work_intervals += period_interval & work_intervals_per_calendar[calendar_period[2]][employee.resource_id.id]
+                else:
+                    employee_work_intervals += period_interval - _adjust_leaves(leave_intervals_per_calendar[employee.company_id.resource_calendar_id][employee.resource_id.id])
+            unavailability_mapping[employee.resource_id.id] = full_interval - employee_work_intervals
+
+        result = {}
+        for employee in self:
+            if employee not in calendar_periods_per_employee:
+                result[employee.id] = [{'start': start.astimezone(UTC), 'stop': stop.astimezone(UTC)}]
+                continue
+            result[employee.id] = [{'start': interval[0].astimezone(UTC), 'stop': interval[1].astimezone(UTC)} for interval in unavailability_mapping.get(employee.resource_id.id, [])]
+
+        return result
+
     @api.model
     def _get_all_versions_with_contract_overlap_with_period(self, date_from, date_to):
         """
@@ -1976,28 +2073,36 @@ class HrEmployee(models.Model):
         return all_employees._get_versions_with_contract_overlap_with_period(date_from, date_to)
 
     def _get_unusual_days(self, date_from, date_to=None):
+        def _generate_unusual_days(date_from, date_to):
+            return {
+                (date_from + timedelta(days=i)).strftime('%Y-%m-%d'): True
+                for i in range((date_to - date_from).days)
+            }
+
         date_from_date = datetime.strptime(date_from, '%Y-%m-%d %H:%M:%S').date()
         date_to_date = datetime.strptime(date_to, '%Y-%m-%d %H:%M:%S').date() if date_to else None
         employee_versions = self.env['hr.version'].sudo().search([('employee_id', '=', self.id)]).filtered(
             lambda v: v._is_overlapping_period(date_from_date, date_to_date))
         if not employee_versions:
-            # Checking the calendar directly allows to not grey out the leaves taken
-            # by the employee or fallback to the company calendar
-            return (self.resource_calendar_id or self.env.company.resource_calendar_id)._get_unusual_days(
-                datetime.combine(fields.Date.from_string(date_from), time.min, tzinfo=UTC),
-                datetime.combine(fields.Date.from_string(date_to), time.max, tzinfo=UTC),
-                self.company_id,
-            )
+            return _generate_unusual_days(date_from_date, date_to_date + timedelta(days=1))
         unusual_days = {}
-        for version in employee_versions:
-            tmp_date_from = max(date_from_date, version.date_start)
+        sorted_versions = employee_versions.sorted(key=lambda v: v.date_version)
+        next_date_to_generate = date_from_date
+        for version in sorted_versions:
+            tmp_date_from = max(date_from_date, version.date_version)
             tmp_date_to = min(date_to_date, version.date_end) if version.date_end else date_to_date
+            if tmp_date_from > next_date_to_generate:
+                unusual_days.update(_generate_unusual_days(next_date_to_generate, tmp_date_from))
             unusual_days.update(version.resource_calendar_id.sudo(False)._get_unusual_days(
-                datetime.combine(fields.Date.from_string(tmp_date_from), time.min, tzinfo=UTC),
-                datetime.combine(fields.Date.from_string(tmp_date_to), time.max, tzinfo=UTC),
+                datetime.combine(tmp_date_from, time.min, tzinfo=UTC),
+                datetime.combine(tmp_date_to, time.max, tzinfo=UTC),
                 self.company_id,
                 self.resource_id,
             ))
+            next_date_to_generate = tmp_date_to + timedelta(days=1)
+
+        if date_to_date and next_date_to_generate <= date_to_date:
+            unusual_days.update(_generate_unusual_days(next_date_to_generate, date_to_date + timedelta(days=1)))
         return unusual_days
 
     def formatted_employee_attendance_intervals(self, start, stop):

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -596,6 +596,31 @@ class TestHrEmployee(TestHrCommon):
             employee_form.job_id = first_job
             self.assertEqual(employee_form.job_title, first_job.name)
 
+    def test_flexible_working_hours(self):
+        """
+        Test to verify that get_unusual_days() return false for flexible work schedule
+        """
+
+        employeeA = self.env['hr.employee'].create({
+            'name': 'Employee',
+            'date_version': datetime(2025, 1, 1),
+            'contract_date_start': datetime(2025, 1, 1),
+        })
+
+        # Testing employeA on regular working schedule
+        days = employeeA._get_unusual_days(str(datetime(2025, 1, 1)), str(datetime(2025, 12, 31)))
+        self.assertTrue(days)
+        self.assertTrue(days['2025-01-04'])
+
+        # Assigning flexible work hours to employeeA
+        employeeA.current_version_id.write({
+            'resource_calendar_id': False,
+            'hours_per_week': 40,
+        })
+        days = employeeA._get_unusual_days(str(datetime(2025, 1, 1)), str(datetime(2025, 12, 31)))
+        self.assertTrue(days)
+        self.assertFalse(days['2025-01-04'])
+
     def test_user_creation_from_employee_with_invalid_email(self):
         employee = self.env['hr.employee'].create({
             'name': 'Test Employee',

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -11,6 +11,7 @@ from odoo.exceptions import ValidationError
 from odoo.addons.resource.models.utils import HOURS_PER_DAY
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tools import OrderedSet, float_round
+from odoo.tools.intervals import Intervals
 
 
 class HrEmployee(models.Model):
@@ -806,3 +807,25 @@ class HrEmployee(models.Model):
         hour_to = max((att['hour_to'] for att in filtered_attendances), default=default_end)
 
         return (hour_from, hour_to)
+
+    def _adjust_leaves(self, leave_intervals):
+        adjusted_leaves = Intervals([])
+        for (start, stop, leave) in leave_intervals:
+            tz = start.tzinfo
+            holiday = leave.holiday_id
+            leave_start = start
+            leave_stop = stop
+            if holiday and holiday.work_entry_type_request_unit == 'half_day':
+                if holiday.request_date_from_period == 'am':
+                    leave_start = datetime.combine(start.date(), time.min, tz)
+                if holiday.request_date_from_period == 'pm':
+                    leave_start = datetime.combine(start.date(), time(12), tz)
+                if holiday.request_date_to_period == 'am':
+                    leave_stop = datetime.combine(stop.date(), time(12), tz)
+                if holiday.request_date_to_period == 'pm':
+                    leave_stop = datetime.combine(stop.date() + timedelta(days=1), time.min, tz)
+            elif holiday and holiday.work_entry_type_request_unit == 'day':
+                leave_start = datetime.combine(start.date(), time.min, tz)
+                leave_stop = datetime.combine(stop.date() + timedelta(days=1), time.min, tz)
+            adjusted_leaves |= Intervals([(leave_start, leave_stop, leave)])
+        return adjusted_leaves

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -300,6 +300,50 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         })
         self.assertEqual(employee_leave.number_of_days, 2, 'Leave duration should be reduced because of public holiday day 3')
 
+    def test_get_unusual_days_for_leaves(self):
+        """
+        Test that get_unusual_days return True
+        for out of contract days so they get greyed out in calendar view
+        """
+        test_emp = self.env['hr.employee'].create({
+            'name': 'Test Emp',
+            'date_version': date(2026, 1, 8),
+            'contract_date_start': date(2026, 1, 8),
+            'contract_date_end': date(2026, 1, 13),
+        })
+        test_emp.create_version({
+            'date_version': date(2026, 1, 16),
+            'contract_date_start': date(2026, 1, 16),
+            'contract_date_end': date(2026, 1, 21),
+        })
+        start = '2026-01-05 00:00:00'
+        end = '2026-01-24 00:00:00'
+
+        unusual_days = self.env['hr.leave'].with_context(employee_id=test_emp.id).get_unusual_days(start, end)
+        expected = {
+            '2026-01-05': True,
+            '2026-01-06': True,
+            '2026-01-07': True,
+            '2026-01-08': False,
+            '2026-01-09': False,
+            '2026-01-10': True,
+            '2026-01-11': True,
+            '2026-01-12': False,
+            '2026-01-13': False,
+            '2026-01-14': True,
+            '2026-01-15': True,
+            '2026-01-16': False,
+            '2026-01-17': True,
+            '2026-01-18': True,
+            '2026-01-19': False,
+            '2026-01-20': False,
+            '2026-01-21': False,
+            '2026-01-22': True,
+            '2026-01-23': True,
+            '2026-01-24': True,
+        }
+        self.assertDictEqual(unusual_days, expected)
+
     def test_multi_day_public_holidays_for_flexible_schedule(self):
         """
         Test that _get_unusual_days return correct value for

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -300,6 +300,52 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         })
         self.assertEqual(employee_leave.number_of_days, 2, 'Leave duration should be reduced because of public holiday day 3')
 
+    def test_get_unusual_days_for_leaves(self):
+        """
+        Test that get_unusual_days return True
+        for out of contract days so they get greyed out in calendar view
+        """
+        test_emp = self.env['hr.employee'].create({
+            'name': 'Test Emp',
+            'date_version': date(2026, 1, 8),
+            'contract_date_start': date(2026, 1, 8),
+            'contract_date_end': date(2026, 1, 13),
+            'resource_calendar_id': self.calendar_1.id,
+        })
+        test_emp.create_version({
+            'date_version': date(2026, 1, 16),
+            'contract_date_start': date(2026, 1, 16),
+            'contract_date_end': date(2026, 1, 21),
+            'resource_calendar_id': self.calendar_1.id,
+        })
+        start = '2026-01-05 00:00:00'
+        end = '2026-01-24 00:00:00'
+
+        unusual_days = self.env['hr.leave'].with_context(employee_id=test_emp.id).get_unusual_days(start, end)
+        expected = {  # starting Monday
+            '2026-01-05': True,  # No contract
+            '2026-01-06': True,  # No contract
+            '2026-01-07': True,  # No contract
+            '2026-01-08': False,
+            '2026-01-09': False,
+            '2026-01-10': True,  # Weekend
+            '2026-01-11': True,  # Weekend
+            '2026-01-12': False,
+            '2026-01-13': False,
+            '2026-01-14': True,  # No contract
+            '2026-01-15': True,  # No contract
+            '2026-01-16': False,
+            '2026-01-17': True,  # Weekend
+            '2026-01-18': True,  # Weekend
+            '2026-01-19': False,
+            '2026-01-20': False,
+            '2026-01-21': False,
+            '2026-01-22': True,  # No contract
+            '2026-01-23': True,  # No contract
+            '2026-01-24': True,  # No contract
+        }
+        self.assertDictEqual(unusual_days, expected)
+
     def test_multi_day_public_holidays_for_flexible_schedule(self):
         """
         Test that _get_unusual_days return correct value for


### PR DESCRIPTION
purpose:
1- We should have a consistent way to compute `_gantt_unavailability` of employees in time off and attendance. Currently, some cases have inconsistent behavior such as out of contract days, flexible and fully flexibe employees. 2- In time off calendar view, if the employee does not have a contract at all, the current working schedule will appear in the calendar and it will not be greyed out. This is inconsistent with the behavior of the attendance application.

Fix:
1:
- implemented `_get_employee_unavailable_intervals` in employee model to be used in both time off and attendance.
    - more optimized than the old implementation in time off as it calls `_work_intervals_batch` once per calendar instead of calling it for each contract in `_unavailable_intervals_batch`
    - greys out "out of contract" periods
    - for flexible and fully flexible employees, the whole period is considered available except leave periods
    - for duration based calendars, morning and afternoon map to 12 hours of availability and full day maps to 24 hours of availability
- made `_get_calendar_periods` use version date start instead of contract date start and corrected a bug in tz conversion 2:
- made `_get_unusual_days` return True for all the days outside of contracts for the employee instead of not returning anything for them or getting values from the working schedule of the employee (means that they will be greyed out in the callendar view) and added a test for it

task-id: 5473055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
