### PR TITLE
[FIX] mail: remove redundant emoji suggestion

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -29,7 +29,12 @@ export class SuggestionService {
      * @returns {Array<[string, number, number]>}
      */
     getSupportedDelimiters(thread, env) {
-        return [["@"], ["#"], ["::"], [":", undefined, 2]];
+        const delimiters = [["@"], ["#"], ["::"]];
+        // the emoji plugin handles the emoji suggestions already
+        if (!this.composer.htmlEnabled) {
+            delimiters.push([":", undefined, 2]);
+        }
+        return delimiters;
     }
 
     async fetchSuggestions({ delimiter, term }, { thread, abortSignal } = {}) {

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1503,16 +1503,15 @@ test("can quickly add emoji with ':' keyword", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, ":sweat");
-    await contains(".o-mail-Composer-suggestionList .o-open");
-    await contains(".o-mail-NavigableList-item:text('😅 :sweat_smile:')");
-    await click(".o-mail-NavigableList-item:text('😅 :sweat_smile:')");
+    await contains(".o-we-SuggestionList");
+    await click(".o-navigable:text('😅 :sweat_smile:')");
     await contains(".o-mail-Composer-html.odoo-editor-editable:text('😅')");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-we-SuggestionList", { count: 0 });
     await htmlInsertText(editor, " :sw");
-    await contains(".o-mail-Composer-suggestionList .o-open");
-    await contains(".o-mail-NavigableList-item:text('😅 :sweat_smile:')");
+    await contains(".o-we-SuggestionList");
+    await contains(".o-navigable:text('😅 :sweat_smile:')");
     await htmlInsertText(editor, ":s", { replace: true });
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-we-SuggestionList", { count: 0 });
 });
 
 test("composer reply-to message is restored on thread change", async () => {


### PR DESCRIPTION
Currently the emoji suggestions are triggered by the ":" delimiter, but this is already handled by the emoji plugin since
https://github.com/odoo/odoo/pull/243077

This commit removes the redundant ":" delimiter from the suggestion service, and only keeps it for the composer when HTML is not enabled (since the emoji plugin only works in HTML mode).

task-6127107




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
