### PR TITLE
[FIX] spreadsheet: show pointer cursor on clickable scorecards

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_link/figure_component.xml
+++ b/addons/spreadsheet/static/src/chart/odoo_link/figure_component.xml
@@ -12,7 +12,7 @@
         <div t-name="spreadsheet.ScorecardChart" t-inherit="o-spreadsheet-ScorecardChart" t-inherit-mode="extension">
             <xpath expr="//canvas[1]" position="attributes">
                 <attribute name="t-on-click">() => this.onClick()</attribute>
-                <attribute name="t-att-role">env.isDashboard() and hasOdooMenu ? "button" : ""</attribute>
+                <attribute name="t-att-role">env.isDashboard() and hasOdooLink ? "button" : ""</attribute>
             </xpath>
     </div>
     <div t-name="spreadsheet.GaugeChartComponent" t-inherit="o-spreadsheet-GaugeChartComponent" t-inherit-mode="extension">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Current behavior before PR:
- The scorecard case was missed when replacing hasOdooMenu with hasOdooLink.
- Clickable scorecards were showing the default arrow cursor instead of a pointer on hover.

Desired behavior after PR is merged:
- Scorecards now correctly use hasOdooLink to determine if they are clickable.
- The pointer cursor is displayed on hover when the scorecard acts as a button in dashboard view.

Task: [6116584](https://www.odoo.com/odoo/2328/tasks/6116584)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
