### PR TITLE
[FIX] l10n_cl: prevent AccessError for branch user

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -181,7 +181,7 @@ class AccountMove(models.Model):
         return self.l10n_latam_document_type_id.code in ['39', '41', '110', '111', '112', '34']
 
     def _is_manual_document_number(self):
-        if self.journal_id.company_id.country_id.code == 'CL':
+        if self.journal_id.country_code == 'CL':
             return self.journal_id.type == 'purchase' and not self.l10n_latam_document_type_id._is_doc_type_vendor()
         return super()._is_manual_document_number()
 


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_cl` module
- Create one branch of the CL company
- Give user(not admin) access to company branch and login with user
- Go to Accounting > Customers > Invoices
- Click New > AccessError

Cause:
This error occurs because the user is working within a branch of the main company. The code tries to access the journal’s company, which is set to the parent company. As the user does not have access to the parent company, fetching the country code fails.

Solution:
In some cases, strict company access rules cause `AccessError` and block normal flows, especially with parent–child company setups where a child needs data from the parent. To ensure smooth processing, temporary `sudo()` usage is required in specific places.

opw-6087460

