### PR TITLE
[FIX] base: report actually failing rules in AccessError

### DIFF
--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -83,7 +83,9 @@ class IrRule(models.Model):
         are OR-ed together, the entire group succeeds or fails, while global
         rules get AND-ed and can each fail)
         """
-        Model = for_records.browse(()).sudo()
+        # disable active_test so rule evaluation considers inactive records
+        # otherwise failing rules may be incorrectly reported
+        Model = for_records.browse(()).sudo().with_context(active_test=False)
         eval_context = self._eval_context()
 
         all_rules = self._get_rules(Model._name, mode=mode).sudo()

--- a/odoo/addons/test_access_rights/models.py
+++ b/odoo/addons/test_access_rights/models.py
@@ -17,6 +17,7 @@ class SomeObj(models.Model):
     )
     forbidden2 = fields.Integer(groups='test_access_rights.test_group')
     forbidden3 = fields.Integer(groups=fields.NO_ACCESS)
+    active = fields.Boolean(default=True)
 
 class Container(models.Model):
     _name = 'test_access_right.container'

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -415,6 +415,29 @@ If you really, really need access, perhaps you can win over your friendly admini
         ):
             p.with_user(self.user).val
 
+    def test_access_error_reports_correct_rules_with_archived_record(self):
+        """ Ensure archived records do not cause unrelated rules to be reported as failing
+        """
+        self._make_rule('rule 0', '[("company_id", "in", company_ids + [False])]', global_=True, attr='read')
+        self._make_rule('rule 1', '[("val", "=", 1)]', global_=False, attr='read')
+        self.record.active = False
+        self.debug_mode()
+        with self.assertRaises(AccessError) as ctx:
+            _ = self.record.val
+        self.maxDiff = None
+        self.assertEqual(
+            ctx.exception.args[0],
+            """Uh-oh! Looks like you have stumbled upon some top-secret records.
+
+Sorry, %s (id=%s) doesn't have 'read' access to:
+- %s, %s (%s: %s)
+
+Blame the following rules:
+- rule 1
+
+If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
+        % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id))
+
 class TestFieldGroupFeedback(Feedback):
 
     @classmethod


### PR DESCRIPTION
When accessing an archived record directly, if access is prevented by a record rule other than a multi-company global rule, the error message incorrectly reports that all rules are failing, suggesting a company issue even though it is not the actual cause.

The problem is that when access is denied, the diagnostic method `_get_failing` is used to determine which rules are failing. This method performs several count queries with different rule domains. However, `active_test` is True by default, excluding archived records from the count, causing the rule evaluation to miss some records and incorrectly mark rules as failing.

With this commit, `_get_failing` evaluates rules with `active_test=False`, ensuring that only actually failing rules are reported.