### PR TITLE
[FIX] mail: fix non-deterministic new activity test

### DIFF
--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -678,6 +678,7 @@ test("activity updates are shared between tabs", async () => {
     ]);
     await click(".o-mail-Activity:eq(0) button:text(Cancel)");
     await expect.waitForSteps([`DELETE - ${firstActivityId}`]);
+    await contains(".o-mail-Activity", { count: 1 });
     await contains(".o-mail-Activity-info:has(:text(“Say hello to Bob”))");
     await click(".o-mail-Activity-markDone");
     await click(".o-mail-ActivityMarkAsDone button:text(Done)");


### PR DESCRIPTION
Recent fix of activity cross-tab data sharing [1] added a new test to make sure the feature works as expected. This test may fail non-determinstically after "cancel" of an activity. The failure happens because while this activity has been canceled, the next step is to click on "mark as done" on the other activity, but due to not awaiting the removal of the cancelled activity, the "mark as done" button may mistakenly target the activity that has just been cancelled.

This commit fixes the issue by awaiting that the cancelled activity has been removed from UI, so that the selector to click on "mark as done" button is necessarily on the other activity

[1] https://github.com/odoo/odoo/pull/255785