### PR TITLE
[FIX] hr_attendance: prevent error on kiosk search

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -156,6 +156,8 @@ class HrAttendance(http.Controller):
     @http.route('/hr_attendance/employees_infos', type="json", auth="public")
     def employees_infos(self, token, limit, offset, domain):
         for condition in domain:
+            if not isinstance(condition, (list, tuple)) or len(condition) != 3:
+                continue
             field_name, operator, _value = condition  # Force '&' implicit syntax
             if field_name not in ('name', 'department_id') or operator not in ('=', 'ilike'):
                 raise UserError(_(

--- a/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
+
 from odoo.tests.common import tagged, HttpCase
 from unittest.mock import patch
 from odoo.http import Request
@@ -37,3 +39,28 @@ class TestHrAttendanceKiosk(HttpCase):
         kiosk_info = kiosk_info['kiosk_backend_info']
         self.assertEqual(kiosk_info['company_name'], 'company_B')
         self.assertEqual(kiosk_info['departments'][0]['count'], 1)
+
+    def test_employee_infos_on_kiosk(self):
+        with patch.object(Request, "render", return_value=None) as render:
+            self.url_open(self.company_B.attendance_kiosk_url)
+        _template, kiosk_info = render.call_args[0]
+
+        kiosk_info = kiosk_info['kiosk_backend_info']
+        token = kiosk_info.get('token')
+        domain = ['&', ('department_id', '=', self.department_A.id), ('name', 'ilike', 'employee')]
+
+        # search the employee with department
+        response = self.url_open(
+            url='/hr_attendance/employees_infos',
+            data=json.dumps({
+                'params': {
+                    'token': token,
+                    'limit': 10,
+                    'offset': 0,
+                    'domain': domain,
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        result = json.loads(response.content).get('result')
+        self.assertTrue(result['records'])


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install `hr_attendance` module with demo data.
2. Go to Attendances > Kiosk Mode > Identify Manually.
3. Select any department.
4. Try searching for an employee.

**Error:**
`ValueError - not enough values to unpack (expected 3, got 1)`

**Cause:**
The `employees_infos()` controller assumes that every item in the domain is a valid triplet (field, operator, value). However, the domain may also contain logical operators ('&'), which are not triplets. And then trying to unpack such entries leads to a ValueError.

**Fix:**
Add a validation to ensure the condition is a proper triplet before unpacking. Non-conforming entries (logical operators) are skipped.

sentry-7401444075
opw-6113268