### PR TITLE
[FIX] im_livechat: only store livechat threads as active visitor chats

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -83,7 +83,8 @@ patch(Thread.prototype, {
         this.storeAsActiveVisitorLivechats = fields.One("Store", {
             /** @this {import("models").Thread} */
             compute() {
-                return !this.livechat_end_dt &&
+                return this.channel_type === "livechat" &&
+                    !this.livechat_end_dt &&
                     (this.self_member_id?.eq(this.livechatVisitorMember) || this.isTransient)
                     ? this.store
                     : null;


### PR DESCRIPTION
Add an explicit `this.channel === "livechat"` guard so only actual livechat conversations kept in `storeAsActiveVisitorLivechats`.