### PR TITLE
[FIX] web: image not visible in printed PDF when resized to percentage

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -463,12 +463,12 @@
 
     <template id="external_layout_standard">
         <div t-attf-class="o_company_#{company.id}_layout header">
-            <table class="table-borderless">
+            <table class="table-borderless w-100">
                 <tr>
                     <td t-if="company.logo" class="align-top pe-3">
                         <img class="o_company_logo_big" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     </td>
-                    <td class="align-top text-start">
+                    <td class="align-top text-start w-100">
                         <t t-call="web.company_address_list"/>
                     </td>
                 </tr>


### PR DESCRIPTION
Problem:
When adding an image in the `company_details` field via **Settings > Configure your document layout** and resizing it to a percentage width (e.g. 50%), the image is not visible when printed.

Cause:
Since fa55c2d1, `wkhtmltopdf` fails to correctly calculate percentage-based image widths because none of the ancestor elements have an explicit width defined.

Solution:
Force the wrapping table to `width: 100%`, giving `wkhtmltopdf` a concrete width to resolve percentage values against.

Steps to reproduce:
- Go to **Settings > Configure your document layout**
- In the address field, add an image via `/media`
- Resize the image to 50%
- Print the document
- Image is missing in the PDF output

opw-6102568

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
