### PR TITLE
[FIX] hr_holidays: handle gantt multi-select search

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -383,6 +383,30 @@ class HrWorkEntryType(models.Model):
         is an employee_id in context and that no other order has been given
         to the method.
         """
+        if self.env.context.get('gantt_multi_create_company_filter'):
+            company_ids = self.env.context.get('allowed_company_ids')
+
+            if company_ids:
+                company = self.env['res.company'].browse(company_ids)
+                country = company.country_id
+
+                existing_system_types = dict(self.with_context(gantt_multi_create_company_filter=False)._read_group(
+                    domain=[
+                        ('country_id', 'in', [False] + country.ids),
+                        ('create_uid', '=', 1),
+                    ],
+                    groupby=['country_id'],
+                    aggregates=['id:count'],
+                ))
+
+                if not country:
+                    extra_domain = [('country_id', '=', False)]
+                elif existing_system_types.get(country):
+                    extra_domain = [('country_id', '=', country.id)]
+                else:
+                    extra_domain = [('country_id', 'in', [False, country.id])]
+
+                domain = Domain.AND([domain, extra_domain])
         employee = self.env['hr.employee']._get_contextual_employee()
         if order == self._order and employee:
             # retrieve all leaves, sort them, then apply offset and limit


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open Time Off App->Management->Time Off->Gantt View
2. Highlight multiple dates/cells to trigger the multi-create popover, then click "Set".
3. Open the "Time Off Type" dropdown. 
The domain is wrongly computed resulting in an empty dropdown.

**Bug Cause:**
The Gantt multi-create popover skips `_loadNewRecord`, meaning `work_entry_type_filter_domain` never computes and evaluates to an empty list. This hardcodes `('id', 'in', [])` into the search, forcing the database to return 0 records.

**Solution:**
Shift the domain to the `_search` method.
Because the Gantt multi-create popover skips standard record initialization, the compute function is never triggered.
Therefore, we replicate the exact same country-filtering logic done in the _compute_work_entry_type_filter_domain function inside the `_search` method.

**Task:** 6109569
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
