### PR TITLE
[IMP] web: force translation dialog when editing translatable fields

### DIFF
--- a/addons/web/static/src/views/fields/char/char_field.js
+++ b/addons/web/static/src/views/fields/char/char_field.js
@@ -1,12 +1,13 @@
 import { useExternalListener, useLayoutEffect, useRef } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
+import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { useDynamicPlaceholder } from "../dynamic_placeholder_hook";
 import { formatChar } from "../formatters";
 import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
-import { TranslationButton } from "../translation_button";
+import { TranslationButton, useTranslationDialog } from "../translation_button";
 
 import { Component } from "@odoo/owl";
 
@@ -40,6 +41,7 @@ export class CharField extends Component {
             getValue: () => this.props.record.data[this.props.name] || "",
             parse: (v) => this.parse(v),
         });
+        this.translationDialog = useTranslationDialog();
 
         this.selectionStart = this.props.record.data[this.props.name]?.length || 0;
     }
@@ -67,6 +69,13 @@ export class CharField extends Component {
             return value.trim();
         }
         return value;
+    }
+
+    onFocus() {
+        if (this.isTranslatable && localization.multiLang && this.props.record.resId) {
+            this.input.el.blur();
+            this.translationDialog({ record: this.props.record, fieldName: this.props.name });
+        }
     }
 
     onBlur() {

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -17,6 +17,7 @@
                 t-att-autocomplete="this.props.autocomplete or (this.props.isPassword ? 'new-password' : 'off')"
                 t-att-maxlength="this.maxLength > 0 and this.maxLength"
                 t-att-placeholder="this.props.placeholder"
+                t-on-focus="this.onFocus"
                 t-on-blur="this.onBlur"
                 t-custom-ref="input"
             />

--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -1,5 +1,6 @@
 import { useExternalListener, useLayoutEffect, useRef } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
+import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { useAutoresize } from "@web/core/utils/autoresize";
 import { useSpellCheck } from "@web/core/utils/hooks";
@@ -7,7 +8,7 @@ import { useDynamicPlaceholder } from "../dynamic_placeholder_hook";
 import { useInputField } from "../input_field_hook";
 import { parseInteger } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
-import { TranslationButton } from "../translation_button";
+import { TranslationButton, useTranslationDialog } from "../translation_button";
 
 import { Component } from "@odoo/owl";
 
@@ -48,6 +49,7 @@ export class TextField extends Component {
             preventLineBreaks: !this.props.lineBreaks,
         });
         useSpellCheck({ refName: "textarea" });
+        this.translationDialog = useTranslationDialog();
 
         useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
 
@@ -63,6 +65,13 @@ export class TextField extends Component {
             return value.trim();
         }
         return value;
+    }
+
+    onFocus() {
+        if (this.isTranslatable && localization.multiLang && this.props.record.resId) {
+            this.textareaRef.el.blur();
+            this.translationDialog({ record: this.props.record, fieldName: this.props.name });
+        }
     }
 
     async onBlur() {

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -16,6 +16,7 @@
                 t-att-placeholder="this.props.placeholder"
                 t-att-rows="this.rowCount"
                 t-custom-ref="textarea"
+                t-on-focus="this.onFocus"
                 t-on-blur="this.onBlur"
             />
             <div class="o_field_input_buttons">

--- a/addons/web/static/src/views/fields/translation_dialog.js
+++ b/addons/web/static/src/views/fields/translation_dialog.js
@@ -4,7 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { loadLanguages, _t } from "@web/core/l10n/translation";
 import { jsToPyLocale } from "@web/core/l10n/utils";
 
-import { Component, onWillStart } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class TranslationDialog extends Component {
     static template = "web.TranslationDialog";
@@ -29,6 +29,9 @@ export class TranslationDialog extends Component {
 
         this.terms = [];
         this.updatedTerms = {};
+        this.state = useState({
+            enValue: undefined,
+        });
 
         onWillStart(async () => {
             const languages = await loadLanguages(this.orm);
@@ -68,6 +71,13 @@ export class TranslationDialog extends Component {
             domain.push(["name", "=", `${this.props.searchName}`]);
         }
         return domain;
+    }
+
+    onTermInput(ev, term) {
+        if (term.lang === "en_US") {
+            this.state.enValue = ev.target.value;
+        }
+        this.updatedTerms[term.id] = ev.target.value;
     }
 
     /**

--- a/addons/web/static/src/views/fields/translation_dialog.xml
+++ b/addons/web/static/src/views/fields/translation_dialog.xml
@@ -22,19 +22,21 @@
                             <t t-if="this.props.isText">
                                 <textarea
                                     class="o_field_text o_field_translate o_field_widget o_input"
-                                    t-att-value="term.value"
+                                    t-att-value="this.updatedTerms[term.id] ?? term.value"
+                                    t-att-placeholder="this.state.enValue ?? term.source"
                                     t-att-data-id="term.id"
                                     t-att-rows="this.props.showSource ? 2 : 5"
-                                    t-on-change="(ev) => this.updatedTerms[term.id] = ev.target.value"
+                                    t-on-input="(ev) => this.onTermInput(ev, term)"
                                 />
                             </t>
                             <t t-else="">
                                 <input
                                     type="text"
                                     class="o_field_char o_input"
-                                    t-att-value="term.value"
+                                    t-att-value="this.updatedTerms[term.id] ?? term.value"
+                                    t-att-placeholder="this.state.enValue ?? term.source"
                                     t-att-data-id="term.id"
-                                    t-on-change="(ev) => this.updatedTerms[term.id] = ev.target.value"
+                                    t-on-input="(ev) => this.onTermInput(ev, term)"
                                 />
                             </t>
                         </div>

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2935,10 +2935,11 @@ class BaseModel(metaclass=MetaModel):
         if not field.translate:
             translations = []
         elif field.translate is True:
+            stored = field._get_stored_translations(self) or {}
             translations = [{
                 'lang': lang,
                 'source': val_en,
-                'value': self_lang.with_context(lang=lang)[field_name]
+                'value': stored.get(lang, ''),
             } for lang in langs]
         else:
             translation_dictionary = field.get_translation_dictionary(


### PR DESCRIPTION
Editing a translatable field inline only updates the current language, silently leaving all other languages with stale content. This is especially harmful after duplicating a record, where the user typically wants to rename or retranslate the copy in all languages at once.

The translation dialog is now opened automatically on focus so that multi-language edits are always made through a single, consistent interface that makes all language slots visible at the same time.

Within the dialog, languages that have no explicit translation were previously shown with the en_US value pre-filled, giving the false impression that a translation was set. They now appear empty with the source value as a placeholder, and that placeholder updates live as the source row is edited, so the user immediately sees which languages will inherit the new value if left blank.
