### PR TITLE
[FIX] html_editor: prevent power buttons from being hidden in knowledge

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -219,7 +219,7 @@ export class PowerButtonsPlugin extends Plugin {
                 blockRect.left - (overlayRect.left - referenceRect.left) + placeholderWidth + 30;
             if (
                 newButtonContainerLeft + this.powerButtonsContainer.offsetWidth >
-                editableRect.width
+                editableRect.right + referenceRect.left
             ) {
                 this.powerButtonsContainer
                     .querySelectorAll(".power_button:not(:last-child)")


### PR DESCRIPTION
**Current behavior before PR:**

- Power buttons in Knowledge were hidden incorrectly because `editableRect.width` was used as the boundary. Since the editable area has margins applied, this width no longer reflects the actual boundary, causing buttons to be hidden.

**Desired behavior after PR is merged:**

- Use `editableRect.right + referenceRect.left` instead of `editableRect.width` to determine the correct boundary, ensuring power buttons remain visible in when editable area has margin applied to it.

task-6102944

