### PR TITLE
[FIX] account_peppol,l10n_dk_nemhandel: add missing key in demo utils

### DIFF
--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -20,11 +20,13 @@ def get_demo_vendor_bill(user):
         'direction': 'incoming',
         'receiver': user.edi_identification,
         'uuid': f'{user.company_id.id}_demo_vendor_bill',
+        'origin_message_uuid': f'{user.company_id.id}_demo_vendor_bill',
         'accounting_supplier_party': '0208:2718281828',
         'state': 'done',
         'filename': f'{user.company_id.id}_demo_vendor_bill',
         'enc_key': file_open(DEMO_ENC_KEY, mode='rb').read(),
         'document': file_open(DEMO_BILL_PATH, mode='rb').read(),
+        'document_type': 'Invoice',
     }
 
 
@@ -54,7 +56,11 @@ def _mock_call_peppol_proxy(func, self, *args, **kwargs):
         message_uuid = args[1]['message_uuids'][0]
         if message_uuid.endswith('_demo_vendor_bill'):
             return {message_uuid: get_demo_vendor_bill(user)}
-        return {message_uuid: {'state': 'done'}}
+        return {message_uuid: {
+            'state': 'done',
+            'origin_message_uuid': message_uuid,
+            'document_type': 'Invoice',
+        }}
 
     def _mock_send_document(user, args, kwargs):
         # Trigger the reception of vendor bills

--- a/addons/l10n_dk_nemhandel/tools/demo_utils.py
+++ b/addons/l10n_dk_nemhandel/tools/demo_utils.py
@@ -29,7 +29,11 @@ def _mock_call_nemhandel_proxy(func, self, *args, **kwargs):
 
     def _mock_get_document(user, args, kwargs):
         message_uuid = args[1]['message_uuids'][0]
-        return {message_uuid: {'state': 'done'}}
+        return {message_uuid: {
+            'state': 'done',
+            'origin_message_uuid': message_uuid,
+            'document_type': 'Invoice'
+        }}
 
     def _mock_send_document(user, args, kwargs):
         # Trigger the reception of vendor bills


### PR DESCRIPTION
With the recent addition of responses in Peppol and Nemhandel, we forgot to adapt the mocking data for demo flows, which resulted in tracebacks in demo mode.
