### PR TITLE
[FIX] old manager gets unsubscribed from department messages when a new manager is assigned

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -983,6 +983,9 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         return holidays
 
     def write(self, values):
+        if 'manager_id' in values:
+            self.message_unsubscribe(partner_ids=[self.manager_id.user_id.partner_id.id])
+
         if 'active' in values and not self.env.context.get('from_cancel_wizard'):
             raise UserError(_("You can't manually archive/unarchive a time off."))
 

--- a/doc/cla/individual/alihad1.md
+++ b/doc/cla/individual/alihad1.md
@@ -1,0 +1,11 @@
+bahrain, 2026-04-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+ali hadi ali.hadi@open-inside.com https://github.com/alihad1


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when an old manager gets changed they stay as a follower of the department and become followers on requests relating to it 

Current behavior before PR:
when an old manager gets changed they stay as a follower of the department and become followers on requests relating to it 
Desired behavior after PR is merged:
old manager gets unsubscribed to the department messages



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
