### PR TITLE
[IMP] survey: always shows answers when printing participant inputs

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -618,7 +618,7 @@ class Survey(http.Controller):
             'is_html_empty': is_html_empty,
             'review': review,
             'survey': survey_sudo,
-            'answer': answer_sudo if survey_sudo.scoring_type != 'scoring_without_answers' else answer_sudo.browse(),
+            'answer': answer_sudo,
             'questions_to_display': answer_sudo._get_print_questions(),
             'scoring_display_correction': survey_sudo.scoring_type == 'scoring_with_answers' and answer_sudo,
             'format_datetime': lambda dt: format_datetime(request.env, dt, dt_format=False),


### PR DESCRIPTION
Previously, printing surveys of type scoring_without_answers omitted participants' answers, resulting in incomplete and inconsistent reports. This commit ensures answers are always included, regardless of survey type.

Task-5407701





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
