### PR TITLE
[FIX] account: attach imported XMLs

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -383,6 +383,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
     # Helpers to consistently attach/unattach attachments to records
     # --------------------------------------------------------------
 
+    # Deprecated, removed in master
     def _fix_attachments_on_record(self, attachments):
         """ Ensure that only attachments of certain types appear in `self`'s attachments.
 
@@ -404,6 +405,13 @@ class AccountDocumentImportMixin(models.AbstractModel):
                 'res_model': False,
                 'res_id': 0,
             })
+
+    def _fix_attachments_on_record_from_files_data(self, valid_files_data, extra_files_data):
+        self.ensure_one()
+        valid_attachments = self._from_files_data(valid_files_data).filtered(lambda a: a.res_model != self._name or a.res_id != self.id)
+        extra_attachments = self._from_files_data(extra_files_data).filtered(lambda a: a.res_model == self._name and not a.res_field)
+        valid_attachments.write({'res_model': self._name, 'res_id': self.id})
+        extra_attachments.write({'res_model': False, 'res_id': 0})
 
     def _should_attach_to_record(self, attachment):
         """ Indicate whether a given attachment should be displayed in the record's attachments. """

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6658,17 +6658,17 @@ class AccountMove(models.Model):
         # see l10n_{es,it}_edi, so to retrieve those attachments you should use the `_from_files_data` method.
         files_data.extend(self._unwrap_attachments(files_data))
 
+        # Dispatch the attachments into groups, and create a new invoice for each group beyond the first.
+        valid_files_data = []
+        extra_files_data = []
+        for file_data in files_data:
+            if self._should_attach_to_record(file_data['attachment']) or file_data['xml_tree'] is not None:
+                valid_files_data.append(file_data)
+            else:
+                extra_files_data.append(file_data)
+
         if self.env.context.get('from_alias'):
             # This is a newly-created invoice from a mail alias.
-            # So dispatch the attachments into groups, and create a new invoice for each group beyond the first.
-            valid_files_data = []
-            extra_files_data = []
-            for file_data in files_data:
-                if self._should_attach_to_record(file_data['attachment']) or file_data['xml_tree'] is not None:
-                    valid_files_data.append(file_data)
-                else:
-                    extra_files_data.append(file_data)
-
             file_data_groups = self._group_files_data_into_groups_of_mixed_types(valid_files_data) or [[]]
             invoices = self
             if len(file_data_groups) > 1:
@@ -6693,7 +6693,7 @@ class AccountMove(models.Model):
                         'attachment_ids': [Command.link(attachment.id) for attachment in attachment_records],
                     }
                     super(AccountMove, invoice)._message_post_after_hook(sub_new_message, sub_message_values)
-                invoice._fix_attachments_on_record(attachment_records)
+                invoice._fix_attachments_on_record_from_files_data(file_data_group, extra_files_data)
 
             for invoice, file_data_group in zip(invoices, file_data_groups):
                 if file_data_group:
@@ -6704,8 +6704,7 @@ class AccountMove(models.Model):
         else:
             # This is an existing invoice on which a message was posted either by e-mail or via the webclient.
             attachment_records = self._from_files_data(files_data)
-            self._fix_attachments_on_record(attachment_records)
-
+            self._fix_attachments_on_record_from_files_data(valid_files_data, extra_files_data)
             # Only trigger decoding if the message was sent by an active internal user (note OdooBot is always inactive).
             if self.env.user.active and self.env.user._is_internal():
                 self._extend_with_attachments(files_data)

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -643,7 +643,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf1_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True, 'is_decoded': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True},
                     'invoice1.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -655,7 +655,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf1_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True},
                     'invoice1.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -677,7 +677,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf1_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True, 'is_decoded': True, 'is_new': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True, 'is_new': True},
                     'invoice1.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -701,8 +701,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.xml1_vals, self.xml2_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True, 'is_decoded': True},
-                    'invoice2.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True},
+                    'invoice2.xml': {'on_invoice': True, 'on_message': True},
                 },
             },
         )
@@ -713,8 +713,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.xml1_vals, self.xml2_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True},
-                    'invoice2.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True},
+                    'invoice2.xml': {'on_invoice': True, 'on_message': True},
                 },
             },
         )
@@ -734,8 +734,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             origin='mail_alias',
             attachments_vals=[self.xml1_vals, self.xml2_vals],
             expected_invoices={
-                1: {'invoice1.xml': {'on_message': True, 'is_decoded': True, 'is_new': True}},
-                2: {'invoice2.xml': {'on_message': True, 'is_decoded': True, 'is_new': True}},
+                1: {'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True, 'is_new': True}},
+                2: {'invoice2.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True, 'is_new': True}},
             },
         )
 
@@ -825,7 +825,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf3_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True, 'is_decoded': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True},
                     'invoice3.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -837,7 +837,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf3_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True},
                     'invoice3.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -864,7 +864,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             attachments_vals=[self.pdf3_vals, self.xml1_vals],
             expected_invoices={
                 1: {
-                    'invoice1.xml': {'on_message': True, 'is_decoded': True, 'is_new': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True, 'is_decoded': True, 'is_new': True},
                     'invoice3.pdf': {'on_invoice': True, 'on_message': True},
                 },
             },
@@ -904,8 +904,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                     'invoice3.pdf': {'on_invoice': True, 'on_message': True},
                     'invoice2.xlsx': {'on_invoice': True, 'on_message': True},
                     # The code doesn't put a hard constraint on which of the XMLs gets decoded.
-                    'invoice1.xml': {'is_decoded': True, 'on_message': True},
-                    'invoice2.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'is_decoded': True, 'on_message': True},
+                    'invoice2.xml': {'on_invoice': True, 'on_message': True},
                 },
             },
         )
@@ -923,8 +923,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                     'invoice2.pdf': {'on_invoice': True, 'on_message': True},
                     'invoice3.pdf': {'on_invoice': True, 'on_message': True},
                     'invoice2.xlsx': {'on_invoice': True, 'on_message': True},
-                    'invoice1.xml': {'on_message': True},
-                    'invoice2.xml': {'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'on_message': True},
+                    'invoice2.xml': {'on_invoice': True, 'on_message': True},
                 },
             },
         )
@@ -958,11 +958,11 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                     'gif1.gif': {'on_message': True},
                     'gif2.gif': {'on_message': True},
                     'invoice1.pdf': {'on_invoice': True, 'on_message': True},
-                    'invoice1.xml': {'is_decoded': True, 'is_new': True, 'on_message': True},
+                    'invoice1.xml': {'on_invoice': True, 'is_decoded': True, 'is_new': True, 'on_message': True},
                 },
                 2: {
                     'invoice2.pdf': {'on_invoice': True, 'on_message': True},
-                    'invoice2.xml': {'is_decoded': True, 'is_new': True, 'on_message': True},
+                    'invoice2.xml': {'on_invoice': True, 'is_decoded': True, 'is_new': True, 'on_message': True},
                     # The XLSX and DOCX are attached to this invoice due to filename similarity
                     'invoice2.xlsx': {'on_invoice': True, 'on_message': True},
                     'invoice2.docx': {'on_invoice': True, 'on_message': True},


### PR DESCRIPTION
When importing files (manually or from email alias),
we unattach the xml files, it can lead to access error in some flows
like with l10n_mx_edi

Steps to reproduce the flow that triggered the bug:

- Install l10n_mx_edi and select MX company
- Create an email alias for purchase journal
- Receive email with xml file
- Create a user with 'group_user' role, 'Administrator' accounting
  access rights
- Login with this user and open the created bill
-> Access Error

This is because we unattach xml attachmentss when importing them, by setting
`res_id` to 0 and `res_model` to False.
The mx edi flow adds the `l10n_mx_edi_cfdi_attachment_id` via
`_get_mail_thread_data_attachments` which lead to an access error during the
`fetch` method

opw-5953578
