### PR TITLE
[FIX] website_slides: opacity on course cards with button in description

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -240,7 +240,7 @@ $line-height-truncate: 1.5em;
 // Move the opacity to the container to ensure opacity is applied even if the card
 // is not wrapped in a <a> tag
 
-div:has(> .card + .card-body, > .o_wslides_course_unpublished > .card-body) {
+div:has(> .o_wslides_course_unpublished + .card-body, > .o_wslides_course_unpublished > .card-body) {
     opacity: 0.5;
 }
 


### PR DESCRIPTION
Steps to reproduce:
=================
1. Go to eLearning > Courses and create a published course
2. In the Description tab, add a button with a link and save
3. Go to /slides on the website
4. The course card appears with a grey overlay (0.5 opacity)

=> Published course cards with a button in the description show a grey overlay
=> Only unpublished course cards should have the grey overlay

Cause:
======
In [1], the opacity for unpublished courses was moved from `.o_wslides_course_unpublished` to its container using a `:has()` selector. However, the selector `div:has(> .card + .card-body, ...)` was too broad: it matched any container whose `.card` child had a sibling `.card-body`, regardless of whether the course was unpublished.

When a course description contains a button (or any block-level element), the browser renders the button outside the `.card` element. This creates the structure `div > .card + .card-body` that the selector matches, applying a 0.5 opacity grey overlay to fully published courses.

Solution:
========
The fix restricts the first selector arm to only match when `.o_wslides_course_unpublished` is the sibling, ensuring published courses with buttons in their descriptions are not affected.

[1]: https://github.com/odoo/odoo/pull/249969

opw-5900287

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
