### PR TITLE
[FIX] payment_mercado_pago: support webhook containing slashes

### DIFF
--- a/addons/payment_mercado_pago/controllers/main.py
+++ b/addons/payment_mercado_pago/controllers/main.py
@@ -34,7 +34,7 @@ class MercadoPagoController(http.Controller):
         return request.redirect('/payment/status')
 
     @http.route(
-        f'{_webhook_url}/<reference>', type='http', auth='public', methods=['POST'], csrf=False
+        f'{_webhook_url}/<path:reference>', type='http', auth='public', methods=['POST'], csrf=False
     )
     def mercado_pago_webhook(self, reference, **_kwargs):
         """ Process the notification data sent by Mercado Pago to the webhook.


### PR DESCRIPTION
Currently, the mercado_pago_webhook http route only takes into consideration 1 url segment. This means that invoices with references like INV/2026/00001 don't match any defined route and the server returns a 404.
/payment/mercado_pago/webhook/S00001 => OK
/payment/mercado_pago/webhook/INV/2026/00001 => KO

This commit allows references with slashes to be matched by the route by capturing the entire remaining url path including the slashes.
/payment/mercado_pago/webhook/S00001 => OK
/payment/mercado_pago/webhook/INV/2026/00001 => OK

opw-6035161
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
