### PR TITLE
[FIX] website: unfold `s_share`'s options when clicking one of its icons

### DIFF
--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -171,10 +171,10 @@ class SocialMediaOptionPlugin extends Plugin {
             ".s_social_media a > i",
             ".s_social_media .s_social_media_title",
         ],
-        auto_unfold_container_providers: {
-            selector: ".s_social_media > a > *",
-            target: ".s_social_media",
-        },
+        auto_unfold_container_providers: [
+            { selector: ".s_social_media > a > *", target: ".s_social_media" },
+            { selector: ".s_share > a > *", target: ".s_share" },
+        ],
     };
 
     /** The social media's name for which there is an entry in the orm */


### PR DESCRIPTION
Commit 10e87773afb92c67ee126460bb899b358869345e added the possibility to unfold the options of an ancestor of the target (in addition to the target's options).

This commit adds that behavior to unfold the `s_share` snippet's options when the user clicks on one of the icon inside.

task-5999383
