### PR TITLE
[FIX] mrp_account: convert BOM line qty to product UOM

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
         total_price_unit = 0
         component_qty_per_kit = defaultdict(float)
         for line in exploded_lines:
-            component_qty_per_kit[line[0].product_id] += line[1]['qty']
+            component_qty_per_kit[line[0].product_id] += line[0].product_uom_id._compute_quantity(line[1]['qty'], line[0].product_id.uom_id)
         for component, valuated_moves in self.grouped('product_id').items():
             price_unit = super(StockMove, valuated_moves)._get_price_unit()
             qty_per_kit = component_qty_per_kit[component] / kit_bom.product_qty

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -176,6 +176,38 @@ class TestMrpAccount(TestBomPriceCommon):
         mo_1 = self._create_mo(self.bom_1, 1)
         mo_1.with_user(mrp_user).button_mark_done()
 
+    def test_kit_price_unit_bom_line_uom_conversion(self):
+        """_get_kit_price_unit must convert the BOM line qty from the BOM line UOM to
+        the component's product UOM before multiplying by price_unit."""
+        self.env.user.group_ids += self.env.ref('uom.group_uom')
+        uom_kg = self.env.ref('uom.product_uom_kgm')
+        uom_gram = self.env.ref('uom.product_uom_gram')
+
+        flour = self._create_product('Flour', 430.0, quantity=0, category=self.category_avco_auto)
+        flour.product_tmpl_id.uom_id = uom_kg
+
+        kit = self._create_product('Bread Kit', 0.0, quantity=0, category=self.category_avco_auto)
+
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': flour.id,
+                'product_qty': 400.0,
+                'product_uom_id': uom_gram.id,
+            })],
+        })
+
+        # Incoming receipt at 430/kg sets the AVCO cost
+        self._make_in_move(flour, 10.0, unit_cost=430.0, uom_id=uom_kg.id)
+        # Outgoing move for 0.4 kg (= 400g) of flour — the component move for one kit
+        out_move = self._make_out_move(flour, 0.4, uom_id=uom_kg.id)
+
+        price_unit = out_move._get_kit_price_unit(kit, bom, 1.0)
+        self.assertAlmostEqual(price_unit, 172.0, places=2,
+            msg="Expected 430/kg * 0.4kg = 172, got %s" % price_unit)
+
 
 class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
 


### PR DESCRIPTION
When computing the kit price unit, the component quantity from bom.explode() is expressed in the BOM line's UOM (e.g. grams), while price_unit is in the product's standard UOM (e.g. kg). Without conversion, a component at 430/kg with 400g in the BOM would yield 430 * 400 = 172000 instead of 172.

Fix by converting the BOM line quantity to the product's UOM using _compute_quantity before accumulating into component_qty_per_kit.

opw-6111342

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
