### PR TITLE
[FIX] spreadsheet: list headers are not fetched

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -84,20 +84,20 @@ export class ListDataSource extends OdooViewsDataSource {
 
     async _load() {
         await super._load();
+        this.fieldPathsToFieldMap = {};
+        const specification = await this._getReadSpec();
+        this.alreadyFetchedFieldPaths = new Set([...this.fieldPathsToFetch]);
         if (this.maxPosition === 0) {
             this.data = [];
             return;
         }
-        this.fieldPathsToFieldMap = {};
         const { domain, orderBy, context } = this._searchParams;
-        const specification = await this._getReadSpec();
         const { records } = await this._orm.webSearchRead(this._metaData.resModel, domain, {
             specification,
             order: orderByToString(orderBy),
             limit: this.maxPosition,
             context,
         });
-        this.alreadyFetchedFieldPaths = new Set([...this.fieldPathsToFetch]);
         this.data = records;
         this.maxPositionFetched = this.maxPosition;
     }

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -1292,7 +1292,7 @@ test("Chaining monetary fields includes the currency field", async function () {
 });
 
 test("List header labels are loaded even if there are no corresponding list values", async function () {
-    const { model } = await createSpreadsheetWithList();
+    const { model } = await createSpreadsheetWithList({ columns: [] });
     const listId = model.getters.getListIds()[0];
     setCellContent(model, "A1", `=ODOO.LIST.HEADER(${listId}, "currency_id")`);
     setCellContent(model, "B1", `=ODOO.LIST.HEADER(${listId}, "product_id.template_id.name")`);


### PR DESCRIPTION
The commit a4a709f was a bit wrong, it didn't work for an empty list. If the list had no value at all, `_load` had an early return, never fetched the headers, and we had an infinite loop of fetches.

Task: [5900769](https://www.odoo.com/web#id=5900769&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
