### PR TITLE
[FIX] l10n_{es,it,lu,ug}:make sure to empty subformula on aggregation

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -1849,6 +1849,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_390_65.result_cross_aeat_mod_390_47 - aeat_mod_390_64.balance</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                             <record id="mod_390_casilla_65_result_cross_aeat_mod_390_47" model="account.report.expression">
                                 <field name="label">result_cross_aeat_mod_390_47</field>

--- a/addons/l10n_es/data/mod390/mod390_section3.xml
+++ b/addons/l10n_es/data/mod390/mod390_section3.xml
@@ -44,6 +44,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">aeat_mod_390_84.result_cross_aeat_mod_390_65 + aeat_mod_390_658.balance</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                             <record id="mod_390_casilla_84_result_cross_aeat_mod_390_65" model="account.report.expression">
                                 <field name="label">result_cross_aeat_mod_390_65</field>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
@@ -33,6 +33,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">VL1.cross_report_ve26 + VL1.cross_report_vj19</field>
+                                        <field name="subformula" eval="False"/>
                                     </record>
                                     <record id="tax_annual_report_line_vl1_cross_report_ve26" model="account.report.expression">
                                         <field name="label">cross_report_ve26</field>

--- a/addons/l10n_lu/data/tax_report/section_1.xml
+++ b/addons/l10n_lu/data/tax_report/section_1.xml
@@ -67,6 +67,7 @@
                                                 <field name="label">balance</field>
                                                 <field name="engine">aggregation</field>
                                                 <field name="formula">LUTAX_021.balance + LUTAX_022.balance - LUTAX_456.balance + LUTAX_455.balance - LUTAX_471.balance</field>
+                                                <field name="subformula" eval="False"/>
                                             </record>
                                         </field>
                                     </record>

--- a/addons/l10n_ug/data/account_tax_report_data.xml
+++ b/addons/l10n_ug/data/account_tax_report_data.xml
@@ -521,6 +521,7 @@
                                 <field name="label">normal_formula_part1</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_F31.result_cross_normal_formula_part1 - UG_TAX_F30.disallowed</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                             <record id="F31_normal_tax_result_cross_part1" model="account.report.expression">
                                 <field name="label">result_cross_normal_formula_part1</field>
@@ -550,6 +551,7 @@
                                 <field name="label">sam_formula_part1</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_F31.result_cross_sam_formula_part1 - UG_TAX_F29.allowed - UG_TAX_F30.disallowed</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                             <record id="F31_sam_tax_result_cross_part1" model="account.report.expression">
                                 <field name="label">result_cross_sam_formula_part1</field>
@@ -608,6 +610,7 @@
                                 <field name="label">allowed</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">UG_TAX_F32.allowed + UG_TAX_F33_a.allowed + UG_TAX_F34.result_cross</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                             <record id="F34_tax_result_cross" model="account.report.expression">
                                 <field name="label">result_cross</field>


### PR DESCRIPTION
- This aggregation expression used to have 'cross_report' as subformula. Though, it was useless (since the aggregation only uses term from the same report), and the subformula was removed from the data file without explicitly resetting it to False. This became a problem in 18.3, because the cross_report syntax changes. Because of that, a migrated report failed to open, since it still was using the old syntax on that expression. We fix that by explicitly emptying the subformula.

see https://github.com/odoo/odoo/pull/193106

```python3
Opération invalide

Dans le rapport "Section I (LU)", à la ligne "472 - Autres Ventes / Recettes", avec le libellé "balance",
Le format de l'expression de rapport croisé est invalide.

Format attendu : cross_report(<report_id>|<xml_id>)
Exemple : cross_report(my_module.my_report) ou cross_report(123)
```

opw-6103170
upg-4166654(lu)
upg-4163103(it)
upg-4175631(ug)
upg-4177165(es)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
