### PR TITLE
[FIX] mail: do not show message actions on right-click on link (2)

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -467,7 +467,7 @@ export class Message extends Component {
             // Mobile OS long press is handled with useLongPress()
             return;
         }
-        if (ev.target.tagName === "A" || !this.props.hasActions || this.isEditing) {
+        if (ev.target.closest("a") || !this.props.hasActions || this.isEditing) {
             return;
         }
         this.showRightClickMessageActions(ev);

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -842,7 +842,7 @@ test("Can right-click on message to opens message actions dropdown", async () =>
             res_id: partnerId,
         },
         {
-            body: "msg-body-2 <a href='#'>Test link</a>",
+            body: "msg-body-2 <a href='#'>Test link</a><a href='#'><font>Test link 2</font></a>",
             model: "res.partner",
             needaction: true,
             res_id: partnerId,
@@ -886,7 +886,11 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     // Test inner-link in body of message doesn't trigger showing of message actions
     await click(".o-mail-Thread");
     await contains(".o-dropdown-item", { count: 0 });
-    await rightClick(".o-mail-Message-body:eq(1) a");
+    await rightClick(".o-mail-Message-body:eq(1) a:eq(0)");
+    await expect.waitForSteps(["Message.onContextMenu"]);
+    await animationFrame();
+    expect.verifySteps([]);
+    await rightClick(".o-mail-Message-body:eq(1) a:eq(1) font");
     await expect.waitForSteps(["Message.onContextMenu"]);
     await animationFrame();
     expect.verifySteps([]);


### PR DESCRIPTION
Before this commit, when right-click on a link in a message, this sometimes show the message actions.

A commit was dedicated on fixing this issue [1], however this was limited to exact click on `<a>`. Many links shared by email are `<a>` with some nested nodes, for example `<a><font>LINK</font></a>`. Such links were not covered by [1] and thus made the message actions show on right-click.

This commit fixes the issue by not showing the message actions on right-click on links, including nested children.

[1]: https://github.com/odoo/odoo/pull/244252

opw-6110949