### PR TITLE
[FIX] product_expiry: removal_date(false) is always less than current

### DIFF
--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//tree" position="attributes">
                 <attribute name="decoration-danger">
-                    removal_date &lt; current_date or quantity &lt; 0
+                    removal_date and removal_date &lt; current_date or quantity &lt; 0
                 </attribute>
             </xpath>
             <xpath expr="//field[@name='quantity']" position="after" >


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Install product_expiry and have products in stock with a quantity greater than 0 and not having any serial or lot configuration.

**Current behavior before PR:**
All lines which have no valid removal_date set (normally just those which are to be subject to be expired) will be marked red.

**Desired behavior after PR is merged:**
The tree view is showing as intended only if a product lot/serial is expired or a quantity less than zero will be marked red.


Info: @wt-io-it



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
