### PR TITLE
[FIX] hr_holidays: show correct time off allocation in time off type dropdown

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -351,6 +351,9 @@
                             <field name="display_name" invisible="not holiday_status_id"/>
                         </div>
                         <group name="col_left" class="m-0">
+                            <!-- When calling .sudo(), context keys starting with default_ get cleaned -->
+                            <!-- so we use leave_date_from in addition to default_date_from -->
+                            <!-- default_date_from and default_date_to are still kept because they are used in different parts of the code -->
                             <field name="holiday_status_id" force_save="1"
                                 domain="[
                                     '|',

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -351,6 +351,9 @@
                             <field name="display_name" invisible="not holiday_status_id"/>
                         </div>
                         <group name="col_left" class="m-0">
+                            <!-- When calling .sudo(), context keys starting with default_ get cleaned -->
+                            <!-- so we use leave_date_from and leave_date_to in addition to default_date_from and default_date_to -->
+                            <!-- default_date_from and default_date_to are still kept because they are used in different parts of the code -->
                             <field name="holiday_status_id" force_save="1"
                                 domain="[
                                     '|',
@@ -363,7 +366,7 @@
                                                     ('virtual_remaining_leaves', '&gt;', 0),
                                                     ('allows_negative', '=', False),
                                 ]"
-                                context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
+                                context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to, 'leave_date_from': date_from, 'leave_date_to': date_to}"
                                 options="{'no_create': True, 'request_type': 'leave'}"
                                 readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                             <label for="request_date_from" invisible="not request_unit_half and not request_unit_hours" string="Date" />


### PR DESCRIPTION
Problem:
When creating a time off request, the time off type dropdown displays incorrect allocation for the employee.

Steps to reproduce:
1. Allocate a time off type to an employee starting from a specific date later than today.
2. Create a time off request for the employee.
3. Set the start date of the time off request to a date after the allocation date (a date where the allocation can be used).
4. Check the time off type dropdown.
5. Notice that the allocation displayed in the dropdown is incorrect and does not reflect the allocation that can be used for the selected date.

Cause:
The start date of the time off request is sent from the view in the context with the key 'default_date_from'. This key gets removed when the context is cleaned because all keys starting with default_ get removed.

Solution:
Send the start date of the time off request in the context with a different key that does not get removed when the context is cleaned. leave_date_from is used as the key to send the start date of the time off request in the context, because it is already used in the code to get the start date of the time off request.