### PR TITLE
[FIX] website: wait for the sidebar update before continuing test

### DIFF
--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -724,6 +724,7 @@ test("Shape should not be applied on replaced CORS-protected image", async () =>
         },
     ]);
     await contains(":iframe img").click();
+    await waitSidebarUpdated();
     await contains("[data-action-id=replaceMedia]").click();
     await contains("img.o_we_attachment_highlight").click();
     await waitSidebarUpdated();


### PR DESCRIPTION
In order to avoid undeterministic error, this commit fixes the test introduced by [1] by ensuring the sidebar is fully loaded before accessing options.

[1]: https://github.com/odoo/odoo/commit/137a6d7e59e1d788745c3b796a14839e52a8c5bc

task-6116678

