### PR TITLE
[FIX] point_of_sale: delete opening_control session on unload

### DIFF
--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -41,6 +41,24 @@ whenReady(() => {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }
+        const pos = app.env.services.pos;
+        if (pos?.session?.state === "opening_control") {
+            const data = JSON.stringify({
+                jsonrpc: "2.0",
+                method: "call",
+                id: 1,
+                params: {
+                    model: "pos.session",
+                    method: "delete_opening_control_session",
+                    args: [[pos.session.id]],
+                    kwargs: {},
+                },
+            });
+            navigator.sendBeacon(
+                "/web/dataset/call_kw",
+                new Blob([data], { type: "application/json" })
+            );
+        }
     });
     const classList = document.body.classList;
     if (localization.direction === "rtl") {


### PR DESCRIPTION
When the user closes the browser tab or navigates away after a session in opening_control, the session is not deleted and it causes confusion.

opw-6114420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
