### PR TITLE
[FIX] point_of_sale: fix getTaxesAfterFiscalPosition to match map_tax

### DIFF
--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -59,4 +59,5 @@ class AccountTax(models.Model):
         return [
             'id', 'name', 'price_include', 'include_base_amount', 'is_base_affected', 'has_negative_factor',
             'amount_type', 'children_tax_ids', 'amount', 'company_id', 'id', 'sequence', 'tax_group_id',
+            'fiscal_position_ids',
         ]

--- a/addons/point_of_sale/static/src/app/models/account_fiscal_position.js
+++ b/addons/point_of_sale/static/src/app/models/account_fiscal_position.js
@@ -6,7 +6,12 @@ export class AccountFiscalPosition extends Base {
 
     getTaxesAfterFiscalPosition(taxes) {
         if (!this.tax_ids?.length) {
-            return [];
+            // Mirror Python's map_tax: only return empty when the taxes themselves
+            // are linked to fiscal positions (tax units pattern). Otherwise pass through.
+            if (taxes.some((tax) => tax.fiscal_position_ids?.length)) {
+                return [];
+            }
+            return taxes;
         }
 
         const newTaxIds = [];

--- a/addons/point_of_sale/static/tests/unit/data/account_tax.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/account_tax.data.js
@@ -18,6 +18,7 @@ export class AccountTax extends models.ServerModel {
             "id",
             "sequence",
             "tax_group_id",
+            "fiscal_position_ids",
         ];
     }
 
@@ -35,6 +36,7 @@ export class AccountTax extends models.ServerModel {
             company_id: 250,
             sequence: 1,
             tax_group_id: 1,
+            fiscal_position_ids: [1],
         },
         {
             id: 2,
@@ -49,6 +51,7 @@ export class AccountTax extends models.ServerModel {
             company_id: 250,
             sequence: 1,
             tax_group_id: 3,
+            fiscal_position_ids: [],
         },
         {
             id: 3,

--- a/addons/point_of_sale/static/tests/unit/models/account_fiscal_position.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/account_fiscal_position.test.js
@@ -1,0 +1,38 @@
+import { expect, test } from "@odoo/hoot";
+import { setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+test("getTaxesAfterFiscalPosition: empty tax_ids, taxes have fiscal_position_ids → returns []", async () => {
+    const store = await setupPosEnv();
+    const models = store.models;
+    const emptyFp = models["account.fiscal.position"].get(2);
+    // tax id=1 has fiscal_position_ids: [1], so it is managed by a fiscal position
+    const taxWithFp = models["account.tax"].get(1);
+
+    const result = emptyFp.getTaxesAfterFiscalPosition([taxWithFp]);
+    expect(result).toEqual([]);
+});
+
+test("getTaxesAfterFiscalPosition: empty tax_ids, taxes have no fiscal_position_ids → passes taxes through", async () => {
+    const store = await setupPosEnv();
+    const models = store.models;
+    const emptyFp = models["account.fiscal.position"].get(2);
+    // tax id=2 has fiscal_position_ids: [], so it is not managed by any fiscal position
+    const taxWithoutFp = models["account.tax"].get(2);
+
+    const result = emptyFp.getTaxesAfterFiscalPosition([taxWithoutFp]);
+    expect(result).toEqual([taxWithoutFp]);
+});
+
+test("getTaxesAfterFiscalPosition: fiscal position has tax_ids, unmapped tax passes through", async () => {
+    const store = await setupPosEnv();
+    const models = store.models;
+    // fiscal position id=1 has tax_ids but no tax_map entry for tax id=2
+    const fp = models["account.fiscal.position"].get(1);
+    const unmappedTax = models["account.tax"].get(2);
+
+    const result = fp.getTaxesAfterFiscalPosition([unmappedTax]);
+    expect(result).toEqual([unmappedTax]);
+});


### PR DESCRIPTION
When a fiscal position has no tax_ids, the JS implementation was unconditionally returning an empty array. The Python map_tax method only removes all taxes when the taxes themselves carry fiscal_position_ids (the tax-units pattern); otherwise it passes the original taxes through.

opw-6126210

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
