### PR TITLE
[FIX] account: fixed wrong sent status for multi send

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5749,21 +5749,32 @@ class AccountMove(models.Model):
         """
         def get_account_notification(moves, is_success: bool):
             _ = self.env._
-            return [
-                'account_notification',
-                {
-                    'type': 'success' if is_success else 'warning',
-                    'title': _('Invoices sent') if is_success else _('Invoices in error'),
-                    'message': _('Invoices sent successfully.') if is_success else _(
-                        "One or more invoices couldn't be processed."),
-                    'action_button': {
-                        'name': _('Open'),
-                        'action_name': _('Sent invoices') if is_success else _('Invoices in error'),
-                        'model': 'account.move',
-                        'res_ids': moves.ids,
+            if any(move.partner_id.email for move in moves):
+                return [
+                    'account_notification',
+                    {
+                        'type': 'success' if is_success else 'warning',
+                        'title': _('Invoices sent') if is_success else _('Invoices in error'),
+                        'message': _('Invoices sent successfully.') if is_success else _(
+                            "One or more invoices couldn't be processed."),
+                        'action_button': {
+                            'name': _('Open'),
+                            'action_name': _('Sent invoices') if is_success else _('Invoices in error'),
+                            'model': 'account.move',
+                            'res_ids': moves.filtered(lambda move: move.partner_id.email).ids,
+                        },
                     },
-                },
-            ]
+                ]
+            else:
+                return [
+                    'simple_notification',
+                    {
+                        'type': 'success' if is_success else 'warning',
+                        'title': _('Invoices generated') if is_success else _('Invoices in error'),
+                        'message': _('Invoices generated successfully.') if is_success else _(
+                            "One or more invoices couldn't be processed."),
+                    },
+                ]
 
         domain = [
             ('sending_data', '!=', False),

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -431,6 +431,9 @@ class AccountMoveSend(models.AbstractModel):
         # note: Binary is used for security reason
         attachment_to_create = [invoice_data['pdf_attachment_values'] for invoice_data in invoices_data.values() if invoice_data.get('pdf_attachment_values')]
         if not attachment_to_create:
+            for invoice, invoice_data in invoices_data.items():
+                if not invoice.is_move_sent and (len(invoices_data.items()) == 1 or invoice.partner_id.email):
+                    invoice.is_move_sent = True
             return
 
         attachments = self.sudo().env['ir.attachment'].create(attachment_to_create)
@@ -440,7 +443,8 @@ class AccountMoveSend(models.AbstractModel):
             if attachment := res_id_to_attachment.get(invoice.id):
                 invoice.message_main_attachment_id = attachment
                 invoice.invalidate_recordset(fnames=['invoice_pdf_report_id', 'invoice_pdf_report_file'])
-                invoice.is_move_sent = True
+                if len(invoices_data.items()) == 1 or invoice.partner_id.email:
+                    invoice.is_move_sent = True
 
     @api.model
     def _hook_if_errors(self, moves_data, allow_raising=True):

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -701,6 +701,41 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertFalse(self._get_mail_message(invoice1))
         self.assertTrue(invoice2.invoice_pdf_report_id)
         self.assertTrue(self._get_mail_message(invoice2))
+        self.assertFalse(invoice1.is_move_sent)
+        self.assertTrue(invoice2.is_move_sent)
+
+    def test_invoice_multi_sent_after_email_missing(self):
+        invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)
+        invoice2 = self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)
+
+        self.partner_a.email = None
+        self.partner_b.email = None
+        wizard = self.create_send_and_print(invoice1 + invoice2)
+
+        self.assertTrue('account_missing_email' in wizard.alerts)
+        self.assertEqual(wizard.alerts['account_missing_email']['level'], 'warning')
+        wizard.action_send_and_print()
+        self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
+        # invoices are generated, and no partner got an email, without raising any errors
+        self.assertTrue(invoice1.invoice_pdf_report_id)
+        self.assertFalse(self._get_mail_message(invoice1))
+        self.assertTrue(invoice2.invoice_pdf_report_id)
+        self.assertFalse(self._get_mail_message(invoice2))
+        self.assertFalse(invoice1.is_move_sent)
+        self.assertFalse(invoice2.is_move_sent)
+
+        self.partner_a.email = "turlututu@tsointsoin"
+        self.partner_b.email = "turlututu@tsointsoin"
+
+        wizard.action_send_and_print()
+        self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
+        # invoices are generated, and both partners got an email, without raising any errors
+        self.assertTrue(invoice1.invoice_pdf_report_id)
+        self.assertTrue(self._get_mail_message(invoice1))
+        self.assertTrue(invoice2.invoice_pdf_report_id)
+        self.assertTrue(self._get_mail_message(invoice2))
+        self.assertTrue(invoice1.is_move_sent)
+        self.assertTrue(invoice2.is_move_sent)
 
     def test_invoice_multi_cron_disabled_alert(self):
         invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -105,13 +105,25 @@ class AccountMoveSendBatchWizard(models.TransientModel):
             'author_partner_id': self.env.user.partner_id.id,
         }
         account_move_send_cron._trigger()
-        return {
-            'type': 'ir.actions.client',
-            'tag': 'display_notification',
-            'params': {
-                'type': 'info',
-                'title': _('Sending invoices'),
-                'message': _('Invoices are being sent in the background.'),
-                'next': {'type': 'ir.actions.act_window_close'},
-            },
-        }
+        if any(move.partner_id.email for move in self.move_ids):
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'info',
+                    'title': _('Sending invoices'),
+                    'message': _('Invoices are being sent in the background.'),
+                    'next': {'type': 'ir.actions.act_window_close'},
+                },
+            }
+        else:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'info',
+                    'title': _('Generating invoices'),
+                    'message': _('Invoices are being generated in the background.'),
+                    'next': {'type': 'ir.actions.act_window_close'},
+                },
+            }


### PR DESCRIPTION
Fixed an issue where mass sending entries would set the sent status to true even if it's not actually sent to the customer

task-6060589