### PR TITLE
[IMP] hr_attendance: remove unnecessary tag in attendance_calendar_overview

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_calendar/attendance_calendar_overview.xml
+++ b/addons/hr_attendance/static/src/components/attendance_calendar/attendance_calendar_overview.xml
@@ -6,7 +6,6 @@
                 <strong class="o_attendance_info_label">Worked Time</strong>
                 <div class="o_attendance_info_value text-primary">
                     <span class="o_attendance_info_number"><t t-out="this.floatTime(this.state.workedHours)"/></span>
-                    <span class="o_attendance_info_unit">Hours</span>
                 </div>
             </div>
 


### PR DESCRIPTION
This commit removes an unnecessary tag in attendance_calendar_overview

task-6124036

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
