### PR TITLE
[FIX] stock_account: fix vacuum anglo-saxon JE company

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -565,12 +565,12 @@ class ProductProduct(models.Model):
             # If delivered quantity is not invoiced then no need to create this entry
             if not account_move:
                 continue
-            accounts = svl_to_vacuum.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=account_move.fiscal_position_id)
+            accounts = svl_to_vacuum.product_id.product_tmpl_id.with_company(vacuum_svl.company_id).get_product_accounts(fiscal_pos=account_move.fiscal_position_id)
             if not accounts.get('stock_output') or not accounts.get('expense'):
                 continue
             svls_accounts[svl_to_vacuum.id] = accounts
             description = "Expenses %s" % (vacuum_svl.description)
-            move_lines = vacuum_svl.stock_move_id._prepare_account_move_line(
+            move_lines = vacuum_svl.stock_move_id.with_company(vacuum_svl.company_id)._prepare_account_move_line(
             vacuum_svl.quantity, vacuum_svl.value * -1,
             accounts['stock_output'].id, accounts['expense'].id,
             vacuum_svl.id, description)

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -565,7 +565,7 @@ class ProductProduct(models.Model):
             # If delivered quantity is not invoiced then no need to create this entry
             if not account_move:
                 continue
-            accounts = svl_to_vacuum.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=account_move.fiscal_position_id)
+            accounts = svl_to_vacuum.product_id.product_tmpl_id.with_company(vacuum_svl.company_id).get_product_accounts(fiscal_pos=account_move.fiscal_position_id)
             if not accounts.get('stock_output') or not accounts.get('expense'):
                 continue
             svls_accounts[svl_to_vacuum.id] = accounts

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -261,6 +261,85 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
 
         self.assertEqual(self.product1.standard_price, 0.02)
 
+    def test_fifo_vacuum_anglo_saxon_expense_entry_multicompany(self):
+        """ The anglo-saxon expense revaluation JE created by the FIFO vacuum
+        must be posted in the SVL's company, regardless of env.company.
+        """
+        company_a = self.env.company
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        self.env.user.write({'company_ids': [Command.link(company_b.id)]})
+        (company_a + company_b).write({'anglo_saxon_accounting': True})
+        in_b, out_b, val_b, exp_b, journal_b = _create_accounting_data(
+            self.env(context={**self.env.context, 'allowed_company_ids': [company_b.id]}))
+
+        self.product1.categ_id.with_company(company_b).write({
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+            'property_stock_account_input_categ_id': in_b.id,
+            'property_stock_account_output_categ_id': out_b.id,
+            'property_stock_valuation_account_id': val_b.id,
+            'property_stock_journal': journal_b.id,
+        })
+        self.product1.product_tmpl_id.with_company(company_b).write({
+            'property_account_expense_id': exp_b.id,
+        })
+        self.product1.with_company(company_b).standard_price = 10.0
+        wh_b = self.env['stock.warehouse'].search([('company_id', '=', company_b.id)], limit=1)
+        customer_loc_b = self.env['stock.location'].search(
+            [('usage', '=', 'customer'), ('company_id', '=', company_b.id)], limit=1
+        ) or self.customer_location
+
+        # Out move in B -> negative SVL.
+        out_move = self.env['stock.move'].with_company(company_b).create({
+            'name': 'out 1', 'product_id': self.product1.id,
+            'location_id': wh_b.lot_stock_id.id, 'location_dest_id': customer_loc_b.id,
+            'product_uom': self.uom_unit.id, 'product_uom_qty': 1.0,
+            'picking_type_id': wh_b.out_type_id.id,
+        })
+        out_move._action_confirm()
+        self.env['stock.move.line'].create({
+            'move_id': out_move.id, 'product_id': self.product1.id,
+            'product_uom_id': self.uom_unit.id, 'quantity': 1.0,
+            'location_id': wh_b.lot_stock_id.id, 'location_dest_id': customer_loc_b.id,
+        })
+        out_move.picked = True
+        out_move._action_done()
+        self.assertEqual(out_move.stock_valuation_layer_ids.company_id, company_b)
+
+        # Reconcile the SVL's stock_output line with an invoice JE
+        fake_invoice = self.env['account.move'].create({
+            'move_type': 'entry',
+            'company_id': company_b.id,
+            'journal_id': journal_b.id,
+            'line_ids': [
+                Command.create({'account_id': exp_b.id, 'debit': 10, 'credit': 0}),
+                Command.create({'account_id': out_b.id, 'debit': 0, 'credit': 10}),
+            ],
+        })
+        fake_invoice.action_post()
+        (out_move.stock_valuation_layer_ids.account_move_id.line_ids + fake_invoice.line_ids
+         ).filtered(lambda l: l.account_id == out_b).reconcile()
+
+        # In move in B while env.company = A -> triggers the vacuum.
+        self.assertEqual(self.env.company, company_a)
+        in_move = self.env['stock.move'].create({
+            'name': 'in 1', 'product_id': self.product1.id,
+            'location_id': self.supplier_location.id, 'location_dest_id': wh_b.lot_stock_id.id,
+            'product_uom': self.uom_unit.id, 'product_uom_qty': 1.0,
+            'price_unit': 15.0, 'picking_type_id': wh_b.in_type_id.id,
+            'company_id': company_b.id,
+        })
+        in_move._action_confirm()
+        in_move.write({'quantity': 1.0, 'picked': True})
+        in_move._action_done()
+
+        revaluation_je = self.env['account.move'].search([
+            ('ref', 'like', 'Expenses Revaluation of%'),
+            ('stock_move_id', '=', out_move.id),
+        ])
+        self.assertTrue(revaluation_je)
+        self.assertEqual(revaluation_je.company_id, company_b)
+
     def test_multi_company_fifo_svl_negative_revaluation(self):
         """
         Check that the journal entries and stock valuation layers are created for the company related

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -261,6 +261,91 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
 
         self.assertEqual(self.product1.standard_price, 0.02)
 
+    def test_fifo_vacuum_anglo_saxon_expense_entry_multicompany(self):
+        """ The anglo-saxon expense revaluation JE created by the FIFO vacuum
+        must be posted in the SVL's company, regardless of env.company.
+        """
+        company_a = self.env.company
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        self.env.user.write({'company_ids': [Command.link(company_b.id)]})
+        (company_a + company_b).write({'anglo_saxon_accounting': True})
+        in_b, out_b, val_b, exp_b, journal_b = _create_accounting_data(
+            self.env(context={**self.env.context, 'allowed_company_ids': [company_b.id]}))
+
+        self.product1.categ_id.with_company(company_b).write({
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+            'property_stock_account_input_categ_id': in_b.id,
+            'property_stock_account_output_categ_id': out_b.id,
+            'property_stock_valuation_account_id': val_b.id,
+            'property_stock_journal': journal_b.id,
+        })
+        self.product1.product_tmpl_id.with_company(company_b).write({
+            'property_account_expense_id': exp_b.id,
+        })
+        self.product1.with_company(company_b).standard_price = 10.0
+        wh_b = self.env['stock.warehouse'].search([('company_id', '=', company_b.id)], limit=1)
+
+        # Out move in B -> negative SVL.
+        out_move = self.env['stock.move'].with_company(company_b).create({
+            'name': 'out 1',
+            'product_id': self.product1.id,
+            'location_id': wh_b.lot_stock_id.id,
+            'location_dest_id': self.customer_location.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'picking_type_id': wh_b.out_type_id.id,
+            'move_line_ids': [Command.create({
+                'product_id': self.product1.id,
+                'product_uom_id': self.uom_unit.id,
+                'quantity': 1.0,
+                'location_id': wh_b.lot_stock_id.id,
+                'location_dest_id': self.customer_location.id,
+            })],
+        })
+        out_move._action_confirm()
+        out_move.picked = True
+        out_move._action_done()
+        self.assertEqual(out_move.stock_valuation_layer_ids.company_id, company_b)
+
+        # Reconcile the SVL's stock_output line with an invoice JE
+        fake_invoice = self.env['account.move'].create({
+            'move_type': 'entry',
+            'company_id': company_b.id,
+            'journal_id': journal_b.id,
+            'line_ids': [
+                Command.create({'account_id': exp_b.id, 'debit': 10, 'credit': 0}),
+                Command.create({'account_id': out_b.id, 'debit': 0, 'credit': 10}),
+            ],
+        })
+        fake_invoice.action_post()
+        (out_move.stock_valuation_layer_ids.account_move_id.line_ids + fake_invoice.line_ids
+         ).filtered(lambda l: l.account_id == out_b).reconcile()
+
+        # In move in B while env.company = A -> triggers the vacuum.
+        self.assertEqual(self.env.company, company_a)
+        in_move = self.env['stock.move'].create({
+            'name': 'in 1',
+            'product_id': self.product1.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': wh_b.lot_stock_id.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'price_unit': 15.0,
+            'picking_type_id': wh_b.in_type_id.id,
+            'company_id': company_b.id,
+        })
+        in_move._action_confirm()
+        in_move.write({'quantity': 1.0, 'picked': True})
+        in_move._action_done()
+
+        revaluation_je = self.env['account.move'].search([
+            ('ref', 'like', 'Expenses Revaluation of%'),
+            ('stock_move_id', '=', out_move.id),
+        ])
+        self.assertTrue(revaluation_je)
+        self.assertEqual(revaluation_je.company_id, company_b)
+
     def test_multi_company_fifo_svl_negative_revaluation(self):
         """
         Check that the journal entries and stock valuation layers are created for the company related


### PR DESCRIPTION
When the FIFO vacuum creates the "Expenses Revaluation" journal entry for an anglo-saxon delivery whose cost is adjusted by a later receipt, the JE was built using `env.company` instead of the company of the vacuumed SVL.

Steps to reproduce:
- Enable multi-company and activate anglo-saxon accounting on two companies A and B.
- In company B, on the product category: set FIFO costing + Automated  valuation, and set the stock input / stock output / stock valuation accounts and the stock journal. The Stock Output account must have "Allow Reconciliation" enabled.
- In company B, on the product: set an Expense Account and set the Cost (e.g. 10.0) this is the price the delivery will be valued at while the stock is negative. The product must have no quantity on hand in company B.
- While working in company B, sell and deliver 1 unit of that product: the delivery is valued at 10.0 and creates a  negative valuation layer.
- Still in company B, create and post the customer invoice of that sale, so the Stock Output line of the delivery entry gets reconciled with the Stock Output line of the anglo-saxon COGS entry of the invoice.
- Switch the active company to A, and from there create a purchase order of that product for company B at a different price (e.g. 15.0), then validate the linked receipt into company B's warehouse.
- The vacuum compensates the negative layer, but the resulting "Expenses Revaluation of ..." journal entry is posted in company A instead of company B.

This fix forces the company context to `vacuum_svl.company_id` when fetching the product accounts and preparing the move lines so the JE is always created in the company of the SVL being vacuumed.

opw-6066970
opw-6419188