### PR TITLE
[FIX] account_peppol: handle None/False attachment

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -167,8 +167,8 @@ class AccountEdiProxyClientUser(models.Model):
 
         try:
             xml_tree = etree.fromstring(attachment.raw)
-        except etree.XMLSyntaxError:
-            _logger.exception("The Peppol XML file is invalid for attachment ID %s", attachment.id)
+        except (etree.XMLSyntaxError, ValueError):
+            _logger.exception("The Peppol XML file is invalid or empty for attachment ID %s", attachment.id)
             return journal, move_type
 
         invoice_type_code = xml_tree.findtext('.//{*}InvoiceTypeCode')


### PR DESCRIPTION
Empty attachments (ex: False/None) could crash parsing during import, this commit falls back on default journal and move type in case of error, allowing the invoice to be created and the issue logged properly.

Root cause of empty XML remains unclear, likely a 3rd party error.

opw-6113211