### PR TITLE
[FIX] calendar: arbitrary attendee shown as contact in event description

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1656,7 +1656,7 @@ class CalendarEvent(models.Model):
     @api.model
     def _get_contact_details_description(self, organizer, partners):
         """Build sanitized HTML with the organizer details and the details
-        of the contact partner (the first partner which is not the organizer).
+        of the contact partner (only when there is a single non-organizer attendee).
         """
         odoobot = self.env.ref('base.user_root')
         contact_description = []
@@ -1664,11 +1664,11 @@ class CalendarEvent(models.Model):
         if organizer and organizer != odoobot:
             contact_description.extend(self._prepare_partner_contact_details_html(_("Organized by"), organizer.partner_id))
         # First contact partner
-        first_partner = partners.filtered(lambda partner: partner not in (odoobot.partner_id + organizer.partner_id))[:1]
-        if first_partner:
+        contact_partners = partners.filtered(lambda partner: partner not in (odoobot.partner_id + organizer.partner_id))
+        if len(contact_partners) == 1:
             if contact_description:
                 contact_description.append("")  # To add a blank line between the organizer and partner details
-            contact_description.extend(self._prepare_partner_contact_details_html(_("Contact Details"), first_partner))
+            contact_description.extend(self._prepare_partner_contact_details_html(_("Contact Details"), contact_partners))
         return Markup("<br/>").join(contact_description)
 
     @api.model

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -676,11 +676,11 @@ class CalendarEvent(models.Model):
                 if vals.get('user_id'):
                     organizer_ids.add(vals['user_id'])
                 # attendee_ids structure = [[2, partner_id_to_remove], [0, 0, {'partner_id': partner_id_to_add}], ...]
-                partner_ids_from_attendees = {
+                partner_ids_from_attendees = list(dict.fromkeys(
                     attendee_vals[2]['partner_id']
                     for attendee_vals in vals['attendee_ids']
                     if len(attendee_vals) > 2 and isinstance(attendee_vals[2], dict) and 'partner_id' in attendee_vals[2]
-                }
+                ))
                 partner_ids.update(partner_ids_from_attendees)
                 vals_partner_list.append(partner_ids_from_attendees)
             organizers = self.env['res.users'].browse(organizer_ids).with_prefetch(organizer_ids)
@@ -1651,7 +1651,7 @@ class CalendarEvent(models.Model):
     @api.model
     def _get_contact_details_description(self, organizer, partners):
         """Build sanitized HTML with the organizer details and the details
-        of the contact partner (the first partner which is not the organizer).
+        of the contact partner (only when there is a single non-organizer attendee).
         """
         odoobot = self.env.ref('base.user_root')
         contact_description = []
@@ -1659,11 +1659,11 @@ class CalendarEvent(models.Model):
         if organizer and organizer != odoobot:
             contact_description.extend(self._prepare_partner_contact_details_html(_("Organized by"), organizer.partner_id))
         # First contact partner
-        first_partner = partners.filtered(lambda partner: partner not in (odoobot.partner_id + organizer.partner_id))[:1]
-        if first_partner:
+        contact_partners = partners.filtered(lambda partner: partner not in (odoobot.partner_id + organizer.partner_id))
+        if len(contact_partners) == 1:
             if contact_description:
                 contact_description.append("")  # To add a blank line between the organizer and partner details
-            contact_description.extend(self._prepare_partner_contact_details_html(_("Contact Details"), first_partner))
+            contact_description.extend(self._prepare_partner_contact_details_html(_("Contact Details"), contact_partners))
         return Markup("<br/>").join(contact_description)
 
     @api.model

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -534,3 +534,36 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'res_id': 0,
         })
         self.assertTrue(event.res_id)
+
+    def test_contact_details_single_vs_multiple_attendees(self):
+        """Contact Details section should only appear for 1-on-1 meetings
+        (single non-organizer attendee)."""
+        organizer = new_test_user(self.env, login='org_user', groups='base.group_user')
+        attendees = self.env['res.partner'].create([
+            {'name': 'Attendee A', 'email': 'a@test.com', 'phone': '+1000000001'},
+            {'name': 'Attendee B', 'email': 'b@test.com', 'phone': '+1000000002'},
+            {'name': 'Attendee C', 'email': 'c@test.com', 'phone': '+1000000003'},
+        ])
+        # Multiple attendees: only organizer info is shown
+        event_multi = self.env['calendar.event'].with_user(organizer).create({
+            'name': 'Group Meeting',
+            'start': '2026-04-01 10:00:00',
+            'stop': '2026-04-01 11:00:00',
+            'user_id': organizer.id,
+            'partner_ids': [Command.link(pid) for pid in attendees.ids],
+        })
+        self.assertIn('Organized by', event_multi.description)
+        self.assertNotIn('Contact Details', event_multi.description)
+        for attendee in attendees:
+            self.assertNotIn(attendee.name, event_multi.description)
+        # Single attendee: Contact Details should appear
+        event_single = self.env['calendar.event'].with_user(organizer).create({
+            'name': '1-on-1 Meeting',
+            'start': '2026-04-01 12:00:00',
+            'stop': '2026-04-01 13:00:00',
+            'user_id': organizer.id,
+            'partner_ids': [Command.link(attendees[0].id)],
+        })
+        self.assertIn('Organized by', event_single.description)
+        self.assertIn('Contact Details', event_single.description)
+        self.assertIn('Attendee A', event_single.description)

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -516,3 +516,36 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'res_id': 0,
         })
         self.assertTrue(event.res_id)
+
+    def test_contact_details_single_vs_multiple_attendees(self):
+        """Contact Details section should only appear for 1-on-1 meetings
+        (single non-organizer attendee)."""
+        organizer = new_test_user(self.env, login='org_user', groups='base.group_user')
+        attendees = self.env['res.partner'].create([
+            {'name': 'Attendee A', 'email': 'a@test.com', 'phone': '+1000000001'},
+            {'name': 'Attendee B', 'email': 'b@test.com', 'phone': '+1000000002'},
+            {'name': 'Attendee C', 'email': 'c@test.com', 'phone': '+1000000003'},
+        ])
+        # Multiple attendees: only organizer info is shown
+        event_multi = self.env['calendar.event'].with_user(organizer).create({
+            'name': 'Group Meeting',
+            'start': '2026-04-01 10:00:00',
+            'stop': '2026-04-01 11:00:00',
+            'user_id': organizer.id,
+            'partner_ids': [Command.link(pid) for pid in attendees.ids],
+        })
+        self.assertIn('Organized by', event_multi.description)
+        self.assertNotIn('Contact Details', event_multi.description)
+        for attendee in attendees:
+            self.assertNotIn(attendee.name, event_multi.description)
+        # Single attendee: Contact Details should appear
+        event_single = self.env['calendar.event'].with_user(organizer).create({
+            'name': '1-on-1 Meeting',
+            'start': '2026-04-01 12:00:00',
+            'stop': '2026-04-01 13:00:00',
+            'user_id': organizer.id,
+            'partner_ids': [Command.link(attendees[0].id)],
+        })
+        self.assertIn('Organized by', event_single.description)
+        self.assertIn('Contact Details', event_single.description)
+        self.assertIn('Attendee A', event_single.description)

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -161,7 +161,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
             'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
             'summary': 'Event',
-            'description': event.description,
+            'description': '',
             'location': '',
             'visibility': 'private',
             'guestsCanModify': True,


### PR DESCRIPTION
When a calendar event has multiple attendees, `_get_contact_details_description` picks the first non-organizer partner from a set-based recordset to render under "Contact Details" in the event description. The recordset is built from `partner_ids_from_attendees`, a set whose iteration order depends on Python's hash seed, so the displayed contact is effectively random and not controllable from the UI.

Restrict the "Contact Details" block in `_get_contact_details_description` to events with exactly one non-organizer attendee (1-on-1 meetings). For group meetings the block is omitted entirely, since any single attendee picked from a larger group is arbitrary by construction.

Steps to reproduce:
1. Go to Calendar > New
2. Add 3+ attendees (e.g. Alice, Bob, Charlie)
3. Save the event
4. Check the Notes tab in the event form

=> One random attendee's contact info appears under "Contact Details"

Ticket [link](https://www.odoo.com/odoo/project.task/6035192)
opw-6035192