### PR TITLE
[FIX] sale: fix missed information_block from SO document

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -16,32 +16,33 @@
         <span t-else="">Order # </span>
         <span t-field="doc.name">SO0000</span>
     </t>
-    <t t-call="web.external_layout"
-        forced_vat="doc.fiscal_position_id.foreign_vat"
-        address="address"
-        layout_document_title="layout_document_title">
-        <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)" /> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
-        <t t-if="doc.partner_shipping_id == doc.partner_invoice_id
-                             and doc.partner_invoice_id != doc.partner_id
-                             or doc.partner_shipping_id != doc.partner_invoice_id">
-            <t t-set="information_block">
-                <strong>
-                    <t t-if="doc.partner_shipping_id == doc.partner_invoice_id">
-                        Invoicing and Shipping Address
-                    </t>
-                    <t t-else="">
-                        Invoicing Address
-                    </t>
-                </strong>
-                <div t-field="doc.partner_invoice_id"
-                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                <t t-if="doc.partner_shipping_id != doc.partner_invoice_id">
-                    <strong class="d-block mt-3">Shipping Address</strong>
-                    <div t-field="doc.partner_shipping_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+    <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)" />
+    <t t-if="doc.partner_shipping_id == doc.partner_invoice_id
+                         and doc.partner_invoice_id != doc.partner_id
+                         or doc.partner_shipping_id != doc.partner_invoice_id">
+        <t t-set="information_block">
+            <strong>
+                <t t-if="doc.partner_shipping_id == doc.partner_invoice_id">
+                    Invoicing and Shipping Address
                 </t>
+                <t t-else="">
+                    Invoicing Address
+                </t>
+            </strong>
+            <div t-field="doc.partner_invoice_id"
+                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+            <t t-if="doc.partner_shipping_id != doc.partner_invoice_id">
+                <strong class="d-block mt-3">Shipping Address</strong>
+                <div t-field="doc.partner_shipping_id"
+                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
             </t>
         </t>
+    </t>
+    <t t-call="web.external_layout"
+        address="address"
+        layout_document_title="layout_document_title"
+        information_block="information_block"
+        forced_vat="doc.fiscal_position_id.foreign_vat"> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
         <div class="page">
             <div class="oe_structure"/>
 


### PR DESCRIPTION
Issue:
---
Delivery and Invoice addresses are not shown SO documents.

Steps to reproduce:
1- Enable customer addresses.
2- Create a contact with a delivery and an invoicing address.
3- Create an SO and print it.

Cause:
---
This issue is introduced after bba2fc505f5d0b4770eacc6877155b1aeda6d772.
Based on d30bc84e277e00a933883bd6562b14e7aad4d118, `information_block` which is a parameter meant for called template, is instead defined as a content inside the call.

Fix:
---
`information_block` can be defined before calling the `external_layout` template, and be used as a parameter.

opw-6113087

