### PR TITLE
[FIX] base, api_doc: Explanations code quality followups

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -219,7 +219,7 @@ class DocController(http.Controller):
         result = {
             'model': model_name,
             'name': ir_model.name,
-            'doc': ir_model.explanation,
+            'doc': ir_model.explanation or '',
             'fields': {
                 field['name']: dict(
                     field,

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -4,9 +4,7 @@
 <t t-name="web.DocModel">
     <div t-if="!this.state.error" class="o-doc-model position-relative d-flex flex-nowrap flex-fill flex-column p-3">
         <h2 class="w-100 mb-2 mt-2" t-out="this.state.model?.name ?? ''"></h2>
-        <p t-if="this.state.model?.doc" class="mb-3" title="Derived from _explanation attribute">
-            <strong>Explanation: </strong><span class="text-muted" t-out="this.state.model.doc"/>
-        </p>
+        <p t-if="this.state.model?.doc" title="Derived from _explanation attribute" t-out="this.state.model.doc"/>
         <DocTable data="this.state.modelData"/>
 
         <h3 class="mt-3 mb-2" id="fields">Fields</h3>

--- a/addons/api_doc/tests/test_doc.py
+++ b/addons/api_doc/tests/test_doc.py
@@ -80,7 +80,12 @@ class TestDoc(HttpCaseWithUserDemo):
         self.assertTrue(res_partner, "res.partner not found in json['models']")
         res_partner_fields = res_partner.pop('fields')
         res_partner_methods = res_partner.pop('methods')
-        self.assertIsInstance(res_partner.pop('doc', None), str)
+        doc_str = res_partner.pop('doc', '')
+        # In CI environment other modules (like hr, mail) might be installed and append their own explanations to the base explaination, hence startswith
+        self.assertTrue(
+            doc_str.startswith("Foundational model for all people and companies (customers, vendors, employees, etc.). Used for identifying individuals or organizations."),
+            f"Unexpected doc content: {doc_str}"
+        )
         self.assertEqual(res_partner, {'name': "Contact", 'model': 'res.partner'})
         self.assertGreater(set(res_partner_methods), {'search'})
         self.assertGreater(set(res_partner_fields), {'id', 'create_uid', 'lang', 'tz'})
@@ -103,7 +108,12 @@ class TestDoc(HttpCaseWithUserDemo):
         json = res.json()
         fields = json.pop('fields', None)
         methods = json.pop('methods', None)
-        self.assertIsInstance(json.pop('doc', None), str)
+        doc_str = json.pop('doc', '')
+        # In CI environment other modules (like hr, mail) might be installed and append their own explanations to the base explaination, hence startswith
+        self.assertTrue(
+            doc_str.startswith("Foundational model for all people and companies (customers, vendors, employees, etc.). Used for identifying individuals or organizations."),
+            f"Unexpected doc content: {doc_str}"
+        )
         self.maxDiff = None
         self.assertEqual(json, {
             'model': 'res.partner',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -3,9 +3,9 @@ import itertools
 import logging
 import random
 import re
-import textwrap
 import psycopg2
 import typing
+from inspect import cleandoc
 from ast import literal_eval
 from collections import defaultdict
 from collections.abc import Mapping
@@ -473,7 +473,7 @@ class IrModel(models.Model):
             explanation = cls.__dict__.get('_explanation')
             # Only include if it matches the target model's name (ignores mixins).
             if explanation and getattr(cls, '_name', None) == model._name:
-                explanations.append(textwrap.dedent(explanation).strip())
+                explanations.append(cleandoc(explanation or ''))
 
         return {
             'model': model._name,


### PR DESCRIPTION
[FIX] base, api_doc: Explanations code quality followups

Couple of code quality improvements:
1.Fall back to an empty string for the doc key removes "false" from the UI
2.inspect.cleandoc is used for better dedenting
3.In the tests asserting type was too generic, replaced with asserting the
  actual content (only the start of it because of the unpredictable CI
  environment)

Follow up of
82ee05c425a5
[IMP] base, api_doc: introduce explanation field for models and actions