### PR TITLE
[IMP] mail, portal: access params in the mail fetch route

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -1,9 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 
+from odoo.fields import Domain
 from odoo.http import request
 
 from odoo.addons.mail.controllers.thread import ThreadController
+from odoo.addons.mail.models.mail_message import SHARE_DOMAIN
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tools.store_handler import store_handler
 
@@ -121,18 +123,35 @@ class WebclientController(ThreadController):
             lost.sudo().unlink()  # no unlink right except admin, ok to remove as lost anyway
         store.add(valid.mail_message_id, "_store_notification_fields")
 
-    @store_handler("/mail/thread/messages", audience="logged_in", readonly=False)
-    def store_get_thread_messages(self, store: Store, thread_model, thread_id, fetch_params=None):
+    @store_handler("/mail/thread/messages", audience="everyone", readonly=False)
+    def store_get_thread_messages(
+        self,
+        store: Store,
+        thread_model,
+        thread_id,
+        fetch_params=None,
+        access_params=None,
+    ):
         request.update_context(add_chatter_fields=True)
         if thread := self._get_thread_with_access(
             thread_model,
             thread_id,
             mode="read",
+            **(access_params or {}),
         ):
+            domain = Domain.TRUE
+            if not request.env.user._is_internal() or not thread.sudo(False).has_access("read"):
+                domain = (
+                    SHARE_DOMAIN
+                    & Domain("message_type", "in", thread._get_customer_portal_message_types())
+                    & ~request.env["mail.message"]._get_empty_domain()
+                )
             messages = self._resolve_messages(
                 store,
+                domain=domain,
                 thread=thread,
                 fetch_params=fetch_params,
+                sudo=thread.env.su,
             )
             if not request.env.user._is_public():
                 messages.set_message_done()

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 
+from odoo.fields import Domain
 from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.mail.tools.discuss import mail_route, Store
@@ -109,6 +110,22 @@ class WebclientController(ThreadController):
                 message = opt_sudo.poll_id.start_message_id
                 if self._get_thread_with_access(message.model, message.res_id, mode="read"):
                     store.add(opt_sudo.vote_ids, "_store_vote_fields")
+        if name == "/mail/thread/messages":
+            if thread := self._get_thread_with_access(
+                params["thread_model"],
+                params["thread_id"],
+                mode="read",
+                **params.get("access_params", {}),
+            ):
+                messages = self._resolve_messages(
+                    store,
+                    domain=self._get_fetch_domain(thread, **params),
+                    thread=thread,
+                    fetch_params=params.get("fetch_params"),
+                    sudo=thread.env.su,
+                )
+                if not request.env.user._is_public():
+                    messages.set_message_done()
 
     @classmethod
     def _process_request_for_logged_in_user(self, store: Store, name, params):
@@ -139,19 +156,6 @@ class WebclientController(ThreadController):
             if lost:
                 lost.sudo().unlink()  # no unlink right except admin, ok to remove as lost anyway
             store.add(valid.mail_message_id, "_store_notification_fields")
-        if name == "/mail/thread/messages":
-            if thread := self._get_thread_with_access(
-                params["thread_model"],
-                params["thread_id"],
-                mode="read",
-            ):
-                messages = self._resolve_messages(
-                    store,
-                    thread=thread,
-                    fetch_params=params.get("fetch_params"),
-                )
-                if not request.env.user._is_public():
-                    messages.set_message_done()
 
     @classmethod
     def _process_request_for_internal_user(self, store: Store, name, params):
@@ -230,3 +234,32 @@ class WebclientController(ThreadController):
             ),
         )
         return messages
+
+    @classmethod
+    def _get_non_empty_message_domain(self):
+        return (
+            Domain("body", "!=", False)
+            & Domain(
+                "body",
+                "not =like",
+                '<span class="o-mail-Message-edited" data-o-datetime="%"></span>',
+            )
+        ) | Domain("attachment_ids", "!=", False)
+
+    @classmethod
+    def _should_apply_share_domain(self, thread, **kwargs):
+        """Determines if the share domain should be applied based on context of fetch."""
+        return not request.env.user._is_internal() or not thread.sudo(False).has_access("read")
+
+    @classmethod
+    def _get_fetch_domain(self, thread, **kwargs):
+        """Defines the fetch domain and restricts the fetched messages by user type. As a security
+        matter, non-internal users can only read the messages with non-internal subtypes. This early
+        check ensures that they won't pass the ACL, even if they are superusers.
+        """
+        if self._should_apply_share_domain(thread, **kwargs):
+            return (
+                request.env["mail.message"]._get_share_domain()
+                & self._get_non_empty_message_domain()
+            )
+        return Domain.TRUE

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -521,10 +521,14 @@ class MailMessage(models.Model):
 
         return domain
 
+    def _get_share_domain(self):
+        """Raw domain for shared content."""
+        return Domain("is_internal", "=", False) & Domain("subtype_id.internal", "=", False)
+
     def _get_search_domain_share(self):
         if self.env.user._is_internal():
             return Domain.TRUE
-        return Domain('is_internal', '=', False) & Domain('subtype_id.internal', '=', False)
+        return self._get_share_domain()
 
     def _filter_accessible_from_query(self, query: models.Query, operation: str) -> Self:
         """ Return the subset of ``self`` that satisfies the specific conditions

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -603,7 +603,7 @@ export class Thread extends Record {
         return {
             thread_id: this.id,
             thread_model: this.model,
-            ...this.rpcParams,
+            ...(Object.keys(this.rpcParams).length > 0 && { access_params: this.rpcParams }),
         };
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -593,7 +593,7 @@ export class Thread extends Record {
         return {
             thread_id: this.id,
             thread_model: this.model,
-            ...this.rpcParams,
+            ...(Object.keys(this.rpcParams).length > 0 && { access_params: this.rpcParams }),
         };
     }
 

--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -39,12 +39,14 @@ class PortalWebClientController(WebclientController):
         thread_model,
         thread_id,
         fetch_params=None,
+        access_params=None,
         **params,
     ):
+        access_params = access_params or {}
         thread = ThreadController._get_thread_with_access(
             thread_model,
             thread_id,
-            token=params.get('token'),
+            token=access_params.get('token'),
         )
         if not thread:
             return
@@ -52,7 +54,7 @@ class PortalWebClientController(WebclientController):
             thread,
             _hash=None,
             pid=None,
-            token=params.get("token"),
+            token=access_params.get("token"),
         ):
             request.update_context(
                 portal_data={"portal_partner": portal_partner, "portal_thread": thread},
@@ -79,7 +81,6 @@ class PortalWebClientController(WebclientController):
         thread_id,
         thread_model,
         access_params=None,
-        **params,
     ):
         access_params = access_params or {}
         store.add_global_values(request.env.user.sudo(False)._store_init_global_fields)

--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -35,12 +35,13 @@ class PortalWebClientController(WebclientController):
         if name == "/mail/chatter_fetch":
             # Only search into website_message_ids, so apply the same domain to perform only one search
             # extract domain from the 'website_message_ids' field
+            access_params = params.get("access_params", {})
             fetch_params = params.pop("fetch_params", None)
             model = request.env[params.pop("thread_model")]
             thread = ThreadController._get_thread_with_access(
                 model._name,
                 params.pop("thread_id"),
-                token=params.get('token'),
+                token=access_params.get('token'),
             )
             if not thread:
                 return
@@ -48,7 +49,7 @@ class PortalWebClientController(WebclientController):
                 thread,
                 _hash=None,
                 pid=None,
-                token=params.get("token"),
+                token=access_params.get("token"),
             ):
                 request.update_context(
                     portal_data={"portal_partner": portal_partner, "portal_thread": thread},
@@ -139,17 +140,6 @@ class PortalWebClientController(WebclientController):
             predicate=lambda t: t in portal_partner_by_thread,
             value=portal_partner_by_thread.get,
         )
-
-    @classmethod
-    def _get_non_empty_message_domain(self):
-        return (
-            Domain("body", "!=", False)
-            & Domain(
-                "body",
-                "not =like",
-                '<span class="o-mail-Message-edited" data-o-datetime="%"></span>',
-            )
-        ) | Domain("attachment_ids", "!=", False)
 
     @classmethod
     def _setup_portal_message_fetch_extra_domain(self, data) -> Domain:

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -74,9 +74,9 @@ class TestPortalControllers(TestPortal):
         )
         self.authenticate(None, None)
         chatter_fetch_params = {
+            "access_params": {"token": self.record_portal.access_token},
             "thread_id": self.record_portal.id,
             "thread_model": self.record_portal._name,
-            "token": self.record_portal.access_token,
         }
         result = self.make_jsonrpc_request(
             "/mail/store",


### PR DESCRIPTION
This is a preparation PR to replace `/mail/chatter_fetch` with `/mail/thread/messages`. This change assumes that the route can be accessed by non internal users. This means that some access params could be sent to the route, and we need to control the domain of the fetch.

