### PR TITLE
[FIX] hr_holidays: correct allocation hours with zero-hour calendar

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 import pytz
 
 from odoo import _, api, fields, models
+from odoo.addons.resource.models.utils import HOURS_PER_DAY
 
 
 class HrEmployee(models.Model):
@@ -142,5 +143,7 @@ class HrEmployee(models.Model):
         ''' Return 24H to handle the case of Fully Flexible (ones without a working calendar)'''
         if not self:
             return 0
+        if self.is_fully_flexible:
+            return 24
         calendars = self._get_calendars(date_from)
-        return calendars[self.id].hours_per_day if calendars[self.id] else 24
+        return calendars[self.id].hours_per_day if calendars[self.id] and calendars[self.id].hours_per_day else HOURS_PER_DAY

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -583,3 +583,24 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': '2023-12-25'
         })
         self.assertEqual(1, self.leave_type.allocation_count)
+
+    def test_allocation_hours_display_with_zero_hours_per_day(self):
+        """
+        Test allocation hours for employee with calendar havinhg 0 average hours per day.
+        """
+        with Form(self.calendar_35h) as calendar_form:
+            attendance_count = len(calendar_form.attendance_ids)
+            for index in range(attendance_count):
+                with calendar_form.attendance_ids.edit(index) as attendance:
+                    attendance.date_from = '2025-01-01'
+        self.assertEqual(self.calendar_35h.hours_per_day, 0.0)
+        self.employee.resource_calendar_id = self.calendar_35h
+        self.leave_type.request_unit = 'hour'
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager).create({
+            'allocation_type': 'regular',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+        })
+        self.assertEqual(allocation.number_of_hours_display, 8)
+        allocation.number_of_hours_display = 12
+        self.assertEqual(allocation.number_of_hours_display, 12)

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -583,3 +583,19 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': '2023-12-25'
         })
         self.assertEqual(1, self.leave_type.allocation_count)
+
+    def test_allocation_hours_display_with_zero_hours_per_day(self):
+        """
+        Test allocation hours for employee with calendar havinhg 0 average hours per day.
+        """
+        self.calendar_35h.hours_per_day = 0
+        self.employee.resource_calendar_id = self.calendar_35h
+        self.leave_type.request_unit = 'hour'
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager).create({
+            'allocation_type': 'regular',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+        })
+        self.assertEqual(allocation.number_of_hours_display, 8)
+        allocation.number_of_hours_display = 12
+        self.assertEqual(allocation.number_of_hours_display, 12)


### PR DESCRIPTION
Pre-requisite:
------------------------------
1. Install the Time Off module with the demo
2. Working schedule > Duplicate 'Standard 40 hours/week' schedule
3. Rename it > Add any Date in 'Starting Date' for all days of the schedule
4. Create a new employee with this New Working Schedule
5. Create a new Time off type with 'Take Time Off in' field set to 'Hours'

Steps to reproduce:
------------------------------
1. Time off > Management > Allocations
2. Click 'New' > Change time off type to Newly created time off type
3. Add the Newly Created Employee to Allocation

Observation:
------------------------------
1. Allocation hours are automatically set to 0
2. Even after manually updating the hours, saving the record resets them to 0

Issue:
------------------------------
The computed field `number_of_hours_display` relies on `_get_hours_per_day` method to get the hours per day.  In the `_get_hours_per_day` method, it will return the calendar hours even when they are 0 and return 24h for the employee with no calendar (fully flexible).
This results in allocation hours always being computed as 0

In the previous version, it was not the issue, as we had statically passed 8 hours, If the calendar has no `hours_per_day`
https://github.com/odoo/odoo/blob/97bde303ab3dae81215f8a1c52714d44916d79e1/addons/hr_holidays/models/hr_leave_allocation.py#L236

Solution:
------------------------------
1. For an employee with no working schedule (Fully flexible) returns 24
2. Returned HOURS_PER_DAY (8h) if the calendar has 0 working hours, as allocation with 0 hours makes no sense

opw-6042203