### PR TITLE
[FIX] im_livechat: sudo operator lookup in chatbot store data

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -472,7 +472,8 @@ class DiscussChannel(models.Model):
                 "scriptStep": current_step_sudo.id,
                 "message": step_message.mail_message_id.id,
                 "operatorFound": current_step_sudo.step_type == "forward_operator"
-                and bool(channel.livechat_agent_partner_ids),
+                # sudo: discuss.channel - visitors/guests can check if an operator exists
+                and bool(channel.sudo().livechat_agent_partner_ids),
             }
             store.add(current_step_sudo, "_store_script_step_fields")
             store.add(chatbot_script, "_store_script_fields")

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -49,7 +49,8 @@ class MailMessage(models.Model):
                         res.attr(
                             "operatorFound",
                             step.step_type == "forward_operator" and
-                            bool(channel.livechat_agent_partner_ids),
+                            # sudo: discuss.channel - visitors/guests can check if an operator exists
+                            bool(channel.sudo().livechat_agent_partner_ids),
                         )
                         if answer := chatbot_message.user_script_answer_id:
                             res.attr("selectedAnswer", {"id": answer.id, "label": answer.name})

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -33,6 +33,21 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
         },
         {
             trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+            run: function () {
+                window.location.reload();
+            },
+            expectUnloadPage: true,
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+            run: "edit Hello, I accidentally refreshed!",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "press Enter",
+        },
+        {
+            trigger: messagesContain("Hello, I accidentally refreshed!"),
         },
     ],
 });


### PR DESCRIPTION
When a livechat visitor reloads the page, `/mail/data` serializes the chatbot state again from the discuss channel / message store data.

In that flow, the visitor cannot read `livechat_agent_partner_ids` directly, so `operatorFound` was computed as false even when an agent had already been assigned. This made the frontend think no operator was available which led to UI bugs like disabled composer.

Use sudo when checking whether a livechat agent exists so the store data keeps returning the correct chatbot forwarding state for visitors.

task-[6102389](https://www.odoo.com/odoo/project/1519/tasks/6102389)