### PR TITLE
[FIX] stock_delivery: use order currency for delivery slip prices

### DIFF
--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -66,7 +66,7 @@ class StockMoveLine(models.Model):
                 base_line.update({'quantity': qty})
                 self.env['account.tax']._add_tax_details_in_base_line(base_line, sale_line_id.company_id)
                 tax_results = base_line['tax_details']
-                move_line.sale_price = tax_results['raw_total_included']
+                move_line.sale_price = tax_results['raw_total_included_currency']
             else:
                 # For kits, use the regular unit price
                 unit_price = move_line.product_id.list_price

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -303,15 +303,25 @@ class StockMoveInvoice(AccountTestInvoicingCommon):
             {'date': today},
         ])
 
+    @freeze_time("2024-06-06 11:00")
     def test_delivery_slip_product_value(self):
         """Test that product value reported on the delivery slip is correct.
         """
         product = self.product_cable_management_box
         tax = self.company_data['default_tax_sale']
+        other_currency = self.setup_other_currency('EUR', rates=[
+            ('2024-06-06', 0.1),
+        ])
+        pricelist_in_other_curr = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist (EUR)',
+            'currency_id': other_currency.id,
+        })
+
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,
             'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': pricelist_in_other_curr.id,
             'order_line': [
                 Command.create({
                     'name': product.name,


### PR DESCRIPTION
The product value reported on delivery slips may incorrectly use the company currency instead of the order currency.

Steps to reproduce:
- Enable multi-currency and create a foreign currency
- Create a pricelist in the foreign currency
- Create and confirm a Sale Order using that pricelist
- Add a delivery via carrier (eg. Fedex)
- Confirm the delivery and generate the commercial invoice.

Issue:
The 'sale_price' on the stock move lines is taken in company currency rather than order currency.

opw-6104130