### PR TITLE
[FIX] website_sale: do not archive partner if comm. partner contacts have users

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -930,15 +930,14 @@ class SaleOrder(models.Model):
             return
         partners_to_archive = self.env['res.partner']
         for order in self:
-            if (
-                not (customer := order.partner_id).user_ids
-                and not (commercial_partner := order.partner_id.commercial_partner_id).user_ids
-            ):
-                partners_to_archive |= (
-                    commercial_partner
-                    | commercial_partner.child_ids
-                    | customer.child_ids
-                )
+            customer = order.partner_id
+            customer_comm_partner_contacts = (
+                customer
+                | customer.commercial_partner_id
+                | customer.commercial_partner_id.child_ids
+            )
+            if not customer_comm_partner_contacts.user_ids:
+                partners_to_archive |= customer_comm_partner_contacts
 
         partners_to_archive.active = False
 

--- a/addons/website_sale/tests/test_sale_order.py
+++ b/addons/website_sale/tests/test_sale_order.py
@@ -103,3 +103,14 @@ class TestSaleOrder(WebsiteSaleCommon):
         self.assertTrue(
             self.cart.partner_id.active, "Registered customers shouldn't be archived on payment"
         )
+
+        # Case when SO is toward the parent company and one of its contact has a user
+        customer = self.env["res.partner"].create({"parent_name": "Company", "name": "Cuzco"})
+        self._create_new_portal_user(login=f"whatever-{customer.id}", partner_id=customer.id)
+        self.assertNotEqual(customer, customer.parent_id)
+
+        cart = self._create_so(partner_id=customer.parent_id.id)
+        cart._archive_partner_if_no_user()
+        self.assertTrue(
+            self.cart.partner_id.active, "Registered company shouldn't be archived if any contact has a user"
+        )


### PR DESCRIPTION
Use case:
- considering a database where `website_event_booth_sale` is installed
- considering a company (ACME Corp., email: info@acme.example.net) and it's contact `Roger` (which have a valid user).

then:
- As an anonymous user, go to an event with some booth to register
- register a booth and enter the company information (important: use the company email: info@acme.example.net, this way the cart is created the company as the `partner_id` !!!)
- you are redirected to the cart
- try to pay it, and upon payment you have the following error:

```
You cannot archive contacts linked to an active user.
You first need to archive their associated user.
```

This commit ensure we also check if any contact of the commercial partner have any user before trying to archive them all.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
