### PR TITLE
[FIX] purchase: handle missing product_uom_id in bill line matching

### DIFF
--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -68,7 +68,10 @@ class PurchaseBillMatch(models.Model):
 
     def _compute_product_uom_qty(self):
         for line in self:
-            line.product_uom_qty = line.line_uom_id._compute_quantity(line.line_qty, line.product_uom_id)
+            if line.product_uom_id:
+                line.product_uom_qty = line.line_uom_id._compute_quantity(line.line_qty, line.product_uom_id)
+            else:
+                line.product_uom_qty = line.line_qty
 
     @api.depends('aml_id.price_unit', 'pol_id.price_unit')
     def _compute_product_uom_price(self):


### PR DESCRIPTION
Steps to reproduce:
- Import or create a vendor bill with a line that has a unit of measure but no product.
- Open the bill and go for the bill matching.

Issue:
Bill lines without a product have product_uom_id set to False. During bill matching, _compute_product_uom_qty calls _compute_quantity without checking this value, which raises a UserError due to missing or invalid UoM configuration.

Solution:
Add a check to ensure _compute_quantity is only called when product_uom_id is set. Otherwise, fall back to the original line quantity to avoid conversion errors.

opw - 6109513
