### PR TITLE
[FIX] web: Prevents accidental mutation in widget field dependencies

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -61,7 +61,8 @@ export function makeActiveField({
 export const AGGREGATABLE_FIELD_TYPES = ["float", "integer", "monetary"]; // types that can be aggregated in grouped views
 
 export function addFieldDependencies(activeFields, fields, fieldDependencies = []) {
-    for (const field of fieldDependencies) {
+    for (let field of fieldDependencies) {
+        field = { ...field };
         if (!("readonly" in field)) {
             field.readonly = true;
         }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9885,7 +9885,7 @@ test("support header button as widgets in submenu on form statusbar on mobile", 
                 <t t-set-slot="toggler">
                     <button>Upload Test</button>
                 </t>
-            </FileUploader>`
+            </FileUploader>`;
         static components = { FileUploader };
 
         onUploaded(ev) {
@@ -13547,4 +13547,43 @@ test(`cached onchange - don't loose changes`, async () => {
     expect(`.o_field_char input`).toHaveValue("This is yop");
     expect(`.o_last_breadcrumb_item`).toHaveText("New");
     expect.verifySteps(["onchange", "onchange"]);
+});
+
+test(`Do not mix dependencies across multiple widgets in multiple views`, async () => {
+    onRpc("web_save", () => expect.step("web_save"));
+    class MyField extends CharField {}
+    fieldsRegistry.add("my_widget", {
+        component: MyField,
+        fieldDependencies: [{ name: "name", type: "char" }],
+    });
+
+    Partner._records[1].child_ids = [1];
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="foo" widget="my_widget"/>
+                <field name="name" />
+                <field name="child_ids">
+                    <list editable="top">
+                        <field name="foo" widget="my_widget"/>
+                        <field name="name" required="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+        resId: 2,
+    });
+    expect(`.o_field_widget[name=name] input`).toHaveValue("second record");
+
+    await contains(`.o_field_widget[name=name] input`).edit("");
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+
+    await contains(`.o_field_one2many:eq(0) .o_field_x2many_list_row_add button`).click();
+    await contains(".o_selected_row input").edit("Foo value");
+    await clickSave();
+    expect(`.o_notification_content`).toHaveText("Missing required fields");
 });


### PR DESCRIPTION
Example of steps:
- Install todo module
- Create a todo task (it will be created without project_id)
- Go to project -> my task
- You can see your previously created todo task (with project set as)
- This todo task is marked as Private (since no project)
- Refresh page
- There is now an error because project is now required and you cannot save the current task

This problem is caused by `addFieldDependencies` from `relational_model/utils` Let's simplify the case with this view for example:

```xml
<form>
    <field name="foo" widget="my_widget"/>
    <field name="name" />
    <field name="child_ids">
        <list editable="top">
            <field name="foo" widget="my_widget"/>
            <field name="name" required="1"/>
        </list>
    </field>
</form>
```
my_widget is defined with these fieldDependencies:
```js
[
    {
        name: "name",
        type: "char",
    }
]
```
We have twice the same group of fields (name + foo with my_widget), one in the form view and the other one in the subview list (child_ids).

Currently, we firstly process subviews in `addFieldDependencies`. As "name" field is used in dependencies of `my_widget` and name is already use in the same view (subview list) with required="1" we will change `my_widget` dependencies to be required too by mutating `widget.fieldDependencies`.

And after, we will do the same with the main form view, but as fieldDependencies object from fieldInfo is the same for every instances of the widget everywhere (from form arch parser), we should not alter it because we might accidentally add attributes to certain fields (for example, in our case, making the “name” field in the main view required when it shouldn't be).

This commit fix this case by using a spread operator to shallow copy fieldDependencies items.

opw-6008266
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
