### PR TITLE
[FIX] account: recompute dependent taxes after removing base-affecting tax

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1428,6 +1428,7 @@ class AccountTax(models.Model):
             results['computation_key'] = extra_tax_data['computation_key']
 
         manual_tax_amounts = extra_tax_data.get('manual_tax_amounts') or {} if extra_tax_data else None
+        extra_tax_data_tax_ids = set(manual_tax_amounts or {})
         sorted_taxes = base_line['tax_ids']._flatten_taxes_and_sort_them()[0]
         if (
             extra_tax_data
@@ -1436,7 +1437,8 @@ class AccountTax(models.Model):
             and base_line['currency_id'].compare_amounts(base_line['price_unit'], extra_tax_data['price_unit']) == 0
             and base_line['currency_id'].compare_amounts(base_line['discount'], extra_tax_data['discount']) == 0
             and base_line['currency_id'].compare_amounts(base_line['quantity'], extra_tax_data['quantity']) == 0
-            and all(str(tax.id) in extra_tax_data['manual_tax_amounts'] for tax in sorted_taxes)
+            and len(sorted_taxes) == len(extra_tax_data_tax_ids)
+            and all(str(tax.id) in extra_tax_data_tax_ids for tax in sorted_taxes)
         ):
             results['price_unit'] = extra_tax_data['price_unit']
 

--- a/addons/sale/tests/test_taxes_downpayment.py
+++ b/addons/sale/tests/test_taxes_downpayment.py
@@ -1018,3 +1018,36 @@ class TestTaxesDownPaymentSale(TestTaxCommonSale, TestTaxesDownPayment):
             {'price_subtotal': 1070.71, 'balance': -1070.71},
             {'price_subtotal': -70.71, 'balance': 70.71},
         ])
+
+    def test_down_payment_invoice_manual_removing_of_tax_affecting_subsequent_taxes(self):
+        """
+        Test that removing a tax from a down payment invoice correctly recomputes remaining taxes.
+        This ensures that cached manual_tax_amounts are not reused when the tax set changes,
+        particularly for taxes with "Affect Base of Subsequent Taxes", and that dependent
+        taxes are recomputed using the updated base instead of stale values.
+        """
+        product = self.company_data['product_order_cost']
+        tax_10_a = self.percent_tax(10.0, include_base_amount=True)
+        tax_10_b = self.percent_tax(10.0)
+
+        product = self._create_product(list_price=100.0, taxes_id=tax_10_a + tax_10_b)
+        so = self._create_sale_order_one_line(product_id=product, confirm=True)
+        self.assertRecordValues(so, [{
+            'amount_untaxed': 100.0,
+            'amount_tax': 21.0,
+            'amount_total': 121.0,
+        }])
+
+        dp_invoice = self._create_down_payment_invoice(so, 'percent', 50)
+        self.assertRecordValues(dp_invoice, [{
+            'amount_untaxed': 50.0,
+            'amount_tax': 10.5,
+            'amount_total': 60.5,
+        }])
+
+        dp_invoice.invoice_line_ids.tax_ids = [Command.set(tax_10_b.ids)]
+        self.assertRecordValues(dp_invoice, [{
+            'amount_untaxed': 50.0,
+            'amount_tax': 5.0,
+            'amount_total': 55.0,
+        }])

--- a/addons/sale/tests/test_taxes_downpayment.py
+++ b/addons/sale/tests/test_taxes_downpayment.py
@@ -1018,3 +1018,58 @@ class TestTaxesDownPaymentSale(TestTaxCommonSale, TestTaxesDownPayment):
             {'price_subtotal': 1070.71, 'balance': -1070.71},
             {'price_subtotal': -70.71, 'balance': 70.71},
         ])
+
+    def test_down_payment_invoice_manual_removing_of_tax_affecting_subsequent_taxes(self):
+        """
+        Test that removing a tax from a down payment invoice correctly recomputes remaining taxes.
+        This ensures that cached manual_tax_amounts are not reused when the tax set changes,
+        particularly for taxes with "Affect Base of Subsequent Taxes", and that dependent
+        taxes are recomputed using the updated base instead of stale values.
+        """
+        product = self.company_data['product_order_cost']
+        tax_10_a = self.percent_tax(10.0)
+        tax_10_a.include_base_amount = True
+        tax_10_b = self.percent_tax(10.0)
+        tax_10_b.sequence = tax_10_a.sequence + 1
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': 'line_1',
+                    'product_id': product.id,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set((tax_10_a + tax_10_b).ids)],
+                }),
+            ],
+        })
+        so.action_confirm()
+        self.assertRecordValues(so, [{
+            'amount_untaxed': 100.0,
+            'amount_tax': 21.0,
+            'amount_total': 121.0,
+        }])
+
+        wizard = (
+            self.env['sale.advance.payment.inv']
+            .with_context(active_model=so._name, active_ids=so.ids)
+            .create({
+                'advance_payment_method': 'percentage',
+                'amount': 50,
+            })
+        )
+        action_values = wizard.create_invoices()
+
+        dp_invoice = self.env['account.move'].browse(action_values['res_id'])
+        self.assertRecordValues(dp_invoice, [{
+            'amount_untaxed': 50.0,
+            'amount_tax': 10.5,
+            'amount_total': 60.5,
+        }])
+
+        dp_invoice.invoice_line_ids.tax_ids = [Command.set(tax_10_b.ids)]
+        self.assertRecordValues(dp_invoice, [{
+            'amount_untaxed': 50.0,
+            'amount_tax': 5.0,
+            'amount_total': 55.0,
+        }])


### PR DESCRIPTION

**Steps to reproduce:**
* Install the *Accounting* module with French localization (*l10n_fr_account*).
* Create a *Sales Tax* with:
  * A new tax group (e.g., 'Codifab').
  * Enable *Affect Base of Subsequent Taxes*.
* Create a *Sales Order*:
  * Add the first tax (with *Affect Base of Subsequent Taxes*).
  * Then add the second tax (eg VAT tax).
* Confirm the *Sales Order*.
* Create a *Down Payment Invoice* (percentage-based).
* Open the generated invoice and:
  * Remove the first tax (the one affecting the base).

**Observed behavior:**
* The amount of the second tax group does not update after removing the first tax, leading to incorrect tax computation.

**Cause:**
* In `_import_base_line_extra_tax_data`, the condition: `all(str(tax.id) in extra_tax_data['manual_tax_amounts'] for tax in sorted_taxes)` only ensured partial matching of taxes.
* This allowed reuse of stale `manual_tax_amounts` when taxes were removed or modified, causing incorrect base values for dependent taxes (e.g., *Affect Base of Subsequent Taxes*).

**Fix:**
* Update the condition to enforce an exact match between current taxes and cached `manual_tax_amounts` by checking both size and membership.
* Prevent reuse of outdated tax data when taxes change, ensuring proper recomputation of dependent taxes.
* Align Python logic with the JS implementation for consistency between `account_tax.py` and `account_tax.js`.

opw-6063970