### PR TITLE
[FIX] point_of_sale: ensure images are loaded before printing receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_ticket_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_ticket_printer_service.js
@@ -5,7 +5,8 @@ import { RetryPrintPopup } from "../components/popups/retry_print_popup/retry_pr
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement, renderToString } from "@web/core/utils/render";
 import { toCanvas } from "../utils/html-to-image";
-import { logPosImage } from "../utils/pretty_console_log";
+import { logPosImage, logPosMessage } from "../utils/pretty_console_log";
+import { waitImages } from "@point_of_sale/utils";
 
 export const posTicketPrinterService = {
     dependencies: ["dialog", "pos_data", "notification"],
@@ -327,6 +328,13 @@ export class PosTicketPrinterService {
         container.innerHTML = "";
         container.appendChild(iframe);
         await new Promise((resolve) => (iframe.onload = resolve));
+        if ((await waitImages(iframe.contentDocument.body)).timedOut) {
+            logPosMessage(
+                "WARNING",
+                "generateIframe",
+                "Timeout while waiting for images to load in the receipt."
+            );
+        }
         return iframe;
     }
 


### PR DESCRIPTION
The receipt logo (and other images like QR codes) was sometimes missing from the printed ticket. This happened intermittently because the receipt image was being generated (captured from an iframe) before the browser had finished decoding and rendering the logo image within that iframe.

This commit updates PosTicketPrinterService to use the waitImages utility, ensuring that all images in the receipt's iframe are fully loaded and rendered before returning the iframe for further processing (printing or canvas capture).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
