### PR TITLE
[FIX] account: bypass analytic mandatory plan validation for auto exchange moves

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2918,7 +2918,7 @@ class AccountMoveLine(models.Model):
 
         # ==== Create the move ====
         exchange_moves = self.env['account.move'].create(exchange_move_values_list)
-        exchange_moves._post(soft=False)
+        exchange_moves.with_context(validate_analytic=False)._post(soft=False)
 
         # ==== Reconcile ====
         reconciliation_plan = []

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -570,3 +570,43 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         self.analytic_account_a.active = False
         with self.assertRaisesRegex(UserError, "archived analytic account"):
             invoice._post()
+
+    def test_exchange_move_with_mandatory_analytic_plan(self):
+        """ Ensure no mandatory analytic plan validation error is raised when an exchange move is auto-created."""
+
+        # Multi-currency setup
+        test_currency = self.setup_multi_currency_data(default_values={
+            'name': 'Diamond',
+            'symbol': '💎',
+            'currency_unit_label': 'Diamond',
+            'currency_subunit_label': 'Carbon',
+        }, rate2016=6.0, rate2017=4.0)
+
+        # Analytic plan setup
+        self.env['account.analytic.applicability'].create({
+            'business_domain': 'general',
+            'applicability': 'mandatory',
+            'analytic_plan_id': self.default_plan.id,
+        })
+
+        # Create an invoice in foreign currency
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': test_currency['currency'].id,
+            'invoice_date': '2016-01-01',
+            'invoice_line_ids': [Command.create({
+                'name': 'test line',
+                'quantity': 1,
+                'price_unit': 100,
+                'analytic_distribution': {self.analytic_account_a.id: 100},
+            })],
+        })
+        invoice.action_post()
+
+        # Create a credit note at a different rate
+        credit_note = invoice._reverse_moves([{'invoice_date': '2017-01-01'}])
+        # Post the credit note with the validate_analytic context key to mimic posting behaviour from the form view.
+        credit_note.with_context(validate_analytic=True).action_post()
+
+        self.assertEqual(credit_note.state, 'posted')


### PR DESCRIPTION
**Issue:**
When a user posts a credit note with a currency exchange difference relative to the reversed move,
the resulting exchange move lines lack the mandatory analytic distribution.
This triggers a validation error, preventing the credit note from being posted.

**Steps to reproduce:**
- Set "mandatory" applicability on any analytic plan.
- Set two different currency rates on two different dates for any foreign currency.
- Create and post an invoice on the first date (ensure the mandatory analytic distribution is set).
- Create a credit note from that invoice using the second date.
- Click on the post button on the credit note.

Result: A validation error occurs even though the credit note itself has the mandatory analytic plan set,
because the auto-generated exchange move does not.

**Fix:**
Since the context key validate_analytic is set to True by the post button action,
it must be manually set to False during the automatic creation of exchange difference moves to bypass the mandatory plan check.

OPW-6081632