### PR TITLE
[FIX] point_of_sale: prevent partner list from crashing in POS UI

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -138,7 +138,7 @@ export class PartnerList extends Component {
         );
 
         const availablePartners = searchWord
-            ? partners.filter((p) => regex.test(normalize(p.searchString)))
+            ? partners.filter((p) => regex.test(normalize(p.searchString))).slice(0, 50)
             : partners
                   .slice(0, 1000)
                   .toSorted((a, b) =>

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -17,7 +17,7 @@
                     icon="{type: 'fa', value: 'fa-search'}"
                     t-on-enter="() => this.searchPartner()"
                     autofocus="true"
-                    debounceMillis="100" />
+                    debounceMillis="300" /> <!-- 200~300ms is industry standard for Software UI debounce -->
             </t>
             <div class="h-100">
                 <t t-set="initialPartners" t-value="getPartners(this.state.initialPartners)"/>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -156,6 +156,13 @@ export function searchCustomerValue(val, pressEnter = false) {
             trigger: `.modal-dialog .input-group input`,
             run: `edit ${val}`,
         },
+        {
+            content: `Wait for search debounce`,
+            trigger: `.modal-dialog .input-group input`,
+            run: async function () {
+                await new Promise((resolve) => setTimeout(resolve, 350));
+            },
+        },
     ];
 
     if (pressEnter) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -129,6 +129,13 @@ export function searchCustomerValue(val, pressEnter = false) {
             trigger: `.modal-dialog .input-group input`,
             run: `edit ${val}`,
         },
+        {
+            content: `Wait for search debounce`,
+            trigger: `.modal-dialog .input-group input`,
+            run: async function () {
+                await new Promise((resolve) => setTimeout(resolve, 350));
+            },
+        },
     ];
 
     if (pressEnter) {


### PR DESCRIPTION
Currently, it's possible to experience very slow loading speed of the partner list and/or browser crashes in the POS when there are thousands of customers stored in the browser cache.

This appears to be caused by a few reasons compounding together:

1. While we limit the number of customers in the initial render of the list, there is no limit during the search. Therefore, if there are thousands of customers matching the search pattern loaded in the browser cache, the browser will attempt to render equally as many `PartnerLine` components.
2. A 100 ms debounce time is fast enough to trigger the render after each key stroke. 200~300ms is the industry standard for Software UI debounce.
3. For each customer rendered in the list, we may perform a search for its parent partner amongst all loaded customers with the function `PosStore.getPartnerCredit()`.

This PR aims at reducing the number of partner lines rendered in a short period of time and thus, at improving speed and avoiding crashes.

Steps to reproduce:
1. Create a fresh db + install the point_of_sale with demo data
2. Populate the res.partner model by a factor of 100 to reach 4000+ partners
3. Update the following system parameter to make sure that we load all partners in the browser cache when we open the POS session:
    - `point_of_sale.limited_customer_count` -> 5000
4. Open a POS session and and click on the `Customer` button to render the partner list
5. Type `adm` in the search bar at normal typing speed
6. Crash

Ticket: opw-5435973

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
