### PR TITLE
[FIX] requirements: bump vulnerable dependencies to fix 9 HIGH severity CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@
 asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.10.3 ; python_version >= '3.11' and python_version < '3.13'
 Babel==2.17.0 ; python_version >= '3.13'
-cbor2==5.6.2 ; python_version >= '3.12'
+cbor2==5.9.0 ; python_version >= '3.12'
 chardet==5.2.0 ; python_version >= '3.11'
-cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
+cryptography==46.0.5 ; python_version >= '3.12'
 docutils==0.20.1 ; python_version >= '3.11'
 freezegun==1.2.1 ; python_version >= '3.11' and python_version < '3.13'
 freezegun==1.5.1 ; python_version >= '3.13'
@@ -24,13 +24,13 @@ num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==10.2.0 ; python_version >= '3.12' and python_version < '3.13'  # (Noble) Mostly to have a wheel package
-Pillow==11.1.0 ; python_version >= '3.13'  # (Noble) Mostly to have a wheel package
+Pillow==12.1.1 ; python_version >= '3.12' and python_version < '3.13'
+Pillow==12.1.1 ; python_version >= '3.13'
 polib==1.1.1
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
-pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
+pyopenssl==26.0.0 ; python_version >= '3.12'
 PyPDF2==2.12.1 ; python_version < '3.13' # (Noble and below)
 PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)
 pypiwin32 ; sys_platform == 'win32'
@@ -46,9 +46,9 @@ requests==2.31.0 ; python_version >= '3.11' # (Noble)
 rjsmin==1.2.0 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
 tzdata; sys_platform == 'win32'  # no version pinning to keep it updated, assume *nix have tzdata (it's a dep of python on debian, fedora, and arch)
-urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
+urllib3==2.6.3  ; python_version >= '3.12'
 vobject==0.9.6.1
-Werkzeug==3.0.1 ; python_version >= '3.12'  # (Noble) Avoid deprecation warnings
+Werkzeug==3.1.6 ; python_version >= '3.12'
 xlrd==2.0.1 ; python_version >= '3.12'
 XlsxWriter==3.1.9 ; python_version >= '3.12'
 xlwt==1.3.0


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes #258733

**Pinned dependency versions in requirements.txt contain 9 HIGH severity security vulnerabilities.**

Impacted versions:
- master

Steps to reproduce:
1. Run `trivy fs requirements.txt --scanners vuln --severity HIGH`
2. Observe 9 HIGH severity CVEs across 6 packages

Current behavior:
- requirements.txt pins outdated versions of Pillow, cryptography, pyopenssl, cbor2, urllib3, and Werkzeug with known HIGH CVEs

Expected behavior:
- All pinned dependencies should be free of known HIGH/CRITICAL vulnerabilities

## Changes

| Package | Old Version | New Version | CVEs Fixed |
|---------|-------------|-------------|------------|
| **Pillow** | 10.2.0 / 11.1.0 | 12.1.1 | CVE-2024-28219, CVE-2026-25990 |
| **cryptography** | 42.0.8 | 46.0.5 | CVE-2026-26007 |
| **pyopenssl** | 24.1.0 | 26.0.0 | CVE-2026-27459 |
| **cbor2** | 5.6.2 | 5.9.0 | CVE-2026-26209 |
| **urllib3** | 2.0.7 | 2.6.3 | CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 |
| **Werkzeug** | 3.0.1 | 3.1.6 | CVE-2024-34069, CVE-2024-49766, CVE-2024-49767, CVE-2025-66221, CVE-2026-21860, CVE-2026-27199 |

Note: `pyopenssl>=26.0.0` requires `cryptography>=44.0.0`, satisfied by the cryptography bump to 46.0.5.

## Related PRs

- #258311 — pyopenssl bump (by @jotamartos)
- #252360 — cryptography update

## Verification

Trivy scan after fix: **0 CRITICAL, 0 HIGH** (down from 9 HIGH).

---
I confirm I have signed the [CLA](https://github.com/odoo/odoo/pull/258804) and read the [PR guidelines](https://www.odoo.com/submit-pr).