### PR TITLE
[FIX] l10n_my_edi_pos: unlink prepayment on individual invoices

### DIFF
--- a/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
@@ -18,6 +18,13 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         # EXTENDS 'account_edi_ubl_cii'
         vals = super()._export_invoice_vals(invoice)
 
+        # For individual POS e-invoices, the prepaid amount must be 0.
+        # POS orders are paid immediately at the point of sale, MyInvois requires
+        # the PayableAmount to reflect the full invoice amount (not reduced by prepayment).
+        if invoice.pos_order_ids:
+            vals['vals']['prepaid_payment_vals']['amount'] = 0
+            vals['vals'].get('monetary_total_vals', {})['payable_amount'] = invoice.amount_total
+
         # Support the unlikely case where we invoice a refund of an order included in a consolidated invoice.
         consolidated_invoice = self._is_consolidated_invoice_refund(invoice)
         if consolidated_invoice:

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -230,6 +230,22 @@ class TestMyInvoisPoS(TestPoSCommon):
             self._assert_node_values(xml_tree, "cac:LegalMonetaryTotal/cbc:PayableAmount", expected_total)
 
     @mute_logger('odoo.addons.point_of_sale.models.pos_order')
+    def test_individual_invoice_prepayment_unlink(self):
+        """Ensure that individual POS e-invoices have a PaidAmount of 0.00 and the correct PayableAmount."""
+        with freeze_time("2025-01-01"):
+            with self.with_pos_session(), patch(CONTACT_PROXY_METHOD, new=self._mock_successful_submission):
+                order = self._create_order({'pos_order_lines_ui_args': [(self.product_two, 1.0)], 'customer': self.invoicing_customer, 'is_invoiced': True})
+
+            invoice = order.account_move
+            xml_tree = etree.fromstring(invoice.l10n_my_edi_file_id.raw)
+            tax_inclusive_node = xml_tree.xpath("cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount", namespaces=NS_MAP)
+            self.assertTrue(tax_inclusive_node, "TaxInclusiveAmount node is missing from the XML.")
+            expected_total = tax_inclusive_node[0].text
+
+            self._assert_node_values(xml_tree, "cac:PrepaidPayment/cbc:PaidAmount", '0.00')
+            self._assert_node_values(xml_tree, "cac:LegalMonetaryTotal/cbc:PayableAmount", expected_total)
+
+    @mute_logger('odoo.addons.point_of_sale.models.pos_order')
     def test_send_consolidated_invoice(self):
         with freeze_time("2025-01-01"):
             # Create the orders


### PR DESCRIPTION
For individual POS e-invoices, the PrePayment Amount was mapped to the payment linked to the invoice. This incorrectly decreased the Total Amount Payable to 0, since POS orders are already paid at the counter.

MyInvois tax officer and helpdesk requires that the Total Amount Payable (cbc:PayableAmount) to reflect the total amount of the issued e-document, regardless of prior payments.

This commit forces the PaidAmount to 0 for individual POS e-invoices, ensuring the PayableAmount correctly matches the TaxInclusiveAmount as expected by the MyInvois API.

task-6057187