### PR TITLE
[IMP] account, account_edi_ubl_cii: Group sections by tax when collapsing composition in both PDF and XML

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3524,9 +3524,10 @@ class AccountMoveLine(models.Model):
         direct_children_lines = children_lines.filtered(lambda l: l.parent_id == self and l.display_type != 'line_subsection')
         section_subtotal = sum(l.price_subtotal for l in children_lines)
         section_total = sum(l.price_total for l in children_lines)
+
         result = [{
             'name': self.name,
-            'taxes': [tax.tax_label for tax in children_lines.tax_ids if tax.tax_label],
+            'taxes': [],
             'price_subtotal': section_subtotal,
             'price_total': section_total,
             'display_type': self.display_type,
@@ -3536,19 +3537,51 @@ class AccountMoveLine(models.Model):
             'discount': 0.0,
         }]
 
-        if not self.collapse_composition:
-            for line in direct_children_lines:
+        if self.collapse_composition and self.display_type in ('line_section', 'line_subsection'):
+            product_lines = children_lines.filtered(lambda l: l.display_type == 'product')
+            result = []
+            for taxes, lines_iter in groupby(product_lines, key=lambda l: l.tax_ids):
+                lines = sum(lines_iter, start=self.env['account.move.line'])
+                tax_labels = [tax.tax_label for tax in taxes if tax.tax_label]
+                subtotal = sum(lines.mapped('price_subtotal'))
+                total = sum(lines.mapped('price_total'))
+                if not subtotal and not total and not tax_labels:
+                    continue
                 result.append({
-                    'name': line.name,
-                    'taxes': [tax.tax_label for tax in line.tax_ids if tax.tax_label] if not self.collapse_prices else [],
-                    'price_subtotal': line.price_subtotal,
-                    'price_total': line.price_total,
-                    'display_type': line.display_type,
-                    'quantity': line.quantity,
-                    'line_uom': line.product_uom_id,
-                    'product_uom': line.product_id.uom_id,
-                    'discount': line.discount,
+                    'name': self.name,
+                    'taxes': tax_labels,
+                    'price_subtotal': subtotal,
+                    'price_total': total,
+                    'display_type': 'product',
+                    'quantity': 1,
+                    'line_uom': False,
+                    'product_uom': False,
+                    'discount': 0.0,
                 })
+            return result or [{
+                'name': self.name,
+                'taxes': [],
+                'price_subtotal': 0.0,
+                'price_total': 0.0,
+                'display_type': 'product',
+                'quantity': 0,
+                'line_uom': False,
+                'product_uom': False,
+                'discount': 0.0,
+            }]
+
+        for line in direct_children_lines:
+            result.append({
+                'name': line.name,
+                'taxes': [tax.tax_label for tax in line.tax_ids if tax.tax_label],
+                'price_subtotal': line.price_subtotal,
+                'price_total': line.price_total,
+                'display_type': line.display_type,
+                'quantity': line.quantity,
+                'line_uom': line.product_uom_id,
+                'product_uom': line.product_id.uom_id,
+                'discount': line.discount,
+            })
 
         for subsection_line in subsection_lines:
             lines_in_subsection = children_lines.filtered(lambda l: l.parent_id == subsection_line)
@@ -3575,7 +3608,7 @@ class AccountMoveLine(models.Model):
                     for line in subsection_line | lines_for_tax_group:
                         result.append({
                             'name': line.name,
-                            'taxes': tax_labels if line == subsection_line else [],
+                            'taxes': tax_labels if line != subsection_line else [],
                             'price_subtotal': subtotal if line == subsection_line else line.price_subtotal,
                             'price_total': total if line == subsection_line else line.price_total,
                             'display_type': line.display_type,

--- a/addons/account/tests/test_account_section_and_subsection.py
+++ b/addons/account/tests/test_account_section_and_subsection.py
@@ -37,9 +37,76 @@ class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
         ]
         section_lines = move.invoice_line_ids[0]._get_child_lines()
         expected_values = [
-            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': ['15%']},
-            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': ['15%']},
             {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 300.0, 'taxes': ['15%']},
+        ]
+        for expected_value, line_value in zip(expected_values, section_lines):
+            for key, value in expected_value.items():
+                self.assertEqual(line_value[key], value)
+
+    def test_grouping_sections_and_subsections_by_taxes(self):
+        move = self.init_invoice('out_invoice')
+
+        move.invoice_line_ids = [
+            Command.create({
+                'move_id': move.id,
+                'name': "Section 1",
+                'display_type': 'line_section',
+                'collapse_composition': True,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 50,
+                'tax_ids': self.tax_sale_b.ids,
+            }),
+            Command.create({
+                'product_id': self.product_b.id,
+                'price_unit': 50,
+                'tax_ids': self.tax_sale_b.ids,
+            }),
+            Command.create({
+                'move_id': move.id,
+                'name': "Section 2",
+                'display_type': 'line_section',
+            }),
+            Command.create({
+                'move_id': move.id,
+                'name': "Subsection 2.1",
+                'display_type': 'line_subsection',
+                'collapse_composition': True,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 50,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 50,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_b.id,
+                'price_unit': 50,
+                'tax_ids': self.tax_sale_b.ids,
+            }),
+        ]
+        lines_to_report = move._get_move_lines_to_report()
+        section_lines = []
+        for line in lines_to_report.filtered(lambda l: l.collapse_composition and l.display_type in ('line_section', 'line_subsection')):
+            section_lines += line._get_child_lines()
+
+        expected_values = [
+            {'display_type': 'product', 'name': 'Section 1', 'price_subtotal': 100.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'Section 1', 'price_subtotal': 100.0, 'taxes': ['15% (copy)']},
+            {'display_type': 'product', 'name': 'Subsection 2.1', 'price_subtotal': 100.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'Subsection 2.1', 'price_subtotal': 50.0, 'taxes': ['15% (copy)']},
         ]
         for expected_value, line_value in zip(expected_values, section_lines):
             for key, value in expected_value.items():
@@ -81,9 +148,9 @@ class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
         ]
         section_lines = move.invoice_line_ids[0]._get_child_lines()
         expected_values = [
-            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 600.0, 'taxes': ['15%', '15% (copy)']},
-            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
-            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 600.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': ['15% (copy)']},
             {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15%']},
             {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15% (copy)']},
         ]
@@ -123,11 +190,11 @@ class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
         )
         section_lines = move.invoice_line_ids[0]._get_child_lines()
         expected_values = [
-            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': ['15%', '15% (copy)']},
-            {'display_type': 'line_subsection', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15%']},
-            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 200.0, 'taxes': []},
-            {'display_type': 'line_subsection', 'name': 'Subsection 1.2', 'price_subtotal': 200.0, 'taxes': ['15% (copy)']},
-            {'display_type': 'product', 'name': 'product_b', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': []},
+            {'display_type': 'line_subsection', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 200.0, 'taxes': ['15%']},
+            {'display_type': 'line_subsection', 'name': 'Subsection 1.2', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'product_b', 'price_subtotal': 200.0, 'taxes': ['15% (copy)']},
         ]
         for expected_value, line_value in zip(expected_values, section_lines):
             for key, value in expected_value.items():

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -5,7 +5,7 @@ import re
 from stdnum.be import vat as be_vat
 
 from odoo import _, api, fields, models, Command
-from odoo.tools import formatLang, frozendict, html2plaintext, html_escape, pdf, str2bool, unique
+from odoo.tools import formatLang, frozendict, groupby, html2plaintext, html_escape, pdf, str2bool, unique
 from odoo.addons.account_edi_ubl_cii.models.account_edi_common import (
     EAS_MAPPING,
     FloatFmt,
@@ -2586,6 +2586,91 @@ class AccountEdiUBL(models.AbstractModel):
 
         self._define_document_type(vals, document_type)
 
+    def _preprocess_base_lines(self, invoice, base_lines):
+        """Collapse the base_lines of sections/subsections flagged with 'collapse_composition'.
+
+        For each section or subsection with `collapse_composition` enabled, all of its
+        product base_lines are hidden and replaced by a single base_line per
+        tax group, whose amounts are the sum of the hidden lines it represents.
+
+        base_lines belonging to sections without `collapse_composition` are left untouched.
+        """
+        def _build_collapsed_base_line(group, section):
+            """Build a single base_line representing all lines of a tax group under a collapsed section"""
+            AccountTax = self.env['account.tax']
+            first_line = group[0]
+            total_excluded_currency = sum(bl['tax_details']['total_excluded_currency'] for bl in group)
+
+            collapsed_line = AccountTax._prepare_base_line_for_taxes_computation(
+                first_line['record'],
+                quantity=1.0,
+                price_unit=total_excluded_currency,
+                discount=0.0,
+                tax_ids=first_line['tax_ids'],
+                currency_id=first_line['currency_id'],
+            )
+            collapsed_line.update({
+                'name': section.name,
+                '_line_name': section.name,
+                'product_id': self.env['product.product'],
+            })
+            AccountTax._add_tax_details_in_base_lines([collapsed_line], invoice.company_id)
+            AccountTax._round_base_lines_tax_details([collapsed_line], invoice.company_id)
+            return collapsed_line
+
+        def _get_collapsed_section_line_ids(invoice, base_lines):
+            """Return collapse roots (sections/subsections), their subsections, and the hidden product lines."""
+
+            collapsed_roots = invoice.invoice_line_ids.filtered(
+                lambda line: line.display_type in ('line_section', 'line_subsection')
+                and all([line.collapse_composition, not line.parent_id.collapse_composition]),  # a collapsed subsection of a collapsed section shouldn't be considered as a root
+            )
+            hidden_lines = [
+                bl for bl in base_lines
+                if bl['record'].parent_id in collapsed_roots  # children of a collapsed section
+                or bl['record'].parent_id.parent_id in collapsed_roots  # children of a standalone collapsed subsection
+            ]
+            return collapsed_roots, hidden_lines
+
+        def _get_collapsed_section_base_lines(invoice, hidden_base_lines, collapsed_roots):
+            """For each collapsed (section/subsection), return one base_line per tax group."""
+
+            result = []
+            for section in collapsed_roots:
+                section_bls = [
+                    bl for bl in hidden_base_lines
+                    if section in (bl['record'].parent_id, bl['record'].parent_id.parent_id)
+                ]
+                if not section_bls:
+                    continue
+
+                for _taxes, lines in groupby(
+                    sorted(section_bls, key=lambda bl: bl['tax_ids'].ids),
+                    key=lambda bl: bl['tax_ids'],
+                ):
+                    result.append(_build_collapsed_base_line(list(lines), section))
+            return result
+
+        collapsed_roots, hidden_lines = _get_collapsed_section_line_ids(invoice, base_lines)
+        if not hidden_lines:
+            return base_lines
+
+        # Keep the original document order
+        # A hidden line is dropped, and its section's collapsed lines are inserted once, in place of its first hidden line.
+        preprocessed_base_lines = []
+        inserted_sections = set()
+        for bl in base_lines:
+            if bl not in hidden_lines:
+                preprocessed_base_lines.append(bl)
+                continue
+            record = bl['record']
+            section = record.parent_id if record.parent_id in collapsed_roots else record.parent_id.parent_id
+            if section not in inserted_sections:
+                preprocessed_base_lines += _get_collapsed_section_base_lines(invoice, hidden_lines, [section])
+                inserted_sections.add(section)
+
+        return preprocessed_base_lines
+
     def _init_invoice_export_values(self, invoice):
         vals = {'invoice': invoice.with_context(lang=invoice.partner_id.lang)}
 
@@ -2605,7 +2690,8 @@ class AccountEdiUBL(models.AbstractModel):
         self._ubl_add_values_customer(vals, customer)
         self._ubl_add_values_delivery(vals, delivery)
 
-        vals['base_lines'], vals['tax_lines'] = invoice._get_rounded_base_and_tax_lines()
+        base_lines, vals['tax_lines'] = invoice._get_rounded_base_and_tax_lines()
+        vals['base_lines'] = self._preprocess_base_lines(invoice, base_lines)
         return vals
 
     def _export_invoice(self, invoice):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1,7 +1,7 @@
 from lxml import etree
 
 from odoo import _, models, Command
-from odoo.tools import html2plaintext
+from odoo.tools import html2plaintext, groupby
 from odoo.tools.float_utils import float_is_zero, float_round
 from odoo.addons.account.tools import dict_to_xml
 from odoo.addons.account_edi_ubl_cii.models.account_edi_common import FloatFmt
@@ -234,9 +234,80 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             return base_lines
         return self._ubl_turn_emptying_taxes_as_new_base_lines(base_lines, company, vals)
 
+    def _build_collapsed_base_line(self, group, section):
+        """Build a single base_line representing all lines of a tax group under a collapsed section"""
+        first_line = group[0]
+        total_excluded_currency = sum(bl['tax_details']['total_excluded_currency'] for bl in group)
+
+        return {
+            **first_line,
+            'quantity': 1.0,
+            'price_unit': total_excluded_currency,
+            'discount': 0.0,
+            'name': section.name,
+            '_line_name': section.name,
+            'product_id': self.env['product.product'],
+            'tax_details': {
+                **first_line['tax_details'],
+                'total_excluded_currency': total_excluded_currency,
+                'total_excluded': sum(bl['tax_details']['total_excluded'] for bl in group),
+                'total_included_currency': sum(bl['tax_details']['total_included_currency'] for bl in group),
+                'total_included': sum(bl['tax_details']['total_included'] for bl in group),
+                'raw_total_excluded_currency': sum(bl['tax_details']['raw_total_excluded_currency'] for bl in group),
+                'raw_total_excluded': sum(bl['tax_details']['raw_total_excluded'] for bl in group),
+            },
+        }
+
+    def _get_collapsed_section_base_lines(self, invoice, hidden_base_lines, collapsed_sections, collapsed_subsections):
+        """For each collapsed section, return one base_line per tax group."""
+        result = []
+        for section in collapsed_sections:
+            section_parents = section | collapsed_subsections.filtered(
+                lambda line: line.parent_id == section,
+            )
+            section_line_ids = set(
+                invoice.invoice_line_ids.filtered(lambda line: line.display_type == 'product' and line.parent_id in section_parents).ids,
+            )
+            section_base_lines = [
+                bl for bl in hidden_base_lines if bl['record'].id in section_line_ids
+            ]
+            if not section_base_lines:
+                continue
+
+            for _taxes, lines in groupby(section_base_lines, key=lambda bl: bl['tax_ids']):
+                result.append(self._build_collapsed_base_line(list(lines), section))
+
+        return result
+
+    def _get_collapsed_section_line_ids(self, invoice):
+        """Return collapsed sections, their subsections, and the set of product line IDs they contain."""
+        collapsed_sections = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == 'line_section' and line.collapse_composition,
+        )
+        collapsed_subsections = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == 'line_subsection' and line.parent_id in collapsed_sections,
+        )
+        hidden_line_ids = set(
+            invoice.invoice_line_ids.filtered(lambda line: line.display_type == 'product' and line.parent_id in (collapsed_sections | collapsed_subsections)).ids,
+        )
+        return collapsed_sections, collapsed_subsections, hidden_line_ids
+
     def _add_invoice_base_lines_vals(self, vals):
         invoice = vals['invoice']
-        vals['base_lines'], _tax_lines = invoice._get_rounded_base_and_tax_lines()
+        base_lines, _tax_lines = invoice._get_rounded_base_and_tax_lines()
+
+        collapsed_sections, collapsed_subsections, hidden_line_ids = self._get_collapsed_section_line_ids(invoice)
+        if not hidden_line_ids:
+            vals['base_lines'] = base_lines
+            return
+
+        normal_lines = [bl for bl in base_lines if bl['record'].id not in hidden_line_ids]
+        hidden_lines = [bl for bl in base_lines if bl['record'].id in hidden_line_ids]
+        collapsed_lines = self._get_collapsed_section_base_lines(
+            invoice, hidden_lines, collapsed_sections, collapsed_subsections,
+        )
+
+        vals['base_lines'] = collapsed_lines + normal_lines
 
     def _setup_base_lines(self, vals):
         base_lines = vals['base_lines']

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_export_sections_as_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_export_sections_as_invoice_lines.xml
@@ -1,0 +1,192 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>___ignore___</cbc:ID>
+	<cbc:IssueDate>___ignore___</cbc:IssueDate>
+	<cbc:DueDate>___ignore___</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cac:OrderReference>
+		<cbc:ID>___ignore___</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject filename="___ignore___" mimeCode="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0202239951</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0202239951</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0477472701</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0477472701</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+		<cac:DeliveryParty>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+		</cac:DeliveryParty>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>___ignore___</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>BE15001559627230</cbc:ID>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">165.00</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">700.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">147.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">150.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">18.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>12.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="EUR">850.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">850.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">1015.00</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">1015.00</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">500.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>product_4</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">500.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">150.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Section 1</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>12.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">150.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Section 1</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">200.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_export_sections_as_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_export_sections_as_invoice_lines.xml
@@ -1,0 +1,197 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>___ignore___</cbc:ID>
+	<cbc:IssueDate>___ignore___</cbc:IssueDate>
+	<cbc:DueDate>___ignore___</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cac:OrderReference>
+		<cbc:ID>___ignore___</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject filename="___ignore___" mimeCode="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0202239951</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0202239951</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0477472701</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0477472701</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+		<cac:DeliveryParty>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+		</cac:DeliveryParty>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>___ignore___</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>BE15001559627230</cbc:ID>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">159.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">150.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">12.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>12.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">700.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">147.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">850.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">850.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">1009.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">-50.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">1015.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">150.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Section 1</cbc:Description>
+            <cbc:Name>Section 1</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>12.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">150.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Section 1</cbc:Description>
+            <cbc:Name>Section 1</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">200.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">500.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>product_4</cbc:Description>
+            <cbc:Name>product_4</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">500.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -954,6 +954,36 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_E_08_line_extension_amount')
 
+    def test_export_sections_as_invoice_lines(self):
+        """
+        A collapsed section should be exported as invoice lines grouped by tax.
+        The order of the cac:InvoiceLine elements should match the order of the lines on the generated PDF.
+        """
+        tax_12 = self.percent_tax(12.0)
+        tax_21 = self.percent_tax(21.0)
+        product_1 = self._create_product(lst_price=100, name="product_1")
+        product_2 = self._create_product(lst_price=50, name="product_2")
+        product_3 = self._create_product(lst_price=200, name="product_3")
+        product_4 = self._create_product(lst_price=500, name="product_4")
+
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                # This section should be ignored, the product line should be exported instead.
+                self._prepare_invoice_line(name="Section 2", display_type='line_section', collapse_composition=False, price_unit=0.0),
+                self._prepare_invoice_line(product_id=product_4, tax_ids=[tax_21.id]),
+                # This section should be exported twice : one for 12%, other for 21%.
+                self._prepare_invoice_line(name="Section 1", display_type='line_section', collapse_composition=True, price_unit=0.0),
+                self._prepare_invoice_line(product_id=product_1, tax_ids=[tax_12.id]),
+                self._prepare_invoice_line(product_id=product_2, tax_ids=[tax_12.id]),
+                self._prepare_invoice_line(product_id=product_3, tax_ids=[tax_21.id]),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_export_sections_as_invoice_lines')
+
     def test_invoice_tax_subtotal_exempt_amount(self):
         """ Test that the taxable amount for exempt taxes is correctly computed,
         regardless of the tax calculation rounding method.

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -858,3 +858,30 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
 
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_E_08_line_extension_amount')
+
+    def test_export_sections_as_invoice_lines(self):
+        """A collapsed section should be exported as invoice lines grouped by tax"""
+        tax_12 = self.percent_tax(12.0)
+        tax_21 = self.percent_tax(21.0)
+        product_1 = self._create_product(lst_price=100, name="product_1")
+        product_2 = self._create_product(lst_price=50, name="product_2")
+        product_3 = self._create_product(lst_price=200, name="product_3")
+        product_4 = self._create_product(lst_price=500, name="product_4")
+
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                # This section should be exported twice : one for 12%, other for 21%.
+                self._prepare_invoice_line(name="Section 1", display_type='line_section', collapse_composition=True, price_unit=0.0),
+                self._prepare_invoice_line(product_id=product_1, tax_ids=[tax_12.id]),
+                self._prepare_invoice_line(product_id=product_2, tax_ids=[tax_12.id]),
+                self._prepare_invoice_line(product_id=product_3, tax_ids=[tax_21.id]),
+                # This section should be ignored, the product line should be exported instead.
+                self._prepare_invoice_line(name="Section 2", display_type='line_section', collapse_composition=False, price_unit=0.0),
+                self._prepare_invoice_line(product_id=product_4, tax_ids=[tax_21.id]),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_export_sections_as_invoice_lines')


### PR DESCRIPTION
Before this commit, collapsing composition in Accounting did not behave the same as in Sales.

In Accounting PDFs, when a section was created and its composition was
hidden, taxes were removed from individual lines and displayed on the
section line as a comma-separated list.

This commit aligns the behavior with the Sales app:
- When collapsing composition, sections are grouped by tax.
- When hiding prices, taxes are removed from the section line and kept
  on each individual line.

Also, hiding composition in sections wasn't taken into account while exporting the XML.

This commit introduces this behaviour for the XML invoices :
- when we export section that hides the composition, we first group the sections by tax, then we create an invoice line with the section's name, with the right tax and amounts calculations.

NOTE:
This commit does not introduce price hiding in XML exports.

task-6101592

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
