### PR TITLE
[FIX] website: fix missing slash in img sources

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -255,10 +255,10 @@
                                 <a href="#" class="o_cookies_bar_toggle btn btn-primary btn-md rounded-circle oe_unremovable">Update My Cookie Preferences</a>
                             </div>
                             <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7 o_colored_level" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
-                                <img src="html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt="" loading="lazy" data-mimetype="image/webp" style=""/>
+                                <img src="/html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt="" loading="lazy" data-mimetype="image/webp" style=""/>
                             </div>
                             <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-2 col-lg-2 d-none d-lg-block o_colored_level" style="grid-area: 2 / 6 / 10 / 8; z-index: 3;" data-invisible="1">
-                                <img src="html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt="" loading="lazy" data-mimetype="image/webp" style=""/>
+                                <img src="/html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt="" loading="lazy" data-mimetype="image/webp" style=""/>
                             </div>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_cta_mobile.xml
+++ b/addons/website/views/snippets/s_cta_mobile.xml
@@ -13,7 +13,7 @@
                     <a href="https://play.google.com/store/"><img src="/web/image/website.google_play_image" class="img img-fluid" alt="Google Play"/></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-4 col-lg-4 d-none d-lg-block" style="grid-area: 1 / 8 / 9 / 12; z-index: 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/galaxy_front_portrait_half.svg" class="img img-fluid" data-shape="html_builder/devices/galaxy_front_portrait_half" data-shape-colors=";;;;#111827" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/galaxy_front_portrait_half.svg" class="img img-fluid" data-shape="html_builder/devices/galaxy_front_portrait_half" data-shape-colors=";;;;#111827" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
                 <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">
                     <h2 class="h3-fs">50,000+ companies trust Odoo.</h2>
@@ -14,7 +14,7 @@
                     <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-2 col-lg-2 d-none d-lg-block" style="grid-area: 2 / 6 / 10 / 8; z-index: 3;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Description of the problem**

A traceback is generated when hovering shape options in the snippets `s_cta_mobile` and `s_cta_mockups`.

**How to reproduce**

Drop `s_cta_mockups` -> click one of the two images -> open the shape selector -> hover a shape -> Traceback

**Why the problem happens**

The "source" attribute of `img` elements in the affected snippets is missing a trailing slash. After PR [1], the regular expression in `loadImageInfo` (html_editor/static/src/utils/image_processing.js) does not match anymore the source, thus the variable that should contain the source string remains empty and a traceback is generated.

**Fix**

All missing trailing slashes are restored.

[1]: https://github.com/odoo/odoo/pull/151858

task-6103616
