### PR TITLE
[FIX] website: add missing '/' in img sources

### DIFF
--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
                 <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
-                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="web_editor/devices/macbook_front" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups.jpg" alt=""/>
+                    <img src="/web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="web_editor/devices/macbook_front" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups.jpg" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">
                     <h3>50,000+ companies trust Odoo.</h3>
@@ -14,7 +14,7 @@
                     <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-2 col-lg-2 d-none d-lg-block" style="grid-area: 2 / 6 / 10 / 8; z-index: 3;">
-                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image_1/web_editor/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="web_editor/devices/iphone_front_portrait" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups_1.jpg" alt=""/>
+                    <img src="/web_editor/image_shape/website.s_cta_mockups_default_image_1/web_editor/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="web_editor/devices/iphone_front_portrait" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups_1.jpg" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit fixes two missing leading slashes in the "src" attribute of two "img" tags in `s_cta_mockups`.

The browser resolves links differently based on leading slashes. Before this commit, the lack of leading slahses caused the snippet to not display properly on deeper pages (for example, "/shop/product-name").

task-6103616
