### PR TITLE
[FIX] mail: less distracting message highlight (remove blur)

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -181,6 +181,5 @@
 
     &:has(.o-highlighted) > *:not(.o-highlighted) {
         opacity: .4;
-        filter: blur(1px);
     }
 }

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -491,6 +491,9 @@ export class Thread extends Component {
     }
 
     onClickLoadOlder() {
+        if (this.messageHighlight?.highlightedMessageId) {
+            return;
+        }
         this.props.thread.fetchMoreMessages();
     }
 
@@ -659,9 +662,7 @@ export class Thread extends Component {
             this.props.thread.loadOlder &&
             this.props.thread.isLoaded &&
             !this.props.thread.isTransient &&
-            !this.props.thread.hasLoadingFailed &&
-            !this.messageHighlight?.initiated &&
-            !this.messageHighlight?.highlightedMessageId
+            !this.props.thread.hasLoadingFailed
         );
     }
 
@@ -694,6 +695,7 @@ export class Thread extends Component {
     get showStartMessage() {
         return (
             this.state.mountedAndLoaded &&
+            !this.props.thread.loadOlder &&
             ["channel", "group", "chat"].includes(this.channel?.channel_type)
         );
     }


### PR DESCRIPTION
Before this commit, the message highlight was too distracting. This was improved [1] so that highlighted message doesn't have the vertical translation during the highlight duration. To make the message more visible than the other messages, other messages have their opacity reduced.

While reduced opacity is good, there was an extra blur, which is more distracting. This commit fixes it by removing it.

Also at the end of message highlight, the scroll position of message list was changing when this shouldn't. This happens for 2 reasons:

1. The "Welcome to conversation" message was mistakenly displayed during the message highlighting, thus when message highlight ended its removal would substract some scrollTop and move scroll up.
2. The "Load More" was temporarily not shown during the message highlight. This is a problem because when message highlight ended, this was adding slightly more scollTop and move scroll down.

The "Welcome to conversation" should not be shown when there's logically a "Load more", which this commit fixes. The hiding of "Load More" was intended to avoid their triggering when opening conversation [2], but the logic around these triggers had been improved [3] therefore this is no longer necessary. This commit relaxes the showing of "Load more" to display them even during a message highlighting.

Task-6121035

[1]: https://github.com/odoo/odoo/pull/246989
[2]: https://github.com/odoo/odoo/pull/181392
[3]: https://github.com/odoo/odoo/pull/216776

Before / After

_(before visual artifacts come from GIF recorder that doesn't like blur)_
![before](https://github.com/user-attachments/assets/2a1ab290-7df3-49db-b132-67599ef693e7)
![after](https://github.com/user-attachments/assets/ad531b18-71af-4704-ad5a-29e630e87d6a)
