### PR TITLE
[FIX] account_edi_ubl_cii: Fix recordset issue

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -82,7 +82,7 @@ class AccountMove(models.Model):
                 move.ubl_cii_xml_id
                 or (
                     (edi_format := move.commercial_partner_id.with_company(move.company_id)._get_ubl_cii_edi_format())
-                    and self._need_ubl_cii_xml(edi_format)
+                    and move._need_ubl_cii_xml(edi_format)
                 )
             )
             for move in posted_moves


### PR DESCRIPTION
`_need_ubl_cii_xml` requires a single record to be passed. However, it is currently called with `self`, which could be a recordset.

Call with the `move` of the current iteration instead.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
