### PR TITLE
[FIX] mrp: run TestMrpOrderPostInstall without enterprise

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5505,7 +5505,7 @@ class TestMrpOrderPostInstall(TestMrpCommon):
             {'name': f"sn#0{13 + i}"} for i in range(20)
         ])
         mo.button_mark_done()
-        self.assertRecordValues(mo.backorder_ids.sorted('state'), [
+        self.assertRecordValues(mo.production_group_id.production_ids.sorted('state'), [
             {'state': 'confirmed', 'product_qty': 16.0, 'qty_produced': 0.0},
             {'state': 'done', 'product_qty': 20.0, 'qty_produced': 20.0},
         ])


### PR DESCRIPTION
The test `test_basic_flow_with_minimal_access_rigths` fails in builds without `stock_barcode_mrp` since the `backorder_ids` mrp.production field is introduced in that module:
https://github.com/odoo/enterprise/blob/92c584cc1426ac70f6f77aa8216c17004fa42d35/stock_barcode_mrp/models/mrp_production.py#L10

runbot-242465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
