### PR TITLE
[FIX] website: resolve non-deterministic age verification popup test

### DIFF
--- a/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
+++ b/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { animationFrame, tick } from "@odoo/hoot-dom";
+import { animationFrame, runAllTimers, tick } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { contains, defineStyle } from "@web/../tests/web_test_helpers";
@@ -104,6 +104,7 @@ test("Yes button closes popup and No button displays the error message", async (
     expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "true");
     expect(modalErrorMessageSelector).toBeVisible();
 
+    await runAllTimers();
     await contains(`${modalSelector} .o_age_verification_yes_btn`).click();
     expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "false");
     expect(modalSelector).not.toBeVisible();


### PR DESCRIPTION
### Issue:
The age verification popup test was failing non-deterministically on 
Runbot. The Bootstrap `show` method sets an internal `_isTransitioning`
flag which is cleared by a callback scheduled in a `setTimeout`. Since 
test assertions run very fast in parallel environments, the hide method
was sometimes called before this delay elapsed. If `_isTransitioning` is
still true, `hide` ignores the call, causing the popup to remain open
and tests to fail.

### Fix:
Await `runAllTimers()` before `hide()` to execute pending timers, clear
`_isTransitioning`, and allow the modal to close.

runbot- [242448](https://runbot.odoo.com/odoo/runbot.build.error/242448)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
