### PR TITLE
[REF] tests: patch get_sequences in test mode

### DIFF
--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
@@ -10,7 +9,5 @@ from odoo.addons.website.tests.test_performance import UtilPerf
 class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
-        select_tables_perf = {
-            'orm_signaling_registry': 1,
-        }
-        self._check_url_hot_query(url, 1, select_tables_perf)
+        select_tables_perf = {}
+        self._check_url_hot_query(url, 0, select_tables_perf)

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -228,7 +228,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
 
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -255,7 +254,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertEqual(self._get_cart_quantity(), 1)
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -279,7 +277,6 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertEqual(self._get_cart_quantity(), 0)
         select_tables_perf = {
             # website queries
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
@@ -295,9 +292,8 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 42  # To increase this number you must ask the permission to al
+        query_count = 41  # To increase this number you must ask the permission to al
         queries = {
-            'orm_signaling_registry': 1,
             'website': 1,
             'res_company': 2,
             'product_pricelist': 4,

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -133,7 +133,7 @@ class TestStandardPerformance(UtilPerf):
         self.assertEqual(self.env.ref('base.user_admin').sudo().website_published, False)
         user_id = self.ref('base.user_admin')
         url = f'/web/image/res.users/{user_id}/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 7)
+        self.assertEqual(self._get_url_hot_query(url), 6)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):
@@ -142,19 +142,17 @@ class TestStandardPerformance(UtilPerf):
         user_id = self.ref('base.user_admin')
         url = f'/web/image/res.users/{user_id}/image_256'
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'res_users': 2,
             'res_partner': 1,
             'ir_attachment': 1,
         }
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
     @mute_logger('odoo.http')
     def test_20_perf_sql_img_controller_bis(self):
         website_id = self.ref('website.default_website')
         url = f'/web/image/website/{website_id}/favicon'
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'website': 2,
             # 1. `_find_record()` performs an access right check through
             #    `exists()` which perform a request on the website.
@@ -164,10 +162,10 @@ class TestStandardPerformance(UtilPerf):
             # 1. `_record_to_stream()` does a `search()`..
             # 2. ..followed by a `_read()`
         }
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
         self.authenticate('portal', 'portal')
-        self._check_url_hot_query(url, 5, select_tables_perf)
+        self._check_url_hot_query(url, 4, select_tables_perf)
 
 
 class TestWebsitePerformanceCommon(UtilPerf):
@@ -213,11 +211,10 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                 }
-                expected_query_count = 2
+                expected_query_count = 1
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -225,7 +222,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
 
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -236,7 +232,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'website_menu': 1,
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 7
+                expected_query_count = 6
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, nocache=True)
                 self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), expected_query_count)
 
@@ -246,11 +242,9 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                 } if cache else {
-                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -261,7 +255,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'website_menu': 1,
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 2 if cache else 7
+                expected_query_count = 1 if cache else 6
                 insert_tables_perf = {}
                 self.page.track = True
 
@@ -274,16 +268,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         for readonly_enabled in (True, False):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
-                select_tables_perf = {
-                    'orm_signaling_registry': 1,
-                }
-                expected_query_count = 1
+                select_tables_perf = {}
+                expected_query_count = 0
                 insert_tables_perf = {}
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
                 self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
 
                 select_tables_perf = {
-                    'orm_signaling_registry': 1,
                     'website_menu': 1,
                     # homepage controller is prefetching all menus for perf in one go
                     'website_page': 2,
@@ -293,7 +284,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # layout
                     'ir_ui_view': 1,
                 }
-                expected_query_count = 6
+                expected_query_count = 5
                 insert_tables_perf = {}
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf, nocache=True)
                 self.assertEqual(self._get_url_hot_query('/', nocache=True), expected_query_count)
@@ -303,15 +294,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         self.page.arch = '<div>I am a blank page</div>'
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
         }
-        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+        self._check_url_hot_query(self.page.url, 1, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 1)
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 1,
@@ -320,8 +309,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 4, select_tables_perf, nocache=True)
-        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 4)
+        self._check_url_hot_query(self.page.url, 3, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 3)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -334,15 +323,13 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         menu_aa.parent_id = menu_a
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
         }
-        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+        self._check_url_hot_query(self.page.url, 1, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 1)
 
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
@@ -352,8 +339,9 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'website_menu': 1,
             'ir_ui_view': 1,
         }
-        self._check_url_hot_query(self.page.url, 7, select_tables_perf, nocache=True)
-        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 7)
+        self._check_url_hot_query(self.page.url, 6, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 6)
+
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):
@@ -363,11 +351,10 @@ class TestWebsitePerformancePost(UtilPerf):
         assets_url = self.env['ir.qweb']._get_asset_bundle('web.assets_frontend_lazy', css=False, js=True).get_links()[0]
         self.assertIn('web.assets_frontend_lazy.min.js', assets_url)
         select_tables_perf = {
-            'orm_signaling_registry': 1,
             'ir_attachment': 2,
             # All 2 coming from the /web/assets and ir.binary stack
             # 1. `search() the attachment`
             # 2. `_record_to_stream` reads the other attachment fields
         }
-        self._check_url_hot_query(assets_url, 3, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(assets_url), 3)
+        self._check_url_hot_query(assets_url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(assets_url), 2)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1032,13 +1032,18 @@ class BaseCase(case.TestCase):
             return test_cursor.TestCursor(
                 cr, _registry_test_lock, readonly and cls._registry_readonly_enabled
             )
+
+        def get_sequences(cr):
+            return registry.registry_sequence, registry.cache_sequences.copy()
+
         return [
             # New cursor should point to the test's cursor
             patch.object(registry, 'cursor', _patched_cursor),
             # Disable locking and signaling
             patch.object(Registry, '_lock', DummyRLock()),
-            patch.object(registry, 'setup_signaling', return_value=None), #noop
+            patch.object(registry, 'setup_signaling', return_value=None),  # noop
             patch.object(registry, 'check_signaling', return_value=registry),
+            patch.object(registry, 'get_sequences', get_sequences),
         ]
 
     @classmethod


### PR DESCRIPTION
In test mode, signaling is not required because only a single real cursor is used. Patching `get_sequences` ensures sequence values remain consistent with the patched `check_signaling` method.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
