### PR TITLE
[FIX] mail: double message right-click shows the browser right-click

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -98,6 +98,13 @@ export class Message extends Component {
     ];
     static template = "mail.Message";
 
+    /**
+     * @type {boolean} Whether the right-click drodpown is being closed.
+     * Useful to detect when close comes from another right-click on the same message,
+     * in order to show the browser right-click instead.
+     */
+    isRightClickDropdownOngoingClose = false;
+
     setup() {
         super.setup();
         this.store = useService("mail.store");
@@ -109,7 +116,12 @@ export class Message extends Component {
             emailHeaderOpen: false,
         });
         this.rightClickDropdownState = useDropdownState({
-            onClose: () => this.props.messageSelection?.clearSelected(),
+            onClose: async () => {
+                this.props.messageSelection?.clearSelected();
+                this.isRightClickDropdownOngoingClose = true;
+                await new Promise((resolve) => setTimeout(() => requestAnimationFrame(resolve)));
+                this.isRightClickDropdownOngoingClose = false;
+            },
         });
         this.rightClickAnchor = useChildRef("rightClickAnchor");
         /** @type {ShadowRoot} */
@@ -467,7 +479,13 @@ export class Message extends Component {
             // Mobile OS long press is handled with useLongPress()
             return;
         }
-        if (ev.target.closest("a") || !this.props.hasActions || this.isEditing) {
+        if (
+            ev.target.closest("a") ||
+            !this.props.hasActions ||
+            this.isEditing ||
+            this.rightClickDropdownState.isOpen ||
+            this.isRightClickDropdownOngoingClose
+        ) {
             return;
         }
         this.showRightClickMessageActions(ev);

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -824,8 +824,10 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Refactoring" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    let lastOnContextMenuEv;
     patchWithCleanup(Message.prototype, {
-        onContextMenu() {
+        onContextMenu(ev) {
+            lastOnContextMenuEv = ev;
             expect.step("Message.onContextMenu");
             super.onContextMenu(...arguments);
         },
@@ -874,6 +876,7 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await rightClick(".o-mail-Message:eq(0)");
     await animationFrame();
     await expect.waitForSteps(["Message.onContextMenu", "Message.showRightClickMessageActions"]);
+    expect(lastOnContextMenuEv.defaultPrevented).toBe(true);
     await contains(".o-dropdown-item", { count: 6 });
     await contains(".o-dropdown-item:contains('Add a Reaction')");
     await contains(".o-dropdown-item:contains('Add Star')");
@@ -883,6 +886,12 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await contains(".o-dropdown-item:contains('Copy Text')");
     await contains(".o-mail-Message:eq(0).o-selected");
     await contains(".o-mail-Message:eq(1):not(.o-selected)");
+    // Test right-click again doesn't show the menu (shows browser context menu instead)
+    await rightClick(".o-mail-Message:eq(0)");
+    await contains(".o-dropdown-item", { count: 0 });
+    await animationFrame();
+    expect.verifySteps(["Message.onContextMenu"]);
+    expect(lastOnContextMenuEv.defaultPrevented).toBe(false);
     // Test inner-link in body of message doesn't trigger showing of message actions
     await click(".o-mail-Thread");
     await contains(".o-dropdown-item", { count: 0 });
@@ -894,6 +903,7 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await expect.waitForSteps(["Message.onContextMenu"]);
     await animationFrame();
     expect.verifySteps([]);
+    expect(lastOnContextMenuEv.defaultPrevented).toBe(false);
     // Test Pinned Panel right-click doesn't show message actions
     await click(".o-mail-DiscussSidebar-item:has(:text('General'))");
     await contains(".o-mail-DiscussContent-threadName:value('General')");
@@ -903,6 +913,7 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await expect.waitForSteps(["Message.onContextMenu"]);
     await animationFrame();
     expect.verifySteps([]);
+    expect(lastOnContextMenuEv.defaultPrevented).toBe(false);
 });
 
 test("Can add reaction from right-click on message", async () => {


### PR DESCRIPTION
Before this commit, when message actions are displayed from right-click, triggering a right-click on the message again would keep displaying the message actions.

Right-click on message to show the actions is useful in many cases, but sometimes the user wants to trigger the browser context menu.

Currently browser context menu is shown on links and when there are some text selection, but there might be some other potential cases where seeing the browser context menu is desirable. In practice users could trigger it through SHIFT + right-click but they are not necessarily aware of it.

This commit let double right-click on same message open the browser context menu, so that if users really want to have the browser context menu then doing it twice will show it.

Before
![before](https://github.com/user-attachments/assets/23c6ba1d-a8a1-4999-9ac0-308282f2f617)

After
![after](https://github.com/user-attachments/assets/fae4ff2e-13bf-4eb6-8f0d-c2d4858fd470)
