### PR TITLE
[FIX] pos_viva_com: keep polling on connection loss during payment

### DIFF
--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -145,21 +145,42 @@ export class PaymentVivaCom extends PaymentInterface {
         return new Promise((resolve) => {
             const sessionId = paymentLine.uiState.vivaSessionId;
             this.paymentLineResolvers[paymentLine.uuid] = resolve;
+            let connectionLost = false;
             const intervalId = setInterval(async () => {
                 const isPaymentStillValid = () =>
                     this.paymentLineResolvers[paymentLine.uuid] &&
-                    paymentLine.payment_status === "waitingCard" &&
                     sessionId === paymentLine.uiState.vivaSessionId;
                 if (!isPaymentStillValid()) {
                     clearInterval(intervalId);
                     return;
                 }
 
-                const result = await this._call_viva_com(
-                    sessionId,
-                    "viva_com_get_payment_status",
-                    paymentLine
-                );
+                let result;
+                try {
+                    // Use a direct silent ORM call instead of _call_viva_com
+                    // so that _handleOdooConnectionFailure is NOT triggered
+                    // during polling (no error dialog spam).
+                    result = await this.env.services.orm.silent.call(
+                        "pos.payment.method",
+                        "viva_com_get_payment_status",
+                        [[this.payment_method_id.id], sessionId]
+                    );
+                } catch {
+                    // Connection failure during polling — the payment may have
+                    // gone through on Viva's side. Keep polling silently until
+                    // we get a definitive answer.
+                    if (!connectionLost) {
+                        connectionLost = true;
+                        this.env.services.notification.add(
+                            _t(
+                                "No internet connection. Waiting for recovery to confirm the payment..."
+                            ),
+                            { type: "warning" }
+                        );
+                    }
+                    return;
+                }
+                connectionLost = false;
                 if ("success" in result && isPaymentStillValid()) {
                     clearInterval(intervalId);
                     if (this.isPaymentSuccessful(result)) {


### PR DESCRIPTION
When a payment was sent to Viva.com and the connection dropped before receiving confirmation, the polling loop in waitForPaymentConfirmation would stop because _handleOdooConnectionFailure set the payment status to "retry" and rejected the promise. This left the payment debited on Viva's side but unconfirmed in the POS.

Now the polling uses a direct silent ORM call instead of _call_viva_com to avoid triggering _handleOdooConnectionFailure. On connection failure, the poll silently retries on the next interval until a definitive success/failure response is received. A one-time warning notification informs the user that connectivity was lost.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
