### PR TITLE
[FIX] l10n_latam_invoice_document: allow non-sequential hashing for vendor bills

### DIFF
--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -408,3 +408,40 @@ class TestArManual(common.TestArCommon):
             .sorted(lambda x: (x.move_id.id, x.tax_line_id.id, x.tax_ids.ids, x.tax_repartition_line_id.id))
 
         self.assertEqual(tax_lines_a.balance, tax_lines_b.balance, 'Tax balances should be equal since both invoices have a single line and the total matches the line amount.')
+
+    def test_vendor_bill_hash_out_of_order(self):
+        """ Vendor bills with 'Lock Posted Entries with Hash' enabled can be posted in any order.
+        Vendors assign document numbers independently of Odoo's sequence, so a bill with a lower
+        document number may be entered after one with a higher number. """
+        purchase_journal = self.env['account.journal'].search([
+            ('type', '=', 'purchase'),
+            ('company_id', '=', self.env.company.id),
+            ('l10n_latam_use_documents', '=', True),
+        ], limit=1)
+        purchase_journal.restrict_mode_hash_table = True
+
+        bill_high = self._create_invoice(
+            move_type='in_invoice',
+            invoice_date='2024-01-01',
+            partner_id=self.res_partner_adhoc,
+            journal_id=purchase_journal,
+            l10n_latam_document_type_id=self.document_type['invoice_a'],
+            invoice_line_ids=[self._prepare_invoice_line(price_unit=100, product_id=self.product_iva_21)],
+        )
+        bill_high.l10n_latam_document_number = '00001-00009999'
+        bill_high.action_post()
+        self.assertEqual(bill_high.state, 'posted')
+        self.assertTrue(bill_high.inalterable_hash)
+
+        bill_low = self._create_invoice(
+            move_type='in_invoice',
+            invoice_date='2024-01-02',
+            partner_id=self.res_partner_adhoc,
+            journal_id=purchase_journal,
+            l10n_latam_document_type_id=self.document_type['invoice_a'],
+            invoice_line_ids=[self._prepare_invoice_line(price_unit=100, product_id=self.product_iva_21)],
+        )
+        bill_low.l10n_latam_document_number = '00001-01009992'
+        bill_low.action_post()
+        self.assertEqual(bill_low.state, 'posted')
+        self.assertTrue(bill_low.inalterable_hash)

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -248,3 +248,16 @@ class AccountMove(models.Model):
     def _set_next_made_sequence_gap(self, made_gap: bool):
         if other_moves := self.filtered(lambda m: not m.journal_id.l10n_latam_use_documents):
             super(AccountMove, other_moves)._set_next_made_sequence_gap(made_gap)
+
+    def _hash_moves(self, **kwargs):
+        latam_purchase = self.filtered(
+            lambda m: m.is_purchase_document() and m.l10n_latam_use_documents
+        )
+        super(AccountMove, self - latam_purchase)._hash_moves(**kwargs)
+        force_hash = kwargs.get('force_hash', False)
+        for move in latam_purchase:
+            if self._is_move_restricted(move, force_hash=force_hash) and not move.inalterable_hash:
+                move_hash = move.sudo()._calculate_hashes('')
+                for m, h in move_hash.items():
+                    m.inalterable_hash = h
+                move._message_log_batch(bodies={move.id: self.env._("This journal entry has been secured.")})


### PR DESCRIPTION
**Steps to reproduce**

Install modules l10n_ar and l10n_latam_invoice_document.
Go to Accounting > Configuration > Journals and enable \"Lock Posted Entries with Hash\" on a Purchase journal that uses LATAM documents.
Create and post a vendor bill with a high document number (e.g., '00001-00009999').
Create another vendor bill with a lower document number (e.g., '00001-00000100') and try to post it.

**Issue**

Posting the second vendor bill fails with a UserError: \"This move could not be locked either because some move with the same sequence prefix has a higher number. You may need to resequence it.\"

This happens because core Odoo hashing logic enforces a strict, continuous sequential numbering per journal and prefix.

The _get_chain_info method identifies moves to be secured by searching for entries with a sequence number strictly greater than the last hashed move in that chain:
https://github.com/odoo/odoo/blob/976c9778c038e821176fc3b273bf4ad58bdc4810/addons/account/models/account_move.py#L4091-L4145

When a vendor bill is entered with a lower number than an already hashed one, it is excluded from the search, triggering the no_document warning:
https://github.com/odoo/odoo/blob/976c9778c038e821176fc3b273bf4ad58bdc4810/addons/account/models/account_move.py#L4140

And the subsequent UserError in _get_chains_to_hash:
https://github.com/odoo/odoo/blob/976c9778c038e821176fc3b273bf4ad58bdc4810/addons/account/models/account_move.py#L4180-L4184

Similarly, jumps in vendor numbering trigger a gap warning:
https://github.com/odoo/odoo/blob/976c9778c038e821176fc3b273bf4ad58bdc4810/addons/account/models/account_move.py#L4130

Causing the error at:
https://github.com/odoo/odoo/blob/976c9778c038e821176fc3b273bf4ad58bdc4810/addons/account/models/account_move.py#L4185-L4188

Since vendor bills are issued by third parties, we do not control their sequence, and forcing them into a single continuous chain is functionally incorrect.

opw-6076673