### PR TITLE
[FIX] website_sale: misleading code

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -931,7 +931,7 @@ class SaleOrder(models.Model):
         partners_to_archive = self.env['res.partner']
         for order in self:
             if (
-                not (customer := order.partner_id.user_ids)
+                not (customer := order.partner_id).user_ids
                 and not (commercial_partner := order.partner_id.commercial_partner_id).user_ids
             ):
                 partners_to_archive |= (


### PR DESCRIPTION
Introduced by 64d9ded9637286ef0cfd9e65ba7c60d4f48d6c16, customer was supposed to hold res.partner record and not res.users one. Logic worked nevertheless because `child_ids` is inherited through the `partner_id` inherits on the `res.users` model.
