### PR TITLE
[FIX] pos_self_order: mobile self-orders leaking across PoS configs

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -323,6 +323,16 @@ registry.category("web_tour.tours").add("test_pay_unpaid_order_from_kiosk", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_no_orders_from_other_config", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickOrders(),
+            TicketScreen.noOrderIsThere(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("refund_multiple_products_amounts_compliance", {
     steps: () =>
         [

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -7,8 +7,7 @@ patch(PosStore.prototype, {
             await this.data.loadServerOrders([
                 ["company_id", "=", this.config.company_id.id],
                 ["state", "=", "draft"],
-                ["source", "in", ["kiosk", "mobile"]],
-                ["self_ordering_table_id", "=", false],
+                ["source", "=", "kiosk"],
             ]);
         }
 

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -396,6 +396,40 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.self_ordering_table_id, order.table_id)
 
+    def test_self_order_mobile_not_visible_in_other_config(self):
+        """Self-orders from config A should not appear in config B's ticket screen."""
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        order = self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'source': 'mobile',
+            'amount_total': self.cola.lst_price,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'lines': [(0, 0, {
+                'qty': 1,
+                'product_id': self.cola.id,
+                'price_unit': self.cola.lst_price,
+                'price_subtotal': self.cola.lst_price,
+                'price_subtotal_incl': self.cola.lst_price,
+            })],
+        })
+        self.assertEqual(order.config_id, self.pos_config)
+
+        other_pos = self.env['pos.config'].create({
+            'name': 'OtherPOS',
+            'module_pos_restaurant': True,
+            'cash_control': False,
+        })
+        self.start_tour(f"/pos/ui/{other_pos.id}", 'test_no_orders_from_other_config', login="pos_admin")
+
     def test_self_order_meal_do_not_change_tracking_number_on_sync(self):
         self.pos_config.write({
             'self_ordering_mode': 'mobile',


### PR DESCRIPTION
Steps to reproduce
------------------
1. Have two PoS configs in the same company (e.g. Bar with QR+ordering and Restaurant)
2. Open Bar, go to its self-order mobile menu, place an order
3. Go back, open Restaurant, click on Orders tab

-> The Bar's self-order shows up in the Restaurant's order list.

What's happening
----------------
In the `getServerOrders` override added by 6782262a4d96, the domain used to fetch tableless self-orders filters by `company_id` instead of `config_id`, so it pulls in self-orders from ALL configs in the company.

But we only want self-orders that are of type "kiosk" to be shown in other configs, while the ones of type "mobile" should only be shown in the config they belong too (or a trusted config).

The fix
-------
We adjust the domain by stop fetching company-wise mobile orders in other configs, we only keep fetching the kiosk ones. Note that mobile ordres belonging to the current config (or trusted ones) are still fetches in the main `getServerOrders` method.

opw-6068187