### PR TITLE
[FIX] payment_stripe: avoid refund payment for uncaptured transactions

### DIFF
--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -115,6 +115,9 @@ class StripeController(http.Controller):
                     stripe_object['payment_method'] = payment_method
                     self._include_setup_intent_in_notification_data(stripe_object, data)
                 elif event['type'] == 'charge.refunded':  # Refund operation (refund creation).
+                    if not stripe_object['captured']:  # The charge was authorized and then voided
+                        return request.make_json_response('')  # Don't process void-related events
+
                     refunds = stripe_object['refunds']['data']
 
                     # The refunds linked to this charge are paginated, fetch the remaining refunds.

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -58,6 +58,15 @@ class StripeCommon(PaymentCommon):
             },
             'type': 'charge.refunded'
         }
+        cls.void_payment_data = {
+            'data': {
+                'object': {
+                    'captured': False,
+                    **cls.refund_notification_data['data']['object'],
+                }
+            },
+            'type': 'charge.refunded',
+        }
         cls.canceled_refund_notification_data = {
             'data': {
                 'object': dict(cls.refund_object, status='failed'),

--- a/addons/payment_stripe/tests/test_refund_flows.py
+++ b/addons/payment_stripe/tests/test_refund_flows.py
@@ -49,3 +49,19 @@ class TestRefundFlows(StripeCommon, PaymentHttpCommon):
         ) as handle_notification_data_mock:
             self._make_json_request(url, data=self.canceled_refund_notification_data)
         self.assertEqual(handle_notification_data_mock.call_count, 1)
+
+    @mute_logger('odoo.addons.payment_stripe.controllers.main')
+    def test_void_webhook_notification_does_not_trigger_processing(self):
+        self.provider.capture_manually = True
+        tx = self._create_transaction('direct', state='authorized')
+        url = self._build_url(StripeController._webhook_url)
+        with patch(
+            'odoo.addons.payment_stripe.controllers.main.StripeController'
+            '._verify_notification_signature'
+        ), patch(
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
+            '._handle_notification_data'
+        ) as handle_notification_data_mock:
+            self._make_json_request(url, data=self.void_payment_data)
+        self.assertEqual(handle_notification_data_mock.call_count, 0)
+        self.assertFalse(tx.child_transaction_ids)


### PR DESCRIPTION
When an uncaptured Stripe payment is voided, the system will still
generate the refund payment entry.

Steps to reproduce:
- Configure the Stripe payment provider
  - enable "Capture Manually"
  - generate webhook
- Create a sales order
- Generate a payment link and pay with Card
- Back to the SO, click 'Void Transaction'

Issue:
Refund payment entry will be created even if no payment has been
collected for the transaction.

opw-5866924