### PR TITLE
[FIX] account,repair: Computes should be private

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -7,7 +7,7 @@ def _set_fiscal_country(env):
     on existing records by the ORM when installing the module, so doing that by hand
     ensures existing records will get a value for it if needed.
     """
-    env['res.company'].search([]).compute_account_tax_fiscal_country()
+    env['res.company'].search([])._compute_account_tax_fiscal_country()
 
 
 def _account_post_init(env):

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -217,7 +217,7 @@ class ResCompany(models.Model):
     account_fiscal_country_id = fields.Many2one(
         string="Fiscal Country",
         comodel_name='res.country',
-        compute='compute_account_tax_fiscal_country',
+        compute='_compute_account_tax_fiscal_country',
         store=True,
         readonly=False,
         help="The country to use the tax reports from for this company")
@@ -420,7 +420,7 @@ class ResCompany(models.Model):
             company.multi_vat_foreign_country_ids = self.env['res.country'].browse(company_to_foreign_vat_country.get(company.id))
 
     @api.depends('country_id')
-    def compute_account_tax_fiscal_country(self):
+    def _compute_account_tax_fiscal_country(self):
         for record in self:
             if not record.account_fiscal_country_id:
                 record.account_fiscal_country_id = record.country_id

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -92,10 +92,10 @@ class RepairOrder(models.Model):
     allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
     uom_id = fields.Many2one(
         'uom.uom', 'Unit', domain="[('id', 'in', allowed_uom_ids)]",
-        compute='compute_uom_id', store=True, precompute=True, readonly=False)
+        compute='_compute_uom_id', store=True, precompute=True, readonly=False)
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial',
-        compute="compute_lot_id", store=True,
+        compute="_compute_lot_id", store=True,
         domain="[('id', 'in', allowed_lot_ids)]", check_company=True,
         help="Products repaired are all belonging to this lot")
     tracking = fields.Selection(string='Product Tracking', related="product_id.tracking", readonly=False)
@@ -261,7 +261,7 @@ class RepairOrder(models.Model):
             )
 
     @api.depends('product_id', 'product_id.uom_id')
-    def compute_uom_id(self):
+    def _compute_uom_id(self):
         for repair in self:
             if not repair.product_id:
                 repair.uom_id = False
@@ -269,7 +269,7 @@ class RepairOrder(models.Model):
                 repair.uom_id = repair.product_id.uom_id
 
     @api.depends('product_id', 'lot_id', 'lot_id.product_id', 'picking_id')
-    def compute_lot_id(self):
+    def _compute_lot_id(self):
         for repair in self:
             if (repair.product_id and repair.lot_id and repair.lot_id.product_id != repair.product_id) or not repair.product_id:
                 repair.lot_id = False


### PR DESCRIPTION
Compute methods should be private (via prefixing it with '_'). Without that, and with no `@api.private` defined on it, they are publicly exposed for RPC, which doesn't make sense for a compute method, reading instead of reading the computed field instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
