### PR TITLE
[FIX] pos_hr: avoid error when accessing settings

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -24,7 +24,7 @@ class PosConfig(models.Model):
         group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
             lambda u: self.company_id in u.company_ids
         )
-        allowed_employees = group_users.sudo().mapped('employee_id')
+        allowed_employees = group_users.sudo().with_context(active_test=False).employee_ids.filtered(lambda e: e.company_id == self.company_id)
         if not allowed_employees and group_users:
             target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_id)[0]
             target_user.action_create_employee()

--- a/addons/pos_hr/tests/test_res_config_settings.py
+++ b/addons/pos_hr/tests/test_res_config_settings.py
@@ -34,11 +34,13 @@ class TestConfigureShopsPoSHR(TestPosHrHttpCommon, TestConfigureShops):
         self.assertEqual(len(self.main_pos_config.advanced_employee_ids), 1)
         self.assertEqual(self.main_pos_config.advanced_employee_ids.company_id, self.main_pos_config.company_id)
         advanced_employee = self.main_pos_config.advanced_employee_ids
+        advanced_employee.action_archive()
 
-        # Test that the previously employee is used
+        # Test that the previously created employee is used, even if it is archived
         self.main_pos_config.with_context(from_settings_view=True).write({
             'advanced_employee_ids': [],
         })
-        self.assertEqual(len(self.main_pos_config.advanced_employee_ids), 1)
-        self.assertEqual(self.main_pos_config.advanced_employee_ids.company_id, self.main_pos_config.company_id)
-        self.assertEqual(self.main_pos_config.advanced_employee_ids, advanced_employee)
+        advanced_employees = self.main_pos_config.with_context(active_test=False).advanced_employee_ids
+        self.assertEqual(len(advanced_employees), 1)
+        self.assertEqual(advanced_employees.company_id, self.main_pos_config.company_id)
+        self.assertEqual(advanced_employees, advanced_employee)


### PR DESCRIPTION
**Steps to reproduce**
- Install `pos_hr` with demo data
- Archive the admin's employee
- Go to Settings > Manage Users
- Validation Error: The operation cannot be completed: A user cannot be linked to multiple employees in the same company.

**Change**
Don't try to create an employee for a user with an archived employee in the company.

opw-6046297