### PR TITLE
[FIX] mrp: fix test_basic_flow_with_minimal_access_rigths AttributeError

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5505,7 +5505,7 @@ class TestMrpOrderPostInstall(TestMrpCommon):
             {'name': f"sn#0{13 + i}"} for i in range(20)
         ])
         mo.button_mark_done()
-        self.assertRecordValues(mo.backorder_ids.sorted('state'), [
+        self.assertRecordValues(mo.production_group_id.production_ids.sorted('state'), [
             {'state': 'confirmed', 'product_qty': 16.0, 'qty_produced': 0.0},
             {'state': 'done', 'product_qty': 20.0, 'qty_produced': 20.0},
         ])


### PR DESCRIPTION
Since the introduction of test_basic_flow_with_minimal_access_rigths in e8ce2d842dd95ee1626f346ee0025abb55beb94e, running the test on 19.0 fails with:

    AttributeError: 'mrp.production' object has no attribute 'backorder_ids'

The mrp.production model on 19.0 does not expose a backorder_ids field anymore: the equivalent relation is now reached through the production group, via production_group_id.production_ids.

The test was backported from master where the same field is also absent, so the assertion was broken as soon as it was introduced on 19.0.

Use production_group_id.production_ids in the assertion to restore the intended check (original MO + its backorder).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
