### PR TITLE
[FIX] stock: unlink scrap move on discard of wizard

### DIFF
--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -4980,6 +4980,27 @@ class TestStockMove(TestStockCommon):
         warning = scrap.action_scrap()
         self.assertEqual(warning.get('res_model'), 'stock.warn.insufficient.qty.scrap', "Should trigger the warning as no qty in location")
 
+    def test_scrap_13_discard_of_insufficient_warning(self):
+        """ Check that the scrap move is not deleted when insufficient
+            quantity warning is discarded via the scrap move form view.
+        """
+        scrap = self.env['stock.move'].create({
+            'is_scrap': True,
+            'product_id': self.productA.id,
+            'quantity': 5,
+        })
+        Form.from_action(self.env, scrap.action_scrap()).save().action_cancel()
+        self.assertTrue(
+            self.env["stock.move"].search([("id", "=", scrap.id)]),
+            "The scrap move should not be deleted after discarding the warning.",
+        )
+
+        Form.from_action(self.env, scrap.with_context(unlink_on_discard=True).action_scrap()).save().action_cancel()
+        self.assertFalse(
+            self.env["stock.move"].search([("id", "=", scrap.id)]),
+            "The scrap move should have been deleted after discarding the warning.",
+        )
+
     def test_in_date_1(self):
         """ Check that moving a tracked quant keeps the incoming date.
         """

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -354,7 +354,7 @@
                         </group>
                     </sheet>
                     <footer>
-                        <button name="action_scrap" type="object" string="Confirm" class="btn-primary" invisible="state in ('done', 'cancel')" context="{'default_is_scrap': True}"/>
+                        <button name="action_scrap" type="object" string="Confirm" class="btn-primary" invisible="state in ('done', 'cancel')" context="{'default_is_scrap': True, 'unlink_on_discard': True}"/>
                     </footer>
                 </form>
             </field>

--- a/addons/stock/wizard/stock_warn_insufficient_qty.py
+++ b/addons/stock/wizard/stock_warn_insufficient_qty.py
@@ -46,4 +46,5 @@ class StockWarnInsufficientQtyScrap(models.TransientModel):
         return self.with_context(clean_context(self.env.context)).scrap_move_id._action_scrap()
 
     def action_cancel(self):
-        return self.scrap_move_id.sudo().unlink()
+        if self.env.context.get('unlink_on_discard'):
+            return self.scrap_move_id.sudo().unlink()


### PR DESCRIPTION
**Steps to Reproduce:**
- Install Inventory with demo data.
- Inventory > Operations > Adjustments > Scrap.
- Create a new scrap with product '**Large Cabinet**' and quantity **1000**.
- Click **Confirm** > (In the warning wizard) Click **Discard**> Click **Confirm**.

**Error:**
`ValueError - Expected singleton: stock.move()`

Before this commit https://github.com/odoo/odoo/commit/c361c3778ef4755b4760039a4fd8f9ed88294b64, in the Shop Floor flow (`button_scrap`), the scrap is created first, and discarding an insufficient warning will unlink the scrap order. However, when using the scrap form view (via adjustments), the scrap was not unlinked on discard.

Later, https://github.com/odoo/odoo/commit/1c7d80a10b5d7db1c4163166bf52b3f3c77044ba, the condition was removed during refactoring, causing the scrap move to be unlinked in all flows.

**Fix:**
This commit adds a context key to ensure that the scrap move is only unlinked in the valid `action_scrap` flow.

sentry-7336640883