### PR TITLE
[IMP] hr_holidays_attendance: improve kiosk overtime hours

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1172,12 +1172,19 @@ class TestHrAttendanceOvertime(HttpCase):
         """Validate that multiple overtime lines for today are summed correctly
         and that the entire attendance_employee_data response is consistent.
         """
-        for _ in range(2):
-            self.env['hr.attendance.overtime.line'].create({
-                'employee_id': self.employee.id,
-                'date': date.today(),
-                'duration': 5,
+        domain = {
+            'employee_id': self.employee.id,
+            'date': date.today(),
+            'duration': 5
+        }
+        if 'compensable_as_leave' in self.env['hr.attendance.overtime.line']._fields:
+            domain.update({
+                'compensable_as_leave': True,
+                'leave_compensation_rate': 1.0,
             })
+        for _ in range(2):
+            self.env['hr.attendance.overtime.line'].create(domain)
+
         token = self.employee.company_id.attendance_kiosk_key
         response = self.make_jsonrpc_request(
             '/hr_attendance/attendance_employee_data',

--- a/addons/hr_holidays_attendance/__init__.py
+++ b/addons/hr_holidays_attendance/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import report

--- a/addons/hr_holidays_attendance/__init__.py
+++ b/addons/hr_holidays_attendance/__init__.py
@@ -1,5 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import report
+
+
+def _assign_compensable_as_leave_to_overtime(env):
+    """
+    Regenerate overtime lines for rulesets containing rules marked as
+    compensable as leave.
+
+    This migration ensures that existing overtime lines are updated with the
+    correct `compensable_as_leave` value based on their overtime rules.
+    """
+
+    overtime_rulesets = env['hr.attendance.overtime.ruleset'].search([
+        ('rule_ids.compensable_as_leave', '=', True),
+    ])
+    for ruleset in overtime_rulesets:
+        ruleset.action_regenerate_overtimes()

--- a/addons/hr_holidays_attendance/__manifest__.py
+++ b/addons/hr_holidays_attendance/__manifest__.py
@@ -27,6 +27,7 @@ Convert employee's extra hours to leave allocations.
             'hr_holidays_attendance/static/tests/tours/*.js',
         ],
     },
+    'post_init_hook': '_assign_compensable_as_leave_to_overtime',
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/hr_holidays_attendance/controllers/__init__.py
+++ b/addons/hr_holidays_attendance/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/hr_holidays_attendance/controllers/main.py
+++ b/addons/hr_holidays_attendance/controllers/main.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import float_round
+
+from odoo.addons.hr_attendance.controllers.main import HrAttendance
+
+
+class HrHolidaysAttendance(HrAttendance):
+
+    @staticmethod
+    def _get_employee_info_response(employee):
+        response = super(HrHolidaysAttendance, HrHolidaysAttendance)._get_employee_info_response(employee)
+
+        if not employee:
+            return response
+
+        remaining_overtime_data = employee._get_deductible_employee_overtime()
+        response['total_overtime'] = float_round(
+            remaining_overtime_data.get(employee, 0.0),
+            precision_digits=2,
+        )
+        return response

--- a/addons/hr_holidays_attendance/controllers/main.py
+++ b/addons/hr_holidays_attendance/controllers/main.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import float_round
+
+from odoo.addons.hr_attendance.controllers.main import HrAttendance
+
+
+class HrHolidaysAttendance(HrAttendance):
+
+    @staticmethod
+    def _get_employee_info_response(employee):
+        response = super(HrHolidaysAttendance, HrHolidaysAttendance)._get_employee_info_response(employee)
+
+        if not employee:
+            return response
+
+        remaining_overtime_data = employee._get_deductible_employee_overtime(compensable_as_leave=False)
+        response['total_overtime'] = float_round(
+            remaining_overtime_data.get(employee, 0.0),
+            precision_digits=2,
+        )
+        return response

--- a/addons/hr_holidays_attendance/models/hr_employee.py
+++ b/addons/hr_holidays_attendance/models/hr_employee.py
@@ -6,15 +6,17 @@ from odoo import models
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
-    def _get_deductible_employee_overtime(self):
+    def _get_deductible_employee_overtime(self, compensable_as_leave=True):
         # return dict {employee: number of hours}
         diff_by_employee = defaultdict(lambda: 0)
+        domain = [
+            ('employee_id', 'in', self.ids),
+            ('status', '=', 'approved'),
+        ]
+        if compensable_as_leave:
+            domain += [('compensable_as_leave', '=', True)]
         for employee, hours in self.env['hr.attendance.overtime.line'].sudo()._read_group(
-            domain=[
-                ('compensable_as_leave', '=', True),
-                ('employee_id', 'in', self.ids),
-                ('status', '=', 'approved'),
-            ],
+            domain=domain,
             groupby=['employee_id'],
             aggregates=['manual_duration:sum'],
         ):

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -490,3 +490,30 @@ class TestHolidaysOvertime(HttpCase, TransactionCase):
 
         leave.action_refuse()
         self.assertEqual(self.employee.total_overtime, 0, 'Should have 0 hours of overtime as the leave has been refused.')
+
+    def test_employee_kiosk_remaining_overtime(self):
+        self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 17))
+        self.new_attendance(check_in=datetime(2021, 1, 3, 8), check_out=datetime(2021, 1, 3, 17))
+        self.assertEqual(self.employee.total_overtime, 18, 'Should have 18 hours of overtime')
+
+        self.env['hr.leave'].with_context(leave_fast_create=True).create({
+            'name': 'overtime leave',
+            'employee_id': self.employee.id,
+            'work_entry_type_id': self.work_entry_type_no_alloc.id,
+            'request_date_from': datetime(2021, 1, 4),
+            'request_date_to': datetime(2021, 1, 4),
+        })
+
+        self._check_deductible(10)
+        response = self.make_jsonrpc_request(
+            '/hr_attendance/attendance_employee_data',
+            {
+                'token': self.employee.company_id.attendance_kiosk_key,
+                'employee_id': self.employee.id,
+            },
+        )
+        self.assertEqual(
+            response.get('total_overtime'),
+            10,
+            "Kiosk should show remaining deductible overtime after leave deduction",
+        )

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -466,3 +466,30 @@ class TestHolidaysOvertime(HttpCase, TransactionCase):
 
         leave.action_refuse()
         self.assertEqual(self.employee.total_overtime, 0, 'Should have 0 hours of overtime as the leave has been refused.')
+
+    def test_employee_kiosk_remaining_overtime(self):
+        self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 17))
+        self.new_attendance(check_in=datetime(2021, 1, 3, 8), check_out=datetime(2021, 1, 3, 17))
+        self.assertEqual(self.employee.total_overtime, 18, 'Should have 18 hours of overtime')
+
+        self.env['hr.leave'].with_context(leave_fast_create=True).create({
+            'name': 'overtime leave',
+            'employee_id': self.employee.id,
+            'work_entry_type_id': self.work_entry_type_no_alloc.id,
+            'request_date_from': datetime(2021, 1, 4),
+            'request_date_to': datetime(2021, 1, 4),
+        })
+
+        self._check_deductible(10)
+        response = self.make_jsonrpc_request(
+            '/hr_attendance/attendance_employee_data',
+            {
+                'token': self.employee.company_id.attendance_kiosk_key,
+                'employee_id': self.employee.id,
+            },
+        )
+        self.assertEqual(
+            response.get('total_overtime'),
+            10,
+            "Kiosk should show remaining deductible overtime after leave deduction",
+        )


### PR DESCRIPTION
This PR improves the overtime hours displayed during check-out through the kiosk. Previously, it showed the total overtime even when some of those hours were already used as leave.
Now, instead of showing the total overtime, it only displays the remaining overtime hours.

task-5977518
