### PR TITLE
[REM] readme: remove runbot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Odoo
 
-[![Build Status](https://runbot.odoo.com/runbot/badge/flat/1/master.svg)](https://runbot.odoo.com/runbot)
 [![Documentation](https://img.shields.io/badge/master-docs-875A7B.svg?style=flat&colorA=8F8F8F)](https://www.odoo.com/documentation/17.0)
 [![Help](https://img.shields.io/badge/master-help-875A7B.svg?style=flat&colorA=8F8F8F)](https://www.odoo.com/forum/help-1)
 [![Nightly Builds](https://img.shields.io/badge/master-nightly-875A7B.svg?style=flat&colorA=8F8F8F)](https://nightly.odoo.com/)


### PR DESCRIPTION
The badge was most likely useful at some point to determine if the current version was green but with mergebot, it should in theory always be green and if red, it will be for a random error. Moreover, the master one is referenced in all versions since it is not adapted when freezing.

The added value of this badge is low while forcing to maintain it in the runbot code base, we can remove it..