### PR TITLE
[FIX] l10n_account_withholding_tax: prevent error on payment update with receivable withholding account

### DIFF
--- a/addons/l10n_account_withholding_tax/wizards/account_payment_register_views.xml
+++ b/addons/l10n_account_withholding_tax/wizards/account_payment_register_views.xml
@@ -27,6 +27,7 @@
                                            options="{'placeholder_field': 'placeholder_value'}"
                                            width="92px"/>
                                     <field name="account_id"
+                                           domain="[('account_type', 'not in', ['asset_receivable', 'liability_payable'])]"
                                            column_invisible="parent.withholding_hide_tax_base_account"
                                            width="184px"
                                            optional="show"/>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the `accountant` and `l10n_account_withholding_tax` modules (with demo data).
2. Create a vendor bill with '**2% WTH**' tax on the invoice line.
3. Make payment with withholding and set the withholding account as receivable.
4. Reset the payment to draft.
5. Modify the amount and save.

video: https://drive.google.com/file/d/1Sz_5Kqs9Le89nAzZIAQoyq3bwQpMijsH/view?usp=drive_link

**Error:**
`Expected singleton: account.move.line(130, 131)`

**Cause:**
During payment update, `_synchronize_to_moves` calls `_seek_for_lines()` to get the liquidity, counterpart, and 
write-off lines - [1]. 
Counterpart lines include accounts of type _Receivable or Payable_ - [2]. 
If the withholding account is also of one of these types, multiple lines are classified as counterpart lines. And this leads to a singleton error.

**Fix:**
Prevent selecting receivable/payable accounts as withholding accounts.

[1] : https://github.com/odoo/odoo/blob/9b57d3d813c03e8d1eeab26a22dd5384106b6cd8/addons/account/models/account_payment.py#L492
[2] : https://github.com/odoo/odoo/blob/9b57d3d813c03e8d1eeab26a22dd5384106b6cd8/addons/account/models/account_payment.py#L221-L222

sentry-7377168925