### PR TITLE
[FIX] web: restore vertical padding in select_menu choices

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -66,6 +66,15 @@
         top: calc(var(--border-width) * -1);
     }
 
+    .o_select_menu-choices {
+        > *:first-child {
+            margin-top: 0.5rem;
+        }
+        > *:last-child {
+            margin-bottom: 0.5rem;
+        }
+    }
+
     &:not(.o_bottom_sheet) {
         max-height: 300px;
 


### PR DESCRIPTION
Recent structural changes added `p-0` to the menu class, removing the vertical padding from the dropdown. Rather than padding the scroll container directly (which would conflict with sticky group headers), apply `margin-top/bottom` on the first/last children of `.o_select_menu-choices` so the spacing scrolls naturally without creating a gap items could bleed through when a group header is stuck.

task-6095912
