### PR TITLE
[FIX] account: display company name in journal selection for ledger

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -23,6 +23,7 @@ class AccountJournalGroup(models.Model):
         'account.journal',
         'journal_group_id',
         string="Included Journals",
+        context={'active_test': False},
     )
     sequence = fields.Integer(default=10)
 
@@ -1050,6 +1051,8 @@ class AccountJournal(models.Model):
             name = journal.name
             if journal.currency_id and journal.currency_id != journal.company_id.sudo().currency_id:
                 name = f"{name} ({journal.currency_id.name})"
+            if len(self.env.companies) > 1 and self.env.context.get('show_company_journal'):
+                name = f"{journal.company_id.name} - {name}"
             journal.display_name = name
 
     def action_configure_bank_journal(self):

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -264,7 +264,7 @@
                 <list editable="bottom">
                     <field name="sequence"  widget="handle"/>
                     <field name="name" placeholder="e.g. GAAP, IFRS, ..."/>
-                    <field name="included_journal_ids" widget="many2many_tags" options="{'no_create': True}" optional="show"/>
+                    <field name="included_journal_ids" widget="many2many_tags" options="{'no_create': True}" context="{'show_company_journal': True}" optional="show"/>
                 </list>
             </field>
         </record>
@@ -279,7 +279,7 @@
                         <group>
                             <field name="name" placeholder="e.g. GAAP, IFRS, ..."/>
                             <field name="sequence" groups="base.group_no_one"/>
-                            <field name="included_journal_ids" options="{'no_create': True}" optional="hide"/>
+                            <field name="included_journal_ids" options="{'no_create': True}" context="{'show_company_journal': True}" optional="hide"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
In multi-company, when choosing the included journals of a journal group,
display the name of the journal's company before the journal name.

Also, add the 'active_test=False' context for the journal in the ledgers
in order that ledgers also take into account the archived journals.

task-6111366


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
