### PR TITLE
[FIX] html_editor: fix non-deterministic icon test

### DIFF
--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -170,11 +170,10 @@ test("Can set icon color", async () => {
     expect(getContent(el)).toBe(
         `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
     );
-    setContent(
-        el,
-        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</p>`
-    );
+    const fa = el.querySelector(".fa");
+    setSelection({ anchorNode: fa, anchorOffset: 0, focusNode: fa, focusOffset: 0 });
     await tick();
+    await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
     );
@@ -185,7 +184,7 @@ test("Can set icon color", async () => {
     const colorButton = await waitFor(".o_color_button[data-color='#6BADDE']");
     colorButton.click();
     await expectElementCount(".o_font_color_selector", 0); // selector closed
-    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6badde']", { timeout: 1500 });
+    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6badde']");
     expect(getContent(el)).toBe(
         `<p>[<font style="color: rgb(107, 173, 222);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font>]</p>`
     );


### PR DESCRIPTION
My last desperate fix attempt did not fix the issue so here is yet another desperate fix attempt. I have seen issues related to the use of `setContent` just to set the selection in the past so I hope it might be that. It's the only noticeable change between this test and the others, be it icon tests or color selector ones.

runbot-242333