### PR TITLE
[FIX] web: hide tooltip for boolean field in calendar popover

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -47,7 +47,7 @@
                     <t t-set="fieldInfo" t-value="props.model.popoverFieldNodes[fieldId]"/>
                     <t t-set="fieldType" t-value="props.model.fields[fieldId].type"/>
                     <t t-if="!isInvisible(fieldInfo, slot.record)">
-                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldId, slot.record)">
+                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="['html', 'boolean'].includes(fieldType) ? '' : getFormattedValue(fieldId, slot.record)">
                             <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel">
                                 <t t-if="fieldInfo.options.icon">
                                     <i t-attf-class="fa-fw {{fieldInfo.options.icon}} text-400" />

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -5771,7 +5771,7 @@ QUnit.module("Views", ({ beforeEach }) => {
         assert.strictEqual(input_stop.value, "12/30/2016 10:00:00", "should display the datetime");
     });
 
-    QUnit.test("html field on calendar shouldn't have a tooltip", async (assert) => {
+    QUnit.test("html and boolean fields on calendar shouldn't have a tooltip", async (assert) => {
         serverData.models.event.fields.description = { string: "Description", type: "html" };
         serverData.models.event.records.push({
             id: 8,
@@ -5793,6 +5793,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             arch: `
                 <calendar date_start="start">
                     <field name="description"/>
+                    <field name="allday"/>
                 </calendar>
             `,
         });
@@ -5801,7 +5802,13 @@ QUnit.module("Views", ({ beforeEach }) => {
         const descriptionField = target.querySelector(
             '.o_cw_popover_field .o_field_widget[name="description"]'
         );
-        const parentLi = descriptionField.closest("li");
+        let parentLi = descriptionField.closest("li");
+        assert.strictEqual(parentLi.getAttribute("data-tooltip"), "");
+
+        const alldayField = target.querySelector(
+            '.o_cw_popover_field .o_field_widget[name="allday"]'
+        );
+        parentLi = alldayField.closest("li");
         assert.strictEqual(parentLi.getAttribute("data-tooltip"), "");
     });
 });


### PR DESCRIPTION
Before this commit, the tooltip of a boolean field in calendar popover shows html content when the user hovers the boolean field.

This commit removes the tooltip of boolean field in calendar popover since the information inside that tooltip is not really useful for the user.

Issue found during the development of task-5994205
