### PR TITLE
[FIX] sale: move proforma set inside content in proforma report

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -377,8 +377,9 @@
 </template>
 
 <template id="report_saleorder_pro_forma">
-    <t t-call="web.html_container" is_pro_forma="True">
+    <t t-call="web.html_container">
         <t t-set="docs" t-value="docs.with_context(proforma=True)"/>
+        <t t-set="is_pro_forma" t-value="True"/>
         <t t-foreach="docs" t-as="doc">
             <t t-call="sale.report_saleorder_document" t-lang="doc.partner_id.lang"/>
         </t>


### PR DESCRIPTION
Issue:
---
f23b7e6b70babc7d3c027963e0ac6f3e562f44c3 partially fixed the proforma issue.
If you use `Send PRO FORMA Invoice` button, the `proforma` will be present in the context:
https://github.com/odoo/odoo/blob/06205b59f56a87d6bb41b202b95c9716775c67b7/addons/sale/views/sale_order_views.xml#L328-L335

leading to correct beahviour as `is_proforma` will be set as context: https://github.com/odoo/odoo/blob/4ef6f93da818789fd63bd8d37c5526d9a85bef53/addons/sale/report/ir_actions_report_templates.xml#L12

However, if it is printed using the action button `print/PRO Forma Invoice`, the proforma will not be present in the record.context itself (it is present in the docs.context): https://github.com/odoo/odoo/blob/4ef6f93da818789fd63bd8d37c5526d9a85bef53/addons/sale/report/ir_actions_report_templates.xml#L379-L386

The commit bba2fc505f5d0b4770eacc6877155b1aeda6d772 has broke `report_saleorder_pro_forma`, by moving `<t t-set="is_pro_forma">` to attributes of the template call, while `is_pro_forma` is not meant for `html_container` template, and we actually need it to be defined inside the contents.

related: #257817

opw-6043669

