### PR TITLE
[FIX] website_sale_collect: fix select store error when city or street is empty

### DIFF
--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -88,8 +88,8 @@ class DeliveryCarrier(models.Model):
                 pickup_location_values = {
                     'id': wh.id,
                     'name': wh_location['name'],
-                    'street': wh_location['street'],
-                    'city': wh_location.city,
+                    'street': wh_location['street'] or '',
+                    'city': wh_location.city or '',
                     'zip_code': wh_location.zip or '',
                     'country_code': wh_location.country_code,
                     'state': wh_location.state_id.code,


### PR DESCRIPTION
Issue:
---
An owl error is raised in select store if the store's company location lacks city or street.

Steps to reproduce:
1- Enable Click and Collect.
2- In pickup locations, set a company with an address with empty street
   or city.
3- Go to the shop.
4- Enable debug mode.
5- Select store.

An owl error is raised due to not city and street not being string.

opw-6050137

