### PR TITLE
[FIX] account_peppol: handle imported document without invoice

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -259,7 +259,8 @@ class AccountEdiProxyClientUser(models.Model):
             if move := self._peppol_import_invoice(attachment, None, content['state'], uuid):
                 # Only acknowledge when we saved the document somewhere
                 processed_uuids.append(uuid)
-                moves += move
+                if not isinstance(move, bool):
+                    moves += move
         return processed_uuids, moves
 
     def _peppol_post_process_new_messages(self, moves):


### PR DESCRIPTION
When a user removes its journal on its Peppol configuration, when receiving one, a new document would be created but the acknowledgement would never be sent to IAP. Everytime the user tries to retrieve new documents, the same document would then be created again.