### PR TITLE
[FIX] account_edi_ubl_cii: filter move without commercial partner to Export XML

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -85,7 +85,7 @@ class AccountMove(models.Model):
                     and move._need_ubl_cii_xml(edi_format)
                 )
             )
-            for move in posted_moves
+            for move in posted_moves.filtered(lambda move: move.ubl_cii_xml_id or move.commercial_partner_id)
         )
         if can_export_xml:
             print_items.append({


### PR DESCRIPTION
Issue:
Confirmed move without partner get a traceback while opening the cog wheel

Steps to reproduce:
- Create a misc move without Partner/commercial partner.
- Confirm it
- Click on the cog wheel button

Current behavior:
- Traceback

Before commit 48983eb6efdd6690f92f2839eedd39d9a288ab42, looping on `move.commercial_partner_id` prevented calling `_get_ubl_cii_edi_format` on empty records.

no-task