### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: fix spurious log message

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -145,7 +145,7 @@ class StockPicking(models.Model):
         for picking in self:
             if picking.country_code != 'TR' or picking.picking_type_code != 'outgoing' or picking.state != 'done':
                 continue
-            else:
+            elif not picking.partner_id:
                 picking.message_post(
                     body=_("e-Dispatch will not be generated as the Delivery Address is not set.")
                 )


### PR DESCRIPTION
PR https://github.com/odoo/odoo/pull/248034 removed the `partner_id` existence check, causing the "No Delivery Address" error to be logged even when a delivery address was present. This commit restores the check so the message is only logged when `partner_id` is actually missing.

task-5933473

