### PR TITLE
[FIX] *: remove unnecessary groups to fix boxed settings layout

### DIFF
--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -33,11 +33,11 @@
                 <xpath expr="//t[@name='allocated_hours_placeholder']" position="replace">
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
-                <xpath expr="//group[@name='group_time_managment']" position="attributes">
+                <xpath expr="//div[@name='group_time_managment']" position="attributes">
                     <attribute name="invisible">0</attribute>
                 </xpath>
-                <xpath expr="//group[@name='group_time_managment']" position="inside">
-                    <setting class="col-lg-12" id="timesheet_settings" string="Timesheets" help="Log time on tasks">
+                <xpath expr="//div[@name='group_time_managment']" position="inside">
+                    <setting id="timesheet_settings" string="Timesheets" help="Log time on tasks">
                         <field name="allow_timesheets"/>
                     </setting>
                 </xpath>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -181,22 +181,23 @@
                                     </group>
                                 </div>
                             </group>
-                            <group>
-                                <group name="group_tasks_managment" string="Tasks Management" col="1" class="row mt16 o_settings_container">
-                                    <div>
-                                        <setting class="col-lg-12" id="recurring_tasks_setting" help="Auto-generate tasks for regular activities">
-                                            <field name="allow_recurring_tasks"/>
-                                        </setting>
-                                        <setting class="col-lg-12" id="task_dependencies_setting" help="Determine the order in which to perform tasks">
-                                            <field name="allow_task_dependencies"/>
-                                        </setting>
-                                        <setting class="col-lg-12" id="project_milestone_setting" help="Track major progress points that must be reached to achieve success">
-                                            <field name="allow_milestones"/>
-                                        </setting>
-                                    </div>
-                                </group>
-                                <group name="group_time_managment" string="Time Management" invisible="1" col="1" class="row mt16 o_settings_container"/>
-                            </group>
+
+                            <div name="group_tasks_managment">
+                                <separator string="Tasks Management"/>
+                                <setting id="recurring_tasks_setting" help="Auto-generate tasks for regular activities">
+                                    <field name="allow_recurring_tasks"/>
+                                </setting>
+                                <setting id="task_dependencies_setting" help="Determine the order in which to perform tasks">
+                                    <field name="allow_task_dependencies"/>
+                                </setting>
+                                <setting id="project_milestone_setting" help="Track major progress points that must be reached to achieve success">
+                                    <field name="allow_milestones"/>
+                                </setting>
+                            </div>
+
+                            <div name="group_time_managment" invisible="1">
+                                <separator string="Time Management"/>
+                            </div>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -138,14 +138,13 @@
             <xpath expr="//i[@name='partner_id']" position="attributes">
                 <attribute name="invisible">not allow_billable or is_template</attribute>
             </xpath>
-            <xpath expr="//group[@name='group_time_managment']" position="before">
-                 <group name="group_sales_invoicing" string="Sales &amp; Invoicing" col="1" class="row mt16 o_settings_container col-lg-6">
-                    <div>
-                        <setting class="col-lg-12" help="Invoice your time and material to customers" id="allow_billable_container">
-                            <field name="allow_billable"/>
-                        </setting>
-                    </div>
-                </group>
+            <xpath expr="//div[@name='group_time_managment']" position="before">
+                <div name="group_sales_invoicing">
+                    <separator string="Sales &amp; Invoicing"/>
+                    <setting help="Invoice your time and material to customers" id="allow_billable_container">
+                        <field name="allow_billable"/>
+                    </setting>
+                </div>
             </xpath>
             <xpath expr="//t[@name='allocated_hours_placeholder']" position="after">
                 <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id or is_template"  context="{'default_partner_id': partner_id}"/>


### PR DESCRIPTION
Before this commit, some unwanted boxes appeared due to the m3 project. This commit removes them from certain settings forms.

To do so, we simplified the view by removing ´<group>´ elements, as the labels were not needed. This avoids the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
