### PR TITLE
[FIX] l10n_tw_edi_ecpay: adding ItemRemark to json

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -496,6 +496,7 @@ class AccountMove(models.Model):
             if not is_allowance:
                 line.l10n_tw_edi_ecpay_item_sequence = index
 
+            # ItemRemark is in TW Chinese Characters because the official document uses TW Chinese Characters
             if self.l10n_tw_edi_is_b2b and is_allowance:
                 item_list.append({
                     "OriginalInvoiceNumber": self.l10n_tw_edi_ecpay_invoice_id,
@@ -515,6 +516,7 @@ class AccountMove(models.Model):
                     "ItemPrice": item_price,
                     "ItemTaxType": line.tax_ids[0].l10n_tw_edi_tax_type if tax_type != "4" and line.tax_ids else "",
                     "ItemAmount": item_amount,
+                    "ItemRemark": f"商品單位: {line.product_uom_id.name[:6]}" if line.product_uom_id else ""
                 })
             if self.l10n_tw_edi_is_b2b:
                 sale_amount += item_amount

--- a/addons/l10n_tw_edi_ecpay/tests/test_edi.py
+++ b/addons/l10n_tw_edi_ecpay/tests/test_edi.py
@@ -287,7 +287,8 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
                     'ItemWord': 'Units',
                     'ItemPrice': 1000.0,
                     'ItemTaxType': '1',
-                    'ItemAmount': 1000.0
+                    'ItemAmount': 1000.0,
+                    'ItemRemark': "商品單位: Units"
                 },
                 {
                     'ItemSeq': 2,
@@ -296,7 +297,8 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
                     'ItemWord': False,
                     'ItemPrice': -10.0,
                     'ItemTaxType': '1',
-                    'ItemAmount': -10.0
+                    'ItemAmount': -10.0,
+                    'ItemRemark': ""
                 },
             ],
         )


### PR DESCRIPTION
Issue:
--
The documents returned by the ECpay API can be confusing as it does not include the measurement (UOM). The make it clearer a description is provided to ECpay through the json with the Key "ItemRemark"

Current behavior:
--
displayed data in PDF
品名	數量	單價	金額	備註
test	1	5	5

Expected behavior:
--
displayed data in PDF
品名	數量	單價	金額	備註
test	1	5	5	商品單位: Units

opw-6070269
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
