### PR TITLE
[FIX] account_edi_ubl_cii: ensure item reference is always displayed on generated PDFs.

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2501,9 +2501,11 @@ class AccountEdiUBL(models.AbstractModel):
 
     def _import_ubl_invoice_line_add_name(self, collected_values):
         line_tree = collected_values['line_tree']
+        item_ref = line_tree.findtext('.//{*}Item/{*}SellersItemIdentification/{*}ID')
+        item_name = line_tree.findtext('.//{*}Item/{*}Name')
         name = collected_values['name'] = (
             line_tree.findtext('.//{*}Item/{*}Description')
-            or line_tree.findtext('.//{*}Item/{*}Name')
+            or (f"[{item_ref}] {item_name}" if (item_ref and item_name) else item_name)
         )
         if name:
             collected_values['to_write']['name'] = name

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -2403,9 +2403,11 @@ class AccountEdiUBL(models.AbstractModel):
 
     def _import_ubl_invoice_line_add_name(self, collected_values):
         line_tree = collected_values['line_tree']
+        item_ref = line_tree.findtext('.//{*}Item/{*}SellersItemIdentification/{*}ID')
+        item_name = line_tree.findtext('.//{*}Item/{*}Name')
         name = collected_values['name'] = (
             line_tree.findtext('.//{*}Item/{*}Description')
-            or line_tree.findtext('.//{*}Item/{*}Name')
+            or (f"[{item_ref}] {item_name}" if bool(item_ref and item_name) else item_name)
         )
         if name:
             collected_values['to_write']['name'] = name


### PR DESCRIPTION
Some XML vendor bills generated by external ERPs were missing the Description tag, which typically contains both the [ITEM_REF] and ITEM_NAME. As a result, product lines in the generated PDF could appear without the internal item reference.

This commit ensures that the item reference is always included in the displayed product line.

task-6080328

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
