### PR TITLE
[FIX] upgrade_code: fix variable used detection when followed by a comma

### DIFF
--- a/odoo/upgrade_code/19.1-00-t-call.py
+++ b/odoo/upgrade_code/19.1-00-t-call.py
@@ -72,7 +72,7 @@ def upgrade(file_manager: FileManager):
     def _varname_is_used_inside(tset, container, skip_to):
         used = set()
         varname = tset.get('t-set')
-        REG = re.compile(rf"(^|[,({{ /*+-]){ varname }([\[\] .()}})/*+-]|$)")
+        REG = re.compile(rf"(^|[,({{ /*+-]){ varname }([\[\] ,.()}})/*+-]|$)")
 
         for el in container.iter():
             if skip_to is not None and el is not skip_to:


### PR DESCRIPTION
When a variable is used as method parameter and followed by a comma it failed to be identified as being used, so the script then incorrectly moved it as a t-call parameter while it's not necessary.

In the example below, the variable `geoip_country` was not correctly identified as being used in the `t-out` statement:
```
<t t-name="website.test">
    <t t-call="website.layout">
        <t t-set="geoip_country" t-value="request.geoip.country_code"/>
        <t t-set="all_countries" t-value="{cc.code: cc.name for cc in request.env['res.country'].search_fetch([], ['code', 'name'])}"/>
        <div>Country: <t t-out="all_countries.get(geoip_country, 'BE')"/></div>
    </t>
</t>
```

This commit fix used variable detection when the variable is immediately followed by a comma.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
