### PR TITLE
[IMP] mail: allow deleting activities from "Other activities"

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -291,7 +291,6 @@
         <field name="priority">32</field>
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">
-                <attribute name="delete">0</attribute>
                 <attribute name="edit">0</attribute>
                 <attribute name="duplicate">0</attribute>
                 <attribute name="js_class">archive_disabled_activity_list</attribute>


### PR DESCRIPTION
The "Cancel" action was removed earlier as it duplicated the delete behavior, but "Other Activities" section had no delete option, making removal impossible.

This commit adds a delete option for activities in the "Other activities" section.

task-6063639