### PR TITLE
[FIX] point_of_sale: don't override payment_date if already set

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -7,7 +7,9 @@ export class PosPayment extends Base {
 
     setup(vals) {
         super.setup(...arguments);
-        this.payment_date = DateTime.now();
+        if (!this.payment_date) {
+            this.payment_date = DateTime.now();
+        }
         this.amount = vals.amount || 0;
         this.ticket = vals.ticket || "";
     }


### PR DESCRIPTION
Before this commit, saved orders that were captured offline, would have their payment_date overridden to the current date when they were loaded in the POS.

opw-6117966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
