### PR TITLE
[FIX] account_edi_ubl_cii: restore Peppol config arch in res.partner

### DIFF
--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -9,10 +9,11 @@
                 <field name="available_peppol_eas" invisible="1"/>
                 <field name="peppol_eas"
                        nolabel="1"
+                       placeholder="Peppol ID"
                        widget="filterable_selection"
                        options="{'whitelist_fname': 'available_peppol_eas'}"
                        class="o_field_peppol_eas_selection"/>
-                <field name="peppol_endpoint"/>
+                <field name="peppol_endpoint" nolabel="1"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Due to the changes made for M3.1 the Peppol config arch in res.partner is broken, so we restore it to match the saas-19.2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
