### PR TITLE
[FIX] partner_autocomplete: fix not deterministic test

### DIFF
--- a/addons/partner_autocomplete/tests/test_res_company.py
+++ b/addons/partner_autocomplete/tests/test_res_company.py
@@ -74,7 +74,7 @@ class TestResCompany(common.TransactionCase, MockIAPPartnerAutocomplete):
             'duns': 'BE1234567',
             'name': 'Test BE Company',
             'country_id': {
-                'id': 20, 'display_name': 'Belgium'
+                'id': self.ref('base.be'), 'display_name': 'Belgium'
             },
             'query': 'BE Comp',
             'description': 'Belgium'


### PR DESCRIPTION
The newly added test `test_enrich_by_duns_with_incorrect_vat` was not deterministic
https://github.com/odoo/odoo/commit/9c89391848ed00de91f3caa8ba6876ec0002d064
This commit ensure the consistency if the id of belgium change

opw-6030164