### PR TITLE
[FIX] html_editor: color picker test by selecting solid tab

### DIFF
--- a/addons/html_editor/static/tests/format/inline_code.test.js
+++ b/addons/html_editor/static/tests/format/inline_code.test.js
@@ -137,6 +137,7 @@ test("should open toolbar for mixed selection and apply formatting outside inlin
     // Apply text color should still affect only the non-inline-code portion.
     await click(".o-we-toolbar .o-select-color-foreground");
     await expectElementCount(".o_font_color_selector", 1);
+    await contains(".btn:contains('Solid')").click();
     await contains(".o_color_button[data-color='#0000FF']").click();
     expect(getContent(el)).toBe(
         `<p>abc<code class="o_inline_code">t[est</code><font style="color: rgb(0, 0, 255);"><strong>de]</strong></font>f</p>`


### PR DESCRIPTION
Purpose of this PR:

Color picker opens different tabs by default because inline code uses a custom color `-900`. In community it opens the custom tab, while in enterprise it opens the solid tab.

This caused the test to fail in community when selecting a color from the solid tab.

runbot-242556

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
