### PR TITLE
[REF] mail: move /members into /mail/data

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -68,6 +68,17 @@ class DiscussChannelWebclientController(WebclientController):
         if name == "discuss.channel":
             channels = request.env["discuss.channel"].search([("id", "in", params)])
             request.update_context(channels=request.env.context["channels"] | channels)
+        if name == "/discuss/channel/members":
+            channel = request.env["discuss.channel"].search([("id", "=", params["channel_id"])])
+            if channel:
+                unknown_members = request.env["discuss.channel.member"].search(
+                    domain=[
+                        ("id", "not in", params["known_member_ids"]),
+                        ("channel_id", "=", channel.id),
+                    ],
+                    limit=100,
+                )
+                store.add(channel, ["member_count"]).add(unknown_members, "_store_member_fields")
         if name == "/discuss/channel/favorite":
             if member := request.env["discuss.channel.member"].search(
                 [("channel_id", "=", params["channel_id"]), ("is_self", "=", True)],
@@ -132,17 +143,6 @@ class DiscussChannelWebclientController(WebclientController):
 
 
 class ChannelController(http.Controller):
-    @mail_route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
-    def discuss_channel_members(self, channel_id, known_member_ids):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
-        if not channel:
-            raise NotFound()
-        unknown_members = self.env["discuss.channel.member"].search(
-            domain=[("id", "not in", known_member_ids), ("channel_id", "=", channel.id)],
-            limit=100,
-        )
-        return Store().add(channel, ["member_count"]).add(unknown_members, "_store_member_fields")
-
     @mail_route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
     def discuss_channel_avatar_update(self, channel_id, data):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -580,9 +580,8 @@ export class DiscussChannel extends Record {
         const previousState = this.fetchMembersState;
         this.fetchMembersState = "pending";
         const known_member_ids = this.channel_member_ids.map((channelMember) => channelMember.id);
-        let data;
         try {
-            data = await rpc("/discuss/channel/members", {
+            await this.store.fetchStoreData("/discuss/channel/members", {
                 channel_id: this.id,
                 known_member_ids: known_member_ids,
             });
@@ -591,7 +590,6 @@ export class DiscussChannel extends Record {
             throw e;
         }
         this.fetchMembersState = "fetched";
-        this.store.insert(data);
     }
 
     async fetchPinnedMessages() {

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -218,6 +218,7 @@ test("Load more button should load more members", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMember");
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
     await click(
         ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) [title='Load more']"

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -33,7 +33,11 @@ test("can create a new channel", async () => {
         }
     });
     listenStoreFetch(undefined, {
-        logParams: ["/discuss/create_channel", "/discuss/channel/messages"],
+        logParams: [
+            "/discuss/create_channel",
+            "/discuss/channel/messages",
+            "/discuss/channel/members",
+        ],
     });
     await start();
     await openDiscuss();
@@ -69,16 +73,15 @@ test("can create a new channel", async () => {
                     fetch_params: { limit: 60, around: selfMember.new_message_separator },
                 },
             ],
-        ],
-        {
-            ignoreOrder: true,
-            stepsAfter: [
-                `/discuss/channel/members - ${JSON.stringify({
+            [
+                "/discuss/channel/members",
+                {
                     channel_id: channelId,
                     known_member_ids: [selfMember.id],
-                })}`,
+                },
             ],
-        }
+        ],
+        { ignoreOrder: true }
     );
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2072,6 +2072,7 @@ test("Can post message with only attachment", async () => {
 });
 
 test("failure on loading messages should display error", async () => {
+    expect.errors(1);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -2085,9 +2086,12 @@ test("failure on loading messages should display error", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread:has(:text('An error occurred while fetching messages.'))");
+    await animationFrame();
+    expect.verifyErrors(["RPC_ERROR"]);
 });
 
 test("failure on loading messages should prompt retry button", async () => {
+    expect.errors(1);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -2101,6 +2105,8 @@ test("failure on loading messages should prompt retry button", async () => {
     await start();
     await openDiscuss(channelId);
     await contains("button:text('Click here to retry')");
+    await animationFrame();
+    expect.verifyErrors(["RPC_ERROR"]);
 });
 
 test("failure on loading more messages should display error and prompt retry button", async () => {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -275,16 +275,6 @@ async function channel_call_leave(request) {
     BusBus._sendmany(notifications);
 }
 
-registerRoute("/discuss/channel/members", discuss_channel_members);
-/** @type {RouteCallback} */
-async function discuss_channel_members(request) {
-    /** @type {import("mock_models").DiscussChannel} */
-    const DiscussChannel = this.env["discuss.channel"];
-
-    const { channel_id, known_member_ids } = await parseRequestParams(request);
-    return DiscussChannel._load_more_members([channel_id], known_member_ids);
-}
-
 registerRoute("/discuss/channel/sub_channel/create", discuss_channel_sub_channel_create);
 async function discuss_channel_sub_channel_create(request) {
     /** @type {import("mock_models").DiscussChannel} */
@@ -1009,6 +999,18 @@ function _process_request_for_all(store, name, params, context = {}) {
     if (name === "res.users") {
         const [userId] = ResUsers.search([["id", "=", params["id"]]]);
         store.add(ResUsers.browse(userId));
+    }
+    if (name === "/discuss/channel/members") {
+        const memberIds = DiscussChannelMember.search(
+            [
+                ["id", "not in", params.known_member_ids || []],
+                ["channel_id", "=", params.channel_id],
+            ],
+            makeKwArgs({ limit: 100 })
+        );
+        const memberCount = DiscussChannelMember.search_count([["channel_id", "=", params.channel_id]]);
+        store.add(DiscussChannel.browse(params.channel_id), { member_count: memberCount });
+        store.add(DiscussChannelMember.browse(memberIds));
     }
     if (name === "/discuss/channel/messages") {
         /** @type {import("mock_models").MailMessage} */

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -715,32 +715,6 @@ export class DiscussChannel extends models.ServerModel {
         return store.get_result();
     }
 
-    /**
-     * @param {number[]} ids
-     * @param {number[]} known_member_ids
-     */
-    _load_more_members(ids, known_member_ids) {
-        const kwargs = getKwArgs(arguments, "ids", "known_member_ids");
-        ids = kwargs.ids;
-        delete kwargs.ids;
-        known_member_ids = kwargs.known_member_ids || [];
-
-        /** @type {import("mock_models").DiscussChannelMember} */
-        const DiscussChannelMember = this.env["discuss.channel.member"];
-
-        const members = DiscussChannelMember.search(
-            [
-                ["id", "not in", known_member_ids],
-                ["channel_id", "in", ids],
-            ],
-            makeKwArgs({ limit: 100 })
-        );
-        const member_count = DiscussChannelMember.search_count([["channel_id", "in", ids]]);
-        return new mailDataHelpers.Store(this.browse(ids[0]), { member_count })
-            .add(DiscussChannelMember.browse(members))
-            .get_result();
-    }
-
     /** @param {number} id */
     message_post(id) {
         const kwargs = getKwArgs(arguments, "id");


### PR DESCRIPTION
Allow grouping this RPC with others, which implies less processing all around: less requests, less queries, less duplicate entries in results.

task-5933817
<img width="504" height="140" alt="image" src="https://github.com/user-attachments/assets/c3795ddb-76bb-45bb-b6d6-74401d6ac673" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
