### PR TITLE
[FIX] crm: give priority to leads with high probabilty

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -614,12 +614,15 @@ class CrmTeam(models.Model):
             ['id:array_agg'],
         ))
 
-        def _assign_lead(lead, members, member_leads, members_quota, assign_lst, optional_lst=None):
+        def _assign_lead(lead, members_to_assign, leads_per_member, preferred_leads_per_member, quota_per_member):
             """ Find relevant member whose domain(s) accept the lead. If found convert
             and update internal structures accordingly. """
-            member_found = next((member for member in members if lead in member_leads[member]), False)
+            member_found = next((member for member in members_to_assign if lead in preferred_leads_per_member.get(member, [])), False)
             if not member_found:
-                return
+                member_found = next((member for member in members_to_assign if lead in leads_per_member.get(member, [])), False)
+                if not member_found:
+                    return
+
             lead.with_context(mail_auto_subscribe_no_notify=True).convert_opportunity(
                 lead.partner_id,
                 user_ids=member_found.user_id.ids
@@ -627,14 +630,10 @@ class CrmTeam(models.Model):
             result_data[member_found]['assigned'] += lead
 
             # if member still has quota, move at end of list; otherwise just remove
-            assign_lst.remove(member_found)
-            if optional_lst is not None:
-                optional_lst.remove(member_found)
-            members_quota[member_found] -= 1
-            if members_quota[member_found] > 0:
-                assign_lst.append(member_found)
-                if optional_lst is not None:
-                    optional_lst.append(member_found)
+            members_to_assign.remove(member_found)
+            quota_per_member[member_found] -= 1
+            if quota_per_member[member_found] > 0:
+                members_to_assign.append(member_found)
             return member_found
 
         for team, leads_to_assign_ids in leads_per_team.items():
@@ -651,6 +650,10 @@ class CrmTeam(models.Model):
             # Previous iteration has committed the change, records may have been deleted in the meanwhile
             to_assign = self.env['crm.lead'].browse(leads_to_assign_ids).exists()
 
+            leads_per_member = {
+                member: to_assign.filtered_domain(literal_eval(member.assignment_domain or '[]'))
+                for member in members_to_assign
+            }
             members_to_assign_wpref = [
                 m for m in members_to_assign
                 if m.assignment_domain_preferred and literal_eval(m.assignment_domain_preferred or '')
@@ -663,30 +666,12 @@ class CrmTeam(models.Model):
                     ])
                 ) for member in members_to_assign_wpref
             }
-            preferred_leads = self.env['crm.lead'].concat(*[lead for lead in preferred_leads_per_member.values()])
-            assigned_preferred_leads = self.env['crm.lead']
 
-            # first assign loop: preferred leads, always priority
-            for lead in preferred_leads.sorted(lambda lead: (-lead.probability, id)):
-                counter += 1
-                member_found = _assign_lead(lead, members_to_assign_wpref, preferred_leads_per_member, quota_per_member, members_to_assign, members_to_assign_wpref)
-                if not member_found:
-                    continue
-                assigned_preferred_leads += lead
-                if auto_commit and counter % commit_bundle_size == 0:
-                    self.env.cr.commit()
-
-            # second assign loop: fill up with other leads
-            to_assign = to_assign - assigned_preferred_leads
-            leads_per_member = {
-                member: to_assign.filtered_domain(literal_eval(member.assignment_domain or '[]'))
-                for member in members_to_assign
-            }
             for lead in to_assign.sorted(lambda lead: (-lead.probability, id)):
-                counter += 1
-                member_found = _assign_lead(lead, members_to_assign, leads_per_member, quota_per_member, members_to_assign)
+                member_found = _assign_lead(lead, members_to_assign, leads_per_member, preferred_leads_per_member, quota_per_member)
                 if not member_found:
                     continue
+                counter += 1
                 if auto_commit and counter % commit_bundle_size == 0:
                     self.env.cr.commit()
 
@@ -696,10 +681,6 @@ class CrmTeam(models.Model):
             # Once we are done with a team we don't need to keep the leads in memory
             # Try to avoid to explode memory usage
             self.env.invalidate_all()
-            _logger.info(
-                'Team %s: Assigned %s leads based on preference, on a potential of %s (limited by quota)',
-                team.name, len(assigned_preferred_leads), len(preferred_leads)
-            )
         _logger.info(
             'Assigned %s leads to %s salesmen',
             sum(len(r['assigned']) for r in result_data.values()), len(result_data)

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -462,6 +462,58 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertMemberAssign(test_sales_team_m2, 3)
         self.assertMemberAssign(test_sales_team_m3, 3)
 
+    def test_assign_preferred_and_probability(self):
+        random.seed(1914)
+        preferred_tag = self.env['crm.tag'].create({'name': 'preferred'})
+        leads = self._create_leads_batch(
+            lead_type='lead',
+            user_ids=[False],
+            count=10,
+        )
+        for proba, lead in enumerate(leads[:5]):
+            lead.write({
+                'tag_ids': [(6, 0, preferred_tag.ids)],
+                'probability': proba,
+            })
+
+        for proba, lead in enumerate(leads[5:]):
+            lead.write({
+                'probability': proba,
+            })
+            proba += 1
+
+        leads.flush_recordset()
+
+        test_sales_team = self.env['crm.team'].create({
+            'name': 'Sales Team 5',
+            'sequence': 15,
+            'alias_name': False,
+            'use_leads': True,
+            'use_opportunities': True,
+            'company_id': False,
+            'user_id': False,
+        })
+        test_sales_team_m1 = self.env['crm.team.member'].create({
+            'user_id': self.user_sales_manager.id,
+            'crm_team_id': test_sales_team.id,
+            'assignment_max': 180,
+            'assignment_domain': False,
+            'assignment_domain_preferred': "[('tag_ids', 'in', %s)]" % preferred_tag.ids,
+        })
+
+        test_sales_team._action_assign_leads()
+
+        member_leads = self.env['crm.lead'].search([
+            ('user_id', '=', test_sales_team_m1.user_id.id),
+            ('team_id', '=', test_sales_team_m1.crm_team_id.id),
+            ('date_open', '>=', Datetime.now() - timedelta(hours=24)),
+        ])
+        self.assertEqual(
+                len(member_leads.filtered_domain(literal_eval(test_sales_team_m1.assignment_domain_preferred))),
+                3
+            )
+        self.assertMemberAssign(test_sales_team_m1, 6)
+
     def test_assign_quota(self):
         """ Test quota computation """
         self.assertInitialData()


### PR DESCRIPTION
Since we've added the preferred domain field, the leads are firstly assigned to members matching the preffered domain. The issue with this behavor is that a memeber with prefered domain can get a lot of leads with low probability because they match his preferred domain.

So we process the leads in the order of probabilities and if it match a preferred domain, it'll be assigned to the member, and if not we choose one without the matching preferred domain.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
