### PR TITLE
[FIX] analytic: project_plan at install time

### DIFF
--- a/addons/analytic/data/analytic_data.xml
+++ b/addons/analytic/data/analytic_data.xml
@@ -10,9 +10,8 @@
             Save which plan is used for Projects. Once it is set, even if not used, it cannot be changed safely without a SQL script.
             The other plans will generate dynamic columns, so changing this param would require renaming the columns also.
         -->
-        <function model="ir.config_parameter" name="set_int" eval="('analytic.project_plan', 1)"/>
         <record id="analytic_plan_projects" model="account.analytic.plan" forcecreate="0">
-            <field name="name">Project</field>
+            <field name="name">Project Plan</field>
             <field name="default_applicability">optional</field>
         </record>
         <function model="ir.config_parameter" name="set_int" eval="('analytic.project_plan', ref('analytic_plan_projects'))"/>

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -103,12 +103,9 @@ class AccountAnalyticPlan(models.Model):
     @ormcache()
     def __get_all_plans(self):
         project_plan = self.browse(self.env['ir.config_parameter'].sudo().get_int('analytic.project_plan'))
-        if not project_plan:
+        if not project_plan and self.env.registry.ready:
             raise UserError(_("A 'Project' plan needs to exist and its id needs to be set as `analytic.project_plan` in the system variables"))
         other_plans = self.sudo().search([('parent_id', '=', False)]) - project_plan
-        if project_plan.id == 1 and not self.env.registry.ready and not project_plan.exists():
-            # temporary fix during load
-            project_plan, other_plans = other_plans[0], other_plans[1:]
         return project_plan.id, other_plans.ids
 
     def _get_all_plans(self):

--- a/addons/analytic/models/ir_config_parameter.py
+++ b/addons/analytic/models/ir_config_parameter.py
@@ -24,7 +24,6 @@ class IrConfigParameter(models.Model):
             raise UserError(_('The value for %s must be the ID to a valid analytic plan that is not a subplan', param.key))
         res = super().write(vals)
         old_plan = self.env['account.analytic.plan'].browse(int(old_plan_id))
-        if not (old_plan.id == 1 and not self.env.registry.ready and not old_plan.exists()):
-            old_plan._sync_all_plan_column()
-            plan_field.unlink()
+        old_plan._sync_all_plan_column()
+        plan_field.unlink()
         return res


### PR DESCRIPTION
We need to set the project_plan in on other to validate it, and we need it to check the first project plan. So we skip the check at installation time to avoid this dependency loop.

runbot-242046


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
