### PR TITLE
[FIX] website_slides: use more robust assertion for empty chatter

### DIFF
--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -20,8 +20,8 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger:
-                "#chatterRoot:shadow .o-mail-Chatter-content:not(:has(.o-mail-Message-content))",
+            // If it fails here, it means that the portal chatter has fetched the notes.
+            trigger: "#chatterRoot:shadow .o-mail-Chatter:has(:text(The conversation is empty.))",
         },
         {
             // If it fails here, it means the log note is considered as a review


### PR DESCRIPTION
The previous negative assertion could pass prematurely during fast tour execution. Switching to a specific text based assertion ensures the step only proceeds once the empty conversation is explicitly confirmed.

