### PR TITLE
[FIX] crm: prevent duplicate parent company on lead conversion

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1954,8 +1954,6 @@ class CrmLead(models.Model):
 
         if with_parent:
             partner_company = with_parent
-        elif self.partner_name:
-            partner_company = Partner.create(self._prepare_customer_values(self.partner_name))
         elif self.partner_id:
             partner_company = self.partner_id
         else:

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -488,6 +488,9 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
                     self.assertTrue(lead.partner_id)
                     self.assertEqual(lead.partner_id.name, lead_contact_name)
                     self.assertEqual(lead.partner_id.parent_id, wizard_company)
+                if wizard_action == 'create' and not lead_partner and not wizard_contact and lead_company_name:
+                    # The company created from partner_name must stay top-level.
+                    self.assertFalse(lead.partner_id.parent_id.parent_id)
                 if wizard_action == 'create' and (wizard_contact or lead_partner):
                     self.assertEqual(lead.partner_id, wizard_contact or lead_partner)
                     self.assertFalse(lead.partner_id.parent_id)


### PR DESCRIPTION
**Issue:**
When converting a lead with both `contact_name` and `partner_name`, the created contact end up with a duplicate company hierarchy, producing an invalid chain like:

Person A < Company < Company

**Cause:**
`_create_customer()` was creating a company from `partner_name` in addition to the normal `parent_name` flow already handled by `res.partner.create()`, so the same company name was effectively used twice.

**Fix:**
Remove the extra company creation and let the existing `parent_name` behavior create the company once, then attach the contact to it directly.

Task-6105653
