### PR TITLE
[IMP] mail, livechat: forward option for messages

### DIFF
--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.scss
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.scss
@@ -1,3 +1,0 @@
-.o-discuss-ChannelInvitation-inCallTextColor {
-    color: lighten($o-action, 5%);
-}

--- a/addons/im_livechat/static/src/core/web/forward_dialog_patch.js
+++ b/addons/im_livechat/static/src/core/web/forward_dialog_patch.js
@@ -1,0 +1,9 @@
+import { ForwardDialog } from "@mail/core/common/forward_dialog";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ForwardDialog.prototype, {
+    _shouldExcludeThreadForForward(thread) {
+        return Boolean(thread.livechat_end_dt) || super._shouldExcludeThreadForForward(thread);
+    },
+});

--- a/addons/im_livechat/static/src/core/web/selectable_list_patch.scss
+++ b/addons/im_livechat/static/src/core/web/selectable_list_patch.scss
@@ -1,0 +1,3 @@
+.o-discuss-SelectableList-inCallTextColor {
+    color: lighten($o-action, 5%);
+}

--- a/addons/im_livechat/static/src/core/web/selectable_list_patch.xml
+++ b/addons/im_livechat/static/src/core/web/selectable_list_patch.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="discuss.ChannelInvitation-selectableItem" t-inherit-mode="extension">
+    <t t-inherit="discuss.SelectableList-selectableItem" t-inherit-mode="extension">
         <xpath expr="//*[@name='selectablePartnerName']" position="inside">
             <span t-if="this.props.channel?.channel_type === 'livechat' and selectablePartner.user_livechat_username" t-out="selectablePartner.user_livechat_username" class="text-truncate text-muted smaller mx-2"/>
             <span t-if="this.props.channel?.channel_type === 'livechat' and selectablePartner.is_in_call" class="flex-shrink-0 opacity-75 smaller mx-2">
                 <i class="fa fa-volume-up o-discuss-inCallIconColor me-1"/>
-                <span class="o-discuss-ChannelInvitation-inCallTextColor">in a call</span>
+                <span class="o-discuss-SelectableList-inCallTextColor">in a call</span>
             </span>
         </xpath>
         <xpath expr="//*[@name='selectablePartnerDetail']" position="inside">

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -53,10 +53,10 @@ test("Can invite a partner to a livechat channel", async () => {
     await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", {
-        parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
+        parent: [".o-discuss-SelectableList-selectable", { text: "James" }],
     });
     await contains(
-        ".o-discuss-ChannelInvitation-selectable:contains('James English French German pricing events')"
+        ".o-discuss-SelectableList-selectable:contains('James English French German pricing events')"
     );
     await click("button:enabled", { text: "Invite" });
     await contains(".o-mail-NotificationMessage", {
@@ -94,9 +94,9 @@ test("Available operators come first", async () => {
     await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Members']");
     await click("button[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
-    await contains(":nth-child(1 of .o-discuss-ChannelInvitation-selectable)", { text: "Ron" });
-    await contains(":nth-child(2 of .o-discuss-ChannelInvitation-selectable)", { text: "Harry" });
+    await contains(".o-discuss-SelectableList-selectable", { count: 2 });
+    await contains(":nth-child(1 of .o-discuss-SelectableList-selectable)", { text: "Ron" });
+    await contains(":nth-child(2 of .o-discuss-SelectableList-selectable)", { text: "Harry" });
 });
 
 test("Partners invited most frequently by the current user come first", async () => {
@@ -150,14 +150,14 @@ test("Partners invited most frequently by the current user come first", async ()
     await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Members']");
     await click("button[title='Invite People']");
-    await click("input", { parent: [".o-discuss-ChannelInvitation-selectable", { text: "John" }] });
+    await click("input", { parent: [".o-discuss-SelectableList-selectable", { text: "John" }] });
     await click("button:enabled", { text: "Invite" });
     await contains(".o-discuss-ChannelMember", { text: "John" });
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #2" });
     await click("button[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
-    await contains(":nth-child(1 of .o-discuss-ChannelInvitation-selectable)", { text: "John" });
-    await contains(":nth-child(2 of .o-discuss-ChannelInvitation-selectable)", { text: "Albert" });
+    await contains(".o-discuss-SelectableList-selectable", { count: 2 });
+    await contains(":nth-child(1 of .o-discuss-SelectableList-selectable)", { text: "John" });
+    await contains(":nth-child(2 of .o-discuss-SelectableList-selectable)", { text: "Albert" });
 });
 
 test("shows operators are in call", async () => {
@@ -195,9 +195,9 @@ test("shows operators are in call", async () => {
     await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Members']");
     await click("[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation-selectable:contains('bob in a call')");
-    await contains(".o-discuss-ChannelInvitation-selectable:contains('john')");
-    await contains(".o-discuss-ChannelInvitation-selectable:contains('john in a call')", {
+    await contains(".o-discuss-SelectableList-selectable:contains('bob in a call')");
+    await contains(".o-discuss-SelectableList-selectable:contains('john')");
+    await contains(".o-discuss-SelectableList-selectable:contains('john in a call')", {
         count: 0,
     });
 });
@@ -233,6 +233,6 @@ test("Operator invite shows livechat_username", async () => {
     await click("button[title='Members']");
     await click("button[title='Invite People']");
     await contains("input", {
-        parent: [".o-discuss-ChannelInvitation-selectable", { text: "Johnny" }],
+        parent: [".o-discuss-SelectableList-selectable", { text: "Johnny" }],
     });
 });

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -37,7 +37,7 @@ test("Thread name unchanged when inviting new users", async () => {
     await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", {
-        parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
+        parent: [".o-discuss-SelectableList-selectable", { text: "James" }],
     });
     await click("button:enabled", { text: "Invite" });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -230,6 +230,29 @@ class ThreadController(http.Controller):
         )
         return Store().add(message, "_store_message_fields")
 
+    @http.route("/mail/message/forward", methods=["POST"], type="jsonrpc", auth="user")
+    def mail_message_forward_to(
+        self,
+        forwarded_from_id,
+        target_channels_ids,
+        optional_msg_body=False,
+        optional_msg_has_link=False,
+        source_msg_has_link=False,
+        **kwargs
+    ):
+        source_message = self._get_message_with_access(forwarded_from_id, mode="create", **kwargs)
+        channels = request.env["discuss.channel"].browse(target_channels_ids).filtered(
+            lambda c: self._get_thread_with_access_for_post("discuss.channel", c.id, **kwargs)
+        )
+        if not channels:
+            return
+        channels._forward_message(
+            source_message,
+            optional_msg_body,
+            optional_msg_has_link,
+            source_msg_has_link,
+        )
+
     # side check for access
     # ------------------------------------------------------------
 

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1119,6 +1119,53 @@ class DiscussChannel(models.Model):
             ]
         return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
+    def _forward_message(
+        self,
+        source_message,
+        optional_msg_body=False,
+        optional_msg_has_link=False,
+        source_msg_has_link=False,
+    ):
+        source_message.ensure_one()
+        attachment_template = []
+        if source_message.attachment_ids:
+            attachment_template = source_message.attachment_ids.copy_data()
+        preview_messages = self.env["mail.message"]
+        for channel in self:
+            if attachment_template:
+                new_attachment_ids = self.env["ir.attachment"].create(
+                    [
+                        dict(vals, res_id=channel.id, res_model="discuss.channel")
+                        for vals in attachment_template
+                    ]
+                ).ids
+            else:
+                new_attachment_ids = []
+            forwarded_msg = channel.message_post(
+                body=source_message.body,
+                message_type="comment",
+                forwarded_from_id=source_message.id,
+                subtype_xmlid="mail.mt_comment",
+                attachment_ids=new_attachment_ids,
+            )
+            if source_msg_has_link:
+                preview_messages |= forwarded_msg
+            if optional_msg_body:
+                optional_msg = channel.message_post(
+                    body=optional_msg_body,
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_comment",
+                    body_is_html=True,
+                )
+                if optional_msg_has_link:
+                    preview_messages |= optional_msg
+        if preview_messages and self.env["mail.link.preview"]._is_link_preview_enabled():
+            # sudo: mail.link.preview requires ERP Manager access, but preview creation
+            # during forwarding must work for all users. Sudo bypasses access restrictions.
+            link_preview_sudo = self.env["mail.link.preview"].sudo()
+            for msg in preview_messages:
+                link_preview_sudo._create_from_message_and_notify(msg)
+
     def _create_attachments_for_post(self, values_list, extra_list):
         # Create voice metadata from meta information
         attachments = super()._create_attachments_for_post(values_list, extra_list)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -175,6 +175,8 @@ class MailMessage(models.Model):
     parent_id = fields.Many2one(
         'mail.message', 'Parent Message', index='btree_not_null', ondelete='set null')
     child_ids = fields.One2many('mail.message', 'parent_id', 'Child Messages')
+    forwarded_from_id = fields.Many2one(
+        'mail.message', 'Forwarded From', index='btree_not_null', ondelete='set null')
     # related document
     model = fields.Char('Related Document Model')
     res_id = fields.Many2oneReference('Related Document ID', model_field='model')
@@ -1184,6 +1186,7 @@ class MailMessage(models.Model):
         res.attr("subject")
         # sudo: mail.message.subtype - reading subtype on accessible message is allowed
         res.one("subtype_id", ["description"], sudo=True)
+        res.one("forwarded_from_id", "_store_message_fields", predicate=lambda m: m.forwarded_from_id)
         res.attr("write_date")
         self._store_linked_messages_fields(res)
         self._store_message_link_previews_fields(res)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2215,7 +2215,7 @@ class MailThread(models.AbstractModel):
     def message_post(self, *,
                      body='', subject=None, message_type='notification',
                      email_from=None, author_id=None, parent_id=False,
-                     subtype_xmlid=None, subtype_id=False,
+                     subtype_xmlid=None, subtype_id=False, forwarded_from_id=False,
                      partner_ids=None, outgoing_email_to=False,
                      incoming_email_to=False, incoming_email_cc=False,
                      attachments=None, attachment_ids=None, body_is_html=False,
@@ -2236,6 +2236,7 @@ class MailThread(models.AbstractModel):
           fetch, will force value of subtype_id;
         :param int subtype_id: subtype_id of the message, used mainly for followers
             notification mechanism;
+        :param int forwarded_from_id: Id of the message that has been forwarded;
         :param list(int) partner_ids: partner_ids to notify in addition to partners
             computed based on subtype / followers matching;
         :param str outgoing_email_to: comma-separated list of emails to notify in
@@ -2348,6 +2349,7 @@ class MailThread(models.AbstractModel):
             'body': escape(body),  # escape if text, keep if markup
             'message_type': message_type,
             'parent_id': self._message_compute_parent_id(parent_id),
+            'forwarded_from_id': forwarded_from_id,
             'subject': subject or False,
             'subtype_id': subtype_id,
             # recipients
@@ -3128,6 +3130,7 @@ class MailThread(models.AbstractModel):
             'email_add_signature',
             'email_from',
             'email_layout_xmlid',
+            'forwarded_from_id',
             'incoming_email_cc',
             'incoming_email_to',
             'is_internal',

--- a/addons/mail/static/src/core/common/forward_dialog.js
+++ b/addons/mail/static/src/core/common/forward_dialog.js
@@ -1,0 +1,291 @@
+import { SelectableList } from "@mail/discuss/core/common/selectable_list";
+import { Gif } from "@mail/core/common/gif";
+
+import { onWillStart, useState } from "@odoo/owl";
+
+import { Dialog } from "@web/core/dialog/dialog";
+import { useSequential } from "@mail/utils/common/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { useDebounced } from "@web/core/utils/timing";
+import { rpc } from "@web/core/network/rpc";
+import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
+import { compareDatetime } from "@mail/utils/common/misc";
+import { url } from "@web/core/utils/urls";
+import { createElementWithContent } from "@web/core/utils/html";
+
+const MAX_FORWARD_SELECTION_LIMIT = 5;
+
+export class ForwardDialog extends SelectableList {
+    static components = {
+        ...SelectableList.components,
+        Dialog,
+        Gif,
+    };
+    static props = ["sourceMessage", "close?"];
+    static template = "mail.ForwardDialog";
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+        this.sequential = useSequential();
+        this.state = useState({
+            selectableChannels: [],
+            selectablePartners: [],
+            optionalMsgBody: "",
+        });
+        this.debouncedFetchThreadsForForward = useDebounced(
+            this.fetchThreadsForForward.bind(this),
+            250
+        );
+        onWillStart(() => {
+            if (this.store.self_user) {
+                this.fetchThreadsForForward();
+            }
+        });
+    }
+
+    get maxSelectionLimit() {
+        return MAX_FORWARD_SELECTION_LIMIT;
+    }
+
+    get subtitleText() {
+        if (
+            this.maxSelectionLimit &&
+            this.internalState.selectedOptions.length >= this.maxSelectionLimit
+        ) {
+            return _t("You can only select up to %s items", this.maxSelectionLimit);
+        }
+        return _t("Select where you want to send this message.");
+    }
+
+    get options() {
+        return this._buildOptions(this.state.selectableChannels, this.state.selectablePartners);
+    }
+
+    get selectedChannels() {
+        return this.internalState.selectedOptions
+            .filter((option) => option.isChannel && option.channel)
+            .map((option) => option.channel);
+    }
+
+    get selectedPartners() {
+        return this.internalState.selectedOptions
+            .filter((option) => option.isPartner && option.partner)
+            .map((option) => option.partner);
+    }
+
+    get emptyStateText() {
+        return _t("No channels or people found.");
+    }
+
+    get searchPlaceholder() {
+        return _t("Search channels or people");
+    }
+
+    get forwardButtonText() {
+        return _t("Send");
+    }
+
+    get sourceMessageAttachments() {
+        if (!this.props.sourceMessage || !this.props.sourceMessage.attachment_ids) {
+            return [];
+        }
+        return this.props.sourceMessage.attachment_ids
+            .map((id) => this.store["ir.attachment"].get(id))
+            .filter(Boolean);
+    }
+
+    get sourceMessageDisplayBody() {
+        if (!this.props.sourceMessage) {
+            return "";
+        }
+        const message = this.props.sourceMessage;
+        if (message.inlineBody) {
+            return message.inlineBody;
+        }
+        if (message.bodyPreview) {
+            return message.bodyPreview;
+        }
+        if (message.hasTextContent && message.richBody) {
+            return message.richBody;
+        }
+        return "";
+    }
+
+    _buildOptions(channels = [], partners = []) {
+        return [
+            ...channels.map((channel) => ({
+                id: channel.id,
+                isChannel: true,
+                channel,
+                displayName: channel.displayName ?? "",
+                avatarUrl: channel.avatarUrl ?? "",
+            })),
+            ...partners.map((partner) => ({
+                id: partner.id,
+                isPartner: true,
+                partner,
+                displayName: partner.displayName ?? partner.name ?? "",
+                avatarUrl: partner.avatarUrl ?? "",
+            })),
+        ];
+    }
+
+    getOptionDisplayName(option) {
+        if (option.isChannel && option.channel) {
+            return option.channel.displayName ?? "";
+        }
+        if (option.isPartner && option.partner) {
+            return option.partner.displayName ?? option.partner.name ?? "";
+        }
+        return super.getOptionDisplayName(option);
+    }
+
+    getOptionAvatarUrl(option) {
+        if (option.isChannel && option.channel) {
+            return option.channel.avatarUrl ?? "";
+        }
+        if (option.isPartner && option.partner) {
+            return option.partner.avatarUrl ?? "";
+        }
+        return super.getOptionAvatarUrl(option);
+    }
+
+    _shouldExcludeThreadForForward(thread) {
+        return false;
+    }
+
+    async fetchThreadsForForward() {
+        this.internalState.isLoading = true;
+        try {
+            await this.store.channels.fetch();
+            await this.sequential(async () => {
+                const data = await rpc("/discuss/search", { term: this.search });
+                this.store.insert(data);
+            });
+            const cleanedTerm = cleanTerm(this.search);
+            const allChannels = Object.values(this.store["discuss.channel"].records).filter(
+                (channel) =>
+                    channel.channel_type &&
+                    (!cleanedTerm || cleanTerm(channel.displayName).includes(cleanedTerm))
+            );
+            const threads = allChannels
+                .map((channel) => this.store["mail.thread"].get(channel))
+                .filter(Boolean)
+                .sort((t1, t2) => {
+                    if (t1.self_member_id && !t2.self_member_id) {
+                        return -1;
+                    } else if (!t1.self_member_id && t2.self_member_id) {
+                        return 1;
+                    }
+                    return (
+                        compareDatetime(t2.channel?.lastInterestDt, t1.channel?.lastInterestDt) ||
+                        t2.id - t1.id
+                    );
+                });
+            const filteredThreads = threads.filter(
+                (thread) => !this._shouldExcludeThreadForForward(thread)
+            );
+            const allPartners = Object.values(this.store["res.partner"].records).filter(
+                (partner) =>
+                    partner.id !== this.store.self_user?.partner_id?.id &&
+                    partner.main_user_id &&
+                    (!cleanedTerm ||
+                        cleanTerm(partner.displayName ?? partner.name ?? "").includes(cleanedTerm))
+            );
+            const partnerIdsWithChats = new Set(
+                filteredThreads
+                    .filter((thread) => thread.channel?.channel_type === "chat")
+                    .map((thread) => thread.channel?.correspondent?.partner_id?.id)
+                    .filter(Boolean)
+            );
+            const selectablePartners = allPartners.filter(
+                (partner) => !partnerIdsWithChats.has(partner.id)
+            );
+            this.state.selectableChannels = filteredThreads;
+            this.state.selectablePartners = selectablePartners;
+        } finally {
+            this.internalState.isLoading = false;
+        }
+    }
+
+    onInput() {
+        const value = this.inputRef.el.value;
+        this.search = value;
+        this.debouncedFetchThreadsForForward();
+    }
+
+    clearSearch() {
+        this.search = "";
+        this.debouncedFetchThreadsForForward();
+    }
+
+    _hasLinkInOptionalMsgBody(body) {
+        const div = createElementWithContent("div", body);
+        return Boolean(div.querySelector("a:not([data-oe-model])"));
+    }
+
+    async onClickForward() {
+        if (
+            !this.props.sourceMessage ||
+            (this.selectedChannels.length === 0 && this.selectedPartners.length === 0)
+        ) {
+            return;
+        }
+        const targetChannelsIds = this.selectedChannels.map((channel) => channel.id);
+        for (const partner of this.selectedPartners) {
+            const chat = await this.store.getChat({ partnerId: partner.id });
+            if (chat) {
+                targetChannelsIds.push(chat.id);
+            }
+        }
+
+        if (targetChannelsIds.length === 0) {
+            return;
+        }
+
+        const optionalMsgBody = await prettifyMessageContent(this.state.optionalMsgBody);
+        await rpc("/mail/message/forward", {
+            forwarded_from_id: this.props.sourceMessage.id,
+            target_channels_ids: targetChannelsIds,
+            optional_msg_body: optionalMsgBody,
+            optional_msg_has_link: this._hasLinkInOptionalMsgBody(optionalMsgBody),
+            source_msg_has_link: this.props.sourceMessage.hasLink ?? false,
+        });
+        this.internalState.selectedOptions = [];
+        this.state.optionalMsgBody = "";
+        this.props.close?.();
+        if (targetChannelsIds.length > 1) {
+            this.env.services.notification.add(_t("Message forwarded successfully."), {
+                type: "success",
+            });
+            return;
+        } else if (
+            targetChannelsIds[0] &&
+            this.props.sourceMessage.thread?.id !== targetChannelsIds[0]
+        ) {
+            const thread = await this.store["mail.thread"].getOrFetch({
+                model: "discuss.channel",
+                id: targetChannelsIds[0],
+            });
+            if (thread) {
+                thread.open({ focus: true });
+            } else {
+                this.env.services.notification.add(_t("This thread is no longer available."), {
+                    type: "danger",
+                });
+            }
+            return;
+        }
+    }
+
+    getImageUrl(attachment) {
+        if (attachment.uploading && attachment.tmpUrl) {
+            return attachment.tmpUrl;
+        }
+        return url(attachment.urlRoute, {
+            ...attachment.urlQueryParams,
+        });
+    }
+}

--- a/addons/mail/static/src/core/common/forward_dialog.js
+++ b/addons/mail/static/src/core/common/forward_dialog.js
@@ -1,7 +1,7 @@
-import { SelectableList } from "@mail/discuss/core/common/selectable_list";
+import { SelectableList, useSelectableListState } from "@mail/discuss/core/common/selectable_list";
 import { Gif } from "@mail/core/common/gif";
 
-import { onWillStart, useState } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useSequential } from "@mail/utils/common/hooks";
@@ -16,11 +16,11 @@ import { createElementWithContent } from "@web/core/utils/html";
 
 const MAX_FORWARD_SELECTION_LIMIT = 5;
 
-export class ForwardDialog extends SelectableList {
+export class ForwardDialog extends Component {
     static components = {
-        ...SelectableList.components,
         Dialog,
         Gif,
+        SelectableList,
     };
     static props = ["sourceMessage", "close?"];
     static template = "mail.ForwardDialog";
@@ -34,6 +34,7 @@ export class ForwardDialog extends SelectableList {
             selectablePartners: [],
             optionalMsgBody: "",
         });
+        this.selectableListState = useSelectableListState();
         this.debouncedFetchThreadsForForward = useDebounced(
             this.fetchThreadsForForward.bind(this),
             250
@@ -52,7 +53,7 @@ export class ForwardDialog extends SelectableList {
     get subtitleText() {
         if (
             this.maxSelectionLimit &&
-            this.internalState.selectedOptions.length >= this.maxSelectionLimit
+            this.selectableListState.selectedOptions.length >= this.maxSelectionLimit
         ) {
             return _t("You can only select up to %s items", this.maxSelectionLimit);
         }
@@ -64,13 +65,13 @@ export class ForwardDialog extends SelectableList {
     }
 
     get selectedChannels() {
-        return this.internalState.selectedOptions
+        return this.selectableListState.selectedOptions
             .filter((option) => option.isChannel && option.channel)
             .map((option) => option.channel);
     }
 
     get selectedPartners() {
-        return this.internalState.selectedOptions
+        return this.selectableListState.selectedOptions
             .filter((option) => option.isPartner && option.partner)
             .map((option) => option.partner);
     }
@@ -149,7 +150,7 @@ export class ForwardDialog extends SelectableList {
         if (option.isPartner && option.partner) {
             return option.partner.avatarUrl ?? "";
         }
-        return super.getOptionAvatarUrl(option);
+        return undefined;
     }
 
     _shouldExcludeThreadForForward(thread) {
@@ -157,7 +158,7 @@ export class ForwardDialog extends SelectableList {
     }
 
     async fetchThreadsForForward() {
-        this.internalState.isLoading = true;
+        this.selectableListState.isLoading = true;
         try {
             await this.store.channels.fetch();
             await this.sequential(async () => {
@@ -206,7 +207,7 @@ export class ForwardDialog extends SelectableList {
             this.state.selectableChannels = filteredThreads;
             this.state.selectablePartners = selectablePartners;
         } finally {
-            this.internalState.isLoading = false;
+            this.selectableListState.isLoading = false;
         }
     }
 
@@ -253,7 +254,7 @@ export class ForwardDialog extends SelectableList {
             optional_msg_has_link: this._hasLinkInOptionalMsgBody(optionalMsgBody),
             source_msg_has_link: this.props.sourceMessage.hasLink ?? false,
         });
-        this.internalState.selectedOptions = [];
+        this.selectableListState.selectedOptions = [];
         this.state.optionalMsgBody = "";
         this.props.close?.();
         if (targetChannelsIds.length > 1) {

--- a/addons/mail/static/src/core/common/forward_dialog.xml
+++ b/addons/mail/static/src/core/common/forward_dialog.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.ForwardDialog">
+        <Dialog size="'sm'" title.translate="Forward To" withBodyPadding="false" footer="false"
+            contentClass="'o-bg-body d-flex flex-column mh-75'" bodyClass="'p-2 d-flex flex-column o-min-height-0'">
+            <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0">
+                <div class="d-flex flex-column flex-grow-1 overflow-hidden o-min-height-0">
+                    <t t-call="discuss.SelectableList"/>
+                </div>
+                <div class="flex-shrink-0 bg-inherit">
+                    <div t-if="props.sourceMessage">
+                        <t t-call="mail.ForwardDialog.forwardPreview"/>
+                        <textarea t-if="selectedOptions.length" class="form-control border rounded"
+                            t-model="state.optionalMsgBody" placeholder="Add an optional message..." rows="3"/>
+                    </div>
+                    <div class="pt-0 pb-1 bg-inherit">
+                        <t t-if="store.self_user">
+                            <button t-if="selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="forwardButtonText" t-on-click="onClickForward">
+                                <t t-out="forwardButtonText"/>
+                            </button>
+                        </t>
+                    </div>
+                </div>
+            </div>
+        </Dialog>
+    </t>
+
+    <t t-name="mail.ForwardDialog.forwardPreview">
+        <div class="o-mail-Forward-core position-relative px-2 py-1 rounded-3 rounded-start-0 mb-2">
+            <small>
+                <div class="text-muted fst-italic mb-1"><i class="fa fa-share"/> Forwarded</div>
+                <div t-if="!props.sourceMessage.isBodyEmpty" class="d-inline-flex align-items-center">
+                    <span class="o-mail-ForwardedMessage-content overflow-hidden smaller o-mail-ForwardedMessage-message ms-1 text-break" t-out="sourceMessageDisplayBody"/>
+                </div>
+                <div t-if="sourceMessageAttachments.length" class="d-flex align-items-center gap-2 mt-1 w-100">
+                    <small class="text-muted flex-grow-1">
+                        <t t-out="sourceMessageAttachments.length"/> attachment(s)
+                    </small>
+                    <div class="position-relative">
+                        <t t-set="firstAttachment" t-value="sourceMessageAttachments[0]"/>
+                        <Gif
+                            t-if="firstAttachment.mimetype === 'image/gif'"
+                            src="getImageUrl(firstAttachment)"
+                            paused="firstAttachment.gifPaused"
+                            alt="firstAttachment.name"
+                            class="'o-mail-ForwardedAttachment-preview rounded border'"
+                        />
+                        <img
+                            t-elif="firstAttachment.isImage"
+                            t-att-src="getImageUrl(firstAttachment)"
+                            t-att-alt="firstAttachment.name"
+                            class="o-mail-ForwardedAttachment-preview rounded border"
+                            draggable="false"
+                        />
+                        <div
+                            t-else=""
+                            class="o-mail-ForwardedAttachment-preview rounded border d-flex align-items-center justify-content-center bg-200 w-100"
+                        >
+                            <div class="o_image" t-att-data-mimetype="firstAttachment.mimetype"/>
+                        </div>
+                        <div
+                            t-if="sourceMessageAttachments.length > 1"
+                            class="position-absolute o-text-white bottom-0 end-0 bg-primary p-1 rounded"
+                        >
+                            +<t t-out="sourceMessageAttachments.length - 1"/>
+                        </div>
+                    </div>
+                </div>
+            </small>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/common/forward_dialog.xml
+++ b/addons/mail/static/src/core/common/forward_dialog.xml
@@ -6,18 +6,18 @@
             contentClass="'o-bg-body d-flex flex-column mh-75'" bodyClass="'p-2 d-flex flex-column o-min-height-0'">
             <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0">
                 <div class="d-flex flex-column flex-grow-1 overflow-hidden o-min-height-0">
-                    <t t-call="discuss.SelectableList"/>
+                    <SelectableList state="this.selectableListState" optionAvatarUrl="(option) => this.getOptionAvatarUrl(option)"/>
                 </div>
                 <div class="flex-shrink-0 bg-inherit">
-                    <div t-if="props.sourceMessage">
+                    <div t-if="this.props.sourceMessage">
                         <t t-call="mail.ForwardDialog.forwardPreview"/>
-                        <textarea t-if="selectedOptions.length" class="form-control border rounded"
-                            t-model="state.optionalMsgBody" placeholder="Add an optional message..." rows="3"/>
+                        <textarea t-if="this.selectableListState.selectedOptions.length" class="form-control border rounded"
+                            t-model="this.state.optionalMsgBody" placeholder="Add an optional message..." rows="3"/>
                     </div>
                     <div class="pt-0 pb-1 bg-inherit">
-                        <t t-if="store.self_user">
-                            <button t-if="selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="forwardButtonText" t-on-click="onClickForward">
-                                <t t-out="forwardButtonText"/>
+                        <t t-if="this.store.self_user">
+                            <button t-if="this.selectableListState.selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="this.forwardButtonText" t-on-click="this.onClickForward">
+                                <t t-out="this.forwardButtonText"/>
                             </button>
                         </t>
                     </div>
@@ -30,25 +30,25 @@
         <div class="o-mail-Forward-core position-relative px-2 py-1 rounded-3 rounded-start-0 mb-2">
             <small>
                 <div class="text-muted fst-italic mb-1"><i class="fa fa-share"/> Forwarded</div>
-                <div t-if="!props.sourceMessage.isBodyEmpty" class="d-inline-flex align-items-center">
-                    <span class="o-mail-ForwardedMessage-content overflow-hidden smaller o-mail-ForwardedMessage-message ms-1 text-break" t-out="sourceMessageDisplayBody"/>
+                <div t-if="!this.props.sourceMessage.isBodyEmpty" class="d-inline-flex align-items-center">
+                    <span class="o-mail-ForwardedMessage-content overflow-hidden smaller o-mail-ForwardedMessage-message ms-1 text-break" t-out="this.sourceMessageDisplayBody"/>
                 </div>
-                <div t-if="sourceMessageAttachments.length" class="d-flex align-items-center gap-2 mt-1 w-100">
+                <div t-if="this.sourceMessageAttachments.length" class="d-flex align-items-center gap-2 mt-1 w-100">
                     <small class="text-muted flex-grow-1">
-                        <t t-out="sourceMessageAttachments.length"/> attachment(s)
+                        <t t-out="this.sourceMessageAttachments.length"/> attachment(s)
                     </small>
                     <div class="position-relative">
-                        <t t-set="firstAttachment" t-value="sourceMessageAttachments[0]"/>
+                        <t t-set="firstAttachment" t-value="this.sourceMessageAttachments[0]"/>
                         <Gif
                             t-if="firstAttachment.mimetype === 'image/gif'"
-                            src="getImageUrl(firstAttachment)"
+                            src="this.getImageUrl(firstAttachment)"
                             paused="firstAttachment.gifPaused"
                             alt="firstAttachment.name"
                             class="'o-mail-ForwardedAttachment-preview rounded border'"
                         />
                         <img
                             t-elif="firstAttachment.isImage"
-                            t-att-src="getImageUrl(firstAttachment)"
+                            t-att-src="this.getImageUrl(firstAttachment)"
                             t-att-alt="firstAttachment.name"
                             class="o-mail-ForwardedAttachment-preview rounded border"
                             draggable="false"
@@ -60,10 +60,10 @@
                             <div class="o_image" t-att-data-mimetype="firstAttachment.mimetype"/>
                         </div>
                         <div
-                            t-if="sourceMessageAttachments.length > 1"
+                            t-if="this.sourceMessageAttachments.length > 1"
                             class="position-absolute o-text-white bottom-0 end-0 bg-primary p-1 rounded"
                         >
-                            +<t t-out="sourceMessageAttachments.length - 1"/>
+                            +<t t-out="this.sourceMessageAttachments.length - 1"/>
                         </div>
                     </div>
                 </div>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -34,6 +34,7 @@ import { ActionList } from "@mail/core/common/action_list";
 import { loadCssFromBundle } from "@mail/utils/common/misc";
 import { MessageContextMenu } from "@mail/core/common/message_context_menu";
 import { Priority } from "@mail/core/common/priority";
+import { ForwardDialog } from "@mail/core/common/forward_dialog";
 
 /**
  * @typedef {Object} Props
@@ -188,7 +189,7 @@ export class Message extends Component {
                         this.message.showTranslation
                             ? this.message.richTranslationValue
                             : this.props.messageSearch?.highlight(this.message.richBody) ??
-                                  this.message.richBody
+                            this.message.richBody
                     );
                     this.prepareMessageBody(bodyEl);
                     this.shadowRoot.appendChild(bodyEl);
@@ -326,7 +327,7 @@ export class Message extends Component {
         return (
             this.message.subtype_id?.description &&
             this.message.subtype_id.description.toLowerCase() !==
-                htmlToTextContentInline(this.message.body || "").toLowerCase()
+            htmlToTextContentInline(this.message.body || "").toLowerCase()
         );
     }
 
@@ -551,6 +552,28 @@ export class Message extends Component {
             !this.message.isSubjectSimilarToThreadName &&
             !this.message.isSubjectDefault
         );
+    }
+
+    openForwardDialog() {
+        this.dialog.add(ForwardDialog, {
+            sourceMessage: this.props.message,
+        });
+    }
+
+    openForwardedConversation() {
+        const showAccessError = () =>
+            this.env.services.notification.add(_t("This conversation isn't available."), {
+                type: "danger",
+            });
+        const thread = this.message.forwarded_from_id.thread;
+        thread.checkReadAccess().then((hasAccess) => {
+            if (hasAccess) {
+                thread.highlightMessage = this.message.forwarded_from_id;
+                thread.open({ focus: true });
+            } else {
+                showAccessError();
+            }
+        });
     }
 }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -107,6 +107,21 @@
     }
 }
 
+.o-mail-ForwardedMessage-link {
+    transition: background-color 0.15s ease;
+    font-size: 10px;
+    line-height: 1.2;
+    min-width: 150px;
+
+    &:hover {
+        background-color: rgba($body-color, 0.2);
+    }
+
+    span {
+        max-width: fit-content;
+    }
+}
+
 .o-mail-ChatWindow .o-mail-Message.o-selfAuthored {
     flex-direction: row-reverse;
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -65,13 +65,13 @@
                             <t t-if="this.isAlignedRight" t-call="mail.Message.notification"/>
                             <t t-if="!this.isAlignedRight and !this.message.bubbleColor and !(this.props.asCard and this.isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
-                        <div class="o-mail-Message-contentContainer position-relative d-flex" t-att-class="{ 'flex-row-reverse': this.isAlignedRight }">
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': this.isEditing, 'opacity-50': this.message.isPending, 'pt-1': !this.showSubject and !this.message.bubbleColor, 'o-mail-Message-pollContent flex-grow-1': this.message.poll }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': this.isEditing }">
-                                    <t t-set="showTextVisually" t-value="!this.message.linkPreviewSquash and (this.message.hasTextContent or this.message.subtype_id?.description or this.message.isEmpty)"/>
-                                    <t t-if="this.message.message_type === 'notification' and this.message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="this.message.isEmpty or (this.message.message_type !== 'notification' and !this.message.is_transient and (this.message.hasTextContent or this.message.subtype_id?.description or this.isEditing or this.message.parent_id))">
-                                        <MessageLinkPreviewList t-if="!this.isEditing and this.message.linkPreviewSquash and !this.message.parent_id" messageLinkPreviews="this.message.message_link_preview_ids"/>
+                        <div class="o-mail-Message-contentContainer position-relative d-flex" t-att-class="{ 'flex-row-reverse': isAlignedRight }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': !showSubject and !message.bubbleColor, 'o-mail-Message-pollContent flex-grow-1': message.poll }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
+                                    <t t-set="showTextVisually" t-value="!message.linkPreviewSquash and (message.hasTextContent or message.subtype_id?.description or message.isEmpty)"/>
+                                    <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
+                                    <t t-if="message.forwarded_from_id or message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_id?.description or isEditing or message.parent_id))">
+                                        <MessageLinkPreviewList t-if="!isEditing and message.linkPreviewSquash and !message.parent_id" messageLinkPreviews="message.message_link_preview_ids"/>
                                         <t t-else="">
                                             <div t-if="this.message.bubbleColor and !this.props.squashed" class="o-mail-Message-bubbleTail position-absolute d-flex" t-att-style="this.isAlignedRight ? 'right: -4px; transform: rotateY(180deg);' : 'left: -4px;'" t-att-class="{
                                                 'o-blue': this.message.bubbleColor === 'blue',
@@ -99,35 +99,58 @@
                                                     'o-green': this.message.bubbleColor === 'green',
                                                     'o-orange': this.message.bubbleColor === 'orange',
                                                 }"/>
-                                                <MessageInReply t-if="this.message.parent_id" class="'mx-2 p-1 pb-0 ' + (showTextVisually ? 'mt-1' : 'my-1')" message="this.message" onClick="this.props.onParentMessageClick"/>
-                                                <div class="position-relative text-break o-mail-Message-body" t-att-class="{
-                                                            'p-1': this.message.isNote,
-                                                            'fs-1': !this.isEditing and !this.env.inChatter and this.message.onlyEmojis,
-                                                            'mb-0': !this.message.isNote,
-                                                            'py-2': !this.message.isNote and !this.isEditing and showTextVisually,
-                                                            'pt-2 pb-1': !this.message.isNote and this.isEditing,
-                                                            'o-note': this.message.isNote,
-                                                            'o-rounded-bubble': this.props.squashed,
-                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !this.isEditing and !this.message.isNote and !this.props.squashed,
-                                                            'flex-grow-1': this.isEditing,
-                                                            }" t-custom-ref="body">
-                                                    <i t-if="this.message.isEmpty" class="text-muted opacity-75" t-out="this.message.inlineBody"/>
-                                                    <Composer t-elif="this.isEditing" autofocus="true" composer="this.message.composer" onDiscardCallback.bind="this.exitEditMode" onPostCallback.bind="this.exitEditMode" mode="'compact'" sidebar="false"/>
-                                                    <t t-else="">
-                                                        <em t-if="this.showSubject" class="d-block text-muted smaller" t-att-class="{ 'mb-2': !this.message.bubbleColor }">Subject: <t t-out="this.props.messageSearch?.highlight(this.message.subject) ?? this.message.subject"/></em>
-                                                        <div class="overflow-x-auto" t-if="this.message.message_type and this.message.message_type.includes('email')" t-custom-ref="shadowBody"/>
-                                                        <t t-elif="this.message.showTranslation" t-out="this.message.richTranslationValue"/>
-                                                        <div class="o-mail-Message-richBody overflow-x-auto" t-elif="this.message.hasTextContent and this.message.richBody and !this.message.linkPreviewSquash" t-out="this.props.messageSearch?.highlight(this.message.richBody) ?? this.message.richBody"/>
-                                                        <p class="fst-italic text-muted small" t-if="this.message.showTranslation">
-                                                            <t t-if="this.message.translationSource" t-out="this.translatedFromText"/>
-                                                        </p>
-                                                        <p class="fst-italic text-muted small" t-if="this.message.translationErrors">
-                                                            <i class="text-danger fa fa-warning" role="img" aria-label="Translation Failure"/>
-                                                            <t t-if="this.message.translationErrors" t-out="this.translationFailureText"/>
-                                                        </p>
-                                                        <t t-if="this.showSubtypeDescription" t-out="this.props.messageSearch?.highlight(this.message.subtype_id?.description) ?? this.message.subtype_id?.description"/>
+                                                <MessageInReply t-if="message.parent_id" class="'mx-2 p-1 pb-0 ' + (showTextVisually ? 'mt-1' : 'my-1')" message="message" onClick="props.onParentMessageClick"/>
+                                                <t t-if="message.forwarded_from_id">
+                                                    <div class="o-mail-Message-bubble" t-att-class="{ 'o-blue': message.bubbleColor === 'blue', 'o-green': message.bubbleColor === 'green', 'o-orange': message.bubbleColor === 'orange'}">
+                                                        <div class="o-mail-MessageInReply-core mx-2 mt-2 border-start position-relative px-2 py-1 rounded-start-0 o-rounded-end-bubble">
+                                                            <small class="text-muted fst-italic">
+                                                                <i class="fa fa-share"/> Forwarded
+                                                            </small>
+                                                            <t t-call="mail.Message-bodyContent">
+                                                                <t t-set="bodyAttClass" t-value="{
+                                                                    'position-relative text-break o-mail-Message-body': true,
+                                                                    'p-1': message.isNote,
+                                                                    'fs-1': !isEditing and !env.inChatter and message.onlyEmojis,
+                                                                    'mb-0': !message.isNote,
+                                                                    'pt-2 pb-1': !message.isNote and isEditing,
+                                                                    'o-note': message.isNote,
+                                                                    'flex-grow-1': isEditing,
+                                                                }"/>
+                                                                <t t-set="showAttachmentsInside" t-value="true"/>
+                                                            </t>
+                                                        </div>
+                                                        <div
+                                                            t-att-title="message.forwarded_from_id.thread.displayName"
+                                                            class="o-mail-ForwardedMessage-link position-relative d-flex gap-1 p-1 text-muted rounded-1"
+                                                            role="button"
+                                                            t-on-click="openForwardedConversation"
+                                                        >
+                                                            <span
+                                                                class="flex-grow-1 flex-shrink-1 flex-basis-0 w-0 text-truncate"
+                                                                t-out="message.forwarded_from_id.thread.displayName"
+                                                            />
+                                                            <i class="fa fa-chevron-right"/>
+                                                            <span t-out="message.forwarded_from_id.dateSimpleWithDay"/>
+                                                        </div>
+                                                    </div>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-call="mail.Message-bodyContent">
+                                                        <t t-set="bodyAttClass" t-value="{
+                                                            'position-relative text-break o-mail-Message-body': true,
+                                                            'p-1': message.isNote,
+                                                            'fs-1': !isEditing and !env.inChatter and message.onlyEmojis,
+                                                            'mb-0': !message.isNote,
+                                                            'py-2': !message.isNote and !isEditing and showTextVisually,
+                                                            'pt-2 pb-1': !message.isNote and isEditing,
+                                                            'o-note': message.isNote,
+                                                            'o-rounded-bubble': props.squashed,
+                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !isEditing and !message.isNote and !props.squashed,
+                                                            'flex-grow-1': isEditing,
+                                                        }"/>
+                                                        <t t-set="showAttachmentsInside" t-value="true"/>
                                                     </t>
-                                                </div>
+                                                </t>
                                             </div>
                                         </t>
                                     </t>
@@ -135,7 +158,7 @@
                                     <PollResult t-if="this.message.ended_poll_ids.length" poll="this.message.poll"/>
                                     <Poll t-elif="this.message.poll" poll="this.message.poll"/>
                                 </div>
-                                <div class="position-relative">
+                                <div class="position-relative" t-if="!message.forwarded_from_id">
                                     <AttachmentList
                                         t-if="this.message.extra_body_attachment_ids.length > 0"
                                         attachments="this.message.extra_body_attachment_ids"
@@ -236,6 +259,34 @@
             <span class="fa fa-angle-right me-1" aria-hidden="true"/>
             <span class="fa fa-comment" aria-hidden="true"/>
         </span>
+    </t>
+
+    <t t-name="mail.Message-bodyContent">
+        <div t-att-class="bodyAttClass" t-ref="body">
+            <i t-if="message.isEmpty" class="text-muted opacity-75" t-out="message.inlineBody"/>
+            <Composer t-elif="isEditing" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
+            <t t-else="">
+                <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
+                <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
+                <t t-elif="message.showTranslation" t-out="message.richTranslationValue"/>
+                <div class="o-mail-Message-richBody overflow-x-auto" t-elif="message.hasTextContent and message.richBody and !message.linkPreviewSquash" t-out="props.messageSearch?.highlight(message.richBody) ?? message.richBody"/>
+                <p class="fst-italic text-muted small" t-if="message.showTranslation">
+                    <t t-if="message.translationSource" t-out="translatedFromText"/>
+                </p>
+                <p class="fst-italic text-muted small" t-if="message.translationErrors">
+                    <i class="text-danger fa fa-warning" role="img" aria-label="Translation Failure"/>
+                    <t t-if="message.translationErrors" t-out="translationFailureText"/>
+                </p>
+                <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_id?.description) ?? message.subtype_id?.description"/>
+            </t>
+        </div>
+        <div t-if="showAttachmentsInside" class="position-relative">
+            <AttachmentList
+                t-if="message.attachment_ids.length > 0"
+                attachments="message.attachment_ids.map((a) => a)"
+                unlinkAttachment.bind="onClickAttachmentUnlink"
+                messageSearch="props.messageSearch"/>
+        </div>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -1,12 +1,13 @@
 import { toRaw } from "@odoo/owl";
 
+import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
+import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { MessageReactionMenu } from "@mail/core/common/message_reaction_menu";
+
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
-import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
-import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
-import { MessageReactionMenu } from "@mail/core/common/message_reaction_menu";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { rpc } from "@web/core/network/rpc";
 
@@ -145,7 +146,7 @@ registerMessageAction("unfollow", {
     icon: "fa fa-user-times",
     name: _t("Unfollow"),
     onSelected: ({ message }) => message.unfollow(),
-    sequence: 60,
+    sequence: 65,
 });
 registerMessageAction("edit", {
     condition: ({ message }) => message.editable,
@@ -213,6 +214,17 @@ registerMessageAction("end-poll", {
     name: _t("End Poll"),
     onSelected: ({ message }) => rpc("/mail/poll/end", { poll_id: message.poll.id }),
     sequence: 115,
+});
+registerMessageAction("forward-message", {
+    condition: ({ message, thread, store }) =>
+        !message.isEmpty &&
+        !message.poll &&
+        thread?.model == "discuss.channel" &&
+        store.self_user?.share === false,
+    icon: "fa fa-share",
+    name: _t("Forward"),
+    onSelected: ({ owner }) => owner.openForwardDialog(),
+    sequence: 60,
 });
 
 export class MessageAction extends Action {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -137,6 +137,8 @@ export class Message extends Record {
     message_link_preview_ids = fields.Many("mail.message.link.preview", { inverse: "message_id" });
     /** @type {number[]} */
     parent_id = fields.One("mail.message");
+    /** @type {number[]} */
+    forwarded_from_id = fields.One("mail.message");
     /**
      * When set, this temporary/pending message failed message post, and the
      * value is a callback to re-attempt to post the message.
@@ -251,7 +253,7 @@ export class Message extends Record {
     }
 
     get editable() {
-        if (this.isEmpty || !this.allowsEdition || this.poll) {
+        if (this.isEmpty || !this.allowsEdition || this.poll || this.forwarded_from_id) {
             return false;
         }
         return this.message_type === "comment";

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -1,25 +1,25 @@
 import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
-import { SelectableList } from "@mail/discuss/core/common/selectable_list";
+import { SelectableList, useSelectableListState } from "@mail/discuss/core/common/selectable_list";
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { MessageLinkPreviewList } from "@mail/core/common/message_link_preview_list";
 import { Gif } from "@mail/core/common/gif";
 
-import { onMounted, onWillStart, useEffect, useState } from "@odoo/owl";
+import { Component, onWillStart, useEffect, useState } from "@odoo/owl";
 
 import { useSequential } from "@mail/utils/common/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
-export class ChannelInvitation extends SelectableList {
+export class ChannelInvitation extends Component {
     static components = {
-        ...SelectableList.components,
         ActionPanel,
         DiscussAvatar,
         AttachmentList,
         MessageLinkPreviewList,
         Gif,
+        SelectableList,
     };
     static defaultProps = { hasSizeConstraints: false };
     static props = [
@@ -49,7 +49,8 @@ export class ChannelInvitation extends SelectableList {
             selectablePartners: [],
             sentEmails: new Set(),
         });
-        this.internalState.search = this.state.searchStr;
+        this.selectableListState = useSelectableListState();
+        this.selectableListState.search = this.state.searchStr;
         this.debouncedFetchPartnersToInvite = useDebounced(
             this.fetchPartnersToInvite.bind(this),
             250
@@ -65,11 +66,6 @@ export class ChannelInvitation extends SelectableList {
         onWillStart(() => {
             if (this.store.self_user) {
                 this.fetchPartnersToInvite();
-            }
-        });
-        onMounted(() => {
-            if (this.store.self_user && this.props.channel) {
-                this.inputRef.el.focus();
             }
         });
         useEffect(
@@ -91,13 +87,13 @@ export class ChannelInvitation extends SelectableList {
     }
 
     get selectedPartners() {
-        return this.internalState.selectedOptions
+        return this.selectableListState.selectedOptions
             .filter((option) => option.isPartner && option.partner)
             .map((option) => option.partner);
     }
 
     get selectedEmails() {
-        return this.internalState.selectedOptions
+        return this.selectableListState.selectedOptions
             .filter((option) => option.email)
             .map((option) => option.email);
     }
@@ -108,7 +104,7 @@ export class ChannelInvitation extends SelectableList {
 
     set searchStr(newSearchStr) {
         this.state.searchStr = newSearchStr;
-        this.internalState.search = newSearchStr;
+        this.selectableListState.search = newSearchStr;
     }
 
     get showingResultNarrowText() {
@@ -152,9 +148,7 @@ export class ChannelInvitation extends SelectableList {
     }
 
     getOptionAvatarUrl(option) {
-        return option.isPartner && option.partner
-            ? option.partner.avatarUrl ?? ""
-            : super.getOptionAvatarUrl(option);
+        return option.isPartner && option.partner ? option.partner.avatarUrl ?? "" : undefined;
     }
 
     get emptyStateText() {
@@ -201,6 +195,10 @@ export class ChannelInvitation extends SelectableList {
             this.state.sentEmails.add(results.selectable_email);
         }
         this.state.selectableEmails = [...new Set(selectableEmails)];
+        this.selectableListState.options = this._buildOptions(
+            this.state.selectablePartners,
+            this.state.selectableEmails
+        );
     }
 
     onInput() {
@@ -248,7 +246,7 @@ export class ChannelInvitation extends SelectableList {
             );
         }
         await Promise.all(invitePromises);
-        this.internalState.selectedOptions = [];
+        this.selectableListState.selectedOptions = [];
         this.props.close?.();
     }
 

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -1,17 +1,26 @@
-import { useState } from "@web/owl2/utils";
 import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { SelectableList } from "@mail/discuss/core/common/selectable_list";
+import { AttachmentList } from "@mail/core/common/attachment_list";
+import { MessageLinkPreviewList } from "@mail/core/common/message_link_preview_list";
+import { Gif } from "@mail/core/common/gif";
 
-import { Component, onWillStart } from "@odoo/owl";
+import { onMounted, onWillStart, useEffect, useState } from "@odoo/owl";
 
 import { useSequential } from "@mail/utils/common/hooks";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
-export class ChannelInvitation extends Component {
-    static components = { ActionPanel, DiscussAvatar };
+export class ChannelInvitation extends SelectableList {
+    static components = {
+        ...SelectableList.components,
+        ActionPanel,
+        DiscussAvatar,
+        AttachmentList,
+        MessageLinkPreviewList,
+        Gif,
+    };
     static defaultProps = { hasSizeConstraints: false };
     static props = [
         "autofocus?",
@@ -19,7 +28,8 @@ export class ChannelInvitation extends Component {
         "channel?",
         "close?",
         "className?",
-        "state?",
+        "searchStr?",
+        "onSelectionChange?",
     ];
     static template = "discuss.ChannelInvitation";
 
@@ -30,72 +40,128 @@ export class ChannelInvitation extends Component {
         this.rtc = useService("discuss.rtc");
         this.notification = useService("notification");
         this.suggestionService = useService("mail.suggestion");
+        this.ui = useService("ui");
         this.sequential = useSequential();
         this.state = useState({
             searchResultCount: 0,
-            searchStr: "",
+            searchStr: this.props.searchStr ?? "",
             selectableEmails: [],
             selectablePartners: [],
-            selectedEmails: [],
-            selectedPartners: [],
             sentEmails: new Set(),
         });
+        this.internalState.search = this.state.searchStr;
         this.debouncedFetchPartnersToInvite = useDebounced(
             this.fetchPartnersToInvite.bind(this),
             250
         );
         this.inputRef = useAutofocus({ refName: "input" });
+        const originalToggleSelection = this.toggleSelection;
+        this.toggleSelection = (option) => {
+            originalToggleSelection.call(this, option);
+            if (this.props.onSelectionChange) {
+                this.props.onSelectionChange(this.selectedPartners);
+            }
+        };
         onWillStart(() => {
             if (this.store.self_user) {
                 this.fetchPartnersToInvite();
             }
         });
-    }
-
-    get selectablePartners() {
-        return this.props.state?.selectablePartners ?? this.state.selectablePartners;
-    }
-
-    set selectablePartners(partners) {
-        if (this.props.state?.selectablePartners) {
-            this.props.state.selectablePartners = partners;
-        } else {
-            this.state.selectablePartners = partners;
-        }
+        onMounted(() => {
+            if (this.store.self_user && this.props.channel) {
+                this.inputRef.el.focus();
+            }
+        });
+        useEffect(
+            () => {
+                if (this.props.autofocus) {
+                    this.inputRef.el?.focus();
+                }
+            },
+            () => [this.props.autofocus]
+        );
+        useEffect(
+            () => {
+                if (this.props.onSelectionChange) {
+                    this.props.onSelectionChange(this.selectedPartners);
+                }
+            },
+            () => []
+        );
     }
 
     get selectedPartners() {
-        return this.props.state?.selectedPartners ?? this.state.selectedPartners;
+        return this.internalState.selectedOptions
+            .filter((option) => option.isPartner && option.partner)
+            .map((option) => option.partner);
     }
 
-    set selectedPartners(partners) {
-        if (this.props.state?.selectedPartners) {
-            this.props.state.selectedPartners = partners;
-        } else {
-            this.state.selectedPartners = partners;
-        }
+    get selectedEmails() {
+        return this.internalState.selectedOptions
+            .filter((option) => option.email)
+            .map((option) => option.email);
     }
 
     get searchStr() {
-        return this.props.state?.searchStr ?? this.state.searchStr;
+        return this.state.searchStr;
     }
 
     set searchStr(newSearchStr) {
-        if (this.props.state?.searchStr !== undefined) {
-            this.props.state.searchStr = newSearchStr;
-        } else {
-            this.state.searchStr = newSearchStr;
-        }
+        this.state.searchStr = newSearchStr;
+        this.internalState.search = newSearchStr;
     }
 
     get showingResultNarrowText() {
         return _t(
             "Showing %(result_count)s results out of %(total_count)s. Narrow your search to see more choices.",
             {
-                result_count: this.selectablePartners.length,
+                result_count: this.state.selectablePartners.length,
                 total_count: this.state.searchResultCount,
             }
         );
+    }
+
+    _buildOptions(partners, emails) {
+        return [
+            ...partners.map((partner) => ({
+                id: partner.id,
+                isPartner: true,
+                partner,
+                displayName: partner.name ?? "",
+                avatarUrl: partner.avatarUrl ?? "",
+            })),
+            ...emails.map((email) => ({
+                id: `email_${email}`,
+                isPartner: false,
+                email,
+                displayName: email,
+                avatarUrl: "",
+            })),
+        ];
+    }
+
+    get options() {
+        return this._buildOptions(this.state.selectablePartners, this.state.selectableEmails);
+    }
+
+    getOptionDisplayName(option) {
+        if (option.isPartner && option.partner) {
+            return option.partner.name ?? "";
+        }
+        return option.email ?? super.getOptionDisplayName(option);
+    }
+
+    getOptionAvatarUrl(option) {
+        return option.isPartner && option.partner
+            ? option.partner.avatarUrl ?? ""
+            : super.getOptionAvatarUrl(option);
+    }
+
+    get emptyStateText() {
+        if (this.props.channel) {
+            return _t("No people found to invite.");
+        }
+        return _t("No user found.");
     }
 
     get searchPlaceholder() {
@@ -119,13 +185,13 @@ export class ChannelInvitation extends Component {
         const selectablePartners = results.partner_ids.map((id) =>
             this.store["res.partner"].get(id)
         );
-        this.selectablePartners = this.suggestionService.sortPartnerSuggestions(
+        this.state.selectablePartners = this.suggestionService.sortPartnerSuggestions(
             selectablePartners,
             this.searchStr,
             this.props.channel?.thread
         );
         this.state.searchResultCount = results["count"];
-        const selectableEmails = this.state.selectedEmails.filter((addr) =>
+        const selectableEmails = this.selectedEmails.filter((addr) =>
             addr.includes(this.searchStr)
         );
         if (results.selectable_email) {
@@ -138,53 +204,14 @@ export class ChannelInvitation extends Component {
     }
 
     onInput() {
-        this.searchStr = this.inputRef.el.value;
+        const value = this.inputRef.el.value;
+        this.searchStr = value;
         this.debouncedFetchPartnersToInvite();
     }
 
-    onClickGenerateNewLink() {
-        this.env.services.dialog.add(ConfirmationDialog, {
-            title: _t("Warning"),
-            body: _t(
-                "You're about to create a new invite link. The current link will no longer grant guests access to the channel. Do you want to proceed?"
-            ),
-            cancel: () => {},
-            confirmLabel: _t("Generate"),
-            confirm: () =>
-                this.orm.call("discuss.channel", "action_reset_invitation_uuid", [
-                    [this.props.channel.id],
-                ]),
-        });
-    }
-
-    onClickSelectablePartner(partner) {
-        if (partner.in(this.selectedPartners)) {
-            const index = this.selectedPartners.indexOf(partner);
-            if (index !== -1) {
-                this.selectedPartners.splice(index, 1);
-            }
-            return;
-        }
-        this.selectedPartners.push(partner);
-    }
-
-    onClickSelectableEmail(email) {
-        const index = this.state.selectedEmails.indexOf(email);
-        if (index !== -1) {
-            this.state.selectedEmails.splice(index, 1);
-            return;
-        }
-        this.state.selectedEmails.push(email);
-    }
-
-    onClickSelectedPartner(partner) {
-        const index = this.selectedPartners.indexOf(partner);
-        this.selectedPartners.splice(index, 1);
-    }
-
-    onClickSelectedEmail(email) {
-        const index = this.state.selectedEmails.indexOf(email);
-        this.state.selectedEmails.splice(index, 1);
+    clearSearch() {
+        this.searchStr = "";
+        this.debouncedFetchPartnersToInvite();
     }
 
     onFocusInvitationLinkInput(ev) {
@@ -213,7 +240,7 @@ export class ChannelInvitation extends Component {
                 })
             );
         }
-        if (this.state.selectedEmails.length) {
+        if (this.selectedEmails.length) {
             invitePromises.push(
                 this.orm.call("discuss.channel", "invite_by_email", [channelId], {
                     emails: this.state.selectedEmails,
@@ -221,8 +248,7 @@ export class ChannelInvitation extends Component {
             );
         }
         await Promise.all(invitePromises);
-        this.state.selectedEmails = [];
-        this.state.selectedPartners = [];
+        this.internalState.selectedOptions = [];
         this.props.close?.();
     }
 

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.scss
@@ -1,32 +1,7 @@
 .o-discuss-ChannelInvitation {
-    min-height: 0;
-}
-
-.o-discuss-ChannelInvitation-selectable {
-    &.o-odd {
-        background-color: $gray-100 !important;;
-    }
-    &:hover {
-        background-color: mix($gray-100, $gray-200) !important;
-    }
-    &.o-selected {
-        background-color: mix($o-view-background-color, $o-action, 85%) !important;;
-    }
-}
-
-.o-discuss-ChannelInvitation-selectedList {
-    max-height: 100px;
-
-    button {
-        background-color: mix($o-view-background-color, $o-action, 85%);
-
-        &:not(:hover) .oi-close {
-            border-color: transparent !important;
-        }
-
-        &:hover .oi-close {
-            color: $danger;
-            border-color: $danger !important;
+    .o-discuss-SelectableList-selectable {
+        &.o-odd {
+            background-color: $gray-100 !important;
         }
     }
 }
@@ -44,3 +19,24 @@
     top: -4px;
     right: -5px;
 }
+.o-mail-ForwardedMessage-content {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+}
+
+.o-mail-ForwardedMessage-message {
+    p {
+        margin: 0;
+    }
+}
+
+.o-mail-ForwardedAttachment-preview {
+    width: 3rem;
+    height: 3rem;
+    max-width: 3rem;
+    max-height: 3rem;
+    object-fit: cover;
+}
+

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -9,107 +9,35 @@
     </t>
 
     <t t-name="discuss.ChannelInvitation.main">
-        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'w-100': this.props.hasSizeConstraints, 'px-1': !this.props.channel }">
-            <t t-if="this.store.self_user?.share === false">
-                <div class="position-relative">
-                    <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="this.searchStr" t-custom-ref="input" t-att-placeholder="this.searchPlaceholder" t-on-input="this.onInput"/>
-                    <div t-if="this.props.channel?.allow_invite_by_email" class="o-discuss-ChannelInvitation-iconContainer position-absolute top-50 end-0 translate-middle-y me-2 smaller opacity-50" data-tooltip="Type email to invite">
-                        <i class="fa fa-envelope-o fa-lg"/>
-                        <i class="fa fa-plus-circle o-discuss-ChannelInvitation-iconPlus position-absolute bg-white rounded-circle"/>
-                    </div>
-                </div>
-                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': this.selectablePartners.length === 0 and this.state.selectableEmails.length === 0 }">
-                    <div t-if="this.selectablePartners.length === 0 and this.state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
-                        <t t-if="this.props.channel">No one found to invite.</t>
-                        <t t-else="">No user found.</t>
-                    </div>
-                    <div t-if="this.state.searchResultCount > this.selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.showingResultNarrowText"/>
-                    <t t-foreach="this.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
-                        <t t-call="discuss.ChannelInvitation-selectableItem">
-                            <t t-set="selectableItemIndex" t-value="selectablePartner_index"/>
-                        </t>
-                    </t>
-                    <t t-foreach="this.state.selectableEmails" t-as="selectableEmailAddress" t-key="selectableEmailAddress">
-                        <t t-call="discuss.ChannelInvitation-selectableItem">
-                            <t t-set="selectableEmailAddress" t-value="selectableEmailAddress"/>
-                            <t t-set="selectableItemIndex" t-value="this.selectablePartners.length + selectableEmailAddress_index"/>
-                        </t>
-                    </t>
-                </ul>
-            </t>
-            <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
-                <t t-if="this.store.self_user" >
-                    <div t-if="this.selectedPartners.length > 0 or this.state.selectedEmails.length > 0" class="pt-2">
-                        <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap overflow-auto o-scrollbar-thin">
-                            <t t-foreach="this.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">
-                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
-                                    <t t-out="selectedPartner.name"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
-                                </button>
-                            </t>
-                            <t t-foreach="this.state.selectedEmails" t-as="selectedEmail" t-key="selectedEmail">
-                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedEmail(selectedEmail)">
-                                    <t t-out="selectedEmail"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
-                                </button>
-                            </t>
-                        </div>
-                    </div>
-                    <button t-if="this.props.channel and (this.selectedPartners.length > 0 or this.state.selectedEmails.length > 0)" class="btn btn-primary w-100 my-2" t-att-title="this.invitationButtonText" t-on-click="this.onClickInvite">
-                        <t t-out="this.invitationButtonText"/>
-                    </button>
+        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.channel }">
+            <div class="d-flex flex-column flex-grow-1 overflow-hidden o-min-height-0">
+                <t t-call="discuss.SelectableList">
+                    <t t-set="beforeOptionsTemplate" t-value="'discuss.ChannelInvitation-beforeOptions'"/>
+                    <t t-set="additionalItemContentTemplate" t-value="'discuss.ChannelInvitation-additionalItemContent'"/>
                 </t>
-                <hr t-if="this.props.channel?.invitationLink" class="border-dark-subtle"/>
-                <t t-if="this.props.channel?.invitationLink">
-                    <div class="input-group">
-                        <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="this.props.channel.invitationLink" readonly="" disabled="" t-on-focus="this.onFocusInvitationLinkInput"/>
-                        <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => this.props.channel.copyInvitationLink()">
+            </div>
+            <div class="flex-shrink-0 bg-inherit">
+                <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
+                    <button t-if="store.self_user and props.channel and selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="invitationButtonText" t-on-click="onClickInvite">
+                        <t t-out="invitationButtonText"/>
+                    </button>
+                    <hr t-if="props.channel?.invitationLink" class="border-dark-subtle"/>
+                    <div t-if="props.channel?.invitationLink" class="input-group">
+                        <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
+                        <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => props.channel.copyInvitationLink()">
                             <i class="fa fa-copy"/>
                         </button>
                     </div>
-                </t>
-                <div t-if="this.props.channel?.accessRestrictedToGroupText or this.props.channel?.invitationLink" class="mt-2 smaller ms-1 gap-1 d-flex align-items-center">
-                    <span class="text-muted me-1" t-out="this.props.channel.accessRestrictedToGroupText"/>
-                    <span class="flex-grow-1"/>
-                    <button
-                        t-if="['owner', 'admin'].includes(this.props.channel.self_member_id?.channel_role)"
-                        class="btn btn-link btn-sm px-2 o-py-0_5 opacity-75 opacity-100-hover me-n2 d-flex align-items-center gap-1 align-self-start flex-shrink-0"
-                        t-on-click="this.onClickGenerateNewLink"
-                    >
-                        <i class="fa fa-refresh opacity-75"/>
-                        Generate new invite link
-                    </button>
+                    <div t-if="props.channel?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-out="props.channel.accessRestrictedToGroupText"/>
                 </div>
             </div>
         </div>
     </t>
-    <t t-name="discuss.ChannelInvitation-selectableItem">
-        <t t-set="isSelected" t-value="selectablePartner ? selectablePartner.in(this.selectedPartners) : this.state.selectedEmails.includes(selectableEmailAddress)"/>
-        <li class="o-discuss-ChannelInvitation-selectable object-fit-cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0 w-100"
-            t-att-class="{ 'o-odd': selectableItemIndex % 2 === 1, 'o-selected': isSelected, 'align-items-center': selectableEmailAddress }"
-            t-on-click="() => selectablePartner ? this.onClickSelectablePartner(selectablePartner) : this.onClickSelectableEmail(selectableEmailAddress) "
-        >
-            <div class="d-flex align-items-center p-1 bg-inherit">
-                <div class="position-relative d-flex flex-shrink-0 bg-inherit">
-                    <DiscussAvatar t-if="selectablePartner" persona="selectablePartner"/>
-                    <div t-else="" class="w-100 h-100 d-flex align-items-center justify-content-center rounded-3 bg-primary text-white">
-                        <i class="fa fa-envelope"/>
-                    </div>
-                </div>
-            </div>
-            <div class="d-flex flex-column mx-2 o-mb-0_5 flex-grow-1 overflow-hidden">
-                <t t-if="selectablePartner">
-                    <div class="d-flex overflow-hidden align-items-baseline" name="selectablePartnerName">
-                        <span class="text-truncate" t-out="selectablePartner.name"/>
-                    </div>
-                    <div class="d-flex flex-column flex-grow-1 gap-1" name="selectablePartnerDetail">
-                        <span t-if="selectablePartner.email" t-out="selectablePartner.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
-                    </div>
-                </t>
-                <div t-else="" class="overflow-hidden d-flex flex-column align-items-baseline">
-                    <span class="text-truncate text-start w-100" t-out="selectableEmailAddress"/>
-                    <span t-if="this.state.sentEmails.has(selectableEmailAddress)" class="text-truncate text-start smaller text-600 fw-normal lh-1 w-100">Invitation already sent to this address</span>
-                </div>
-            </div>
-            <input class="form-check-input flex-shrink-0 mt-0 mx-1" type="checkbox" t-att-checked="isSelected ? 'checked' : undefined"/>
-        </li>
+    <t t-name="discuss.ChannelInvitation-beforeOptions">
+        <div t-if="state.searchResultCount > state.selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="showingResultNarrowText"/>
     </t>
+    <t t-name="discuss.ChannelInvitation-additionalItemContent">
+        <span t-if="option.email and state.sentEmails.has(option.email)" class="text-truncate text-start smaller text-600 fw-normal lh-1 w-100">Invitation already sent to this address</span>
+    </t>
+
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -9,35 +9,33 @@
     </t>
 
     <t t-name="discuss.ChannelInvitation.main">
-        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.channel }">
+        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': this.props.hasSizeConstraints, 'px-1': !this.props.channel }">
             <div class="d-flex flex-column flex-grow-1 overflow-hidden o-min-height-0">
-                <t t-call="discuss.SelectableList">
-                    <t t-set="beforeOptionsTemplate" t-value="'discuss.ChannelInvitation-beforeOptions'"/>
-                    <t t-set="additionalItemContentTemplate" t-value="'discuss.ChannelInvitation-additionalItemContent'"/>
-                </t>
+                <SelectableList state="this.selectableListState" autofocus="this.store.self_user and this.props.channel" optionAvatarUrl="(option) => this.getOptionAvatarUrl(option)">
+                    <t t-set-slot="beforeOptionsTemplate">
+                        <div t-if="this.state.searchResultCount > this.state.selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.showingResultNarrowText"/>
+                    </t>
+                    <t t-set-slot="additionalItemContentTemplate" t-slot-scope="option">
+                        <span t-if="option.email and this.state.sentEmails.has(option.email)" class="text-truncate text-start smaller text-600 fw-normal lh-1 w-100">Invitation already sent to this address</span>
+                    </t>
+                </SelectableList>
             </div>
             <div class="flex-shrink-0 bg-inherit">
                 <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
-                    <button t-if="store.self_user and props.channel and selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="invitationButtonText" t-on-click="onClickInvite">
-                        <t t-out="invitationButtonText"/>
+                    <button t-if="this.store.self_user and props.channel and this.selectableListState.selectedOptions.length" class="btn btn-primary w-100 my-2" t-att-title="invitationButtonText" t-on-click="onClickInvite">
+                        <t t-out="this.invitationButtonText"/>
                     </button>
-                    <hr t-if="props.channel?.invitationLink" class="border-dark-subtle"/>
-                    <div t-if="props.channel?.invitationLink" class="input-group">
-                        <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
-                        <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => props.channel.copyInvitationLink()">
+                    <hr t-if="this.props.channel?.invitationLink" class="border-dark-subtle"/>
+                    <div t-if="this.props.channel?.invitationLink" class="input-group">
+                        <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="this.props.channel.invitationLink" readonly="" disabled="" t-on-focus="this.onFocusInvitationLinkInput"/>
+                        <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => this.props.channel.copyInvitationLink()">
                             <i class="fa fa-copy"/>
                         </button>
                     </div>
-                    <div t-if="props.channel?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-out="props.channel.accessRestrictedToGroupText"/>
+                    <div t-if="this.props.channel?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-out="this.props.channel.accessRestrictedToGroupText"/>
                 </div>
             </div>
         </div>
-    </t>
-    <t t-name="discuss.ChannelInvitation-beforeOptions">
-        <div t-if="state.searchResultCount > state.selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="showingResultNarrowText"/>
-    </t>
-    <t t-name="discuss.ChannelInvitation-additionalItemContent">
-        <span t-if="option.email and state.sentEmails.has(option.email)" class="text-truncate text-start smaller text-600 fw-normal lh-1 w-100">Invitation already sent to this address</span>
     </t>
 
 </templates>

--- a/addons/mail/static/src/discuss/core/common/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/message_patch.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Message" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o-mail-Message-body')]" position="after">
-            <div class="o-mail-Message-seenContainer position-absolute">
+    <t t-inherit="mail.Message-bodyContent" t-inherit-mode="extension">
+        <xpath expr="//div[@t-ref='body']" position="after">
+            <div t-if="message.isBodyEmpty and message.attachment_ids.length > 0 and props.message.showSeenIndicator(props.thread)" class="o-mail-Message-seenContainer position-absolute ratio-1x1 rounded-circle p-1">
                 <MessageSeenIndicator
-                    t-if="this.props.message.showSeenIndicator(this.props.thread)"
-                    message="this.props.message"
-                />
-            </div>
-        </xpath>
-        <xpath expr="//AttachmentList" position="after">
-            <div t-if="this.props.message.isBodyEmpty and this.message.attachment_ids.length > 0" class="o-mail-Message-seenContainer position-absolute ratio-1x1 rounded-circle p-1">
-                <MessageSeenIndicator
-                    t-if="this.props.message.showSeenIndicator(this.props.thread)"
-                    message="this.props.message"
+                    message="props.message"
                 />
             </div>
         </xpath>

--- a/addons/mail/static/src/discuss/core/common/selectable_list.js
+++ b/addons/mail/static/src/discuss/core/common/selectable_list.js
@@ -1,0 +1,94 @@
+import { ImStatus } from "@mail/core/common/im_status";
+
+import { Component, useState, useRef } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+export class SelectableList extends Component {
+    static components = { ImStatus };
+    static props = {};
+    static template = "discuss.SelectableList";
+
+    setup() {
+        this.store = useService("mail.store");
+        this.inputRef = useRef("input");
+        this.internalState = useState({
+            search: "",
+            selectedOptions: [],
+            isLoading: false,
+        });
+    }
+
+    get search() {
+        return this.internalState.search;
+    }
+
+    set search(value) {
+        this.internalState.search = value;
+    }
+
+    get selectedOptions() {
+        return this.internalState.selectedOptions;
+    }
+
+    get options() {
+        return [];
+    }
+
+    get maxSelectionLimit() {
+        return false;
+    }
+
+    get searchPlaceholder() {
+        return _t("Search...");
+    }
+
+    onInput() {
+        const value = this.inputRef.el?.value ?? "";
+        this.search = value;
+    }
+
+    clearSearch() {
+        this.search = "";
+    }
+
+    toggleSelection = (option) => {
+        const selectedOptions = [...this.selectedOptions];
+        const idx = selectedOptions.findIndex((selected) => selected.id === option.id);
+        if (idx === -1) {
+            if (this.maxSelectionLimit && selectedOptions.length >= this.maxSelectionLimit) {
+                return;
+            }
+            selectedOptions.push(option);
+        } else {
+            selectedOptions.splice(idx, 1);
+        }
+        this.internalState.selectedOptions = selectedOptions;
+    };
+
+    isSelected(option) {
+        return this.selectedOptions.some((selected) => selected.id === option.id);
+    }
+
+    getOptionDisplayName(option) {
+        if (option.isPartner && option.partner) {
+            return option.partner.displayName ?? option.partner.name ?? "";
+        }
+        if (option.email) {
+            return option.email;
+        }
+        return option.displayName ?? option.name ?? "";
+    }
+
+    getOptionAvatarUrl(option) {
+        if (option.isPartner && option.partner) {
+            return option.partner.avatarUrl;
+        }
+        return option.avatarUrl ?? "";
+    }
+
+    get emptyStateText() {
+        return this.isLoading ? _t("Searching...") : _t("No results found");
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/selectable_list.js
+++ b/addons/mail/static/src/discuss/core/common/selectable_list.js
@@ -1,39 +1,49 @@
 import { ImStatus } from "@mail/core/common/im_status";
 
-import { Component, useState, useRef } from "@odoo/owl";
+import { Component, useState, useRef, onMounted } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
+function makeSelectableListState() {
+    return useState({
+        searchTerm: "",
+        options: [],
+        selectedOptions: [],
+        isLoading: false,
+    });
+}
+
+export function useSelectableListState() {
+    return makeSelectableListState();
+}
+
 export class SelectableList extends Component {
     static components = { ImStatus };
-    static props = {};
+    static props = ["state?", "slots", "autofocus?", "optionAvatarUrl"];
     static template = "discuss.SelectableList";
 
     setup() {
         this.store = useService("mail.store");
         this.inputRef = useRef("input");
-        this.internalState = useState({
-            search: "",
-            selectedOptions: [],
-            isLoading: false,
+        this.internalState = makeSelectableListState();
+        onMounted(() => {
+            if (this.props.autofocus) {
+                this.inputRef.el.focus();
+            }
         });
     }
 
+    get state() {
+        return this.props.state || this.internalState;
+    }
+
     get search() {
-        return this.internalState.search;
+        return this.state.search;
     }
 
     set search(value) {
-        this.internalState.search = value;
-    }
-
-    get selectedOptions() {
-        return this.internalState.selectedOptions;
-    }
-
-    get options() {
-        return [];
+        this.state.search = value;
     }
 
     get maxSelectionLimit() {
@@ -54,7 +64,7 @@ export class SelectableList extends Component {
     }
 
     toggleSelection = (option) => {
-        const selectedOptions = [...this.selectedOptions];
+        const selectedOptions = [...this.state.selectedOptions];
         const idx = selectedOptions.findIndex((selected) => selected.id === option.id);
         if (idx === -1) {
             if (this.maxSelectionLimit && selectedOptions.length >= this.maxSelectionLimit) {
@@ -64,11 +74,11 @@ export class SelectableList extends Component {
         } else {
             selectedOptions.splice(idx, 1);
         }
-        this.internalState.selectedOptions = selectedOptions;
+        this.state.selectedOptions = selectedOptions;
     };
 
     isSelected(option) {
-        return this.selectedOptions.some((selected) => selected.id === option.id);
+        return this.state.selectedOptions.some((selected) => selected.id === option.id);
     }
 
     getOptionDisplayName(option) {
@@ -82,6 +92,10 @@ export class SelectableList extends Component {
     }
 
     getOptionAvatarUrl(option) {
+        const optionFromProp = this.props.optionAvatarUrl(option);
+        if (optionFromProp) {
+            return optionFromProp;
+        }
         if (option.isPartner && option.partner) {
             return option.partner.avatarUrl;
         }

--- a/addons/mail/static/src/discuss/core/common/selectable_list.scss
+++ b/addons/mail/static/src/discuss/core/common/selectable_list.scss
@@ -1,0 +1,30 @@
+.o-discuss-SelectableList-avatar {
+    width: 32px;
+    aspect-ratio: 1;
+}
+
+.o-discuss-SelectableList-selectable {
+    &:hover {
+        background-color: mix($gray-100, $gray-200) !important;
+    }
+    &.o-selected {
+        background-color: mix($o-view-background-color, $o-action, 85%) !important;
+    }
+}
+
+.o-discuss-SelectableList-selectedList {
+    max-height: 100px;
+
+    button {
+        background-color: mix($o-view-background-color, $o-action, 85%);
+
+        &:not(:hover) .oi-close {
+            border-color: transparent !important;
+        }
+
+        &:hover .oi-close {
+            color: $danger;
+            border-color: $danger !important;
+        }
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/selectable_list.xml
+++ b/addons/mail/static/src/discuss/core/common/selectable_list.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.SelectableList">
+        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0">
+            <div t-if="subtitleText" class="smaller p-1 text-muted" t-att-class="{ 'text-warning': maxSelectionLimit and selectedOptions.length >= maxSelectionLimit }">
+                <t t-out="subtitleText"/>
+            </div>
+            <t t-if="store and store.self_user">
+                <div class="input-group mb-2 border rounded">
+                    <input class="o-discuss-SelectableList-search form-control form-control-sm border-0"
+                        t-att-value="search" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                    <button class="btn btn-link" t-on-click="clearSearch" aria-label="Clear search">
+                        <i class="fa p-1" t-att-class="{'fa-search': !search, 'fa-times': search}"/>
+                    </button>
+                </div>
+                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1"
+                    t-att-class="{ 'align-items-center justify-content-center': !options.length }">
+                    <div t-if="!options.length" class="d-flex flex-column align-items-center justify-content-center text-muted">
+                        <i t-if="internalState.isLoading" class="fa fa-2x fa-spin fa-spinner mb-2"/>
+                        <div class="smaller" t-out="emptyStateText"/>
+                    </div>
+                    <t t-if="beforeOptionsTemplate" t-call="{{ beforeOptionsTemplate }}"/>
+                    <t t-foreach="options" t-as="option" t-key="option.id">
+                        <t t-call="{{ selectableItemTemplate or 'discuss.SelectableList-selectableItem' }}">
+                            <t t-set="optionIndex" t-value="option_index"/>
+                        </t>
+                    </t>
+                </ul>
+            </t>
+            <div class="o-discuss-SelectableList-selectedList pt-0 pb-1 bg-inherit">
+                <t t-if="store and store.self_user">
+                    <div t-if="selectedOptions.length > 0" class="pt-2">
+                        <div class="d-flex flex-wrap overflow-auto o-scrollbar-thin">
+                            <t t-foreach="selectedOptions" t-as="selectedOption" t-key="selectedOption.id">
+                                <button class="btn btn-light fw-bolder smaller pe-1" title="Unselect" t-on-click="() => toggleSelection(selectedOption)">
+                                    <t t-out="getOptionDisplayName(selectedOption)"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
+                                </button>
+                            </t>
+                        </div>
+                    </div>
+                </t>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="discuss.SelectableList-selectableItemAvatar">
+        <div class="o-discuss-SelectableList-avatar position-relative d-flex flex-shrink-0 bg-inherit">
+            <t t-if="option.isPartner and option.partner">
+                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="getOptionAvatarUrl(option)"/>
+                <ImStatus persona="option.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
+            </t>
+            <t t-elif="option.email">
+                <div class="w-100 h-100 d-flex align-items-center justify-content-center rounded-3 bg-primary text-white">
+                    <i class="fa fa-envelope"/>
+                </div>
+            </t>
+            <t t-else="">
+                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="getOptionAvatarUrl(option)"/>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="discuss.SelectableList-selectableItem">
+        <t t-set="isSelected" t-value="isSelected(option)"/>
+        <t t-set="selectablePartner" t-value="option.isPartner and option.partner ? option.partner : null"/>
+        <li class="o-discuss-SelectableList-selectable object-fit-cover d-flex align-items-start px-1 py-0 btn list-group-item border-0 rounded-0 w-100"
+            t-att-class="{ 'o-odd': optionIndex % 2 === 1, 'o-selected': isSelected, 'align-items-center': option.email }"
+            t-on-click="() => toggleSelection(option)">
+            <div class="d-flex align-items-center p-1 bg-inherit">
+                <t t-call="discuss.SelectableList-selectableItemAvatar"/>
+            </div>
+            <div class="d-flex flex-column mx-2 flex-grow-1 overflow-hidden o-mt-0_5">
+                <div class="d-flex overflow-hidden align-items-baseline" name="selectablePartnerName">
+                    <span class="text-truncate" t-out="getOptionDisplayName(option)"/>
+                </div>
+                <t t-if="option.isPartner and option.partner">
+                    <div class="d-flex flex-column flex-grow-1 gap-1" name="selectablePartnerDetail">
+                        <span t-if="option.partner.email" t-out="option.partner.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
+                        <t t-if="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+                    </div>
+                </t>
+                <div t-elif="option.email" class="overflow-hidden d-flex flex-column align-items-baseline">
+                        <span class="text-truncate text-start w-100" t-out="option.email"/>
+                        <t t-if="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+                </div>
+                <t t-elif="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+            </div>
+            <input class="form-check-input flex-shrink-0 me-1" type="checkbox" t-att-checked="isSelected ? 'checked' : undefined"
+                t-att-disabled="maxSelectionLimit and selectedOptions.length >= maxSelectionLimit and !isSelected"/>
+        </li>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/core/common/selectable_list.xml
+++ b/addons/mail/static/src/discuss/core/common/selectable_list.xml
@@ -3,25 +3,25 @@
 
     <t t-name="discuss.SelectableList">
         <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0">
-            <div t-if="subtitleText" class="smaller p-1 text-muted" t-att-class="{ 'text-warning': maxSelectionLimit and selectedOptions.length >= maxSelectionLimit }">
-                <t t-out="subtitleText"/>
+            <div t-if="this.subtitleText" class="smaller p-1 text-muted" t-att-class="{ 'text-warning': this.maxSelectionLimit and this.state.selectedOptions.length >= this.maxSelectionLimit }">
+                <t t-out="this.subtitleText"/>
             </div>
-            <t t-if="store and store.self_user">
+            <t t-if="this.store?.self_user">
                 <div class="input-group mb-2 border rounded">
                     <input class="o-discuss-SelectableList-search form-control form-control-sm border-0"
-                        t-att-value="search" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                        t-att-value="this.state.searchTerm" t-ref="input" t-att-placeholder="this.searchPlaceholder" t-on-input="this.onInput"/>
                     <button class="btn btn-link" t-on-click="clearSearch" aria-label="Clear search">
-                        <i class="fa p-1" t-att-class="{'fa-search': !search, 'fa-times': search}"/>
+                        <i class="fa p-1" t-att-class="{'fa-search': !this.state.searchTerm, 'fa-times': this.state.searchTerm}"/>
                     </button>
                 </div>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1"
-                    t-att-class="{ 'align-items-center justify-content-center': !options.length }">
-                    <div t-if="!options.length" class="d-flex flex-column align-items-center justify-content-center text-muted">
-                        <i t-if="internalState.isLoading" class="fa fa-2x fa-spin fa-spinner mb-2"/>
-                        <div class="smaller" t-out="emptyStateText"/>
+                    t-att-class="{ 'align-items-center justify-content-center': !this.state.options.length }">
+                    <div t-if="!this.state.options.length" class="d-flex flex-column align-items-center justify-content-center text-muted">
+                        <i t-if="this.state.isLoading" class="fa fa-2x fa-spin fa-spinner mb-2"/>
+                        <div class="smaller" t-out="this.emptyStateText"/>
                     </div>
-                    <t t-if="beforeOptionsTemplate" t-call="{{ beforeOptionsTemplate }}"/>
-                    <t t-foreach="options" t-as="option" t-key="option.id">
+                    <t t-slot="beforeOptionsTemplate"/>
+                    <t t-foreach="this.state.options" t-as="option" t-key="option.id">
                         <t t-call="{{ selectableItemTemplate or 'discuss.SelectableList-selectableItem' }}">
                             <t t-set="optionIndex" t-value="option_index"/>
                         </t>
@@ -29,12 +29,12 @@
                 </ul>
             </t>
             <div class="o-discuss-SelectableList-selectedList pt-0 pb-1 bg-inherit">
-                <t t-if="store and store.self_user">
-                    <div t-if="selectedOptions.length > 0" class="pt-2">
+                <t t-if="this.store?.self_user">
+                    <div t-if="this.state.selectedOptions.length > 0" class="pt-2">
                         <div class="d-flex flex-wrap overflow-auto o-scrollbar-thin">
-                            <t t-foreach="selectedOptions" t-as="selectedOption" t-key="selectedOption.id">
-                                <button class="btn btn-light fw-bolder smaller pe-1" title="Unselect" t-on-click="() => toggleSelection(selectedOption)">
-                                    <t t-out="getOptionDisplayName(selectedOption)"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
+                            <t t-foreach="this.state.selectedOptions" t-as="selectedOption" t-key="selectedOption.id">
+                                <button class="btn btn-light fw-bolder smaller pe-1" title="Unselect" t-on-click="() => this.toggleSelection(selectedOption)">
+                                    <t t-out="this.getOptionDisplayName(selectedOption)"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
                                 </button>
                             </t>
                         </div>
@@ -47,7 +47,7 @@
     <t t-name="discuss.SelectableList-selectableItemAvatar">
         <div class="o-discuss-SelectableList-avatar position-relative d-flex flex-shrink-0 bg-inherit">
             <t t-if="option.isPartner and option.partner">
-                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="getOptionAvatarUrl(option)"/>
+                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="this.getOptionAvatarUrl(option)"/>
                 <ImStatus persona="option.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
             </t>
             <t t-elif="option.email">
@@ -56,13 +56,13 @@
                 </div>
             </t>
             <t t-else="">
-                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="getOptionAvatarUrl(option)"/>
+                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="this.getOptionAvatarUrl(option)"/>
             </t>
         </div>
     </t>
 
     <t t-name="discuss.SelectableList-selectableItem">
-        <t t-set="isSelected" t-value="isSelected(option)"/>
+        <t t-set="isSelected" t-value="this.isSelected(option)"/>
         <t t-set="selectablePartner" t-value="option.isPartner and option.partner ? option.partner : null"/>
         <li class="o-discuss-SelectableList-selectable object-fit-cover d-flex align-items-start px-1 py-0 btn list-group-item border-0 rounded-0 w-100"
             t-att-class="{ 'o-odd': optionIndex % 2 === 1, 'o-selected': isSelected, 'align-items-center': option.email }"
@@ -77,17 +77,17 @@
                 <t t-if="option.isPartner and option.partner">
                     <div class="d-flex flex-column flex-grow-1 gap-1" name="selectablePartnerDetail">
                         <span t-if="option.partner.email" t-out="option.partner.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
-                        <t t-if="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+                        <t t-slot="additionalItemContentTemplate" t-call-context="option"/>
                     </div>
                 </t>
                 <div t-elif="option.email" class="overflow-hidden d-flex flex-column align-items-baseline">
-                        <span class="text-truncate text-start w-100" t-out="option.email"/>
-                        <t t-if="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+                    <span class="text-truncate text-start w-100" t-out="option.email"/>
+                    <t t-slot="additionalItemContentTemplate" t-call-context="option"/>
                 </div>
-                <t t-elif="additionalItemContentTemplate" t-call="{{ additionalItemContentTemplate }}"/>
+                <t t-else="" t-slot="additionalItemContentTemplate" t-call-context="option"/>
             </div>
             <input class="form-check-input flex-shrink-0 me-1" type="checkbox" t-att-checked="isSelected ? 'checked' : undefined"
-                t-att-disabled="maxSelectionLimit and selectedOptions.length >= maxSelectionLimit and !isSelected"/>
+                t-att-disabled="this.maxSelectionLimit and this.state.selectedOptions.length >= this.maxSelectionLimit and !isSelected"/>
         </li>
     </t>
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -25,10 +25,12 @@ class CreateChatDialog extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.invitePeopleState = useState({
-            selectablePartners: [],
             selectedPartners: [],
-            searchStr: this.props.name,
         });
+    }
+
+    onSelectionChange(selectedPartners) {
+        this.invitePeopleState.selectedPartners = selectedPartners;
     }
 
     get createText() {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -47,7 +47,7 @@
             <div class="d-flex align-items-center px-0 mb-1 gap-1">
                 <span class="ms-2 my-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="oi oi-user-plus"/> Invite people</span>
             </div>
-            <ChannelInvitation state="this.invitePeopleState"/>
+            <ChannelInvitation searchStr="props.name" onSelectionChange.bind="onSelectionChange"/>
         </div>
         <t t-set-slot="footer">
             <button class="btn btn-primary me-2" t-on-click="this.onClickConfirm" t-out="this.createText"/>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -402,7 +402,7 @@ test("'New Meeting' in mobile", async () => {
     await contains("button[title*='Close Chat Window']");
     await click("button:text('Chats')");
     await click("button[title='New Meeting']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Partner 2'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Partner 2'))");
     await click("button:not([disabled]):text('Invite to Meeting')");
     await contains(".o-discuss-Call");
     await click("[title='Exit Fullscreen']");
@@ -824,9 +824,9 @@ test("should also invite to the call when inviting to the channel", async () => 
     await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     await click("button[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation:has(:text('Invite people'))");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner'))");
-    await click("button[title='Invite']:enabled");
+    await contains(".o-discuss-ChannelInvitation");
+    await click(".o-discuss-SelectableList-selectable:has(:text('TestPartner'))");
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-CallParticipantCard.o-isInvitation");
 });
 

--- a/addons/mail/static/tests/discuss/core/bus_subscription.test.js
+++ b/addons/mail/static/tests/discuss/core/bus_subscription.test.js
@@ -69,7 +69,7 @@ test("bus subscription updated when joining locally pinned thread", async () => 
     await waitForChannels([`discuss.channel_${channelId}`]);
     await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Mitchell Admin'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Mitchell Admin'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
 });

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -57,7 +57,7 @@ test("can invite users in channel from chat window", async () => {
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item:text('Invite People')");
     await contains(".o-discuss-ChannelInvitation");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('TestPartner'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(
@@ -89,8 +89,8 @@ test("should be able to search for a new user to invite from an existing chat", 
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
-    await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
-    await contains(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner2'))");
+    await insertText(".o-discuss-SelectableList-search", "TestPartner2");
+    await contains(".o-discuss-SelectableList-selectable:has(:text('TestPartner2'))");
 });
 
 test("Invitation form should display channel group restriction", async () => {
@@ -144,8 +144,8 @@ test("should be able to create a new group chat from an existing chat", async ()
     await openDiscuss(channelId);
     await click(".o-mail-DiscussContent-header button[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation");
-    await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner2'))");
+    await insertText(".o-discuss-SelectableList-search", "TestPartner2");
+    await click(".o-discuss-SelectableList-selectable:has(:text('TestPartner2'))");
     await click("button[title='Create Group Chat']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(
@@ -226,8 +226,8 @@ test("invite user to self chat opens DM chat with user", async () => {
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('TestGuest and Mitchell Admin')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('TestPartner')");
     await click(".o-mail-DiscussContent-header button[title='Invite People']");
-    await insertText(".o-discuss-ChannelInvitation-search", "TestPartner");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner'))");
+    await insertText(".o-discuss-SelectableList-search", "TestPartner");
+    await click(".o-discuss-SelectableList-selectable:has(:text('TestPartner'))");
     await click("button:contains('Go to Conversation'):enabled");
     await contains(".o-mail-DiscussSidebarChannel.o-active:text('TestPartner')");
 });

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -232,7 +232,7 @@ test("Channel member count update after user joined", async () => {
     await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await contains(".o-discuss-ChannelMemberList h6:text('Offline - 1')");
     await click("[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Harry'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-discuss-ChannelMemberList h6:text('Offline - 2')");

--- a/addons/mail/static/tests/discuss/core/common/channel_group_name.test.js
+++ b/addons/mail/static/tests/discuss/core/common/channel_group_name.test.js
@@ -27,21 +27,21 @@ test("Group name is based on channel members when name is not set", async () => 
     await openDiscuss(channelId);
     await contains(".o-mail-DiscussContent-threadName[title='Mitchell Admin']");
     await click("button[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Alice'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Alice'))");
     await click("button:text('Invite to Group Chat')");
     await contains(".o-mail-DiscussContent-threadName[title='Mitchell Admin and Alice']");
     await click("button[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Bob'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Bob'))");
     await click("button:text('Invite to Group Chat')");
     await contains(".o-mail-DiscussContent-threadName[title='Mitchell Admin, Alice, and Bob']");
     await click("button[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Eve'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Eve'))");
     await click("button:text('Invite to Group Chat')");
     await contains(
         ".o-mail-DiscussContent-threadName[title='Mitchell Admin, Alice, Bob, and 1 other']"
     );
     await click("button[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('John'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('John'))");
     await click("button:text('Invite to Group Chat')");
     await contains(
         ".o-mail-DiscussContent-threadName[title='Mitchell Admin, Alice, Bob, and 2 others']"
@@ -54,7 +54,7 @@ test("Group name is based on channel members when name is not set", async () => 
     await press("Enter");
     // Ensure that after setting the name, members are not taken into account for the group name.
     await click("button[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Sam'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Sam'))");
     await click("button:text('Invite to Group Chat')");
     await contains(".o_mail_notification:text('invited Sam to the channel')");
     await contains(".o-mail-DiscussContent-threadName[title='Custom name']");

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -22,7 +22,7 @@ test("Add member to channel", async () => {
     await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await contains(".o-discuss-ChannelMember:text('Mitchell Admin')");
     await click("[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Harry'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-discuss-ChannelMember:text('Harry')");

--- a/addons/mail/static/tests/discuss/core/forward_message.test.js
+++ b/addons/mail/static/tests/discuss/core/forward_message.test.js
@@ -1,0 +1,52 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    insertText,
+    openDiscuss,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { describe, test } from "@odoo/hoot";
+
+import { serverState } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("Should redirect the user to the target channel once a message is forwarded", async () => {
+    const pyEnv = await startServer();
+    const [sourceChannelId] = pyEnv["discuss.channel"].create([
+        { name: "Source Channel" },
+        { name: "Target Channel" },
+    ]);
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "hola amigo, a message to forward!",
+        model: "discuss.channel",
+        res_id: sourceChannelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(sourceChannelId);
+    await contains(".o-mail-Message-content", { text: "hola amigo, a message to forward!" });
+    await click(".o-mail-Message-actions [title='Expand']");
+    await click(".dropdown-item", { text: "Forward" });
+    await contains(".modal-dialog", { text: "Forward To" });
+    await contains(".o-mail-Forward-core", { text: "hola amigo, a message to forward!" });
+    await insertText(".o-discuss-SelectableList-search", "Target Channel");
+    await contains(".list-group-item", { text: "Target Channel" });
+    await click(".list-group-item", { text: "Target Channel" });
+    await contains(".list-group-item input[type='checkbox']:checked");
+    await insertText("textarea[placeholder='Add an optional message...']", "Check this out!");
+    await click("button", { text: "Send" });
+    await contains(".modal-dialog", { count: 0 });
+    await contains(".o-mail-DiscussContent-threadName[title='Target Channel']");
+    await contains(".o-mail-Message-bubble", { text: "hola amigo, a message to forward!" });
+    await contains(".o-mail-Message-bubble", { text: "Forwarded" });
+    await contains(".o-mail-Message-content", { text: "Check this out!" });
+    await click(".o-mail-ForwardedMessage-link");
+    await contains(".o-mail-DiscussContent-threadName[title='Source Channel']");
+    await contains(".o-mail-Message.o-highlighted", { text: "hola amigo, a message to forward!" });
+});

--- a/addons/mail/static/tests/discuss/core/web/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab.test.js
@@ -24,7 +24,7 @@ test("Channel subscription is renewed when channel is manually added", async () 
     await openDiscuss(channelId);
     await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable:has(:text('Mitchell Admin'))");
+    await click(".o-discuss-SelectableList-selectable:has(:text('Mitchell Admin'))");
     await click("[title='Invite']:enabled");
     await expect.waitForSteps(["update-channels"]);
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -628,6 +628,33 @@ registerRoute("/mail/message/translate", translate);
 /** @type {RouteCallback} */
 async function translate(request) {}
 
+registerRoute("/mail/message/forward", mail_message_forward);
+/** @type {RouteCallback} */
+async function mail_message_forward(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    const {
+        forwarded_from_id,
+        optional_msg_body,
+        target_channels_ids,
+        optional_msg_has_link = false,
+        source_msg_has_link = false,
+    } = await parseRequestParams(request);
+    const channels = DiscussChannel.browse(target_channels_ids);
+    if (!channels.length) {
+        return;
+    }
+    DiscussChannel._forward_message(
+        target_channels_ids,
+        makeKwArgs({
+            source_message_id: forwarded_from_id,
+            optional_msg_body,
+            optional_msg_has_link,
+            source_msg_has_link,
+        })
+    );
+}
+
 registerRoute("/mail/message/update_content", mail_message_update_content);
 /** @type {RouteCallback} */
 async function mail_message_update_content(request) {

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -963,4 +963,75 @@ export class DiscussChannel extends models.ServerModel {
         });
         MailGuest._set_auth_cookie(guestId);
     }
+
+    /**
+     * @param {number[]} ids
+     * @param {number} source_message_id
+     * @param {string} [optional_msg_body]
+     * @param {boolean} [optional_msg_has_link]
+     * @param {boolean} [source_msg_has_link]
+     */
+    _forward_message(
+        ids,
+        source_message_id,
+        optional_msg_body,
+        optional_msg_has_link,
+        source_msg_has_link
+    ) {
+        const kwargs = getKwArgs(
+            arguments,
+            "ids",
+            "source_message_id",
+            "optional_msg_body",
+            "optional_msg_has_link",
+            "source_msg_has_link"
+        );
+        ids = kwargs.ids;
+        delete kwargs.ids;
+        optional_msg_body = kwargs.optional_msg_body || false;
+        optional_msg_has_link = kwargs.optional_msg_has_link || false;
+        source_msg_has_link = kwargs.source_msg_has_link || false;
+
+        /** @type {import("mock_models").IrAttachment} */
+        const IrAttachment = this.env["ir.attachment"];
+        /** @type {import("mock_models").MailMessage} */
+        const MailMessage = this.env["mail.message"];
+        const [forwardedMessage] = MailMessage.browse(kwargs.source_message_id);
+
+        for (const channel of this.browse(ids)) {
+            const newAttachmentIds = [];
+            if (forwardedMessage.attachment_ids?.length) {
+                const attachments = IrAttachment.browse(forwardedMessage.attachment_ids);
+                for (const attachment of attachments) {
+                    const newAttachmentId = IrAttachment.create({
+                        name: attachment.name,
+                        mimetype: attachment.mimetype,
+                        res_model: "discuss.channel",
+                        res_id: channel.id,
+                    });
+                    newAttachmentIds.push(newAttachmentId);
+                }
+            }
+            this.message_post(
+                channel.id,
+                makeKwArgs({
+                    body: forwardedMessage.body,
+                    message_type: "comment",
+                    forwarded_from_id: forwardedMessage.id,
+                    subtype_xmlid: "mail.mt_comment",
+                    attachment_ids: newAttachmentIds,
+                })
+            );
+            if (optional_msg_body) {
+                this.message_post(
+                    channel.id,
+                    makeKwArgs({
+                        body: optional_msg_body,
+                        message_type: "comment",
+                        subtype_xmlid: "mail.mt_comment",
+                    })
+                );
+            }
+        }
+    }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -9,6 +9,7 @@ export class MailMessage extends models.ServerModel {
     _name = "mail.message";
 
     author_id = fields.Generic({ default: () => serverState.partnerId });
+    forwarded_from_id = fields.Many2one({ relation: "mail.message" });
     pinned_at = fields.Generic({ default: false });
 
     /** @param {DomainListRepr} [domain] */
@@ -185,6 +186,7 @@ export class MailMessage extends models.ServerModel {
             mailDataHelpers.Store.attr("body", (m) => ["markup", m.body]),
             "create_date",
             "date",
+            mailDataHelpers.Store.one("forwarded_from_id"),
             "message_type",
             "model",
             "message_link_preview_ids",

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -10,13 +10,13 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
             run: "click",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-search[placeholder='Enter name or email']",
+            trigger: ".o-discuss-SelectableList-search[placeholder='Enter name or email']",
             run: "edit john@test.com",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-selectable:contains('john (base.group_user)')",
+            trigger: ".o-discuss-SelectableList-selectable:contains('john (base.group_user)')",
             async run({ waitFor, click }) {
-                await waitFor(".o-discuss-ChannelInvitation-selectable", {
+                await waitFor(".o-discuss-SelectableList-selectable", {
                     only: true,
                     timeout: 5000,
                 });
@@ -24,20 +24,18 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
             },
         },
         {
-            trigger:
-                ".o-discuss-ChannelInvitation-selectedList :contains('john (base.group_user)')",
+            trigger: ".o-discuss-SelectableList-selectedList :contains('john (base.group_user)')",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-search",
+            trigger: ".o-discuss-SelectableList-search",
             run: "edit unknown_email@test.com",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-selectable:contains('unknown_email@test.com')",
+            trigger: ".o-discuss-SelectableList-selectable:contains('unknown_email@test.com')",
             run: "click",
         },
         {
-            trigger:
-                ".o-discuss-ChannelInvitation-selectedList :contains('unknown_email@test.com')",
+            trigger: ".o-discuss-SelectableList-selectedList :contains('unknown_email@test.com')",
         },
         {
             trigger: "button:contains(Invite to Group Chat)",


### PR DESCRIPTION
Adds message forwarding feature to Discuss and Livechat,
allowing users to share messages across channels and private chats efficiently.

Features:

- Forward messages to up to 5 destinations in one action
- Automatically duplicate and attach original message's attachments
- Include optional custom note with forwarded content
- Generate link previews when messages contain links
- Search destinations with recent suggestions

Dialog collects destinations and optional note, then calls /mail/message/forward
The controller validates post access per destination and calls
`discuss.channel._forward_message()`, which duplicates attachments
via `copy_data()`, creates new attachments per channel, and posts the original
message body with `forwarded_from_id` to track the source. The optional note is
posted as a separate message. Link previews are generated asynchronously when
applicable. The ForwardedMessage component displays forwarded messages with
a reference to the original conversation.

task-4633375