### PR TITLE
[FIX] website: avoid persisting legacy cookies bar value

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -541,8 +541,6 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @private
      */
     _toggleCookiesBar() {
-        this.cookieValue = cookie.get(this.el.id);
-
         const popupEl = this.el.querySelector(".modal");
         $(popupEl).modal("toggle");
         // As we're using Bootstrap's events, the PopupWidget prevents the modal
@@ -609,6 +607,11 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @override
      */
     _onHideModal() {
+        // cookieValue starts as true and is only replaced after consent.
+        // If it is still true here, the modal closed without a choice.
+        if (this.cookieValue === true) {
+            return;
+        }
         this._super(...arguments);
         const params = new URLSearchParams(window.location.search);
         const trackingFields = {


### PR DESCRIPTION
Steps to reproduce:
- Set the cookies bar
- Do not accept nor reject it
- On the website homepage, click on the search button => Check the cookies: website_cookies_bar=true is set.

`Popup` initializes `cookieValue` to `true` and writes it in `onHideModal()`. If the cookies bar is closed before any explicit consent choice, it can therefore recreate the legacy invalid value `website_cookies_bar=true`.

This happens because the search button uses `data-bs-toggle="modal"`, which is controlled by Bootstrap: if it is opened while another bootstrap modal is already open on the page, the latter is hidden. This in turn calls the popup interaction's `onHideModal()`, which sets `website_cookies_bar=true` as `cookieValue` hasn't been changed.

That value is later treated as invalid and cleared repeatedly during website rendering, which can accumulate duplicate `Set-Cookie` headers in the same response and lead to `upstream sent too big header` behind nginx.

Avoid persisting that legacy value by returning early from `CookiesBar.onHideModal()` while `cookieValue` is still the inherited default `true`.

opw-6037573

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Backport of: https://github.com/odoo/odoo/pull/258938