### PR TITLE
[FIX] account_edi_ubl_cii: fixes import of bis3 files with price inc...

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -730,13 +730,14 @@ class AccountEdiCommon(models.AbstractModel):
             line_values = self.with_company(record.company_id)._retrieve_invoice_line_vals(line_tree, document_type, qty_factor)
             if line_values is None:
                 continue
-
-            line_values['tax_ids'], tax_logs = self._retrieve_taxes(record, line_values, tax_type)
+            line_values['tax_ids'] = []
+            lines_values += self._retrieve_line_charges(record, line_values, line_values['tax_ids'])
+            tax_ids, tax_logs = self._retrieve_taxes(record, line_values, tax_type)
+            line_values['tax_ids'] += tax_ids
             logs += tax_logs
             if not line_values['product_uom_id']:
                 line_values.pop('product_uom_id')  # if no uom, pop it so it's inferred from the product_id
             lines_values.append(line_values)
-            lines_values += self._retrieve_line_charges(record, line_values, line_values['tax_ids'])
         return lines_values, logs
 
     def _import_rounding_amount(self, invoice, tree, xpath, document_type=False, qty_factor=1):

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_tax_with_tax_included_in_price_config_with_allowance_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_partial_import_tax_with_tax_included_in_price_config_with_allowance_charge.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0
+    </cbc:CustomizationID>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.0</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">100.0</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">21.0</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.0</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.0</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">121.0</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">121.0</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:LineExtensionAmount currencyID="EUR">100.0</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+            <cbc:AllowanceChargeReason>Charge</cbc:AllowanceChargeReason>
+            <cbc:Amount currencyID="EUR">20.0</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_retrieve_tax.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_retrieve_tax.py
@@ -119,3 +119,18 @@ class TestUblImportBis3InvoiceBERetrieveTax(TestUblImportBis3InvoiceBE):
                 },
             ],
         )
+
+    def test_partial_import_tax_with_tax_included_in_price_config_with_allowance_charge(self):
+        self.company.account_price_include = 'tax_included'
+        tax_21 = self.percent_tax(21.0, type_tax_use='purchase')
+        invoice = self._import_invoice_as_attachment_on(test_name='test_partial_import_tax_with_tax_included_in_price_config_with_allowance_charge')
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'price_unit': 121.0,
+                'quantity': 1.0,
+                'discount': 0.0,
+                'price_subtotal': 100.0,
+                'price_total': 121.0,
+                'tax_ids': tax_21.ids,
+            },
+        ])


### PR DESCRIPTION
…luded config

**PROBLEM**
With a company configured with tax included in price. If you import a bis3 file with a a line, that have a tax, and an allowance/charge the tax will not be computed on the allowance/charge. This is because we apply the allowance/charge on the lines AFTER applying the taxes. We should apply the taxes after applying the allowance/charge.

**STEP**
1. Setup a company with tax included in price.
2. import a vendor bill with lines that have taxes and allowance/charges.
3. the invoice generated has the wrong amount.

opw-6086523