### PR TITLE
[FIX] orm: validate domain with search_domain=False

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -416,7 +416,8 @@ class Domain:
     def validate(self, model: BaseModel) -> None:
         """Validates that the current domain is correct or raises an exception"""
         # just execute the optimization code that goes through all the fields
-        self._optimize(model, OptimizationLevel.FULL)
+        # the search domain is set to False to avoid performing searches
+        self._optimize(model.with_context(search_domain=Domain.FALSE), OptimizationLevel.FULL)
 
     def _as_predicate[M: BaseModel](self, records: M) -> Callable[[M], bool]:
         """Return a predicate function from the domain (bound to records).


### PR DESCRIPTION
When validating the domain, avoid searching for all attachments. The `search_domain` context indicates the user's search, we can set it to false for validation of the domain which avoids trying to fetch all records in ir.attachments when validating the security domain.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
