### PR TITLE
[FIX] mail, web: pager should be disabled during chatter attachment upload

### DIFF
--- a/addons/mail/static/src/chatter/web/file_handler_patch.js
+++ b/addons/mail/static/src/chatter/web/file_handler_patch.js
@@ -1,0 +1,26 @@
+import { useState } from "@odoo/owl";
+
+import { FileUploader } from "@web/views/fields/file_handler";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+
+const fileUploaderPatch = {
+    setup() {
+        super.setup(...arguments);
+        if (this.env.services["mail.store"]) {
+            this.mailStore = useState(useService("mail.store"));
+        }
+    },
+    async onFileChange() {
+        if (!this.env.inChatter || this.env.inComposer) {
+            return super.onFileChange(...arguments);
+        }
+        this.mailStore.isChatterUploading = true;
+        try {
+            await super.onFileChange(...arguments);
+        } finally {
+            this.mailStore.isChatterUploading = false;
+        }
+    },
+};
+patch(FileUploader.prototype, fileUploaderPatch);

--- a/addons/mail/static/src/chatter/web/pager_patch.js
+++ b/addons/mail/static/src/chatter/web/pager_patch.js
@@ -1,0 +1,18 @@
+import { useState } from "@odoo/owl";
+
+import { Pager } from "@web/core/pager/pager";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+
+const pagerPatch = {
+    setup() {
+        super.setup();
+        if (this.env.services["mail.store"]) {
+            this.mailStore = useState(useService("mail.store"));
+        }
+    },
+    get isDisabled() {
+        return super.isDisabled || this.mailStore?.isChatterUploading;
+    },
+};
+patch(Pager.prototype, pagerPatch);

--- a/addons/mail/static/tests/chatter/web/attachment_box.test.js
+++ b/addons/mail/static/tests/chatter/web/attachment_box.test.js
@@ -3,6 +3,7 @@ import {
     click,
     contains,
     defineMailModels,
+    inputFiles,
     openFormView,
     patchUiSize,
     scroll,
@@ -10,6 +11,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -206,4 +208,39 @@ test("attachment box auto-closed on switch to record wih no attachments", async 
     await contains(".o-mail-AttachmentBox");
     await click(".o_pager_next");
     await contains(".o-mail-AttachmentBox", { count: 0 });
+});
+
+test("pager should be disabled during chatter attachment upload", async () => {
+    const pyEnv = await startServer();
+    const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
+        { display_name: "first partner" },
+        { display_name: "second partner" },
+    ]);
+    await start();
+    await openFormView("res.partner", partnerId_1, {
+        arch: `
+            <form>
+                <sheet><field name="name"/></sheet>
+                <chatter/>
+            </form>`,
+        resIds: [partnerId_1, partnerId_2],
+    });
+    await contains(".o_pager_next:enabled");
+    await contains(".o_pager_previous:enabled");
+    let resolveUpload;
+    const uploadPromise = new Promise((resolve) => {
+        resolveUpload = resolve;
+    });
+    onRpc("/mail/attachment/upload", async () => {
+        await uploadPromise;
+    });
+    await click(".o-mail-Chatter-attachFiles");
+    await inputFiles(".o_input_file", [
+        new File(["image"], "testing.jpeg", { type: "image/jpeg" }),
+    ]);
+    await contains(".o_pager_next:disabled");
+    await contains(".o_pager_previous:disabled");
+    resolveUpload();
+    await contains(".o_pager_next:enabled");
+    await contains(".o_pager_previous:enabled");
 });

--- a/addons/web/static/src/core/pager/pager.js
+++ b/addons/web/static/src/core/pager/pager.js
@@ -80,6 +80,12 @@ export class Pager extends Component {
         return parts.join("-");
     }
     /**
+     * @returns {boolean}
+     */
+    get isDisabled() {
+        return this.state.isDisabled || this.isSinglePage;
+    }
+    /**
      * Note: returns false if we received the props "updateTotal", as in this case we don't know
      * the real total so we can't assert that there's a single page.
      * @returns {boolean} true if there is only one page

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -20,10 +20,10 @@
             </span>
             <span class="btn-group d-print-none" aria-atomic="true">
                 <!-- accesskeys not wanted in X2Many widgets -->
-                <button type="button" class="btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" data-tooltip="Previous" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'p' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(-1)">
+                <button type="button" class="btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" data-tooltip="Previous" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'p' : false" t-att-disabled="isDisabled" t-on-click.stop="() => this.navigate(-1)">
                     <i class="oi oi-chevron-left"/>
                 </button>
-                <button type="button" class="btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" data-tooltip="Next" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'n' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(1)">
+                <button type="button" class="btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" data-tooltip="Next" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'n' : false" t-att-disabled="isDisabled" t-on-click.stop="() => this.navigate(1)">
                     <i class="oi oi-chevron-right"/>
                 </button>
             </span>


### PR DESCRIPTION
Currently, when uploading a bunch of attachments or a big one to the chatter, if
 you click on the pager (e.g. next) before the upload is complete, the
 attachments that have not yet been uploaded are uploaded to the next record.

This change disables the pager buttons if there is an ongoing upload in the chatter attachment box.

task-5119290


