### PR TITLE
[FIX] l10n_dk_nemhandel_response: fill document only when valid partner

### DIFF
--- a/addons/l10n_dk_nemhandel_response/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel_response/models/res_partner.py
@@ -36,5 +36,6 @@ class ResPartner(models.Model):
         if not company:
             company = self.env.company
         self_partner = self.with_company(company)
-        self_partner._nemhandel_fill_participant_supported_documents()
+        if self_partner.nemhandel_verification_state == 'valid':
+            self_partner._nemhandel_fill_participant_supported_documents()
         return False


### PR DESCRIPTION
The method to fill the supported documents of a partner was called even if it was not a valid Nemhandel participant. This would cause some test to fail as the call was unexpectedly done on tests without any setup for it.