### PR TITLE
[FIX] mail: fetching inbox messages

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -63,7 +63,8 @@ class WebclientController(ThreadController):
                     store.add(
                         records,
                         lambda res: (
-                            res.attr("message_needaction_counter"),
+                            # sudo: mail.thread: users can read their own message_needaction_counter on the thread
+                            res.attr("message_needaction_counter", sudo=True),
                             res.attr("message_needaction_counter_bus_id", bus_last_id),
                         ),
                         as_thread=True,

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -3,6 +3,7 @@
 from itertools import chain
 
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.exceptions import AccessError
 from odoo.tests.common import HttpCase, tagged, warmup
 
 
@@ -24,7 +25,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search ir_rule (_get_rules)
         #       - search mail_message
         #   - search bus_bus (_bus_last_id)
-        #   30 store add message:
+        #   32 store add message:
         #       - search mail_message
         #       - fetch mail_message
         #       - search mail_message_schedule
@@ -32,7 +33,8 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search ir_rule (_get_rules for rating.rating)
         #       - read group rating_rating (_rating_get_stats_per_record for slide.channel)
         #       - read group rating_rating (_rating_get_stats_per_record for product.template)
-        #       2 thread:
+        #       3 thread:
+        #           - fetch hr_employee
         #           - fetch slide_channel
         #           - fetch product_template
         #       - search mail_message_res_partner_bookmarked_rel (_compute_is_bookmarked)
@@ -56,16 +58,22 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - fetch mail_message_subtype
         #       - read group rating_rating (_compute_rating_stats for slide.channel)
         #       - read group rating_rating (_compute_rating_stats for product.template)
+        #       - compute message_needaction for hr.employee
         #       - compute message_needaction for slide.channel
         #       - compute message_needaction for product.template
 
+        # rating stats enabled
         first_model_records = self.env["product.template"].create(
             [{"name": "Product A1"}, {"name": "Product A2"}]
         )
         second_model_records = self.env["slide.channel"].create(
             [{"name": "Course B1"}, {"name": "Course B2"}]
         )
-        for record in chain(first_model_records, second_model_records):
+        # group restricted fields
+        third_model_record = self.env["hr.employee"].create({"name": "Employee"})
+        with self.assertRaises(AccessError):
+            third_model_record.with_user(self.user_employee).read("message_needaction_counter")
+        for record in chain(first_model_records, second_model_records, third_model_record):
             record.message_post(
                 body=f"<p>Test message for {record.name}</p>",
                 message_type="comment",
@@ -73,5 +81,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(38):
+        with self.assertQueryCount(40):
             self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -16,16 +16,14 @@ class TestInboxPerformance(HttpCase, MailCommon):
         # Queries (in order):
         #   - search website (get_current_website by domain)
         #   - search website (get_current_website default)
-        #   - search website_rewrite (_get_rewrites) sometimes occurs depending on the routing cache
-        #   - _get ir_config_parameter (web.max_file_upload_size) sometimes occurs depending on the routing cache
-        #   - fetch ir_attachment (res.lang flag_image) sometimes occurs depending on the routing cache
+        #   - sometimes could occur depending on the routing cache (website_rewrite, ir_config_parameter, res.lang flag_image)
         #   4 _message_fetch:
         #       2 _search_needaction:
         #           - fetch res_users (current user)
         #           - search ir_rule (_get_rules for mail.notification)
         #       - search ir_rule (_get_rules)
         #       - search mail_message
-        #   - fetch bus_bus (_bus_last_id)
+        #   - search bus_bus (_bus_last_id)
         #   30 store add message:
         #       - search mail_message
         #       - fetch mail_message
@@ -56,11 +54,11 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - fetch res_users
         #           - fetch res_partner
         #       - fetch mail_message_subtype
-        #       6 rating stats computation:
-        #           - read group rating_rating (_rating_get_stats_per_record for slide.channel)
-        #           - read group rating_rating (_rating_get_stats_per_record for product.template)
-        #           - compute message_needaction for slide.channel
-        #           - compute message_needaction for product.template
+        #       - read group rating_rating (_compute_rating_stats for slide.channel)
+        #       - read group rating_rating (_compute_rating_stats for product.template)
+        #       - compute message_needaction for slide.channel
+        #       - compute message_needaction for product.template
+
         first_model_records = self.env["product.template"].create(
             [{"name": "Product A1"}, {"name": "Product A2"}]
         )
@@ -75,5 +73,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(40):
+        with self.assertQueryCount(38):
             self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})


### PR DESCRIPTION
Since PR #253273, the value of the `message_needaction_counter` field has been
added to the store data when fetching inbox messages. The `hr` module adds a
specific group to this field, that could cause fetching inbox messages to crash
if the needaction message is related to an `hr.employee` record and the user is
not involved in that group. This change adds sudo when accessing to this field
to get the store data for inbox messages.

Steps to reproduce:
- Set the notification preference to `inbox` for the demo user.
- Log in as admin and mention the demo user in an employee record.
- Go to inbox as demo. The messages will not be fetched, with an access error to
`message_needaction_counter` field.