### PR TITLE
[FIX] sale_gelato: mail template issue with ul inside p on normalization

### DIFF
--- a/addons/sale_gelato/data/mail_template_data.xml
+++ b/addons/sale_gelato/data/mail_template_data.xml
@@ -8,37 +8,35 @@
         <field name="partner_to">{{ object.partner_id.email and object.partner_id.id or object.partner_id.parent_id.id }}</field>
         <field name="description">Sent to the customer when Gelato updates the status of an order</field>
         <field name="body_html" type="html">
-            <div style="margin: 0px; padding: 0px;">
-                <p style="margin: 0px; padding: 0px; font-size: 13px;">
-                    Hello <t t-out="object.partner_id.name or ''">Brandon Freeman</t>,<br/><br/>
-                    <!-- Order in transit body -->
-                    <t t-if="ctx.get('tracking_data')">
-                        We are glad to inform you that your order is in transit.
-                        <t t-if="len(ctx['tracking_data']) == 1">
-                            <t t-set="tracking_url" t-value="list(ctx['tracking_data'].keys())[0]"/>
-                            Your tracking number is <a t-att-href="tracking_url" t-out="ctx['tracking_data'][tracking_url]"/>.
-                            <br/><br/>
-                        </t>
-                        <t t-else="">
-                            Your tracking numbers are:
-                            <ul>
-                                <li t-foreach="ctx['tracking_data']" t-as="tracking_url">
-                                    <a t-att-href="tracking_url" t-out="ctx['tracking_data'][tracking_url]"/>
-                                </li>
-                            </ul>
-                        </t>
-                    </t>
-                    <!-- Order delivered body -->
-                    <t t-if="ctx.get('order_delivered')">
-                        We are glad to inform you that your order has been delivered.
+            <div style="margin: 0px; padding: 0px; font-size: 13px;">
+                Hello <t t-out="object.partner_id.name or ''">Brandon Freeman</t>,<br/><br/>
+                <!-- Order in transit body -->
+                <t t-if="ctx.get('tracking_data')">
+                    We are glad to inform you that your order is in transit.
+                    <t t-if="len(ctx['tracking_data']) == 1">
+                        <t t-set="tracking_url" t-value="list(ctx['tracking_data'].keys())[0]"/>
+                        Your tracking number is <a t-att-href="tracking_url" t-out="ctx['tracking_data'][tracking_url]"/>.
                         <br/><br/>
                     </t>
-                    Thank you,
-                    <t t-if="object.user_id.name">
-                        <br />
-                        <div>--<br/><t t-out="object.user_id.name or ''">Mitchell Admin</t></div>
+                    <t t-else="">
+                        Your tracking numbers are:
+                        <ul>
+                            <li t-foreach="ctx['tracking_data']" t-as="tracking_url">
+                                <a t-att-href="tracking_url" t-out="ctx['tracking_data'][tracking_url]"/>
+                            </li>
+                        </ul>
                     </t>
-                </p>
+                </t>
+                <!-- Order delivered body -->
+                <t t-if="ctx.get('order_delivered')">
+                    We are glad to inform you that your order has been delivered.
+                    <br/><br/>
+                </t>
+                Thank you,
+                <t t-if="object.user_id.name">
+                    <br />
+                    <div>--<br/><t t-out="object.user_id.name or ''">Mitchell Admin</t></div>
+                </t>
             </div>
         </field>
         <field name="auto_delete" eval="True"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Technical > Email > Email Templates
- Try to edit and save "Gelato: Order status update"
- QWebError is raised: `KeyError: 'tracking_data'`

**Issue:**
Browser html normalization silently move block elements such as `<ul>` outside `<p>` when rendering the template body_html as it is invalid html. This moved the `t-foreach="ctx['tracking_data']"` evaluation outside the surrounding `<t t-if="ctx.get('tracking_data')">` which triggered the error.

**Fix:**
Removed `p` element to use the outer `div` and avoid the issue for now.

related: https://github.com/odoo/odoo/commit/b24974d64c3afe5febdad9abff9cb23a333f1ada
similar: https://github.com/odoo/odoo/pull/256605

opw-6114223