### PR TITLE
[FIX] tests: fix autoretry

### DIFF
--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -4,7 +4,7 @@ from odoo.tests import BaseCase, TransactionCase, tagged, BaseCase
 from odoo.tests.common import _logger as test_logger
 
 import logging
-import os
+import inspect
 
 from unittest.mock import patch
 
@@ -26,11 +26,13 @@ class TestRetryCommon(BaseCase):
         patcher = patch.object(test_logger, 'runbot', runbot)
         cls.startClassPatcher(patcher)
 
-    def get_tests_run_count(self):
-        return BaseCase._tests_run_count
-
-    def update_count(self):
-        self.count = getattr(self, 'count', 0) + 1
+    def is_soft_fail(self):
+        for frame in inspect.stack():
+            if frame.function == 'run':
+                result = frame.frame.f_locals.get('result')
+                if result and hasattr(result, '_soft_fail') and result._soft_fail:
+                    return True
+        return False
 
 
 @tagged('test_retry', 'test_retry_success')
@@ -42,11 +44,8 @@ class TestRetry(TestRetryCommon):
         _logger.info('test info')
 
     def test_retry_success(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             _logger.error('Failure')
-        self.assertEqual(tests_run_count, self.count)
 
 
 @tagged('test_retry', 'test_retry_success')
@@ -54,21 +53,15 @@ class TestRetryTraceback(TestRetryCommon):
     """ Check some tests behaviour when ODOO_TEST_FAILURE_RETRIES is set"""
 
     def test_retry_traceback_success(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             _logger.error('Traceback (most recent call last):\n')
-        self.assertEqual(tests_run_count, self.count)
 
 
 @tagged('test_retry', 'test_retry_success')
 class TestRetryTracebackArg(TestRetryCommon):
     def test_retry_traceback_args_success(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             _logger.error('%s', 'Traceback (most recent call last):\n')
-        self.assertEqual(tests_run_count, self.count)
 
 
 @tagged('-standard', 'test_retry', 'test_retry_failures')
@@ -83,27 +76,21 @@ class TestRetryFailures(TestRetryCommon):
 @tagged('test_retry', 'test_retry_success')
 class TestRetryRollbackedCursor(TestRetryCommon, TransactionCase):
     def test_broken_cursor(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             self.env.cr.rollback()
 
 
 @tagged('test_retry', 'test_retry_success')
 class TestRetryCommitedCursor(TestRetryCommon, TransactionCase):
     def test_broken_cursor(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             self.env.cr.commit()
 
 
 @tagged('test_retry', 'test_retry_success')
 class TestRetryRollbackedCursorError(TestRetryCommon, TransactionCase):
     def test_broken_cursor(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             self.env.cr.rollback()
             raise Exception('a')
 
@@ -111,9 +98,7 @@ class TestRetryRollbackedCursorError(TestRetryCommon, TransactionCase):
 @tagged('test_retry', 'test_retry_success')
 class TestRetryCommitedCursorError(TestRetryCommon, TransactionCase):
     def test_broken_cursor(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             self.env.cr.commit()
             raise Exception('a')
 
@@ -122,23 +107,22 @@ class TestRetryCommitedCursorError(TestRetryCommon, TransactionCase):
 class TestRetrySubtest(TestRetryCommon):
 
     def test_retry_subtest_success_one(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
+        is_soft_fail = self.is_soft_fail()
         for i in range(3):
             if i == 1:
                 with self.subTest():
-                    if tests_run_count != self.count:
+                    if is_soft_fail:
                         _logger.error('Failure')
-                    self.assertEqual(tests_run_count, self.count)
 
+
+@tagged('test_retry', 'test_retry_success')
+class TestRetrySubtestAll(TestRetryCommon):
     def test_retry_subtest_success_all(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
+        is_soft_fail = self.is_soft_fail()
         for _ in range(3):
             with self.subTest():
-                if tests_run_count != self.count:
+                if is_soft_fail:
                     _logger.error('Failure')
-                self.assertEqual(tests_run_count, self.count)
 
 
 @tagged('-standard', 'test_retry', 'test_retry_failures')
@@ -162,9 +146,7 @@ class TestRetrySubtestFailures(TestRetryCommon):
 class TestRetry1Disable(TestRetryCommon):
 
     def test_retry_0_retry_success(self):
-        tests_run_count = self.get_tests_run_count()
-        self.update_count()
-        if tests_run_count != self.count:
+        if self.is_soft_fail():
             raise Exception('Should success on retry')
 
     def test_retry_1_fails(self):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -41,7 +41,6 @@ from functools import lru_cache, partial, wraps
 from itertools import islice, zip_longest
 from textwrap import shorten
 from typing import Optional, Iterable, cast
-from unittest import TestResult
 from unittest.mock import patch, _patch, Mock
 from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 from xmlrpc import client as xmlrpclib
@@ -67,12 +66,11 @@ from odoo.service import security
 from odoo.sql_db import Cursor, Savepoint
 from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
 from odoo.tools.mail import single_email_re
-from odoo.tools.misc import find_in_path, lower_logging
+from odoo.tools.misc import find_in_path
 from odoo.tools.xml_utils import _validate_xml
 from odoo.addons.base.models import ir_actions_report
 
 from . import case, test_cursor
-from .result import OdooTestResult
 
 try:
     import websocket
@@ -323,8 +321,6 @@ class BaseCase(case.TestCase):
     warm = True             # False during warm-up phase (see :func:`warmup`)
     _python_version = sys.version_info
 
-    _tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
-
     _registry_patched = False
     _registry_readonly_enabled = True
     test_cursor_lock_timeout: int = 20
@@ -354,32 +350,6 @@ class BaseCase(case.TestCase):
         _logger.getChild('requests').info(
             "Blocking un-mocked external HTTP request %s %s", r.method, r.url)
         raise BlockedRequest(f"External requests verboten (was {r.method} {r.url})")
-
-    def run(self, result: OdooTestResult) -> None:
-        testMethod = getattr(self, self._testMethodName)
-
-        if getattr(testMethod, '_retry', True) and getattr(self, '_retry', True):
-            tests_run_count = self._tests_run_count
-        else:
-            tests_run_count = 1
-            _logger.info('Auto retry disabled for %s', self)
-
-        for retry in range(tests_run_count):
-            result.had_failure = False  # reset in case of retry without soft_fail
-            if retry:
-                _logger.runbot(f'Retrying a failed test: {self}')
-            if retry < tests_run_count-1:
-                with warnings.catch_warnings(), \
-                        result.soft_fail(), \
-                        lower_logging(25, logging.INFO) as quiet_log:
-                    super().run(cast(TestResult, result))
-                if not (result.had_failure or quiet_log.had_error_log):
-                    break
-            else:  # last try
-                super().run(cast(TestResult, result))
-                if not result.wasSuccessful() and BaseCase._tests_run_count != 1:
-                    _logger.runbot('Disabling auto-retry after a failed test')
-                    BaseCase._tests_run_count = 1
 
     @classmethod
     def setUpClass(cls):

--- a/odoo/tests/suite.py
+++ b/odoo/tests/suite.py
@@ -14,13 +14,17 @@ to minimise the code to maintain
 """
 
 import logging
+import os
 import sys
+import warnings
 
 import odoo
 from . import case
 from .common import HttpCase
 from .result import stats_logger
 from unittest import util, BaseTestSuite, TestCase
+
+_logger = logging.getLogger(__name__)
 
 __unittest = True
 
@@ -34,6 +38,7 @@ class TestSuite(BaseTestSuite):
     """
 
     def run(self, result, debug=False):
+        default_tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', '0')) + 1
         for test in self:
             if result.shouldStop:
                 break
@@ -44,7 +49,29 @@ class TestSuite(BaseTestSuite):
             result._previousTestClass = test.__class__
 
             if not test.__class__._classSetupFailed:
-                test(result)
+                if not hasattr(test, '_retry') or test._retry:
+                    tests_run_count = default_tests_run_count
+                else:
+                    tests_run_count = 1
+                    _logger.info('Auto retry disabled for %s', test)
+
+                for retry in range(tests_run_count):
+                    result.had_failure = False  # reset in case of retry without soft_fail
+                    if retry:
+                        _logger.runbot(f'Retrying a failed test: {test}')
+                    if retry < tests_run_count - 1:
+                        with warnings.catch_warnings(), \
+                                result.soft_fail(), \
+                                odoo.tools.misc.lower_logging(25, logging.INFO) as quiet_log:
+                            test(result)
+                        if not (result.had_failure or quiet_log.had_error_log):
+                            break
+                        test = test.__class__(test._testMethodName)  # re-create the test to reset its state
+                    else:  # last try
+                        test(result)
+                        if not result.wasSuccessful() and default_tests_run_count != 1:
+                            _logger.runbot('Disabling auto-retry after a failed test')
+                            default_tests_run_count = 1
 
         self._tearDownPreviousClass(None, result)
         return result


### PR DESCRIPTION
The autoretry don't recreate the test instance meaning that some pollution can remain there breaking the next test with a strange error.

This pr recreates the test instance for each retry to avoid this kind of issue, and move the retry mechanism to the suite level.

The core part of the fix is 

`test = test.__class__(test._testMethodName)  # re-create the test to reset its state`

While on it, moving the retry mechanism in the test suite since it makes more sense and allow a better control on what is retried or not since we don't rely on inheritance, and avoid dirty code with super(test) call to recreate the instance and execute it again. 

The tests needs to be adapted since the retry attribute is now in the loop, but we can have a quite reliable way to know if we are in a retry or not using inspect. 



