### PR TITLE
[PERF] base: Fix OOM in _increase_rank during batch payments

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -753,9 +753,17 @@ class ResPartner(models.Model):
             fields_to_sync = self._commercial_fields()
         sync_vals = commercial_partner._convert_fields_to_values(fields_to_sync)
         sync_children = self.child_ids.filtered(lambda c: not c.is_company)
+        children_ids_to_sync = tools.OrderedSet()
         for child in sync_children:
+            if any(
+                self.env['res.partner']._fields[fname].convert_to_write(child[fname], self) != sync_vals[fname]
+                for fname in fields_to_sync
+            ):
+                children_ids_to_sync.add(child.id)
             child._commercial_sync_to_descendants(fields_to_sync)
-        sync_children.write(sync_vals)
+        if children_ids_to_sync:
+            children_to_sync = self.env['res.partner'].browse(children_ids_to_sync)
+            children_to_sync.write(sync_vals)
 
     def _fields_sync(self, values):
         """ Sync commercial fields and address fields from company and to children.
@@ -765,6 +773,7 @@ class ResPartner(models.Model):
 
         :param dict values: updated values, triggering sync
         """
+        self.fetch(['parent_id', 'type', 'commercial_partner_id'])
         # 1. From UPSTREAM: sync from parent
         if values.get('parent_id') or values.get('type') == 'contact':
             # 1a. Commercial fields: sync if parent changed
@@ -1130,6 +1139,7 @@ class ResPartner(models.Model):
                         result[record.type] = record.id
                     if len(result) == len(adr_pref):
                         return result
+                    record.child_ids.fetch(['type', 'child_ids', 'is_company', 'parent_id'])
                     to_scan = [c for c in record.child_ids
                                  if c not in visited
                                  if not c.is_company] + to_scan

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -750,9 +750,17 @@ class ResPartner(models.Model):
             fields_to_sync = self._commercial_fields()
         sync_vals = commercial_partner._convert_fields_to_values(fields_to_sync)
         sync_children = self.child_ids.filtered(lambda c: not c.is_company)
+        children_ids_to_sync = set()
         for child in sync_children:
+            if any(
+                self.env['res.partner']._fields[fname].convert_to_write(child[fname], self) != sync_vals[fname]
+                for fname in fields_to_sync
+            ):
+                children_ids_to_sync.add(child.id)
             child._commercial_sync_to_descendants(fields_to_sync)
-        sync_children.write(sync_vals)
+        if children_ids_to_sync:
+            children_to_sync = self.env['res.partner'].browse(children_ids_to_sync)
+            children_to_sync.write(sync_vals)
 
     def _fields_sync(self, values):
         """ Sync commercial fields and address fields from company and to children.
@@ -762,6 +770,7 @@ class ResPartner(models.Model):
 
         :param dict values: updated values, triggering sync
         """
+        self.fetch(['parent_id', 'type', 'commercial_partner_id'])
         # 1. From UPSTREAM: sync from parent
         if values.get('parent_id') or values.get('type') == 'contact':
             # 1a. Commercial fields: sync if parent changed
@@ -1127,6 +1136,7 @@ class ResPartner(models.Model):
                         result[record.type] = record.id
                     if len(result) == len(adr_pref):
                         return result
+                    record.child_ids.fetch(['type', 'child_ids', 'is_company', 'parent_id'])
                     to_scan = [c for c in record.child_ids
                                  if c not in visited
                                  if not c.is_company] + to_scan

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -9,7 +9,7 @@ from odoo.addons.base.models.res_partner import ResPartner
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.exceptions import AccessError, RedirectWarning, UserError, ValidationError
 from odoo.tests import Form
-from odoo.tests.common import new_test_user, tagged, TransactionCase, users
+from odoo.tests.common import new_test_user, tagged, TransactionCase, users, warmup
 
 # samples use effective TLDs from the Mozilla public suffix
 # list at http://publicsuffix.org
@@ -746,6 +746,28 @@ class TestPartnerAddressCompany(TransactionCase):
         self.assertEqual(leaf111.address_get([]),
                         {'contact': branch11.id}, 'Invalid address resolution, branch11 should now be contact')
 
+    @warmup
+    def test_address_get_fetch_optimization(self):
+        """Check that address_get prefetches required fields to reduce memory.
+
+        The fetch() call ensures type/child_ids/is_company/parent_id are loaded
+        in batch. If a new field is accessed without adding it to fetch(), this
+        test will fail due to extra queries.
+
+        Fix: update fetch() in res_partner.py address_get() around L1139.
+        """
+        res_partner = self.env['res.partner']
+        company = res_partner.create({'name': 'Company', 'is_company': True})
+        res_partner.create([
+            {'name': 'Invoice', 'parent_id': company.id, 'type': 'invoice'},
+            {'name': 'Delivery', 'parent_id': company.id, 'type': 'delivery'},
+            {'name': 'Contact 1', 'parent_id': company.id, 'type': 'contact'},
+            {'name': 'Contact 2', 'parent_id': company.id, 'type': 'contact'},
+        ])
+        self.env.invalidate_all()
+        with self.assertQueryCount(4):
+            company.address_get(['delivery', 'invoice', 'contact'])
+
     @users('employee')
     def test_address_parent_company_creation(self):
         """ When creating parent company, it should be populated with information
@@ -997,6 +1019,30 @@ class TestPartnerAddressCompany(TransactionCase):
         self.assertEqual(company.vat, 'BECOMPANY', 'No upstream support of reset')
         self.assertFalse(individual.industry_id)
         self.assertFalse(individual.vat)
+
+    @warmup
+    def test_fields_sync_fetch_optimization(self):
+        """Check that _fields_sync prefetches required fields to reduce memory.
+
+        The fetch() call ensures parent_id/type/commercial_partner_id are loaded
+        in batch. If a new field is accessed without adding it to fetch(), this
+        test will fail due to extra queries.
+
+        Fix: update fetch() in res_partner.py _fields_sync() around L773.
+        """
+        company = self.env['res.partner'].create({
+            'is_company': True,
+            'name': 'Test Company',
+            'vat': 'BE0123456789',
+            **self.test_address_values,
+        })
+        contacts = self.env['res.partner'].create([
+            {'name': f'Contact {i}', 'parent_id': company.id}
+            for i in range(5)
+        ])
+        self.env.invalidate_all()
+        with self.assertQueryCount(7):
+            contacts.write({'street': 'New Street'})
 
     def test_company_dependent_commercial_sync(self):
         ResPartner = self.env['res.partner']


### PR DESCRIPTION
### Description:

Processing batch payments for multiple invoices triggers the `_increase_rank` method across numerous partners. Previously, this could lead to Out-Of-Memory (OOM) errors in databases with extensive partner hierarchies (parent/child relationships), primarily due to cascaded writes triggered by `_commercial_sync_to_descendants`.

This commit optimizes the rank increment process, significantly reducing both memory consumption and execution time.

### Benchmark:

| Partner Count | Time Before | Time After | Memory After |
|---------------|-------------|------------|--------------|
| 191,946       | 2 min       | 47s        | 111 Mb       |
| 393,509       | OOM         | 1 min 45   | 216 Mb       |

### Reference:
opw-5152687