### PR TITLE
[IMP] web: add "password" field widget

### DIFF
--- a/addons/web/static/src/views/fields/password/password_field.js
+++ b/addons/web/static/src/views/fields/password/password_field.js
@@ -1,0 +1,42 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useInputField } from "@web/views/fields/input_field_hook";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+import { Component, useState } from "@odoo/owl";
+
+export class PasswordField extends Component {
+    static template = "web.PasswordField";
+    static props = {
+        ...standardFieldProps,
+        placeholder: { type: String, optional: true },
+    };
+
+    setup() {
+        this.state = useState({ isRevealed: false });
+        useInputField({
+            getValue: () => this.props.record.data[this.props.name] || "",
+        });
+    }
+
+    get buttonTitle() {
+        return this.state.isRevealed ? _t("Hide value") : _t("Reveal value");
+    }
+
+    get displayedValue() {
+        return this.props.record.data[this.props.name] || "";
+    }
+
+    onToggleReveal() {
+        this.state.isRevealed = !this.state.isRevealed;
+    }
+}
+
+export const passwordField = {
+    component: PasswordField,
+    displayName: _t("Password"),
+    supportedTypes: ["char", "text"],
+    extractProps: ({ placeholder }) => ({ placeholder }),
+};
+
+registry.category("fields").add("password", passwordField);

--- a/addons/web/static/src/views/fields/password/password_field.xml
+++ b/addons/web/static/src/views/fields/password/password_field.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.PasswordField">
+        <div class="d-flex justify-content-between">
+            <t t-if="this.props.readonly">
+                <span t-if="this.state.isRevealed" t-out="this.displayedValue"/>
+                <input t-else="" class="o_input border-0 py-0 o_disabled opacity-100" type="password" t-att-value="'a'.repeat(16)"/>
+            </t>
+            <t t-else="">
+                <input
+                    class="o_input"
+                    autocomplete="new-password"
+                    t-att-id="this.props.id"
+                    t-att-type="this.state.isRevealed ? 'text' : 'password'"
+                    t-att-placeholder="this.props.placeholder"
+                    t-ref="input"
+                />
+            </t>
+            <button
+                class="btn fa"
+                t-att-class="this.state.isRevealed ? 'fa-eye-slash' : 'fa-eye'"
+                t-att-title="this.buttonTitle"
+                t-on-click.stop="this.onToggleReveal"
+            />
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/tests/views/fields/password_field.test.js
+++ b/addons/web/static/tests/views/fields/password_field.test.js
@@ -1,0 +1,138 @@
+import { expect, test } from "@odoo/hoot";
+import {
+    clickSave,
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    name = fields.Char({ string: "Name" });
+    bio = fields.Text({ string: "Bio" });
+    _records = [{ id: 1, name: "secret", bio: "my long bio" }];
+}
+
+defineModels([Partner]);
+
+onRpc("res.users", "has_group", () => true);
+
+test("PasswordField: readonly in form view", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="name" widget="password" readonly="1"/></form>`,
+    });
+
+    expect(".o_field_password input[type=password].o_disabled").toHaveCount(1);
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password button.fa-eye-slash").toHaveCount(1);
+    expect(".o_field_password input").toHaveCount(0);
+    expect(".o_field_password span").toHaveText("secret");
+});
+
+test("PasswordField: edition in form view", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1].name);
+    });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="name" widget="password"/></form>`,
+    });
+
+    // edit while hidden
+    expect(".o_field_password input[type=password]").toHaveCount(1);
+    await contains(".o_field_password input").edit("newsecret1");
+    await clickSave();
+
+    // reveal and edit
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password input[type=text]").toHaveValue("newsecret1");
+    await contains(".o_field_password input").edit("newsecret2");
+    await clickSave();
+
+    expect.verifySteps(["newsecret1", "newsecret2"]);
+});
+
+test("PasswordField in non-editable list view", async () => {
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `<list><field name="name" widget="password"/></list>`,
+    });
+
+    expect(".o_field_password input[type=password].o_disabled").toHaveCount(1);
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password button.fa-eye-slash").toHaveCount(1);
+    expect(".o_field_password input").toHaveCount(0);
+    expect(".o_field_password span").toHaveText("secret");
+});
+
+test("PasswordField: edition in editable list view", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1].name);
+    });
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `<list editable="bottom"><field name="name" widget="password"/></list>`,
+    });
+
+    expect(".o_field_password input[type=password].o_disabled").toHaveCount(1);
+    await contains(".o_data_row td.o_data_cell").click();
+    expect(".o_field_password input[type=password]:not([disabled])").toHaveCount(1);
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password input[type=text]").toHaveValue("secret");
+    await contains(".o_field_password input").edit("newsecret");
+
+    expect.verifySteps(["newsecret"]);
+});
+
+test("PasswordField: placeholder attribute", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `<form><field name="name" widget="password" placeholder="Enter password"/></form>`,
+    });
+    expect(".o_field_password input").toHaveAttribute("placeholder", "Enter password");
+});
+
+test("PasswordField on readonly text field in form view", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="bio" widget="password" readonly="1"/></form>`,
+    });
+
+    expect(".o_field_password input[type=password].o_disabled").toHaveCount(1);
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password button.fa-eye-slash").toHaveCount(1);
+    expect(".o_field_password input").toHaveCount(0);
+    expect(".o_field_password span").toHaveText("my long bio");
+});
+
+test("PasswordField on text field: edition in form view", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1].bio);
+    });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="bio" widget="password"/></form>`,
+    });
+
+    expect(".o_field_password input[type=password]").toHaveCount(1);
+    await contains(".o_field_password button.fa-eye").click();
+    expect(".o_field_password input[type=text]").toHaveValue("my long bio");
+    await contains(".o_field_password input").edit("updated bio");
+    await clickSave();
+
+    expect.verifySteps(["updated bio"]);
+});


### PR DESCRIPTION
This commit introduces a new "password" field widget. This widget can be set on char and text fields. It renders the value inside an input with `type="password"` such that the real value is hidden. Next to the input, an "eye" is displayed and allows to show the real value. The widget can be used in form, list and kanban views.

Such a widget is sometimes necessary to be security compliant.

Task~6116365

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
