### PR TITLE
[IMP] cli: upgrade_code specify script path

### DIFF
--- a/odoo/cli/upgrade_code.py
+++ b/odoo/cli/upgrade_code.py
@@ -163,9 +163,13 @@ def migrate(
     dry_run: bool = False,
 ):
     if script:
-        script_path = next(UPGRADE.glob(f'*{script.removesuffix(".py")}*.py'), None)
-        if not script_path:
-            raise FileNotFoundError(script)
+        script_path = Path(script).absolute()
+        if not script_path.is_file():
+            candidate_paths = list(UPGRADE.glob(f'*{script.removesuffix(".py")}*.py'))
+            if len(candidate_paths) == 1:
+                script_path = candidate_paths[0]
+            else:
+                raise FileNotFoundError(script)
         script_path.relative_to(UPGRADE)  # safeguard, prevent going up
         module = SourceFileLoader(script_path.name, str(script_path)).load_module()
         modules = [(script_path.name, module)]


### PR DESCRIPTION
When executing upgrade code, it is sometimes easier to give the path to the script file instead of just typing a name. If there are multiple candidates, don't just one at random, make sure what we run.

`odoo-bin upgrade_code --script odoo/upgrade_code/abc.py`


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
