### PR TITLE
[FIX] pos_self_order: limit the number of loaded fields

### DIFF
--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -30,6 +30,10 @@ class PosSession(models.Model):
         return sessions
 
     @api.model
+    def _load_pos_self_data_fields(self, config_id):
+        return ['id', 'user_id', 'config_id', 'payment_method_ids', 'state']
+
+    @api.model
     def _load_pos_self_data_domain(self, data):
         return [('config_id', '=', data['pos.config']['data'][0]['id']), ('state', '=', 'opened')]
 


### PR DESCRIPTION
This commit optimizes pos_config and pos_session data loading by only loading the fields required for self-ordering.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
