### PR TITLE
[IMP] hr_work_entry: add work entry for sick time off without certificate

### DIFF
--- a/addons/hr_holidays/data/hr_work_entry_type_data.xml
+++ b/addons/hr_holidays/data/hr_work_entry_type_data.xml
@@ -172,7 +172,7 @@
         <field name="country_id" ref="base.be"/>
     </record>
 
-    <record id="hr_work_entry.be_work_entry_type_sick_leave" model="hr.work.entry.type">
+    <record id="hr_work_entry.be_work_entry_type_sick_leave_without_certificate" model="hr.work.entry.type">
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
         <field name="unit_of_measure">day</field>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -428,6 +428,15 @@
         <field name="country_id" ref="base.be"/>
     </record>
 
+    <record id="be_work_entry_type_sick_leave_without_certificate" model="hr.work.entry.type">
+        <field name="name">Sick Time Off Without Certificate</field>
+        <field name="display_code">STOWC</field>
+        <field name="code">LEAVE111</field>
+        <field name="color">5</field>
+        <field name="count_as">absence</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
     <record id="be_work_entry_type_legal_leave" model="hr.work.entry.type">
         <field name="name">Paid Time Off</field>
         <field name="display_code">PTO</field>


### PR DESCRIPTION
Before merging time off type and work entry type, we had both sick time off and sick time off without certificate pointing to the same work entry type, which can not be the case now as each time off type maps to exactly one work entry type.

This commit adds a dedicated work entry for the Belgian sick time off without certificate.

task-6110080