### PR TITLE
[IMP] l10n_be_hr_payroll, hr_payroll, hr_work_entry_attendance: Add f…

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -160,8 +160,10 @@ class HrAttendanceOvertimeRule(models.Model):
         employee = attendances.employee_id
         company = self.company_id or employee.company_id
         if company.absence_management and float_compare(overtime_amount, -self.employee_tolerance, 5) == -1:
-            last_attendance = sorted(intervals_attendance_by_attendance.keys(), key=lambda att: att.check_out)[-1]
-            return {}, {last_attendance: [(overtime_amount, self)]}
+            if intervals_attendance_by_attendance:
+                last_attendance = sorted(intervals_attendance_by_attendance.keys(), key=lambda att: att.check_out)[-1]
+                return {}, {last_attendance: [(overtime_amount, self)]}
+            return {}, {}
 
         if float_compare(overtime_amount, self.employer_tolerance, 5) != 1:
             return {}, {}

--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -1,6 +1,22 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
+from odoo import api
+
+MONTHS_SELECTION = [
+    ('1', 'January'),
+    ('2', 'February'),
+    ('3', 'March'),
+    ('4', 'April'),
+    ('5', 'May'),
+    ('6', 'June'),
+    ('7', 'July'),
+    ('8', 'August'),
+    ('9', 'September'),
+    ('10', 'October'),
+    ('11', 'November'),
+    ('12', 'December'),
+]
 
 
 class HrAttendanceOvertimeRuleset(models.Model):
@@ -30,6 +46,39 @@ class HrAttendanceOvertimeRuleset(models.Model):
             "    e.g.: combined rate for 150% & 120% = 100% (baseline) + (150-100)% + (120-100)% = 170%\n"
         ),
     )
+    max_positive_hours = fields.Float(
+        string="Maximum Positive Hours",
+        default=0.0,
+        help="Maximum number of hours per month that will be counted as positive hours. "
+             "Hours above this limit will not be counted. Set to 0 for unlimited.",
+    )
+    max_negative_hours = fields.Float(
+        string="Maximum Negative Hours",
+        default=0.0,
+        help="Maximum negative hours (undertime) per month allowed without salary deduction. "
+             "Employee keeps full salary if negative hours are within this limit. Set to 0 for unlimited.",
+    )
+    l10n_be_flexibility_type = fields.Selection([
+        ('none', 'None'),
+        ('small_flexibility', 'Small Flexibility'),
+        ('floating', 'Floating Hours'),
+    ], string="Flexibility Type", default='none',
+        help="Select the applicable regime: 'Small Flexibility' for employer-planned high/low cycles "
+             "(constant salary), or 'Floating Hours' for employee autonomy within core hours "
+             "(subject to potential salary deductions).")
+
+    l10n_be_flexibility_reference_month = fields.Selection(
+        MONTHS_SELECTION,
+        string="Reference Month",
+        default='1',
+        help="The month marking the start of the reference period for Small Flexibility.")
+
+    l10n_be_flexibility_reference_period = fields.Selection([
+        ('monthly', 'Monthly'),
+        ('quarterly', 'Quarterly'),
+        ('annually', 'Annually'),
+    ], string="Reference Period", default='quarterly',
+        help="The period at the end of which the flexibility balance is evaluated.")
     rules_count = fields.Integer(compute='_compute_rules_count')
     active = fields.Boolean(default=True, readonly=False)
     version_ids = fields.One2many('hr.version', 'ruleset_id')
@@ -83,3 +132,8 @@ class HrAttendanceOvertimeRuleset(models.Model):
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
         return [dict(vals, name=self.env._("%s (copy)", ruleset.name)) for ruleset, vals in zip(self, vals_list)]
+
+    # @api.onchange('l10n_be_flexibility_type')
+    # def _onchange_l10n_be_flexibility_type(self):
+    #     if self.l10n_be_flexibility_type == 'small_flexibility':
+    #         self.absence_management = True

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -135,6 +135,13 @@
                             <field name="country_id" options="{'no_create': True, 'no_open': True}" groups="base.group_multi_company"/>
                         </group>
                     </group>
+                    <group>
+                        <field name="max_negative_hours" widget="float_time"/>
+                        <field name="max_positive_hours" widget="float_time"/>
+                        <field name="l10n_be_flexibility_type"/>
+                        <field name="l10n_be_flexibility_reference_month" invisible="l10n_be_flexibility_type != 'small_flexibility'"/>
+                        <field name="l10n_be_flexibility_reference_period" invisible="l10n_be_flexibility_type == 'none'"/>
+                    </group>
                     <group colspan="4">
                         <field 
                             name="description" colspan="4"
@@ -166,6 +173,8 @@
                 <field name="name"/>
                 <field name="country_id" groups="base.group_multi_company" optional="hide"/>
                 <field name="rate_combination_mode" string="Rate Mode"/>
+                <field name="max_positive_hours" widget="float_time"/>
+                <field name="max_negative_hours" widget="float_time"/>
                 <field name="rules_count"/>
             </list>
         </field>


### PR DESCRIPTION
…lexibility hours management (Small Flexibility & Floating Hours)

This feature implements two flexible working hour regimes for Belgian employees:

Small Flexibility: Employer-planned cycles where employees receive constant salary regardless of hours worked. Overtime is only paid at the end of the reference period—extra hours get paid, but undertime doesn't result in deductions.

Floating Hours: Employee-controlled flexibility with carry-over caps (default 12h). Hours within limits carry forward; excess positive hours are lost, and excess negative hours are deducted from salary.

Changes: I created a new model called "Flexibility Hours" where each record represents the hours that an employee currently has for the current payslip. If the type is "Overtime," then the current payslip will have overtime hours equal to the sum of all flexibility hours related to this payslip. If it's "Deduction," it will be the same but will be deducted. If it's "Carry-over," that means the payslip is not at the end of the period yet, so we will save all the flexibility hours of that payslip as carry-over to be counted in the next one. We also extended the Belgian payroll settings to have the configuration for flexible hours.

To manually test flexible hours, best way to first enable the flexible hours option in the settings. Then set the Work Source Entry to “Attendance.” Next, go to the Employee Settings tab and set the Overtime Ruleset field to empty. After that, open the Attendance app. You will then be able to enter working hours manually, and those hours will follow the flexible hours rules.

Task Id: 5486144

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
