### PR TITLE
[IMP] pos_self_order: add phone number country prefix selector

### DIFF
--- a/addons/pos_self_order/models/res_country.py
+++ b/addons/pos_self_order/models/res_country.py
@@ -8,4 +8,4 @@ class ResCountry(models.Model):
     @api.model
     def _load_pos_self_data_fields(self, config):
         fields = super()._load_pos_self_data_fields(config)
-        return fields + ["state_ids"]
+        return fields + ["state_ids", "phone_code"]

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -25,7 +25,11 @@ export class PresetInfoPopup extends Component {
             selectedPartnerId: partner?.id || null,
             name: partner?.name || "",
             email: partner?.email || "",
-            phone: partner?.phone || "",
+            phoneCode:
+                partner?.country_id?.phone_code ||
+                this.selfOrder.config.company_id.country_id.phone_code ||
+                "",
+            phoneLocal: "",
             phoneError: "",
             street: partner?.street || "",
             countryId: partner?.country_id?.id || companyCountryId || null,
@@ -40,13 +44,13 @@ export class PresetInfoPopup extends Component {
     }
 
     async setInformations() {
-        if (this.preset.needsPartner || this.state.phone) {
+        if (this.preset.needsPartner || this.state.phoneLocal) {
             const countryId = parseInt(this.state.countryId, 10) || null;
             const stateId = parseInt(this.state.stateId, 10) || null;
             const partnerData = {
                 name: this.state.name,
                 email: this.state.email,
-                phone: this.state.phone,
+                phone: this.getFullPhone(),
                 street: this.state.street,
                 city: this.state.city,
                 country_id: countryId,
@@ -74,7 +78,7 @@ export class PresetInfoPopup extends Component {
         } else {
             this.selfOrder.currentOrder.floating_order_name = this.state.name;
         }
-        this.props.getPayload(this.state);
+        this.props.getPayload({ ...this.state, phone: this.getFullPhone() });
         this.props.close();
     }
 
@@ -101,12 +105,30 @@ export class PresetInfoPopup extends Component {
         return country?.state_ids || [];
     }
 
+    get selectedCountry() {
+        return this.selfOrder.models["res.country"]
+            .getAll()
+            .find((c) => c.phone_code === this.state.phoneCode);
+    }
+
+    flagEmoji(code) {
+        return [...code.toUpperCase()]
+            .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+            .join("");
+    }
+
+    getFullPhone() {
+        return this.state.phoneLocal.trim()
+            ? `+${this.state.phoneCode}${this.state.phoneLocal.trim()}`
+            : "";
+    }
+
     get validSelection() {
         return this.selfOrder.isValidSelection(this.selfOrder.currentOrder.raw.preset_time, {
             id: parseInt(this.state.selectedPartnerId),
             name: this.state.name,
             email: this.state.email,
-            phone: this.state.phone,
+            phone: this.getFullPhone(),
             street: this.state.street,
             city: this.state.city,
             country_id: this.state.countryId,
@@ -121,6 +143,6 @@ export class PresetInfoPopup extends Component {
     }
 
     checkPhoneFormat() {
-        return !this.state.phone || isValidPhone(this.state.phone);
+        return !this.state.phoneLocal || isValidPhone(this.getFullPhone());
     }
 }

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
@@ -22,11 +22,25 @@
                         placeholder="Email"
                         t-custom-model="state.email"/>
                     <t t-if="this.preset.needsName || this.preset.needsPartner">
-                        <input type="text"
-                            class="form-control form-control-lg"
-                            placeholder="Phone"
-                            t-custom-model="state.phone"/>
-                        <p t-if="!this.checkPhoneFormat()" class="text-danger">Enter a valid phone number starting with the country code (e.g. +32)</p>
+                        <div class="input-group">
+                            <div class="position-relative w-25 me-3">
+                                <div class="form-control form-control-lg d-flex align-items-center gap-1 pe-none">
+                                    <t t-out="this.flagEmoji(this.selectedCountry?.code || '')"/>
+                                    <span>+<t t-out="state.phoneCode"/></span>
+                                </div>
+                                <select class="position-absolute top-0 start-0 w-100 h-100 opacity-0"
+                                        t-custom-model.number="state.phoneCode">
+                                    <option t-foreach="this.selfOrder.models['res.country'].getAll()" t-as="c" t-key="c.id" t-att-value="c.phone_code">
+                                        <t t-out="this.flagEmoji(c.code)"/> +<t t-out="c.phone_code"/> <t t-out="c.name"/>
+                                    </option>
+                                </select>
+                            </div>
+                            <input type="text"
+                                class="form-control form-control-lg"
+                                placeholder="Phone"
+                                t-custom-model="state.phoneLocal" />
+                        </div>
+                        <p t-if="!this.checkPhoneFormat()" class="text-danger">Enter a valid phone number</p>
                     </t>
                     <t t-if="this.preset.needsPartner">
                         <select class="partner-select form-select form-select-lg" t-custom-model="state.countryId">

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add("self_order_preset_delivery_tour", {
         Utils.clickBtn("Order"),
         CartPage.fillInput("Name", "Dr Dre"),
         CartPage.fillInput("Email", "dre@dr.com"),
-        CartPage.fillInput("Phone", "+32490904390"),
+        CartPage.fillInput("Phone", "490904390"),
         CartPage.fillInput("Street and Number", "Rue du Bronx 90"),
         CartPage.fillInput("Zip", "9999"),
         CartPage.fillInput("City", "New York"),
@@ -115,7 +115,7 @@ registry.category("web_tour.tours").add("test_preset_takeaway_email_tour", {
         Utils.clickBtn("Order"),
         CartPage.fillInput("Name", "Public user"),
         CartPage.fillInput("Email", "public.user@test.com"),
-        CartPage.fillInput("Phone", "+32000111222"),
+        CartPage.fillInput("Phone", "000111222"),
         Utils.clickBtn("Continue"),
         // Waiting for mail to be sent
         {

--- a/addons/pos_self_order/static/tests/unit/components/preset_info_popup.test.js
+++ b/addons/pos_self_order/static/tests/unit/components/preset_info_popup.test.js
@@ -9,6 +9,7 @@ definePosSelfModels();
 test("validSelection", async () => {
     const store = await setupSelfPosEnv();
     store.config.company_id.country_id.state_ids = [];
+    store.config.company_id.country_id.phone_code = 1;
     const models = store.models;
 
     const order = await getFilledSelfOrder(store);
@@ -33,7 +34,7 @@ test("validSelection", async () => {
     // Partner
     preset.identification = "address";
     expect(comp.validSelection).toBeEmpty();
-    comp.state.phone = "+1987-654-3210";
+    comp.state.phoneLocal = "2025551234";
     comp.state.street = "21, Wonderfull Street";
     comp.state.city = "Vice City";
     comp.state.zip = "000021";

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -6,6 +6,7 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 class TestSelfOrderPreset(SelfOrderCommonTest):
     def setUp(self):
         super().setUp()
+        self.env.company.country_id = self.env.ref('base.be')
         self.preset_dine_in = self.env['pos.preset'].create({
             'name': 'Dine in',
             'available_in_self': True,


### PR DESCRIPTION
Replace the plain phone text input (which required users to manually type the country code) with a country prefix picker combined with a local number input. The prefix is selected via a styled select overlay showing the flag emoji and dial code, while the local number is entered in a separate tel input. The two are combined into a full E.164 number before validation and submission.

Task: 5913205




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
