### PR TITLE
[FIX] pos_online_payment, pos_mollie, pos_viva_com: sync payment status on app switch

### DIFF
--- a/addons/pos_mollie/models/pos_payment_method.py
+++ b/addons/pos_mollie/models/pos_payment_method.py
@@ -70,3 +70,22 @@ class PosPaymentMethod(models.Model):
     def _mollie_get_payment(self, payment_id: str):
         self.ensure_one()
         return self.mollie_payment_provider_id._send_api_request("GET", f"/payments/{payment_id}")
+
+    def mollie_get_payment_status(self, transaction_id: str):
+        self.ensure_one()
+        payment_info = self._mollie_get_payment(transaction_id)
+        payment_details = payment_info.get("details", {})
+        message = {
+            'session_id': self.env.context.get("pos_session_id"), # Just for reference
+            'payment_id': transaction_id,
+            'status': payment_info.get("status"),
+        }
+        if message['status'] == "paid":
+            message.update({
+                'card_type': payment_details.get("cardFunding"),
+                'card_no': payment_details.get("cardNumber"),
+                'card_brand': payment_details.get("cardLabel"),
+            })
+        elif message['status'] in ['expired', 'failed', 'canceled']:
+            message['status_reason'] = payment_info.get("statusReason")
+        return message

--- a/addons/pos_mollie/static/src/payment_mollie.js
+++ b/addons/pos_mollie/static/src/payment_mollie.js
@@ -62,8 +62,32 @@ export class PaymentMollie extends PaymentInterface {
             paymentLine.transaction_id = data.id;
             await this.pos.data.synchronizeLocalDataInIndexedDB();
 
-            const { promise, resolve } = Promise.withResolvers();
-            this.paymentLineResolvers[paymentLine.uuid] = resolve;
+            let resolveFunc;
+            const promise = new Promise((resolve) => {
+                resolveFunc = resolve;
+            });
+
+            const visibilityHandler = async () => {
+                if (document.visibilityState === "visible") {
+                    try {
+                        const status = await this.pos.data.call("pos.payment.method", "mollie_get_payment_status", [
+                            this.payment_method_id.id,
+                            paymentLine.transaction_id,
+                        ]);
+                        if (status && !["open", "pending"].includes(status.status)) {
+                            this.handleMollieStatusResponse(paymentLine, status);
+                        }
+                    } catch (e) {
+                        // ignore error and let bus_service handle it or try again later
+                    }
+                }
+            };
+            browser.addEventListener("visibilitychange", visibilityHandler);
+
+            this.paymentLineResolvers[paymentLine.uuid] = (result) => {
+                browser.removeEventListener("visibilitychange", visibilityHandler);
+                resolveFunc(result);
+            };
 
             return promise;
         } catch (error) {

--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -1,6 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { CONSOLE_COLOR, PosStore } from "@point_of_sale/app/services/pos_store";
 import { logPosMessage } from "@point_of_sale/app/utils/pretty_console_log";
+import { browser } from "@web/core/browser/browser";
 
 patch(PosStore.prototype, {
     async setup() {
@@ -12,6 +13,22 @@ patch(PosStore.prototype, {
             // the server to check the new state of the order.
             if (this.getOrder()?.id === id) {
                 this.updateOnlinePaymentsDataWithServer(this.getOrder(), false);
+            }
+        });
+
+        browser.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "visible") {
+                const order = this.getOrder();
+                if (
+                    order &&
+                    order.payment_ids.some(
+                        (line) =>
+                            line.payment_method_id.is_online_payment &&
+                            line.getPaymentStatus() === "waiting"
+                    )
+                ) {
+                    this.updateOnlinePaymentsDataWithServer(order, false);
+                }
             }
         });
     },

--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -1,4 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
+import { browser } from "@web/core/browser/browser";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { roundPrecision } from "@web/core/utils/numbers";
@@ -145,14 +146,14 @@ export class PaymentVivaCom extends PaymentInterface {
         return new Promise((resolve) => {
             const sessionId = paymentLine.uiState.vivaSessionId;
             this.paymentLineResolvers[paymentLine.uuid] = resolve;
-            const intervalId = setInterval(async () => {
+
+            const checkStatus = async () => {
                 const isPaymentStillValid = () =>
                     this.paymentLineResolvers[paymentLine.uuid] &&
                     paymentLine.payment_status === "waitingCard" &&
                     sessionId === paymentLine.uiState.vivaSessionId;
                 if (!isPaymentStillValid()) {
-                    clearInterval(intervalId);
-                    return;
+                    return false;
                 }
 
                 const result = await this._call_viva_com(
@@ -161,7 +162,6 @@ export class PaymentVivaCom extends PaymentInterface {
                     paymentLine
                 );
                 if ("success" in result && isPaymentStillValid()) {
-                    clearInterval(intervalId);
                     if (this.isPaymentSuccessful(result)) {
                         this.handleSuccessResponse(paymentLine, result);
                         resolve(true);
@@ -170,8 +170,29 @@ export class PaymentVivaCom extends PaymentInterface {
                         resolve(false);
                     }
                     this.paymentLineResolvers[paymentLine.uuid] = null;
+                    return false;
+                }
+                return true;
+            };
+
+            const intervalId = setInterval(async () => {
+                const shouldContinue = await checkStatus();
+                if (!shouldContinue) {
+                    clearInterval(intervalId);
+                    browser.removeEventListener("visibilitychange", visibilityHandler);
                 }
             }, POLLING_INTERVAL_MS);
+
+            const visibilityHandler = async () => {
+                if (document.visibilityState === "visible") {
+                    const shouldContinue = await checkStatus();
+                    if (!shouldContinue) {
+                        clearInterval(intervalId);
+                        browser.removeEventListener("visibilitychange", visibilityHandler);
+                    }
+                }
+            };
+            browser.addEventListener("visibilitychange", visibilityHandler);
         });
     }
 


### PR DESCRIPTION
When using a single mobile device to process a POS order and paying via a local terminal app or banking app, the user leaves the POS app.

During this app switch, the mobile OS typically suspends the POS tab/app. As a result, the WebSocket connection drops and JavaScript interval timers are heavily throttled. When the payment completes, the Odoo server receives the webhook and emits a bus notification. However, since the client app is suspended, it misses this real-time push.

When the user returns to the POS app, the POS was historically waiting indefinitely (for websocket reconnection) or waiting up to 5 seconds (for interval loops) to sync the payment state.

This commit resolves the issue by hooking into the native browser `visibilitychange` event. As soon as the POS tab regains visibility:
- `pos_online_payment`: Triggers an RPC `updateOnlinePaymentsDataWithServer`
- `pos_mollie`: Executes a new RPC `mollie_get_payment_status` to fetch the backend state directly without waiting for a re-emitted bus message.
- `pos_viva_com`: Triggers the status check manually, bypassing its 5s `setInterval`.

This guarantees immediate synchronization and instant UI validation upon switching back to the Odoo POS from a banking app.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
