### PR TITLE
[FIX] website_sale: set default value for product.feed.website_id

### DIFF
--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -23,7 +23,9 @@ class ProductFeed(models.Model):
     _description = "Product Feed"
 
     name = fields.Char(required=True)
-    website_id = fields.Many2one('website', required=True)
+    website_id = fields.Many2one(
+        "website", required=True, default=lambda self: self.env.company.website_id
+    )
     pricelist_id = fields.Many2one(
         'product.pricelist',
         help="Specify a pricelist to localize the feed with a specific currency."


### PR DESCRIPTION
Issue:
---
Due to this issue, we cannot create a `product.feed` record in single website db.

Steps to reproduce:
1- Create a fresh db with single website.
2- Enable Google Merchant Center.
3- Try to create a `website.feed` record.

It's not possible to create the record due to language field.

Cause:
---
`website_id` is only shown in `group_multi_website`. When there is only one website set, there is no default value for the website. `lang_id`'s domain is also `website_id.language_ids`, as a result record creation will fail.

opw-6110843

