### PR TITLE
[FIX] account_edi_ubl_cii: fix for BR-CO-16 validation

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -292,21 +292,29 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             amount_total = invoice.amount_total_signed * -invoice.direction_sign
             amount_residual = invoice.amount_residual_signed * -invoice.direction_sign
 
-        node['cbc:PayableAmount']['_text'] = FloatFmt(
-            amount_residual,
-            min_dp=currency.decimal_places,
-        )
-        node['cbc:PrepaidAmount']['_text'] = FloatFmt(
-            amount_total
-            - amount_residual
-            # WithholdingTaxTotal is not allowed.
-            # Instead, withholding tax amounts are reported as a PrepaidAmount.
-            # Suppose an invoice of 1000 with a tax 21% +100 -100.
-            # The super will compute a PrepaidAmount or 0.0 and a PayableAmount or 1000.
-            # This extension is there to increase PrepaidAmount to 210 and PayableAmount to 1210.
-            + vals['_ubl_values']['tax_withholding_amount'],
-            min_dp=currency.decimal_places,
-        )
+        # WithholdingTaxTotal is not allowed. Instead, withholding tax amounts are reported
+        # as a PrepaidAmount. Suppose an invoice of 1000 with a tax 21% +100 -100. The super
+        # will compute a PrepaidAmount of 0.0 and a PayableAmount of 1000. This extension is
+        # there to increase PrepaidAmount to 210 and PayableAmount to 1210.
+        tax_withholding_amount = vals['_ubl_values']['tax_withholding_amount']
+        prepaid_amount = amount_total - amount_residual + tax_withholding_amount
+        payable_amount = amount_residual
+        # Enforce BR-CO-16: BT-115 = BT-112 - BT-113 + BT-114. Overriding PayableAmount to
+        # amount_residual can desync it from the aggregated tax-inclusive amount used by super
+        # (e.g. when line-level rounding makes invoice.amount_total differ from that aggregate),
+        # so we recompute the PayableRoundingAmount here to keep the rule satisfied.
+        tax_inclusive_amount = node['cbc:TaxInclusiveAmount']['_text']
+        payable_rounding_amount = payable_amount + prepaid_amount - tax_inclusive_amount
+
+        node['cbc:PayableAmount']['_text'] = FloatFmt(payable_amount, min_dp=currency.decimal_places)
+        node['cbc:PrepaidAmount']['_text'] = FloatFmt(prepaid_amount, min_dp=currency.decimal_places)
+        if currency.is_zero(payable_rounding_amount):
+            node['cbc:PayableRoundingAmount'] = {'_text': None, 'currencyID': None}
+        else:
+            node['cbc:PayableRoundingAmount'] = {
+                '_text': FloatFmt(payable_rounding_amount, min_dp=currency.decimal_places),
+                'currencyID': currency.name,
+            }
 
     def _add_invoice_monetary_total_nodes(self, document_node, vals):
         # OVERRIDE

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_CO_16_payable_amount_with_line_rounding.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_CO_16_payable_amount_with_line_rounding.xml
@@ -1,0 +1,211 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>___ignore___</cbc:ID>
+	<cbc:IssueDate>___ignore___</cbc:IssueDate>
+	<cbc:DueDate>___ignore___</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cac:OrderReference>
+		<cbc:ID>___ignore___</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject filename="___ignore___" mimeCode="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0202239951</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0202239951</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>company_1_data</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0208">0477472701</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
+				<cbc:CompanyID schemeID="0208">0477472701</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+				<cbc:CityName>Ramillies</cbc:CityName>
+				<cbc:PostalZone>1367</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+		<cac:DeliveryParty>
+			<cac:PartyName>
+				<cbc:Name>partner_be</cbc:Name>
+			</cac:PartyName>
+		</cac:DeliveryParty>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>___ignore___</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>BE15001559627230</cbc:ID>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">1.65</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">27.50</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">1.65</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>6.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">0.60</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="EUR">28.10</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">28.10</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">29.75</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">29.75</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">3.05</cbc:LineExtensionAmount>
+		<cac:AllowanceCharge>
+			<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+			<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+			<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+			<cbc:MultiplierFactorNumeric>15.0</cbc:MultiplierFactorNumeric>
+			<cbc:Amount currencyID="EUR">0.53</cbc:Amount>
+			<cbc:BaseAmount currencyID="EUR">3.58</cbc:BaseAmount>
+		</cac:AllowanceCharge>
+		<cac:Item>
+			<cbc:Name>Test Product</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>6.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">3.584906</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">24.45</cbc:LineExtensionAmount>
+		<cac:AllowanceCharge>
+			<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+			<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+			<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+			<cbc:MultiplierFactorNumeric>15.0</cbc:MultiplierFactorNumeric>
+			<cbc:Amount currencyID="EUR">4.32</cbc:Amount>
+			<cbc:BaseAmount currencyID="EUR">28.77</cbc:BaseAmount>
+		</cac:AllowanceCharge>
+		<cac:Item>
+			<cbc:Description>Test Product</cbc:Description>
+			<cbc:Name>Test Product</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>6.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">28.773585</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">0.60</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>fixed_0.6_(1)</cbc:Description>
+			<cbc:Name>fixed_0.6_(1)</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">0.6</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -858,3 +858,29 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
 
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_E_08_line_extension_amount')
+
+    def test_invoice_BR_CO_16_payable_amount_with_line_rounding(self):
+        """ BR-CO-16: Amount due for payment (BT-115) = Invoice total amount with VAT (BT-112)
+            - Paid amount (BT-113) + Rounding amount (BT-114).
+
+            When combining tax-included percent taxes, fixed per-unit taxes and a line discount
+            on many small-priced lines, the per-line rounding can make invoice.amount_total
+            differ from the aggregated tax-inclusive amount. In that case the PayableRoundingAmount
+            must be recomputed so that BR-CO-16 stays satisfied.
+        """
+        tax_consigne = self.fixed_tax(0.60)
+        tax_6 = self.percent_tax(6.0, price_include_override='tax_included')
+        product_consigne = self._create_product(lst_price=3.8, taxes_id=tax_consigne + tax_6)
+        product_vat_only = self._create_product(lst_price=30.5, taxes_id=tax_6)
+
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                self._prepare_invoice_line(product_id=product_consigne, discount=15.0),
+                self._prepare_invoice_line(product_id=product_vat_only, discount=15.0),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_CO_16_payable_amount_with_line_rounding')


### PR DESCRIPTION
BR-CO-16 requires:
    PayableAmount (BT-115) = TaxInclusiveAmount (BT-112)
                           - PrepaidAmount (BT-113)
                           + PayableRoundingAmount (BT-114)

BIS3 overrides PayableAmount with `invoice.amount_residual` and PrepaidAmount with withholding taxes, but leaves PayableRoundingAmount as computed by the super from the aggregated tax-inclusive amount. When per-line rounding makes `amount_total` diverge from that aggregate, the rule is violated.

Steps to reproduce:
- Setup a Peppol company
- Create 2 taxes:
    - Conso tax, with a fixed amount of 0.30€ per line
    - 6% tax, price included
- Create a customer invoice with 2 lines:
  - qty 2, price 1.90, 15% discount, taxes: Conso and 6%
  - qty 5, price 6.10, 15% discount, tax: 6%
- Send via Peppol -> BR-CO-16 rejection.

This fix recomputes PayableRoundingAmount from the values we actually write so the rule is satisfied.

opw-6006269