### PR TITLE
[FIX] pos_self_order: prevent error Download Receipt of self-order POS orders

### DIFF
--- a/addons/pos_self_order/receipt/pos_order_receipt.xml
+++ b/addons/pos_self_order/receipt/pos_order_receipt.xml
@@ -7,8 +7,8 @@
                     <t t-set="ordering_mode" t-value="config['self_ordering_mode']"/>
                     <t t-set="service_mode" t-value="config['self_ordering_service_mode']"/>
                     <div t-if="ordering_mode != 'nothing'" class="picking-service text-center pt-3">
-                        <span t-if="preset.get('identification') == 'none' or (not preset and service_mode == 'table')">Service at Table</span>
-                        <span t-elif="preset.get('identification') == 'name' or (not preset and service_mode != 'table')">Pickup At Counter</span>
+                        <span t-if="(preset and preset.get('identification') == 'none') or (not preset and service_mode == 'table')">Service at Table</span>
+                        <span t-elif="(preset and preset.get('identification') == 'name') or (not preset and service_mode != 'table')">Pickup At Counter</span>
                         <span t-else="">Delivery</span>
                     </div>
                     <div t-if="order['tracking_number'] and config['self_ordering_mode'] != 'nothing'" class="tracking-number text-center text-bold" style="font-size: 100px; line-height: 130px;" t-out="order['tracking_number']" />

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -343,3 +343,32 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "test_self_order_parent_category")
+
+    def test_self_order_receipt_without_preset(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        order = self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'amount_paid': 0.0,
+            'source': 'mobile',
+            'lines': [(0, 0, {
+                'qty': 1,
+                'product_id': self.cola.id,
+                'price_unit': self.cola.lst_price,
+                'price_subtotal': self.cola.lst_price,
+                'price_subtotal_incl': self.cola.lst_price,
+            })],
+        })
+        html = order.order_receipt_generate_html()
+        self.assertTrue("Service at Table" in html)


### PR DESCRIPTION
Currently an error occurs when the user tries to `Download Receipt`
of self-orders as the following steps:
- Install the pos_self_order module
- Create a new POS shop with `Self Ordering` as `Kiosk`
- Add Online `Payment Methods` on the above POS shop
- Make an order from kiosk mode
- Go to Point of Sale > Orders > Orders
- Open the recent order which was created from the kiosk.
- Click `Download Receipt` > Error

Error:
`QWebError:Error while rendering the template: AttributeError: 'bool' obje...`

This issue occurs because, while rendering pos_order_receipt_header`,
the `preset` value is `False`. Attempting to call `.get()` on a falsy
value leads to an error.

This commit fixes the issue by accessing `preset` only when it is available,
preventing errors during rendering.

sentry-7402711985