### PR TITLE
[FIX] spreadsheet: treemap chart without data

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_datasource.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_datasource.js
@@ -15,7 +15,7 @@ const { CHART_TYPES } = constants;
 const EXCLUDED_CHART_TYPES = ["scorecard", "gauge", "calendar"];
 
 function generateDataSetId(dataSource, dataSet) {
-    const identifiers = JSON.parse([...dataSet.identifiers][0]);
+    const identifiers = JSON.parse([...dataSet.identifiers][0] ?? "[]");
     const mainAxis = dataSource.metaData.groupBy[0];
     const dataSetId = identifiers
         .slice(1) // first groupBy is the horizontal axis

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -1265,6 +1265,39 @@ test("See records when clicking on a sunburst chart slice", async () => {
     ]);
 });
 
+test("treemap without any data", async () => {
+    const serverData = getBasicServerData();
+    serverData.models.partner.records = [];
+    const { model } = await createSpreadsheetWithChart({
+        type: "treemap",
+        serverData,
+        definition: {
+            type: "treemap",
+            dataSource: {
+                type: "odoo",
+                metaData: {
+                    groupBy: ["date:month", "bar"],
+                    measure: "probability",
+                    order: null,
+                    resModel: "partner",
+                },
+                searchParams: { context: {}, domain: [], groupBy: [], orderBy: [] },
+            },
+            title: { text: "Partners" },
+            dataSourceId: "42",
+            id: "42",
+        },
+    });
+    const sheetId = model.getters.getActiveSheetId();
+    const chartId = model.getters.getChartIds(sheetId)[0];
+    await waitForDataLoaded(model);
+    const runtime = model.getters.getChartRuntime(chartId);
+    expect(runtime.chartJsConfig.data).toMatchObject({
+        labels: [],
+        datasets: [{ data: [], tree: [] }],
+    });
+});
+
 test("See records when clicking on a treemap chart item", async () => {
     let lastActionCalled = undefined;
     const fakeActionService = {


### PR DESCRIPTION
Steps to reproduce:
- go to any chart view
- insert the chart into a spreadsheet
- edit the domain such that no data matches the domain
- change the chart type to "treemap" ⮕ boom SyntaxError: "undefined" is not valid JSON

Task-6127130



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
