### PR TITLE
[FIX] sale_service: check with_price_unit in context to display it

### DIFF
--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -44,11 +44,14 @@ class SaleOrderLine(models.Model):
     def _compute_display_name(self):
         sol = self.browse()
         if self.env.context.get('formatted_display_name'):
+            with_price_unit = self.env.context.get('with_price_unit')
             for line in self:
                 if line.is_service:
-                    name = f"{line.order_id.name} - {line.product_id.display_name}"
-                    formatted_price = format_amount(self.env, line.product_id.lst_price, line.currency_id)
-                    line.display_name = f"{name} --({line.order_partner_id.name})-- --({formatted_price})--"
+                    name = f"{line.order_id.name} - {line.product_id.display_name} --({line.order_partner_id.name})--"
+                    if with_price_unit:
+                        formatted_price = format_amount(self.env, line.product_id.lst_price, line.currency_id)
+                        name += f" --({formatted_price})--"
+                    line.display_name = name
                     sol |= line
         super(SaleOrderLine, self - sol)._compute_display_name()
 


### PR DESCRIPTION
Before this commit, when `formatted_display_name` is true in the context, the display name of `sale.order.line` records will always show the partner and the price unit if it contains a service product. The problem is `with_price_unit` is no longer checked in the context to really know if we want to display or not the price unit in the formatted display name.

This commit checks `with_price_unit` in the context to display the price unit in the formatted display name if it is truly in the context.
