### PR TITLE
[FIX] account: avoid archived user in demo records

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -134,7 +134,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.company_xmlid('demo_invoice_1'): {
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_12',
-                'invoice_user_id': 'base.user_demo',
+                'invoice_user_id': 'base.user_admin',
                 'invoice_payment_term_id': 'account.account_payment_term_end_following_month',
                 'invoice_date': time.strftime('%Y-%m-01'),
                 'delivery_date': time.strftime('%Y-%m-01'),
@@ -168,7 +168,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.company_xmlid('demo_invoice_followup'): {
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_2',
-                'invoice_user_id': 'base.user_demo',
+                'invoice_user_id': 'base.user_admin',
                 'invoice_payment_term_id': 'account.account_payment_term_immediate',
                 'invoice_date': (fields.Date.today() + timedelta(days=-15)).strftime('%Y-%m-%d'),
                 'delivery_date': (fields.Date.today() + timedelta(days=-15)).strftime('%Y-%m-%d'),
@@ -180,7 +180,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.company_xmlid('demo_invoice_5'): {
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_5',
-                'invoice_user_id': 'base.user_demo',
+                'invoice_user_id': 'base.user_admin',
                 'invoice_payment_term_id': 'account.account_payment_term_end_following_month',
                 'invoice_date': (fields.Date.today() + timedelta(days=-40)).strftime('%Y-%m-%d'),
                 'delivery_date': (fields.Date.today() + timedelta(days=-40)).strftime('%Y-%m-%d'),
@@ -191,7 +191,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.company_xmlid('demo_invoice_6'): {
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_5',
-                'invoice_user_id': 'base.user_demo',
+                'invoice_user_id': 'base.user_admin',
                 'invoice_payment_term_id': 'account.account_payment_term_end_following_month',
                 'invoice_date': (fields.Date.today() + timedelta(days=-35)).strftime('%Y-%m-%d'),
                 'delivery_date': (fields.Date.today() + timedelta(days=-35)).strftime('%Y-%m-%d'),
@@ -202,7 +202,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.company_xmlid('demo_invoice_7'): {
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_5',
-                'invoice_user_id': 'base.user_demo',
+                'invoice_user_id': 'base.user_admin',
                 'invoice_payment_term_id': 'account.account_payment_term_end_following_month',
                 'invoice_date': (fields.Date.today() + relativedelta(months=-1)).strftime('%Y-%m-%d'),
                 'delivery_date': (fields.Date.today() + relativedelta(months=-1)).strftime('%Y-%m-%d'),


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a new trial DB with demo data and French localization
2. Archive Marc Demo if you create the DB locally (this happens 
   automatically on Odoo.com trials due to the user seat limit probably)
3. Select the demo company only (unselect the main one)
4. Open Accounting and click the Sales journal from the dashboard

Access Error about reading Marc Demo.
Unarchiving him would work around this issue.

Why the bug
-----------
The sales demo invoices set invoice_user_id to Marc Demo (base.user_demo).
Marc Demo belongs to the main company and can't be read from another
company when archived.

On 19.0 this did not break because the avatar widget only needed
display_name (read with sudo). Commit https://github.com/odoo/odoo/commit/3732ca85b03bea9eabfb05cc306ce0bf5bac88d4 added write_date to it
for cache busting, so now the read is real and the rule fails.

The fix
-------
Use base.user_admin instead: it's never archived, so it stays readable
from any company.

opw-6106870