### PR TITLE
[FIX] project: show only template tasks when template filter is applied

### DIFF
--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -19,7 +19,7 @@ export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends 
             ]);
             const templateTaskDomain = Domain.or([[["has_template_ancestor", "=", true]],
                 "default_project_id" in this.env.searchModel.globalContext ?
-                        Domain.TRUE :
+                        Domain.FALSE :
                         [["project_id.is_template", "=", true]]]);
             domain = Domain.and([domain, templateTaskDomain]).toList({});
         }


### PR DESCRIPTION
Steps to reproduce:
-
1. Open a project and view its tasks.
2. Apply the "Templates" filter from the search view.

Issue:
-
Both normal tasks and template tasks are displayed. Only template tasks (and descendants of template tasks) should be shown.

Cause:
-
In `project_task_model_mixin.js`, `_processSearchDomain` rebuilds the template domain as `OR(has_template_ancestor = True, Domain.TRUE) when `default_project_id` is in context. So the OR collapses to TRUE and all template filtering is lost, so every task of the project is shown.

Fix:
-
Use `Domain.FALSE` instead of `Domain.TRUE`.

task-6116833
