### PR TITLE
[FIX] hr_recruitment: render mail body in wizard

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -101,11 +101,16 @@ class ApplicantGetRefuseReason(models.TransientModel):
             'subject': 'subject',
         }
         for wizard in self:
+            template = wizard.template_id
             for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
-                if wizard.template_id:
-                    wizard[wizard_field_name] = wizard.template_id[template_field_name]
-                else:
-                    wizard[wizard_field_name] = False
+                wizard[wizard_field_name] = template[template_field_name] if template else False
+
+            if template and len(wizard.applicant_ids) == 1:
+                rendered_values = self._prepare_mail_values(wizard.applicant_ids._origin)
+                wizard.update({
+                    'subject': rendered_values.get('subject'),
+                    'body': rendered_values.get('body'),
+                })
 
     def action_refuse_reason_apply(self):
         if self.send_mail:


### PR DESCRIPTION
Issue:
----------------------------------------
The `applicant.get.refuse.reason` wizard displays the mail body with the placeholders, not the values actually sent.

Steps to reproduce:
----------------------------------------
- Open Recruitments and go to an applicant form view
- Click "Refuse"
- Select the template "Job already fulfilled"
- The subject and the mail body have placeholder values

Cause:
----------------------------------------
We don't render the body for the wizard, only when we send the mails.

Solution:
----------------------------------------
Render the body when we get it from the template.

This only works if `applicant_ids` have one value. Otherwise, we display the placeholders because the values can be different from an applicant to another.

opw-6082883