### PR TITLE
[FIX] account_edi_ubl_cii: tax matching country

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -1013,6 +1013,8 @@ class AccountEdiCommon(models.AbstractModel):
                 ('type_tax_use', '=', tax_type),
                 ('amount', '=', amount),
             ]
+            if record.partner_id.country_id:
+                domain += [('country_id.id', '=', record.partner_id.country_id.id)]
             tax = self.env['account.tax']
             if hasattr(record, '_get_specific_tax'):
                 tax = record._get_specific_tax(line_values['name'], 'percent', amount, tax_type).filtered_domain(domain)[:1]

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -1274,3 +1274,56 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
         self.assertEqual(due_date.text, '20251231')
         self.assertEqual(days.text, '15')
         self.assertEqual(percent.text, '3.0')
+
+    def test_import_tax_country(self):
+        """ We are going to create 2 tax with same value but different countries and import the e-invoice.
+            The tax linked to the same country as the partner should be selected.
+            Then we test the case where no country is set on the partner, it should then select the first
+            matching tax it finds.
+        """
+        self.env.ref('base.EUR').active = True  # EUR might not be active and is used in the xml testing file
+        # Tax with a country different than the partner in the XML
+        new_tax_1 = self.env["account.tax"].create({
+            'name': 'tax 1',
+            'amount_type': 'percent',
+            'country_id': self.env.ref('base.de').id,
+            'tax_group_id': self.env['account.tax.group'].create({
+                'name': 'Tax group',
+                'company_id': self.company.id,
+                'country_id': self.env.ref('base.de').id,
+            }).id,
+            'type_tax_use': 'purchase',
+            'amount': 16.0,
+        })
+
+        # Tax for Luxembourg as the partner in the XML is from Luxembourg
+        new_tax_2 = self.env["account.tax"].create({
+            'name': 'tax 2',
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'country_id': self.env.ref('base.lu').id,
+            'amount': 16.0,
+            'tax_group_id': self.env['account.tax.group'].create({
+                'name': 'Tax group',
+                'company_id': self.company.id,
+                'country_id': self.env.ref('base.lu').id,
+            }).id,
+        })
+
+        file_path = "bis3_bill_example.xml"
+        file_path = f"{self.test_module}/tests/test_files/{file_path}"
+        with file_open(file_path, 'rb') as file:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_invoice.xml',
+                'raw': file.read(),
+            })
+
+        # Import the document for the first time
+        bill = self._import_as_attachment_on(attachment=xml_attachment)
+        self.assertEqual(bill.invoice_line_ids.tax_ids, new_tax_2)
+
+        bill.partner_id.country_id = False
+        # Partner has no country set so it should fallback to first tax matching amount
+        bill = self._import_as_attachment_on(attachment=xml_attachment)
+        self.assertEqual(bill.invoice_line_ids.tax_ids, new_tax_1)


### PR DESCRIPTION
When retrieving a tax from a document it would take the first tax that matches the amount/type/usage without taking the country into account. So if you have 2 taxes with the same amount/type/usage but different countries it would take the one with the lowest id which could lead to wrong tax being applied.

Steps to reproduce:
-------------------
* You can use the XML in the ticket to reproduce the issue.
* Create a Belgian company.
* Create a copy of the 21% purchase tax from Belgium and set the country to anything else.
* Make sure that the newly created tax has a lower sequence than the belgian one.
* Import the XML
> Observation: The newly created tax is used even if the partner is from
  Belgium.

Why the fix:
------------
If the partner has a country set we only select tax from the same country. If not we fallback to the previous behavior of selecting the first tax matching

opw-5928724