### PR TITLE
[FIX] website: avoid persisting legacy cookies bar value

### DIFF
--- a/addons/website/static/src/interactions/cookies/cookies_bar.js
+++ b/addons/website/static/src/interactions/cookies/cookies_bar.js
@@ -127,7 +127,6 @@ export class CookiesBar extends Popup {
     }
 
     onToggleCookiesBar() {
-        this.cookieValue = cookie.get(this.el.id);
         this.bsModal.toggle();
         // As we're using Bootstrap's events, the Popup class prevents the modal
         // from being shown after hiding it: override that behavior.
@@ -150,6 +149,12 @@ export class CookiesBar extends Popup {
     }
 
     onHideModal() {
+        // cookieValue starts as true in Popup.setup() and is only replaced
+        // after explicit consent. If it is still true here, the modal was
+        // closed without a user choice, so nothing should be persisted.
+        if (this.cookieValue === true) {
+            return;
+        }
         super.onHideModal();
         const params = new URLSearchParams(window.location.search);
         const trackingFields = {

--- a/addons/website/static/tests/interactions/cookies/cookies.test.js
+++ b/addons/website/static/tests/interactions/cookies/cookies.test.js
@@ -119,6 +119,14 @@ test("toggling the cookies bar should not rewrite the cookie preferences", async
     expect(cookie.get("website_cookies_bar")).toBe(essentialConsentCookies);
 });
 
+test("toggling the cookies bar before any consent should not write any cookie", async () => {
+    await startInteractions(getCookiesBarTemplate(true));
+    expect(cookie.get("website_cookies_bar")).toBe(undefined);
+    await click(".o_cookies_bar_toggle");
+    await click(".o_cookies_bar_toggle");
+    expect(cookie.get("website_cookies_bar")).toBe(undefined);
+});
+
 test("show warning instead of iframe if no consent", async () => {
     const { core } = await startInteractions(cookiesApprovalTemplate);
     expect(core.interactions).toHaveLength(2);


### PR DESCRIPTION
Steps to reproduce:
- Set the cookies bar
- Do not accept nor reject it
- On the website homepage, click on the search button 
=> Check the cookies: website_cookies_bar=true is set.

`Popup` initializes `cookieValue` to `true` and writes it in `onHideModal()`. If the cookies bar is closed before any explicit consent choice, it can therefore recreate the legacy invalid value `website_cookies_bar=true`.

This happens because the search button uses `data-bs-toggle="modal"`, which is controlled by Bootstrap: if it is opened while another bootstrap modal is already open on the page, the latter is hidden. This in turn calls the popup interaction's `onHideModal()`, which sets `website_cookies_bar=true` as `cookieValue` hasn't been changed.

That value is later treated as invalid and cleared repeatedly during website rendering, which can accumulate duplicate `Set-Cookie` headers in the same response and lead to `upstream sent too big header` behind nginx.

Avoid persisting that legacy value by returning early from `CookiesBar.onHideModal()` while `cookieValue` is still the inherited default `true`.

opw-6037573