### PR TITLE
[FIX] l10n_in: access error while adding TDS Entry in branch company

### DIFF
--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
@@ -144,7 +144,7 @@ class L10n_InWithholdWizard(models.TransientModel):
             if wizard.tax_id:
                 taxes_res = wizard.tax_id.compute_all(
                     wizard.base,
-                    currency=wizard.tax_id.company_id.currency_id,
+                    currency=wizard.company_id.currency_id,
                     quantity=1.0,
                     product=False,
                     partner=False,


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **l10n_in** module.
* Create a **branch company** under an Indian company.
* Switch to the branch company only.
* Create a user with **Accounting Administrator** access (and bank validation rights) and also give permission of this branch company.
* Login from this user .
* Create and confirm a vendor bill in the branch company.
* Click **TDS Entry** and select any TDS section.

**Observed behavior:**
* An **AccessError** is raised when selecting the TDS section.

**Cause:**
* In `_compute_amount` (wizard), currency is taken from `tax_id.company_id`.
* For branch setups, taxes (and related accounts) belong to the **parent company**, so `tax_id.company_id` points to the parent.
* The user operating in the branch company does not have access to the parent company, triggering an access error.

**Fix:**
* Use the wizard’s `company_id` instead of `tax_id.company_id` when determining currency.
* The wizard `company_id` is correctly computed based on the active company, ensuring proper access rights.

**Note:**
* Regression test is not feasible due to ORM cache behavior:
  * In tests, `mock` environments share a transaction-level cache.
  * `compute_sudo=True` fields populate cache with superuser access.
  * By the time `_compute_amount` runs, values are already cached.
  * No database fetch occurs, so record rules are not evaluated and the AccessError cannot be reproduced.

opw-6095312
