### PR TITLE
[IMP] orm: check permissions of commands in context

### DIFF
--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -334,17 +334,15 @@ class TestProjectSharing(TestProjectSharingCommon):
         # However, cache is updated, but nothing is written.
         with self.assertRaisesRegex(AccessError, "top-secret records"):
             Task.with_context(default_child_ids=[Command.update(self.task_no_collabo.id, {'name': 'Foo'})]).create({'name': 'foo'})
-        with Task.env.cr.savepoint() as sp:
+        with self.assertRaisesRegex(AccessError, "not allowed to delete"):
             task = Task.with_context(default_child_ids=[Command.delete(self.task_no_collabo.id)]).create({'name': 'foo'})
             task.env.invalidate_all()
             self.assertTrue(self.task_no_collabo.exists(), "Task should still be there, no delete is sent")
-            sp.rollback()
-        with self.env.cr.savepoint() as sp:
+        with self.assertRaisesRegex(AccessError, "top-secret records"):
             self.task_no_collabo.parent_id = self.task_no_collabo.create({'name': 'parent collabo'})
             task = Task.with_context(default_child_ids=[Command.unlink(self.task_no_collabo.id)]).create({'name': 'foo'})
             task.env.invalidate_all()
             self.assertTrue(self.task_no_collabo.parent_id, "Task should still be there, no delete is sent")
-            sp.rollback()
         with self.assertRaisesRegex(AccessError, "top-secret records"):
             task = Task.with_context(default_child_ids=[Command.link(self.task_no_collabo.id)]).create({'name': 'foo'})
             task.env.invalidate_all()
@@ -365,16 +363,14 @@ class TestProjectSharing(TestProjectSharingCommon):
         # Same thing but using context defaults
         with self.assertRaisesRegex(AccessError, "not allowed to create 'Project Tag'"):
             Task.with_context(default_tag_ids=[Command.create({'name': 'Bar'})]).create({'name': 'foo'})
-        with Task.env.cr.savepoint() as sp:
+        with self.assertRaisesRegex(AccessError, "not allowed to modify 'Project Tag'"):
             task = Task.with_context(default_tag_ids=[Command.update(self.task_tag.id, {'name': 'Bar'})]).create({'name': 'foo'})
             task.env.invalidate_all()
             self.assertNotEqual(self.task_tag.name, 'Bar')
-            sp.rollback()
-        with Task.env.cr.savepoint() as sp:
+        with self.assertRaisesRegex(AccessError, "not allowed to delete 'Project Tag'"):
             Task.with_context(default_tag_ids=[Command.delete(self.task_tag.id)]).create({'name': 'foo'})
             task.env.invalidate_all()
             self.assertTrue(self.task_tag.exists())
-            sp.rollback()
 
         task = Task.create({'name': 'foo', 'color': 1, 'tag_ids': [Command.link(self.task_tag.id)]})
         self.assertEqual(task.color, 1)

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -34,7 +34,7 @@ import typing
 import uuid
 import warnings
 from collections import defaultdict, deque
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from inspect import getmembers
 from operator import attrgetter, itemgetter
 
@@ -73,7 +73,7 @@ from .utils import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Iterator, Reversible, Sequence
+    from collections.abc import Collection, Iterator, Reversible, Sequence
     from types import MappingProxyType
     from typing import Self
     from .table_objects import TableObject
@@ -1354,6 +1354,19 @@ class BaseModel(metaclass=MetaModel):
         for fname, value in defaults.items():
             if fname in self._fields:
                 field = self._fields[fname]
+                if (
+                    field.relational
+                    and not self.env.su
+                    and isinstance(value, Iterable)
+                ):
+                    # since the value will be converted into a SET, we still
+                    # need to check permissions for these actions
+                    for cmd in value:
+                        command_code = cmd[0] if isinstance(cmd, (tuple, list)) and len(cmd) >= 2 else None
+                        if command_code == Command.DELETE:
+                            self.env[field.comodel_name].browse(cmd[1]).check_access('unlink')
+                        elif command_code == Command.UPDATE or (field.type == 'one2many' and command_code in (Command.UNLINK, Command.LINK)):
+                            self.env[field.comodel_name].browse(cmd[1]).check_access('write')
                 value = field.convert_to_cache(value, self, validate=False)
                 defaults[fname] = field.convert_to_write(value, self)
 


### PR DESCRIPTION
Some commands may perform a change on related records by using Commands. When passed through the context, unallowed actions are ignored instead of rising access errors. This check aligns the behaviour with normal writes of fields. A test in `project` module shows this behaviour.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
