### PR TITLE
[FIX] mail: show 'CMD-Enter' for message edition in chatter (MacOS)

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -394,7 +394,7 @@ export class Composer extends Component {
     }
 
     get CANCEL_OR_SAVE_EDIT_TEXT() {
-        const tags = {
+        const substitutions = {
             open_samp: markup`<samp>`,
             close_samp: markup`</samp>`,
             open_em: markup`<em>`,
@@ -403,16 +403,16 @@ export class Composer extends Component {
             close_cancel: markup`</button>`,
             open_save: markup`<button class="btn btn-link fst-italic p-0 align-baseline" data-type="${EDIT_CLICK_TYPE.SAVE}">`,
             close_save: markup`</button>`,
+            save_keyboard_shortcut: this.env.inChatter
+                ? isMacOS()
+                    ? markup`CMD-Enter`
+                    : markup`CTRL-Enter`
+                : markup`Enter`,
         };
-        return this.env.inChatter
-            ? _t(
-                  "Press %(open_samp)sESC%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sCTRL-Enter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
-                  tags
-              )
-            : _t(
-                  "Press %(open_samp)sESC%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
-                  tags
-              );
+        return _t(
+            "Press %(open_samp)sESC%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)s%(save_keyboard_shortcut)s%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
+            substitutions
+        );
     }
 
     get SEND_TEXT() {

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -17,7 +17,7 @@ import {
     triggerHotkey,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, mockUserAgent, test } from "@odoo/hoot";
 import { Deferred, advanceTime } from "@odoo/hoot-mock";
 
 import { range } from "@web/core/utils/numbers";
@@ -282,16 +282,27 @@ test("should not display user notification messages in chatter", async () => {
     await contains(".o-mail-Message", { count: 0 });
 });
 
-test('post message with "CTRL-Enter" keyboard shortcut in chatter', async () => {
+async function postMesssageShortcutInChatter({ isMacOS = false } = {}) {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
+    if (isMacOS) {
+        mockUserAgent("mac");
+    }
     await start();
     await openFormView("res.partner", partnerId);
     await click("button:text('Send message')");
     await contains(".o-mail-Message", { count: 0 });
     await insertText(".o-mail-Composer-input", "Test");
-    triggerHotkey("control+Enter");
+    triggerHotkey("control+Enter"); // hot-key converts control to command
     await contains(".o-mail-Message");
+}
+
+test('post message with "CTRL-Enter" keyboard shortcut in chatter', async () => {
+    await postMesssageShortcutInChatter();
+});
+
+test('post message with "CMD-Enter" keyboard shortcut in chatter (MacOS)', async () => {
+    await postMesssageShortcutInChatter({ isMacOS: true });
 });
 
 test("base rendering when chatter has no attachment", async () => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -283,7 +283,7 @@ test("Editing message keeps the mentioned roles", async () => {
     await contains(".o-discuss-mention", { text: "@admin" });
 });
 
-test("Can edit message comment in chatter", async () => {
+async function canEditMessageCommentInChatter({ isMacOS = false } = {}) {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
     pyEnv["mail.message"].create({
@@ -293,6 +293,9 @@ test("Can edit message comment in chatter", async () => {
         model: "res.partner",
         res_id: partnerId,
     });
+    if (isMacOS) {
+        mockUserAgent("mac");
+    }
     await start();
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Edit']");
@@ -301,22 +304,40 @@ test("Can edit message comment in chatter", async () => {
     await click(".o-mail-Message button:text('save')");
     await contains(".o-mail-Message-content:text('edited message (edited)')");
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message:contains('Press ESC to cancel, CTRL-Enter to save')");
+    await contains(
+        `.o-mail-Message:contains('Press ESC to cancel, ${isMacOS ? "CMD" : "CTRL"}-Enter to save')`
+    );
     await contains(".o-mail-Message .o-mail-Composer.o-focused");
     await webContains(".o-mail-Message .o-mail-Composer-input").edit("edited again");
     await webContains(".o-mail-Message .o-mail-Composer-input").press("Enter");
     await animationFrame();
     await contains(".o-mail-Message .o-mail-Composer-input"); // still editing message
     await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')"); // FIXME: even though value has trailing '\n', HOOT selector doesn't see it on the node
-    await webContains(".o-mail-Message .o-mail-Composer-input").press(["Control", "Enter"]);
+    await webContains(".o-mail-Message .o-mail-Composer-input").press([
+        isMacOS ? "Command" : "Control",
+        "Enter",
+    ]);
     await contains(".o-mail-Message-content:text('edited again (edited)')");
     // save without change should keep (edited)
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer.o-focused");
     await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')");
-    await contains(".o-mail-Message:contains('Press ESC to cancel, CTRL-Enter to save')");
-    await webContains(".o-mail-Message .o-mail-Composer-input").press(["Control", "Enter"]);
+    await contains(
+        `.o-mail-Message:contains('Press ESC to cancel, ${isMacOS ? "CMD" : "CTRL"}-Enter to save')`
+    );
+    await webContains(".o-mail-Message .o-mail-Composer-input").press([
+        isMacOS ? "Command" : "Control",
+        "Enter",
+    ]);
     await contains(".o-mail-Message-content:text('edited again (edited)')");
+}
+
+test("Can edit message comment in chatter", async () => {
+    await canEditMessageCommentInChatter();
+});
+
+test("Can edit message comment in chatter (MacOS)", async () => {
+    await canEditMessageCommentInChatter({ isMacOS: true });
 });
 
 test("Basic list of edit message actions in chatter", async () => {


### PR DESCRIPTION
Recent commit changed the shortcut in MacOS for posting and editing message to CMD-Enter, instead of CTRL-Enter [1].

The hint was changed in the composer to post message, but the hint when editing message was still showing "CTRL-Enter" instead of "CMD-Enter", which this commit fixes.

[1]: https://github.com/odoo/odoo/pull/248862

Task-6124496

Before / After
<img width="904" height="116" alt="Screenshot 2026-04-15 at 14 04 34" src="https://github.com/user-attachments/assets/a7ad0450-f110-45b1-82c8-d6d251625ca1" /> <img width="894" height="119" alt="Screenshot 2026-04-15 at 14 03 53" src="https://github.com/user-attachments/assets/770b13b9-d882-4ea8-9fe3-f4b334de78ba" />
