### PR TITLE
[FIX] account: prevent AccessError when computing invoice payment info in portal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6628,7 +6628,7 @@ class AccountMove(models.Model):
                 self.company_id,
                 payment.date
             )
-            for payment in self.reconciled_payment_ids.filtered(
+            for payment in self.sudo().reconciled_payment_ids.filtered(
                 lambda p: (
                     not p.is_reconciled
                     and not p.is_matched

--- a/addons/account/tests/test_portal_invoice.py
+++ b/addons/account/tests/test_portal_invoice.py
@@ -55,3 +55,13 @@ class TestPortalInvoice(AccountTestInvoicingHttpCommon):
         res = self.url_open(url)
         self.assertEqual(res.status_code, 200)
         self.assertIn("Proforma", res.content.decode('utf-8'))
+
+    def test_portal_invoice_next_payment_values_access(self):
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.portal_partner.id,
+            'invoice_line_ids': [Command.create({'name': 'line', 'price_unit': 100})]
+        })
+        invoice.action_post()
+        invoice.invalidate_recordset(['reconciled_payment_ids'])
+        invoice.with_user(self.user_portal)._get_invoice_next_payment_values()


### PR DESCRIPTION
Steps to produce:
---
- Install `Accounting` module.
- Create a new customer.
- From the gear icon, `grant Portal Access` to the customer.
- Create an invoice for this customer.
- Log in using the customer’s portal account.
- Navigate to `My Invoices`.

Issue:
---
```
You are not allowed to access 'Payment' (account.payment) records.

```

Root cause:
---
- After the [commit], the system attempts to compute the next payment values for display in the portal.
- This computation is triggered via `_get_invoice_portal_extra_values()`, which calls `_get_invoice_next_payment_values()`.
- During this process, the method iterates over `reconciled_payment_ids`. Accessing this field triggers its computation (`_compute_reconciled_payment_ids`), which depends on `matched_payment_ids`.
- Both `reconciled_payment_ids` and `matched_payment_ids` are relational fields pointing to `account.payment` records.
- Since portal users do not have read access to the `account.payment` model, attempting to access these fields results in an AccessError

[commit]: https://github.com/odoo/odoo/commit/b76836680540eb7687021f48b3532e8a495e771a

opw-6042693
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
