### PR TITLE
[FIX] sale_subscription: "Recurring Plan" & "Until" display

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -396,6 +396,18 @@
             }
         }
 
+        .oe_inline {
+            min-width: map-get($spacers, 5);
+            max-width: fit-content !important;
+            .o_input_dropdown {
+                min-width: map-get($spacers, 5);
+            }
+            .o_input {
+                max-width: 100%;
+                field-sizing: content;
+            }
+        }
+
         @include media-breakpoint-up(sm) {
             .o_field_widget {
                 &.o_text_overflow {


### PR DESCRIPTION
Go to Subscription and open a subscription.
=> "Recurring Plan" & "Until" should share the width and be on the same    line.

task-6033618

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
