### PR TITLE
[FIX] account_payment: allow bookkeeper register payment

### DIFF
--- a/addons/account_payment/wizards/account_payment_register.py
+++ b/addons/account_payment/wizards/account_payment_register.py
@@ -38,7 +38,7 @@ class AccountPaymentRegister(models.TransientModel):
                 wizard.can_edit_wizard
                 and wizard.use_electronic_payment_method
                 and (provider := wizard.payment_method_line_id.payment_provider_id)
-                and not provider.capture_manually
+                and not provider.sudo().capture_manually
             ):
                 token_partners = wizard.partner_id
                 lines_partners = wizard.batches[0]['lines'].move_id.partner_id


### PR DESCRIPTION
Issue:
---
Bookkeeper user cannot register payment using a payment method due to access issues.

Steps to reproduce:
1- Setup a payment provider. e.g. Demo
2- Set Demo user accounting access as bookkeeper.
3- Login using Demo user.
4- Create an invoice and register a payment.
5- Choose Demo payment method.

An access error is raised.

Cause:
---
Before cb7fba0782d8af365e29832ac7dd166590d80b16, `provider.capture_manually` was checked inside the search filter. As the search was `sudo`, there was no access issue. After that commit, the `capture_manually` is checked with no sudo, causing this access issue if the user doesn't have read access on the payment provider.

opw-6001170

