### PR TITLE
[FIX] account_edi_ubl_cii: correcting unit price with price allowance

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2593,7 +2593,7 @@ class AccountEdiUBL(models.AbstractModel):
                 price_subtotal = price_allowance_base_amount
             elif price_allowance_amount:
                 price_discount_amount = -price_allowance_amount
-                price_subtotal = price_amount
+                price_subtotal = price_amount - price_allowance_amount
             else:
                 price_discount_amount = 0.0
                 price_subtotal = price_amount

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2495,7 +2495,7 @@ class AccountEdiUBL(models.AbstractModel):
                 price_subtotal = price_allowance_base_amount
             elif price_allowance_amount:
                 price_discount_amount = -price_allowance_amount
-                price_subtotal = price_amount
+                price_subtotal = price_amount - price_allowance_amount
             else:
                 price_discount_amount = 0.0
                 price_subtotal = price_amount

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_invoice_line_line_extension_amount_price_allowance_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_invoice_line_line_extension_amount_price_allowance_amount.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+    <cac:InvoiceLine>
+        <cbc:LineExtensionAmount currencyID="EUR">950.00</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+            <cbc:Amount currencyID="EUR">50.0</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:Amount currencyID="EUR">100.0</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Price>
+			<cbc:PriceAmount currencyID="EUR">200</cbc:PriceAmount>
+            <cac:AllowanceCharge>
+                <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+                <cbc:Amount currencyID="EUR">50</cbc:Amount>
+            </cac:AllowanceCharge>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_invoice_line_line_extension_amount_price_allowance_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_invoice_line_line_extension_amount_price_allowance_amount.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+    <cac:InvoiceLine>
+        <cbc:LineExtensionAmount currencyID="EUR">950.00</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+            <cbc:Amount currencyID="EUR">50.0</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:Amount currencyID="EUR">100.0</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Price>
+			<cbc:PriceAmount currencyID="EUR">200</cbc:PriceAmount>
+                <cac:AllowanceCharge>
+                <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+                <cbc:Amount currencyID="EUR">50</cbc:Amount>
+            </cac:AllowanceCharge>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_decode_invoice_line.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_decode_invoice_line.py
@@ -39,6 +39,16 @@ class TestUblImportBis3InvoiceBEDecodeInvoiceLine(TestUblImportBis3InvoiceBE):
             },
         ])
 
+    def test_partial_import_invoice_line_line_extension_amount_price_allowance_amount(self):
+        invoice = self._import_invoice_as_attachment_on(test_name='test_partial_import_invoice_line_line_extension_amount_price_allowance_amount')
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'price_unit': 260.00,
+                'quantity': 5.0,
+                'discount': 26.92307692307695,
+            },
+        ])
+
     def test_partial_import_invoice_line_line_extension_amount_full_price_node_no_invoiced_quantity(self):
         invoice = self._import_invoice_as_attachment_on(test_name='test_partial_import_invoice_line_line_extension_amount_full_price_node_no_invoiced_quantity')
         self.assertRecordValues(invoice.invoice_line_ids, [


### PR DESCRIPTION
**PROBLEM**
When importing a ubl bis3 file, with only the amount in the AllowanceCharge on PriceAmount it doesn't add the discount to PriceAmount to get the undiscounted price. Which means we create an invoice with the wrong price. This PR fixes that.

opw-6102962