### PR TITLE
[FIX] l10n_es_edi_tbai_pos: fetch QR code when reprinting paid orders

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/l10n_es_edi_tbai_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -2,6 +2,7 @@ import { patch } from "@web/core/utils/patch";
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { AddTbaiRefundReasonPopup } from "@l10n_es_edi_tbai_pos/app/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup";
+import { qrCodeSrc } from "@point_of_sale/utils";
 
 patch(TicketScreen.prototype, {
     async addAdditionalRefundInfo(order, destinationOrder) {
@@ -15,5 +16,18 @@ patch(TicketScreen.prototype, {
             }
         }
         await super.addAdditionalRefundInfo(...arguments);
+    },
+    async print(order) {
+        if (
+            this.pos.company.l10n_es_tbai_is_enabled &&
+            typeof order.id === "number" &&
+            !order.l10n_es_pos_tbai_qrsrc
+        ) {
+            const url = await this.pos.data.call("pos.order", "get_l10n_es_pos_tbai_qrurl", [
+                order.id,
+            ]);
+            order.l10n_es_pos_tbai_qrsrc = url ? qrCodeSrc(url) : undefined;
+        }
+        return super.print(...arguments);
     },
 });


### PR DESCRIPTION
When printing a paid order after reloading the POS, the TicketBai QR code was missing. The QR source (l10n_es_pos_tbai_qrsrc) was only set during _postPushOrderResolve after payment, but not when loading historical orders from the backend.

opw-6068076

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
