### PR TITLE
[IMP] website: reduce overlay opacity on snippets

### DIFF
--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -28,7 +28,7 @@ registerWebsitePreviewTour("snippet_translation", {}, () => [
     ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
         content: "Check that contact us contain Parseltongue",
-        trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
+        trigger: ':iframe .s_cover .btn-outline-primary:contains("Contact us in Parseltongue")',
     },
     {
         content: "Check that the save button contains 'in fu_GB'",
@@ -92,7 +92,7 @@ registerWebsitePreviewTour(
         {
             content: "Check that contact us contain Parseltongue",
             trigger:
-                ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
+                ':iframe .s_cover .btn-outline-primary:contains("Contact us in Parseltongue")',
         },
     ]
 );
@@ -102,7 +102,7 @@ registerWebsitePreviewTour("snippet_translation_switching_website", {}, () => [
     ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
         content: "Check that contact us contain Parseltongue",
-        trigger: ":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')",
+        trigger: ":iframe .s_cover .btn-outline-primary:contains('Contact us in Parseltongue')",
     },
     ...clickOnSave(),
     ...testSwitchWebsite("website fu_GB"),
@@ -110,7 +110,7 @@ registerWebsitePreviewTour("snippet_translation_switching_website", {}, () => [
     ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
         content: "Check that contact us contain Fake User Lang",
-        trigger: ":iframe .s_cover .btn-outline-secondary:contains('Fake User Lang')",
+        trigger: ":iframe .s_cover .btn-outline-primary:contains('Fake User Lang')",
     },
 ]);
 registerWebsitePreviewTour("snippet_dialog_rtl", {}, () => [

--- a/addons/website/views/snippets/s_banner_categories.xml
+++ b/addons/website/views/snippets/s_banner_categories.xml
@@ -5,7 +5,7 @@
     <section class="s_banner_categories oe_img_bg o_cc o_cc5 o_bg_img_center pb56"
             data-oe-shape-data="{'shape': 'html_builder/Connections/20', 'colors': {'c5': 'rgb(255, 255, 255)'}, 'showOnMobile': false}"
             style="background-position: 50% 75%; background-image: url('/web/image/website.s_banner_categories_default_image_1');">
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="o_html_builder_Connections_20 o_we_shape"
             style="background-image: url('/html_editor/shape/html_builder/Connections/20.svg?c5=rgb%28255%2C255%2C255%29');"/>
         <div class="container">

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -6,14 +6,14 @@
         <span class="s_parallax_bg_wrap">
             <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 75%;"/>
         </span>
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="container s_allow_columns">
             <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-out="cta_btn_text">Discover more</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2 o_translate_inline"><t t-out="cta_btn_text">Discover more</t></a>
                 <t t-set="contact_us_label">Contact us</t>
-                <a href="/contactus" class="btn btn-outline-secondary mb-2 o_translate_inline"><t t-out="contact_us_label"/></a>
+                <a href="/contactus" class="btn btn-outline-primary mb-2 o_translate_inline"><t t-out="contact_us_label"/></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/s_image_title.xml
+++ b/addons/website/views/snippets/s_image_title.xml
@@ -3,7 +3,7 @@
 
 <template id="s_image_title" name="Image Title">
     <section class="s_image_title o_cc o_cc5 oe_img_bg pt32 pb32" style="background-image: url('/web/image/website.s_image_title_default_image'); background-position: 50% 70%;">
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
                 <div class="o_grid_item g-height-9 g-col-lg-8 col-lg-8" style="--grid-item-padding-y: 32px; grid-area: 1 / 1 / 10 / 9; z-index: 1;">

--- a/addons/website/views/snippets/s_kickoff.xml
+++ b/addons/website/views/snippets/s_kickoff.xml
@@ -6,7 +6,7 @@
         <span class="s_parallax_bg_wrap">
             <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_kickoff_default_image');"/>
         </span>
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="o_we_shape o_html_builder_Connections_06" style="background-image: url('/html_editor/shape/html_builder/Connections/06.svg?c5=o-color-4');"/>
         <div class="container s_allow_columns">
             <p class="lead">Your Journey Starts Here,</p>

--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -75,12 +75,12 @@ Use t-snippet-call and fill it with its inner grid-mode row.
     <t t-snippet-call="website.s_masonry_block">
         <div class="row o_grid_mode" data-row-count="8" style="gap: 16px;">
             <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 1; grid-area: 1 / 1 / 9 / 7; background-image: url(/web/image/website.s_masonry_block_default_image_2); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
-                <div class="o_we_bg_filter bg-black-50"/>
+                <div class="o_we_bg_filter bg-black-25"/>
                 <h2 class="display-4-fs">Key <br class="d-none d-lg-inline"/>Milestone</h2>
                 <p class="lead">Reaching new heights together</p>
             </div>
             <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 2; grid-area: 1 / 7 / 9 / 13; background-image: url(/web/image/website.s_masonry_block_default_image_1); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
-                <div class="o_we_bg_filter bg-black-50"/>
+                <div class="o_we_bg_filter bg-black-25"/>
                 <h2 class="display-4-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h2>
                 <p class="lead">Where ideas come to life</p>
             </div>

--- a/addons/website/views/snippets/s_parallax.xml
+++ b/addons/website/views/snippets/s_parallax.xml
@@ -2,11 +2,11 @@
 <odoo>
 
 <template id="s_parallax" name="Parallax">
-    <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_three_quarter_height" data-scroll-background-ratio="1">
+    <section class="s_parallax parallax s_parallax_is_fixed bg-black-25 o_three_quarter_height" data-scroll-background-ratio="1">
         <span class="s_parallax_bg_wrap">
             <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
         </span>
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="oe_structure oe_empty"/>
     </section>
 </template>

--- a/addons/website/views/snippets/s_website_form_overlay.xml
+++ b/addons/website/views/snippets/s_website_form_overlay.xml
@@ -3,7 +3,7 @@
 
 <template id="s_website_form_overlay" name="Form Overlay">
     <section class="s_website_form_overlay pt64 pb64 oe_img_bg o_bg_img_center o_colored_level" style="background-image: url('/web/image/website.s_website_form_overlay_default_image');">
-        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_bg_filter bg-black-25"/>
         <div class="container">
             <div class="row">
                 <div class="o_cc o_cc1 col-lg-6 offset-lg-6 rounded px-3 px-lg-4 pt40 pb16">


### PR DESCRIPTION
- requires https://github.com/odoo/design-themes/pull/1251

Reduce the overall overlay opacity across snippets to provide a sleeker
look and prevent conflict with buttons color.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
