### PR TITLE
[IMP] website_sale: redirect to correct variant from search bar

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1309,8 +1309,15 @@ class ProductTemplate(models.Model):
             "sequence": 20,
         }
 
+    def _search_fetch(self, search_detail, search, offset, limit, order):
+        results, count = super()._search_fetch(search_detail, search, offset, limit, order)
+        return results.with_context(search_term=search), count
+
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
+        search_term = self.env.context.get("search_term", "")
+        search_words = search_term.lower().split() if search_term else []
+
         for product, data in zip(self, results_data):
             combination_info = product._get_combination_info(only_template=True)
             values = product.mapped("attribute_line_ids.value_ids")
@@ -1320,6 +1327,17 @@ class ProductTemplate(models.Model):
             if price:
                 data["price"] = price
             data["image_url"] = "/web/image/product.template/%s/image_128" % data["id"]
+
+            if search_words and values:
+                matched_values = values.filtered(
+                    lambda attribute_value: any(
+                        word in (attribute_value.name or "").lower() for word in search_words
+                    )
+                )
+                if matched_values:
+                    data["website_url"] = product._get_product_url(
+                        grouped_attributes_values=matched_values.grouped("attribute_id")
+                    )
         return results_data
 
     def _search_render_results_prices(self, mapping, combination_info):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -936,8 +936,15 @@ class ProductTemplate(models.Model):
             "sequence": 20,
         }
 
+    def _search_fetch(self, search_detail, search, offset, limit, order):
+        results, count = super()._search_fetch(search_detail, search, offset, limit, order)
+        return results.with_context(search_term=search), count
+
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
+        search_term = self.env.context.get("search_term", "")
+        search_words = search_term.lower().split() if search_term else []
+
         for product, data in zip(self, results_data):
             combination_info = product._get_combination_info(only_template=True)
             values = product.mapped("attribute_line_ids.value_ids")
@@ -949,6 +956,16 @@ class ProductTemplate(models.Model):
             if price:
                 data["price"] = price
             data["image_url"] = "/web/image/product.template/%s/image_128" % data["id"]
+
+            if search_words and values:
+                matched_values = values.filtered(
+                    lambda attribute_value: any(
+                        word in (attribute_value.name or "").lower() for word in search_words
+                    )
+                )
+                if matched_values:
+                    pav_ids = ",".join(str(pav_id) for pav_id in sorted(matched_values.ids))
+                    data["website_url"] = "%s?attribute_values=%s" % (data["website_url"], pav_ids)
         return results_data
 
     def _search_render_results_prices(self, mapping, combination_info):


### PR DESCRIPTION
When searching for a product in the search bar, products matched through variant attribute values were opened with the default variant selected on the product page.

This commit changes that behavior so the matching variant is selected when opening the product from the search results, when it can be determined from the search query.

task-6106086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
