### PR TITLE
[FIX] website_sale: pricelist inverse ignores website filtering

### DIFF
--- a/addons/website_sale/models/product_pricelist.py
+++ b/addons/website_sale/models/product_pricelist.py
@@ -84,7 +84,7 @@ class ProductPricelist(models.Model):
     def _get_partner_pricelist_multi_search_domain_hook(self, company_id):
         domain = super()._get_partner_pricelist_multi_search_domain_hook(company_id)
         website = ir_http.get_request_website()
-        if website:
+        if website and not self.env.context.get('website_sale_pricelist_default'):
             domain += self._get_website_pricelists_domain(website)
         return domain
 

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -29,6 +29,9 @@ class ResPartner(models.Model):
             else:
                 partner.last_website_so_id = SaleOrder  # Not in a website context or public User
 
+    def _inverse_product_pricelist(self):
+        return super(ResPartner, self.with_context(website_sale_pricelist_default=True))._inverse_product_pricelist()
+
     @api.onchange('property_product_pricelist')
     def _onchange_property_product_pricelist(self):
         open_order = self.env['sale.order'].sudo().search([

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -844,3 +844,43 @@ class TestWebsiteSaleSession(HttpCaseWithUserPortal):
         })
         test_user.partner_id.property_product_pricelist = user_pricelist
         self.start_tour("/shop", 'website_sale.website_sale_shop_pricelist_tour', login="")
+
+
+@tagged('post_install', '-at_install')
+class TestWebsitePriceListInverse(WebsiteSaleCommon):
+
+    def test_inverse_pricelist_website_context(self):
+        """The pricelist inverse should store the correct value regardless of
+        the website request context.
+
+        When creating a partner via a website form with a specific pricelist,
+        the inverse of `property_product_pricelist` determines the "default"
+        pricelist to decide whether to store the value explicitly or not. If
+        the default lookup is filtered by website availability, the inverse may
+        incorrectly clear the stored value for the pricelist that happens to be
+        the first website-available one (2nd by global sequence), causing it to
+        revert to the global default (1st by sequence).
+        """
+        self.env['product.pricelist'].create({
+            'name': 'Backend Default',
+            'sequence': 1,
+            'website_id': False,
+            'selectable': False,
+        })
+        pl_second = self.env['product.pricelist'].create({
+            'name': 'Second PL',
+            'sequence': 2,
+            'website_id': self.website.id,
+        })
+
+        simulate_frontend_context(self, self.website.id)
+        partner_second = self.env['res.partner'].create({
+            'name': 'Partner Second',
+            'property_product_pricelist': pl_second.id,
+        })
+
+        self.assertEqual(
+            partner_second.specific_property_product_pricelist, pl_second,
+            "The 2nd pricelist by sequence should be stored explicitly, not "
+            "cleared because it matches the website-filtered default",
+        )


### PR DESCRIPTION
Steps to reproduce:
===================
1. Create 2 pricelists, pricelist 1 is backend-only (no website_id, not selectable), pricelists 2 have website_id set
2. Create a website form creating a customer with a pricelist field
3. Submit the form selecting pricelist 2 (first website-available one)

=> Pricelist reverts to pricelist 1 (the global default)

Cause:
======
When creating a partner via a website form with a specific pricelist, the inverse of `property_product_pricelist` calls
`_get_country_pricelist_multi` to determine the "default" pricelist and decide whether to store the value explicitly or store False (meaning "use the default"). With `website_sale` installed, the search domain hook adds website-availability filtering during website requests. This causes the inverse to compute a different "default" pricelist than what the compute uses outside the website context.

The inverse sees pricelist 2 as the "website default" (first by sequence matching the website domain) and stores False. The compute later runs without website context, finds pricelist 1 as the global default, and returns the wrong value.

Solution:
=========
The fix bypasses website filtering in the search domain hook when called from the inverse, ensuring the stored value is based on the context-independent default.

opw-6092161

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
