### PR TITLE
[FIX] html_editor: don't open emoji suggestion list when space is typed

### DIFF
--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -177,9 +177,13 @@ export class EmojiPlugin extends Plugin {
 
         const selection = this.dependencies.selection.getEditableSelection();
         const searchTerm = this.searchNode.nodeValue.slice(this.offset, selection.endOffset) || "";
-        const emojis = fuzzyLookup(searchTerm, emojiLoader.emojis, (e) =>
-            [e.name].concat(e.shortcodes, e.keywords)
-        ).slice(0, 8);
+        // Keywords may contain spaces (e.g. "grinning face") which
+        // would cause suggestion list to open on space. Replacing
+        // them with underscores prevents this.
+        const emojis = fuzzyLookup(searchTerm, emojiLoader.emojis, (e) => [
+            ...e.shortcodes,
+            ...e.keywords.map((k) => k.replaceAll(" ", "_")),
+        ]).slice(0, 8);
         this.emojiListState.list = emojis.map((e) => ({
             value: e.codepoints,
             label: e.shortcodes[0],

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { advanceTime, describe, expect, test } from "@odoo/hoot";
 import { click, press, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { preloadBundle } from "@web/../tests/web_test_helpers";
@@ -100,5 +100,31 @@ describe("Emoji list picker", () => {
         await expectElementCount(".o-we-SuggestionList", 1);
         press("escape");
         await expectElementCount(".o-we-SuggestionList", 0);
+    });
+
+    test("should not open emoji list picker when a space is typed between ':' and the search term", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        await insertText(editor, ": t");
+        // `updateEmojiList` is debounced by 100ms, wait for it to resolve.
+        await advanceTime(100);
+        expect(".o-we-SuggestionList").toHaveCount(0);
+    });
+
+    test("should not open emoji list picker when a space is typed after the search term", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        await insertText(editor, ":t ");
+        // `updateEmojiList` is debounced by 100ms, wait for it to resolve.
+        await advanceTime(100);
+        expect(".o-we-SuggestionList").toHaveCount(0);
+    });
+
+    test("should close emoji list picker on space and reopen it on backspace", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        await insertText(editor, ":wave");
+        await expectElementCount(".o-we-SuggestionList", 1);
+        await insertText(editor, " ");
+        await expectElementCount(".o-we-SuggestionList", 0);
+        await press("backspace");
+        await expectElementCount(".o-we-SuggestionList", 1);
     });
 });


### PR DESCRIPTION
### Purpose of this PR:

- Keywords contained spaces (e.g. "grinning face") which caused the suggestion list to open when the user typed a space. Replacing spaces with underscores in keywords fixes this since a space will no longer match any keyword. Shortcodes never contain spaces so they are unaffected. Names are removed from the lookup as they are already covered by shortcodes or keywords.

task-6123666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
