### PR TITLE
[FIX] l10n_lu: fix formula of expressions in tax report

### DIFF
--- a/addons/l10n_lu/data/tax_report/section_1.xml
+++ b/addons/l10n_lu/data/tax_report/section_1.xml
@@ -263,7 +263,7 @@
                                     <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
-                                        <field name="formula">226</field>
+                                        <field name="formula">-226</field>
                                     </record>
                                 </field>
                             </record>


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_lu` module
- Switch to `LU Company`
- Create a invoice and in journal items use tax grid `226`
- Open the Tax Report and check the line `226 - Supplies carried out within the scope of the special arrangement of art. 56sexies`
- The value appears negative instead of positive.

Cause:
This issue is caused by the major tax revamp introduced in version 19 [commit]. The credited amount is currently displayed as a negative value, which is incorrect, it should be shown as positive.

Solution:
To resolve this issue, the formula has been modified from `226` to `-226`.

[commit]: https://github.com/odoo/odoo/commit/17a6117ed88c29b5bc4db0c872bcdbc109a7d98b#diff-3441c5d05315ec0562923797f973eae66488452a6772d23e198998c1890aa06c

opw-6050665
