### PR TITLE
[FIX] hr_attendance: fix broken layout

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_helper_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.xml
@@ -70,7 +70,7 @@
             <h3 class="py-2">
                 Ready to track attendances ?
             </h3>
-            <div class="d-flex align py-2">
+            <div class="d-flex justify-content-center py-2">
                 <a class="mx-5" type="object" t-on-click="() => this.LoadTryKiosk()">
                     <img src="/hr_attendance/static/img/mock-tablet.png" height="180" class="mb-2"/>
                     <div class="row justify-content-center mt-1">


### PR DESCRIPTION
[FIX] hr_attendance: fix broken layout

Bug reproduction: go to master, attendance app, select a company with no attendance, the layout in the down of the page is not centralized.

Bug cause: It is indeed centralized but when the sale_renting is installed, the style of o_nocontent_help changes and that change cause the not centralized layout.

Bug solution: I added justify-content-center to centralize the layout

task - 6113225

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
