### PR TITLE
[FIX] html_editor: power buttons displayed at wrong position

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -180,7 +180,8 @@ export class PowerButtonsPlugin extends Plugin {
             this.powerButtonsContainer.style.transform = "translateX(-100%)";
         } else {
             this.powerButtonsContainer.style.transform = "unset";
-            this.powerButtonsContainer.style.left = placeholderWidth + 30 + "px";
+            this.powerButtonsContainer.style.left =
+                blockRect.left - overlayRect.left + placeholderWidth + 30 + "px";
         }
         this.powerButtonsContainer.style.top = blockRect.top - overlayRect.top + "px";
     }


### PR DESCRIPTION
Current behavior before PR:

- In knowledge, the power buttons were displayed at the wrong position. They were displayed before the block hint instead of after it.

Desired behavior after PR is merged:

- In knowledge, the editable has a margin applied to it. As a result, the block does not start at the editable's left position but slightly inside it, causing the power buttons to be displayed at the wrong position. Now, the power buttons' position is set using the block's left position so that they are displayed correctly.

task-6102944

