### PR TITLE
[FIX] purchase: do not remove stock reference on purchase cancel

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -198,9 +198,6 @@ class PurchaseOrder(models.Model):
                 if picking.state == 'done':
                     picking.message_post(body=self.env._("The purchase order %s this receipt is linked to was cancelled.", order._get_html_link()))
 
-            if order.reference_ids:
-                order.reference_ids.purchase_ids = [Command.unlink(order.id)]
-
         order_lines = self.env['purchase.order.line'].browse(order_lines_ids)
         moves_to_cancel_ids = OrderedSet()
         moves_to_recompute_ids = OrderedSet()

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -275,6 +275,14 @@ class TestSalePurchaseStockFlow(TransactionCase):
         ])
         so.action_cancel()
         self.assertEqual(delivery.state, 'cancel')
+        po = so.stock_reference_ids.purchase_ids
+        self.assertRecordValues(po, [{'state': 'draft'}])
+        self.assertRegex(po.activity_ids.note, fr"Exception\(s\) occurred on the sale order\(s\)[\s\S]*{so.name}[\s\S]*Manual actions may be needed")
+        # Cancel the associated PO and reset to draft to see if it is properly re-considered
+        po.button_cancel()
+        po.button_draft()
+
+        # Reset the SO to draft and re-confirm
         so.action_draft()
         so.action_confirm()
         new_delivery = so.picking_ids - delivery
@@ -282,12 +290,19 @@ class TestSalePurchaseStockFlow(TransactionCase):
         self.assertRecordValues(new_delivery.move_ids, [
             {'product_id': self.mto_product.id, 'product_uom_qty': 2.0},
         ])
+        self.assertEqual(po, so.stock_reference_ids.purchase_ids)
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.mto_product.id, 'product_uom_qty': 4.0},
+        ])
         with Form(so) as so_form:
             with so_form.order_line.edit(0) as line:
                 line.product_uom_qty = 1
         self.assertEqual(so.picking_ids, delivery | new_delivery)
         self.assertRecordValues(new_delivery.move_ids, [
             {'product_id': self.mto_product.id, 'product_uom_qty': 1.0},
+        ])
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.mto_product.id, 'product_uom_qty': 3.0},
         ])
 
     def test_two_step_delivery_forecast_after_first_picking(self):


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: Multi-Steps Routes
- Inventory > Configuration > Warehouse Management > Routes
- Unarchive MTO
- Create a storable product with a vendor using the MTO route
- Create and confirm an SO for 1 unit of that product
- Cancel and reset to draft the associated draft PO
- Update the SO demand from 1 to 2 units
#### > A new draft PO is created rather than updating the existing one.

### Cause of the issue:

Both the confirmation and the demand updates of the SO call the `_action_launch_stock_rule` to generate the related PO. The procurement and PO generated in both cases including the `stock_reference_ids` of the SO: https://github.com/odoo/odoo/blob/3891dd471d64629634644c0b022a171bbaa65b49/addons/sale_stock/models/sale_order_line.py#L277-L289
However, cancelling the PO will remove its assocaited stock reference: https://github.com/odoo/odoo/blob/3891dd471d64629634644c0b022a171bbaa65b49/addons/purchase_stock/models/purchase_order.py#L201-L202
As such, when the second procurement is run, the `_run_buy` will not consider the existing PO without reference as a valid candidate to update:
https://github.com/odoo/odoo/blob/3891dd471d64629634644c0b022a171bbaa65b49/addons/purchase_stock/models/stock_rule.py#L370-L372
An it will therefore create a new one:
https://github.com/odoo/odoo/blob/3891dd471d64629634644c0b022a171bbaa65b49/addons/purchase_stock/models/stock_rule.py#L101-L115

opw-5940590

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
