### PR TITLE
[FIX] core: avoid calling already gc functions

### DIFF
--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -35,6 +35,9 @@ def _to_ms(ns):
 
 def _timing_gc_callback(event, info):
     """Called before and after each run of the gc, see gc_set_timing."""
+    # Avoid calling time's methods if module has already been unloaded
+    if _gc_time is None:
+        return
     global _gc_start  # noqa: PLW0603
     gen = info['generation']
     if event == 'start':


### PR DESCRIPTION
Odoo registers a callback function to track how much time is spent in garbage collection.

But while the Python interpreter is shutting down and clearing out global modules and variables to free up memory and the Garbage Collector triggers one last time, the callback function `_timing_gc_callback` tries to run, but the function it depends on (like time.thread_time_ns) have already been set to None by the interpreter.
