### PR TITLE
[FIX] mail: no rounded-circle on message inline actions without icon

### DIFF
--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -62,6 +62,20 @@ class Action extends Component {
         );
     }
 
+    get isInlineCircleButtonValue() {
+        if (!this.props.inline || !this.action.icon) {
+            return false;
+        }
+        if (this.env.inComposer || this.env.inMessage) {
+            return true;
+        }
+        return (
+            this.action.tags.includes("JOIN_LEAVE_CALL") &&
+            this.action.icon &&
+            !this.action.inlineName
+        );
+    }
+
     onSelected(action, ev) {
         action.onSelected?.(ev);
         this.env.inCallDropdown?.close();

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -43,7 +43,7 @@
 </t>
 
 <t t-name="mail.Action.main">
-    <t t-set="isInlineCircleButton" t-value="this.env.inComposer or this.env.inMessage or (this.action.tags.includes('JOIN_LEAVE_CALL') and this.action.icon and !this.action.inlineName)"/>
+    <t t-set="isInlineCircleButton" t-value="this.isInlineCircleButtonValue"/>
     <!-- core-->
     <t t-set="btnClass" t-value="this.attClassObjectToString({
         'o-mail-ActionList-button btn btn-group-item position-relative': true,


### PR DESCRIPTION
Before this commit, messages inline actions in ai conversations were circle buttons instead of square.

This is a problem because on named actions this doesn't look good: the circled outline turns shape of button as an ellipse and it crops with the text.

This happens due to [1] that improved inline message actions to be `.rounded-circle`. The intent of [1] is to apply on inline actions that are icons, which applies to all messages but the specific actions available in `ai` conversations.

This commit fixes the issue by not applying `.rounded-circle` on inline actions that have no icon but a name.

[1]: https://github.com/odoo/odoo/pull/253137

Task-6121182

Before / After
<img width="165" height="84" alt="Screenshot 2026-04-14 at 15 56 58" src="https://github.com/user-attachments/assets/a5e8c2d1-cd04-4fd0-957c-42a4c46d6093" />
<img width="171" height="88" alt="Screenshot 2026-04-14 at 15 56 33" src="https://github.com/user-attachments/assets/c2046ab0-8e18-4946-9063-04e01ac0364f" />

