### PR TITLE
[FIX] html_editor: prevent editor removal when deleting a button

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1376,6 +1376,7 @@ export class DeletePlugin extends Plugin {
             !this.isUnremovable(closestUnmergeable)
         ) {
             closestUnmergeable.remove();
+            this.fillShrunkBlocks(commonAncestor);
             this.dependencies.selection.setSelection({
                 anchorNode: destContainer,
                 anchorOffset: destOffset,

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -112,6 +112,22 @@ describe("button style", () => {
             `),
         });
     });
+
+    test("backspace on button should not remove editor", async () => {
+        const { el, editor } = await setupEditor(
+            '<p><a href="https://test.com/" class="btn btn-lg btn-primary">#</a>[]</p>'
+        );
+        expect(getContent(el)).toBe(
+            `<p>\ufeff<a href="https://test.com/" class="btn btn-lg btn-primary">\ufeff#\ufeff</a>\ufeff[]</p>`
+        );
+        deleteBackward(editor);
+        deleteBackward(editor);
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        );
+        expect(editor.editable.isConnected).toBe(true);
+    });
 });
 
 const allowCustomOpt = {


### PR DESCRIPTION
### Steps to reproduce:

- Create a button, set its URL to #, and click Apply.
- Place the cursor right after the link.
- Press Backspace until the button/link is removed.
- Entire editor also gets removed.

### In previous version:

- Issue is due to [1](https://github.com/odoo/odoo/commit/7685e562b1036d08724ba91ed5064b6fe20c2ce2
) change in `isEmptyBlock` (because of `isButton`).
- When we had `<a>#[]</a>` and pressed backspace, `deleteRange` was called.
- Then `fillShrunkBlocks` ran and `isEmptyBlock` returned true (no isButton).
- So `<br>` was added and block never became fully empty.

### In current version:

- Because of `isButton` condition, some empty blocks are not treated as empty.
- So `<br>` is not added & block stays actually empty. Then `removeFEFF` runs & `nodeSize` becomes false &  `cleanEmptyAncestors` removes parent even editable.

### After this PR:

- Case like `<a>[]</a>`, backspace is handled by override which directly removes `<a>`. Since this skips `deleteRange`, manually call `fillShrunkBlocks` there.
- Now after removing `<a>`, block is properly detected as empty and `<br>` gets added.

task-6109145

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
