### PR TITLE
[FIX] account,purchase: prevent error when creating accrual entries

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -163,7 +163,8 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                 values = _get_aml_vals(order, self.amount, 0, account.id, label=_('Manual entry'), analytic_distribution=distribution)
                 move_lines.append(Command.create(values))
             else:
-                accrual_entry_date = self.env.context.get('accrual_entry_date', self.date)
+                accrual_entry_date = self.env.context.get('accrual_entry_date')
+                accrual_entry_date = fields.Date.from_string(accrual_entry_date) if accrual_entry_date else self.date
                 order_lines = lines.with_context(accrual_entry_date=accrual_entry_date).filtered(
                     # We only want non-comment lines (no sections, notes, ...) and include all lines
                     # for purchase orders but exclude downpayment lines for sales orders.

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -235,3 +235,26 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             {'debit': 90.0, 'credit': 0.0},
             {'debit': 0.0, 'credit': 90.0},
         ])
+
+    def test_accrual_entry_date_as_string_from_context(self):
+        """
+        Test that passing `accrual_entry_date` as a string in the context
+        does not raise an error and accrual entries are created correctly.
+        """
+        self.purchase_order.order_line.qty_received = 10
+        move = self.env['account.move'].browse(self.purchase_order.action_create_invoice()['res_id'])
+        move.invoice_date = '2020-01-01'
+        move.action_post()
+        self.purchase_order.order_line.qty_received = 5
+        wizard = self.wizard.with_context(accrual_entry_date='2020-01-30')
+        res = self.env['account.move'].search(wizard.create_entries()['domain']).line_ids
+        self.assertRecordValues(res, [
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 5000.0},
+            {'account_id': self.alt_exp_account.id, 'debit': 0.0, 'credit': 1000.0},
+            {'account_id': self.account_revenue.id, 'debit': 6000.0, 'credit': 0.0},
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 5000.0, 'credit': 0.0},
+            {'account_id': self.alt_exp_account.id, 'debit': 1000.0, 'credit': 0.0},
+            {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 6000.0},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**
- Install the `accountant` and `purchase` modules.
- Create and confirm a Purchase Order (with 1 quantity).
- Create a vendor bill using `auto-complete` from the PO, 
  set the quantity to 1, and `confirm` it.
- Navigate to Accounting > Review > `Billed Not Received`.
- Change the `date` from the top left.
- Select a record and click `Create Accrual Entries`.

**Error:**
`TypeError: '<=' not supported between instances of 'datetime.date' and 'str'`

**Root cause:**
At [1], the `accrual_entry_date` is set in the context as a `string`. 
Later, at [2], this value is retrieved from the context and used 
directly in a comparison with `ivl.date`, which is a `datetime.date`.

**Fix:**
This commit converts `accrual_entry_date` to a `datetime.date` object at [2], 
allowing users to create accrual entries without errors.

[1]:
https://github.com/odoo/enterprise/blob/3ab460a935c6caf013202ec6be1c3708178c8d7d/account_reports/static/src/views/accrual_list_controller.js#L61-L76

[2]:
https://github.com/odoo/odoo/blob/7e17c788babc2715e85456467db9172bb0b8e42d/addons/account/wizard/accrued_orders.py#L166-L188

opw-6110907