### PR TITLE
[FIX] point_of_sale: use Odoo-configured date format

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -10,6 +10,9 @@ import { AbstractAwaitablePopup } from "@point_of_sale/app/popup/abstract_awaita
 import { CashMoveReceipt } from "@point_of_sale/app/navbar/cash_move_popup/cash_move_receipt/cash_move_receipt";
 import { useAsyncLockedMethod } from "@point_of_sale/app/utils/hooks";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
+import { formatDateTime } from "@web/core/l10n/dates";
+
+const { DateTime } = luxon;
 
 export class CashMovePopup extends AbstractAwaitablePopup {
     static template = "point_of_sale.CashMovePopup";
@@ -59,7 +62,7 @@ export class CashMovePopup extends AbstractAwaitablePopup {
             translatedType,
             formattedAmount,
             headerData: this.pos.getReceiptHeaderData(),
-            date: new Date().toLocaleString(),
+            date: formatDateTime(DateTime.now()),
         });
         this.props.close();
         this.notification.add(

--- a/addons/point_of_sale/static/src/app/navbar/sale_details_button/sale_details_button.js
+++ b/addons/point_of_sale/static/src/app/navbar/sale_details_button/sale_details_button.js
@@ -5,6 +5,10 @@ import { renderToElement } from "@web/core/utils/render";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { formatDateTime } from "@web/core/l10n/dates";
+
+const { DateTime } = luxon;
+
 
 export class SaleDetailsButton extends Component {
     static template = "point_of_sale.SaleDetailsButton";
@@ -29,7 +33,7 @@ export class SaleDetailsButton extends Component {
         const report = renderToElement(
             "point_of_sale.SaleDetailsReport",
             Object.assign({}, saleDetails, {
-                date: new Date().toLocaleString(),
+                date: formatDateTime(DateTime.now()),
                 pos: this.pos,
                 formatCurrency: this.env.utils.formatCurrency,
             })


### PR DESCRIPTION
Why this commit:
---

There are two instances in version 17.0 where dates use toLocaleString(), which relies on the device's local format instead of the Odoo-configured format.

Since Odoo already defines a standard date format, all toLocaleString() usages in pos should be replaced to ensure consistency.

Starting from version 17.0, cash in/out receipts and the sales report use the local device time format.

This commit updates those references and aligns them with the Odoo-configured date format. 
During forwardporting the fix in version 19.0 needs to be added to [base.js](https://github.com/odoo/odoo/blob/0352c5e8543b75083cf555c3d5b4f164f949b465/addons/point_of_sale/static/src/app/models/related_models/base.js#L64-L69).
As formatDateOrTime function is used in the [reciept header](https://github.com/odoo/odoo/blob/0352c5e8543b75083cf555c3d5b4f164f949b465/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml#L13) printing date on all reciepts. 

After this commit:
---

<img width="947" height="982" alt="image" src="https://github.com/user-attachments/assets/2d9e4199-75dd-40ea-aeb1-27401c9022f3" />


All date references consistently use the Odoo-configured date format.

OPW: 6087341





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
