### PR TITLE
[FIX] account: retrieve partner not with contact first

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -1042,7 +1042,7 @@ class ResPartner(models.Model):
                         full_domain = expression.AND([static_domain, domain])
                         partner = self.search(
                             full_domain,
-                            order='company_id, id DESC',
+                            order='company_id, parent_id DESC, id DESC',
                             limit=1,
                         )
                     elif search_method:

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_retrieve_partner.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_retrieve_partner.py
@@ -34,3 +34,18 @@ class TestUblImportBis3InvoiceBERetrievePartner(TestUblImportBis3InvoiceBE):
             journal=self.company_data['default_journal_sale'],
         )
         self.assertRecordValues(invoice.partner_id, [{'id': partner.id}])
+
+    @freeze_time('2020-01-01')
+    def test_import_partner_retrieval_no_contact(self):
+        self.env['res.partner'].create({
+            'parent_id': self.partner_be.id,
+            'name': 'My contact',
+            'company_id': self.partner_be.company_id.id,
+        })
+
+        # Test the partner has been retrieved.
+        invoice = self._import_invoice_as_attachment_on(
+            test_name='test_import_partner_creation',
+            journal=self.company_data['default_journal_sale'],
+        )
+        self.assertEqual(self.partner_be, invoice.partner_id, "We find the belgian partner, not his contact")


### PR DESCRIPTION
Currently, the contact will be retrieved on import of a BIS3,
as we retrieve the last partner created with this VAT,
which would be all the contacts





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
