### PR TITLE
[IMP] pos_self_order: support for cash machines

### DIFF
--- a/addons/pos_cashdro/__manifest__.py
+++ b/addons/pos_cashdro/__manifest__.py
@@ -11,7 +11,7 @@
             'pos_cashdro/static/src/**/*',
             ('remove', 'pos_cashdro/static/src/app/**/*'),
         ],
-        'point_of_sale._assets_pos': [
+        'point_of_sale.payment_terminals': [
             'pos_cashdro/static/src/**/*',
             ('remove', 'pos_cashdro/static/src/backend/**/*'),
         ],

--- a/addons/pos_glory_cash/__manifest__.py
+++ b/addons/pos_glory_cash/__manifest__.py
@@ -11,6 +11,11 @@
             'pos_glory_cash/static/src/**/*',
             ('remove', 'pos_glory_cash/static/src/app/**/*'),
         ],
+        'point_of_sale.payment_terminals': [
+            'pos_glory_cash/static/src/**/*',
+            ('remove', 'pos_glory_cash/static/src/backend/**/*'),
+            ('remove', 'pos_glory_cash/static/src/app/screens/**/*'),
+        ],
         'point_of_sale._assets_pos': [
             'pos_glory_cash/static/src/**/*',
             ('remove', 'pos_glory_cash/static/src/backend/**/*'),

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -221,7 +221,7 @@ class PosConfig(models.Model):
 
     @api.constrains("payment_method_ids", "self_ordering_mode")
     def _onchange_payment_method_ids(self):
-        if any(record.self_ordering_mode == 'kiosk' and any(pm.is_cash_count for pm in record.payment_method_ids) for record in self):
+        if any(record.self_ordering_mode == 'kiosk' and any(pm.is_cash_count and not pm.payment_provider for pm in record.payment_method_ids) for record in self):
             raise ValidationError(_("You cannot add cash payment methods in kiosk mode."))
 
     def _get_qr_code_data(self):

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -50,7 +50,7 @@ class ResConfigSettings(models.TransientModel):
             self.use_kiosk_mode = True
             self.pos_module_pos_restaurant = False
             self.pos_self_ordering_pay_after = "each"
-            cash_payment_methods = self.pos_payment_method_ids.filtered(lambda x: x.is_cash_count)
+            cash_payment_methods = self.pos_payment_method_ids.filtered(lambda x: x.is_cash_count and not x.payment_provider)
             self.pos_payment_method_ids = self.pos_payment_method_ids - cash_payment_methods
         else:
             self.use_kiosk_mode = False
@@ -60,7 +60,7 @@ class ResConfigSettings(models.TransientModel):
 
     @api.onchange("pos_payment_method_ids")
     def _onchange_pos_payment_method_ids(self):
-        if self.pos_self_ordering_mode == 'kiosk' and any(pm.is_cash_count for pm in self.pos_payment_method_ids):
+        if self.pos_self_ordering_mode == 'kiosk' and any(pm.is_cash_count and not pm.payment_provider for pm in self.pos_payment_method_ids):
             raise ValidationError(_("You cannot add cash payment methods in kiosk mode."))
 
     @api.onchange("pos_self_ordering_pay_after", "pos_self_ordering_mode")

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -70,6 +70,13 @@ export class PaymentPage extends Component {
                 const newPaymentLine = result.data;
                 try {
                     const paymentSuccessful = await newPaymentLine.pay();
+                    if (
+                        this.selectedPaymentMethod.payment_method_type === "cash_machine" &&
+                        newPaymentLine.amount > this.selfOrder.currentOrder.totalDue
+                    ) {
+                        // This fixes payments from cash machines which give change
+                        newPaymentLine.setAmount(this.selfOrder.currentOrder.totalDue);
+                    }
                     if (!paymentSuccessful) {
                         if (newPaymentLine.useQr && newPaymentLine.qr_code) {
                             this.state.fadeOut = true;

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -31,6 +31,12 @@
                                 <img class="w-100" t-att-src="state.qrCode" />
                             </div>
                         </t>
+                        <t name="cash_machine" t-elif="this.state.paymentMethodType === 'cash_machine'">
+                            <h1 class="text-center">Follow instructions on the cash machine</h1>
+                            <div class="btn btn-light btn-lg w-100 py-5 border border-light shadow-sm">
+                                Remaining: <t t-out="this.selfOrder.formatMonetary(this.selfOrder.currentOrder.totalDue - this.selectedPaymentMethod.payment_interface.amountInserted)" />
+                            </div>
+                        </t>
                         <t t-else="">
                             <h1 class="text-center">Processing your payment...</h1>
                             <div class="btn btn-light btn-lg w-100 py-5 border border-light shadow-sm">

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -79,6 +79,11 @@ export class SelfOrder extends Reactive {
         this.availableCategories = [];
         this.snoozedProductTracker = new SnoozedProductTracker();
 
+        this.env.utils = {
+            roundCurrency: (amount) => this.currency.round(amount),
+            formatCurrency: (amount) => this.formatMonetary(amount),
+        };
+
         this.initData();
         if (this.config.self_ordering_mode === "kiosk") {
             await this.initKioskData();

--- a/addons/pos_self_order/static/tests/unit/pages/payment_page.test.js
+++ b/addons/pos_self_order/static/tests/unit/pages/payment_page.test.js
@@ -11,12 +11,19 @@ definePosSelfModels();
 class MockPaymentInterface extends PaymentInterface {
     setup() {
         this.hasBeenCalled = false;
+        this.amountPaid = 0;
+        this.amountChange = 0;
     }
     sendPaymentRequest(line) {
         this.hasBeenCalled = true;
         if (line.useQr) {
             line.qr_code = "mock_qr_code";
             return false;
+        }
+        if (line.payment_method_id.payment_method_type === "cash_machine") {
+            // Simulate cash payment with change returned
+            this.amountPaid = line.amount;
+            line.setAmount(line.amount + this.amountChange);
         }
         return true;
     }
@@ -64,6 +71,12 @@ const setupPaymentPage = async () => {
     });
     paymentExternalQrWithError.payment_interface = new MockPaymentInterfaceWithError();
 
+    const paymentCashMachine = store.models["pos.payment.method"].create({
+        payment_provider: "mock_cash_machine",
+        payment_method_type: "cash_machine",
+    });
+    paymentCashMachine.payment_interface = new MockPaymentInterface();
+
     await getFilledSelfOrder(store);
     const paymentPage = await mountWithCleanup(PaymentPage, {});
 
@@ -75,6 +88,7 @@ const setupPaymentPage = async () => {
         paymentTerminalWithError,
         paymentExternalQr,
         paymentExternalQrWithError,
+        paymentCashMachine,
     };
 };
 
@@ -156,5 +170,33 @@ describe("startPayment", () => {
 
         expect(paymentExternalQrWithError.payment_interface.hasBeenCalled).toBe(true);
         expect(store.paymentError).toBe(true);
+    });
+
+    test("succeeds if the cash machine payment interface succeeds", async () => {
+        const { paymentPage, store, paymentCashMachine } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentCashMachine.id;
+
+        onRpc("/kiosk/payment/1/kiosk", () => true);
+        await paymentPage.startPayment();
+
+        expect(paymentCashMachine.payment_interface.hasBeenCalled).toBe(true);
+        expect(store.paymentError).toBe(false);
+    });
+
+    test("sets the cash machine payment amount to the order price if change is given", async () => {
+        const { paymentPage, store, paymentCashMachine } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentCashMachine.id;
+        paymentCashMachine.payment_interface.amountChange = 5;
+
+        onRpc("/kiosk/payment/1/kiosk", async (request) => {
+            const requestBody = await request.json();
+            const amountPaid = requestBody.params.order.payment_ids[0][2].amount;
+            expect(amountPaid).toBe(paymentCashMachine.payment_interface.amountPaid);
+            return true;
+        });
+        await paymentPage.startPayment();
+
+        expect(paymentCashMachine.payment_interface.hasBeenCalled).toBe(true);
+        expect(store.paymentError).toBe(false);
     });
 });

--- a/addons/pos_self_order/tests/test_self_order_payment_method.py
+++ b/addons/pos_self_order/tests/test_self_order_payment_method.py
@@ -2,6 +2,7 @@
 
 import odoo.tests
 from odoo import Command
+from odoo.exceptions import ValidationError
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 
 
@@ -13,6 +14,16 @@ class TestSelfOrderPaymentMethod(SelfOrderCommonTest):
             'name': 'Terminal',
             'journal_id': self.bank_journal.id,
             'payment_provider': 'stripe',
+        })
+        self.cash_journal = self.env['account.journal'].create({
+            'name': 'Cash',
+            'type': 'cash',
+            'company_id': self.pos_config.company_id.id,
+            'code': 'CASH',
+        })
+        self.cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash',
+            'journal_id': self.cash_journal.id
         })
 
         self.pos_config.write(
@@ -38,3 +49,23 @@ class TestSelfOrderPaymentMethod(SelfOrderCommonTest):
 
             self.assertEqual(len(payment_methods_to_load), 0)
             self.assertFalse(self.pos_config.has_valid_self_payment_method())
+
+    def test_cash_payment_method_not_allowed_for_kiosk(self):
+        self.assertRaises(ValidationError, lambda: self.pos_config.write(
+            {
+                "self_ordering_mode": "kiosk",
+                "payment_method_ids": [Command.link(self.cash_payment_method.id)],
+            }
+        ))
+
+    def test_cash_machine_payment_method_allowed_for_kiosk(self):
+        self.cash_payment_method.write({
+            "payment_method_type": "cash_machine",
+            "payment_provider": "cashdro",
+        })
+        self.pos_config.write(
+            {
+                "self_ordering_mode": "kiosk",
+                "payment_method_ids": [Command.link(self.cash_payment_method.id)],
+            }
+        )


### PR DESCRIPTION
This commit makes the following changes to allow cash machines to work in the kiosk:

- Cash payment methods can now be added to a self order kiosk if they have a cash machine integration set.
- The self order displays a simple UI showing the amount remaining to be inserted when a cash machine payment is in progress.

No changes were needed to the cash machine modules themselves, except moving the assets to the `point_of_sale.payment_terminals` bundle.

task-6010265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
