### PR TITLE
[IMP] core,packaging: don't require pkg_resources anymore

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -8,7 +8,6 @@ import functools
 import importlib
 import logging
 import os
-import pkg_resources
 import re
 import sys
 import warnings
@@ -19,6 +18,36 @@ import odoo.tools as tools
 import odoo.release as release
 from odoo.tools import pycompat
 from odoo.tools.misc import file_path
+
+try:
+    from pkg_resources import DistributionNotFound, VersionConflict, get_distribution
+except ImportError:
+    class DistributionNotFound(Exception):
+        ...
+
+    class VersionConflict(Exception):
+        ...
+
+    RE_PKG_NAME = re.compile(r'^([a-zA-Z0-9\-_.]+)')
+
+    def get_distribution(pydep: str):
+        """
+        Replacement for pkg_resources.get_distribution(pydep).
+        """
+        match = RE_PKG_NAME.match(pydep)
+        if not match:
+            raise ValueError(f"Invalid requirement string: {pydep}")
+        pkg_name = match.group(1)
+        try:
+            dist = importlib.metadata.distribution(pkg_name)
+            # Mimic VersionConflict for exact '==' matches
+            if '==' in pydep:
+                pydep = pydep.split(';', maxsplit=1)[0].strip()  # strip markers
+                required_version = pydep.split('==')[-1].strip()
+                if dist.version != required_version:
+                    raise VersionConflict(f'{dist.version} is installed, but {pydep} is required')
+        except importlib.metadata.PackageNotFoundError:
+            raise DistributionNotFound(pkg_name)
 
 
 MANIFEST_NAMES = ('__manifest__.py', '__openerp__.py')
@@ -464,8 +493,8 @@ current_test = False
 
 def check_python_external_dependency(pydep):
     try:
-        pkg_resources.get_distribution(pydep)
-    except pkg_resources.DistributionNotFound as e:
+        get_distribution(pydep)
+    except DistributionNotFound as e:
         try:
             importlib.import_module(pydep)
             _logger.info("python external dependency on '%s' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
@@ -473,7 +502,7 @@ def check_python_external_dependency(pydep):
             # backward compatibility attempt failed
             _logger.warning("DistributionNotFound: %s", e)
             raise Exception('Python library not installed: %s' % (pydep,))
-    except pkg_resources.VersionConflict as e:
+    except VersionConflict as e:
         _logger.warning("VersionConflict: %s", e)
         raise Exception('Python library version conflict: %s' % (pydep,))
     except Exception as e:

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -14,7 +14,6 @@ import traceback
 import warnings
 
 import werkzeug.serving
-from pkg_resources import PkgResourcesDeprecationWarning
 
 from . import release
 from . import sql_db
@@ -225,8 +224,12 @@ def init_logger():
     #
     # - the first signals a fallback after failing to parse the above as a `Version`
     # - the second signals the use of the `LegacyVersion`... as fallback
-    warnings.filterwarnings("ignore", r'.*-VERSION-', category=PkgResourcesDeprecationWarning, module="pkg_resources")
-    warnings.filterwarnings("ignore", r'.*\bLegacyVersion\b', category=DeprecationWarning, module="pkg_resources")
+    try:
+        from pkg_resources import PkgResourcesDeprecationWarning  # noqa: PLC0415
+        warnings.filterwarnings("ignore", r'.*-VERSION-', category=PkgResourcesDeprecationWarning, module="pkg_resources")
+        warnings.filterwarnings("ignore", r'.*\bLegacyVersion\b', category=DeprecationWarning, module="pkg_resources")
+    except ImportError:
+        pass
     from .tools.translate import resetlocale
     resetlocale()
 

--- a/setup/requirements-check.py
+++ b/setup/requirements-check.py
@@ -33,8 +33,6 @@ import re
 import shutil
 import tempfile
 
-import pkg_resources
-
 try:
     import ansitoimg
 except ImportError:
@@ -47,14 +45,17 @@ from typing import Dict, List, Optional, Tuple
 from urllib.request import HTTPError
 from urllib.request import urlopen as _urlopen
 
+from packaging.markers import Marker
+from packaging.requirements import Requirement
+from packaging.tags import mac_platforms  # noqa: PLC2701
+from packaging.utils import canonicalize_name
+from packaging.version import parse, InvalidVersion
+
 from pip._internal.index.package_finder import (
     LinkEvaluator,  # noqa: PLC2701
-    canonicalize_name,  # noqa: PLC2701
 )
 from pip._internal.models.link import Link  # noqa: PLC2701
 from pip._internal.models.target_python import TargetPython  # noqa: PLC2701
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.tags import mac_platforms  # noqa: PLC2701
 
 Version = Tuple[int, ...]
 
@@ -80,9 +81,10 @@ def urlopen(url):
 
 
 def parse_version(vstring: str) -> Optional[Version]:
-    if not vstring:
+    try:
+        return parse(vstring).release
+    except InvalidVersion:
         return None
-    return tuple(map(int, vstring.split('.')))
 
 
 def cleanup_debian_version(s: str) -> str:
@@ -260,6 +262,10 @@ class Ubuntu(Distribution):
         return None
 
 
+def _strip_comment(line):
+    return line.split('#', 1)[0].strip()
+
+
 def parse_requirements(reqpath: Path) -> Dict[str, List[Tuple[str, Marker]]]:
     """ Parses a requirement file to a dict of {package: [(version, markers)]}
 
@@ -267,12 +273,16 @@ def parse_requirements(reqpath: Path) -> Dict[str, List[Tuple[str, Marker]]]:
     """
     reqs = {}
     with reqpath.open('r', encoding='utf-8') as f:
-        for requirement in pkg_resources.parse_requirements(f):
+        for req_line in f:
+            req_line = _strip_comment(req_line)
+            if not req_line:
+                continue
+            requirement = Requirement(req_line)
             version = None
-            if requirement.specs:
-                if len(requirement.specs) > 1:
-                    raise NotImplementedError('mutli spec not supported yet')
-                version = requirement.specs[0][1]
+            if requirement.specifier:
+                if len(requirement.specifier) > 1:
+                    raise NotImplementedError('multi spec not supported yet')
+                version = next(iter(requirement.specifier)).version
             reqs.setdefault(requirement.name, []).append((version, requirement.marker))
     return reqs
 
@@ -413,7 +423,7 @@ def main(args):
     output_format = 'ansi'
     if args.format:
         output_format = args.format
-        assert format in SUPPORTED_FORMATS
+        assert output_format in SUPPORTED_FORMATS
     elif args.output:
         output_format = 'txt'
         ext = args.output.split('.')[-1]


### PR DESCRIPTION
pkg_resources is deprecated as a library.

It's use becomes problematic as, for instance, since setuptools 71,
importing pkg_resources makes all vendored dependencies of setuptools
visible on sys.path. pkg_resources is even entirely removed since
setuptools 81.

This commit keeps pkg_resources as a primary approach for compatibility
reason but provides a fallback when not present (like with an up-to-date
setuptools) without changing the current requirements (i.e. no
additional dependency on `packaging`).

Note: while not a backport, this is inspired by odoo/odoo#181768