### PR TITLE
[FIX] website_sale: impossible to load product feed

### DIFF
--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -132,7 +132,7 @@ class ProductFeed(models.Model):
             self.cache_expiry = fields.Datetime.today() + relativedelta(days=1)
             return compressed_gmc_xml  # Avoid encoding and directly decoding
 
-        return self.feed_cache
+        return self.feed_cache.content
 
     def _render_gmc_feed(self):
         """Render the Google Merchant Center feed.


### PR DESCRIPTION
Since 41fe2ebdb9cc37341362d7af829c087a5f72f9f1, binary fields return `BinaryValue` objects. One case was missed during the transition.

As a result, the product feed could no longer be accessed after its first render.

```python
Traceback (most recent call last):
  File "/Users/lipiraux/.pyenv/versions/3.12.7/envs/odoo/lib/python3.12/site-packages/werkzeug/serving.py", line 362, in run_wsgi
    execute(self.server.app)
  File "/Users/lipiraux/.pyenv/versions/3.12.7/envs/odoo/lib/python3.12/site-packages/werkzeug/serving.py", line 325, in execute
    for data in application_iter:
                ^^^^^^^^^^^^^^^^^
  File "/Users/lipiraux/.pyenv/versions/3.12.7/envs/odoo/lib/python3.12/site-packages/werkzeug/wsgi.py", line 256, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/Users/lipiraux/.pyenv/versions/3.12.7/envs/odoo/lib/python3.12/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded
    for item in iterable:
                ^^^^^^^^^
TypeError: 'BinaryValueAttachment' object is not iterable
```