### PR TITLE
[FIX] web: prevent text cropping in badge tags

### DIFF
--- a/addons/web/static/src/core/tags_list/badge_tag.js
+++ b/addons/web/static/src/core/tags_list/badge_tag.js
@@ -27,7 +27,7 @@ export class BadgeTag extends Component {
 
     get cssClass() {
         return mergeClasses(
-            `o_badge badge rounded-pill lh-1 ${this.tagColorClass}`,
+            `o_badge badge rounded-pill ${this.tagColorClass}`,
             { "cursor-pointer": this.props.onClick },
             this.props.cssClass
         );

--- a/addons/web/static/src/core/tags_list/badge_tag.xml
+++ b/addons/web/static/src/core/tags_list/badge_tag.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BadgeTag">
-        <span class="o_tag position-relative d-inline-flex align-items-center user-select-none mw-100 o_badge badge rounded-pill lh-1" tabindex="-1" t-att-class="this.cssClass" t-att-data-color="this.props.color" t-att-data-tooltip="this.props.tooltip or this.props.text" t-att-aria-label="this.props.tooltip or this.props.text" t-on-click="(ev) => this.props.onClick?.(ev)" t-custom-ref="ref">
+        <span class="o_tag position-relative d-inline-flex align-items-center user-select-none mw-100 o_badge badge rounded-pill" tabindex="-1" t-att-class="this.cssClass" t-att-data-color="this.props.color" t-att-data-tooltip="this.props.tooltip or this.props.text" t-att-aria-label="this.props.tooltip or this.props.text" t-on-click="(ev) => this.props.onClick?.(ev)" t-custom-ref="ref">
             <t t-slot="default">
                 <div class="o_tag_badge_text o_badge_text" t-out="this.props.text"/>
             </t>


### PR DESCRIPTION
Text inside badges/chips containing letters with descenders (like 'g', 'p', 'y', 'q') were getting visually cropped at the bottom.
This PR removes the `lh-1` class from both `badge_tag.js` and `badge_tag.xml` to allow the font's natural line height to accommodate the full character shapes.

**Task: 6022948**