### PR TITLE
[FIX] calendar: prevent autosave on allday toggle

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -336,7 +336,7 @@
                         <!-- This is needed so that show_as can be set as 'free' when creating all day events -->
                         <field name="show_as" invisible="1"/>
                         <label for="allday" string="All day" class="ms-md-3"/>
-                        <field name="allday" widget="boolean_toggle" title="All Day" nolabel="1"/>
+                        <field name="allday" widget="boolean_toggle" options="{'autosave': False}" title="All Day" nolabel="1"/>
                     </span>
                     <field name="stop" invisible="1"/>
                 </div>


### PR DESCRIPTION
Purpose
=======
When a calendar.event is created using the quick create form, and the allday field is toggled, the record is autosaved and created even if the form is discarded. Prevent the allday toggle from autosaving the record.

Specification
=============
Following odoo/odoo@b501f0ba64552f7bd9fe97f96416942fab677671 , the boolean_toggle widget has been set on the allday field in the quick create form.
This widget makes it so that toggling the boolean auto saves the record. Fixing the issue by setting the widget autosave option to False.

Task-6109928


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
