### PR TITLE
[FIX] resource: use first week day if different from locale's default

### DIFF
--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from collections import defaultdict
-from dateutil.relativedelta import relativedelta
+from dateutil.relativedelta import relativedelta, weekdays
 from datetime import datetime, timedelta, time
 from pytz import timezone
 
@@ -10,7 +10,7 @@ from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.tools import get_lang, babel_locale_parse
 from odoo.tools.intervals import Intervals
-from odoo.tools.date_utils import localized, sum_intervals, to_timezone, weeknumber, weekstart, weekend
+from odoo.tools.date_utils import localized, sum_intervals, to_timezone, weeknumber
 
 
 class ResourceResource(models.Model):
@@ -269,6 +269,7 @@ class ResourceResource(models.Model):
         leave_start_day = leave[0].date()
         leave_end_day = leave[1].date()
         tz = timezone(self.tz or self.env.user.tz)
+        week_start_day = int(get_lang(self.env).week_start) - 1
 
         while leave_start_day <= leave_end_day:
             if not self._is_fully_flexible():
@@ -276,7 +277,7 @@ class ResourceResource(models.Model):
                 # only days inside the original period
                 if leave_start_day >= start_day and leave_start_day <= end_day:
                     resource_hours_per_day[self.id][leave_start_day] -= hours
-                year_and_week = weeknumber(babel_locale_parse(locale), leave_start_day)
+                year_and_week = weeknumber(babel_locale_parse(locale), leave_start_day, week_start_day)
                 resource_hours_per_week[self.id][year_and_week] -= hours
 
             range_start_datetime = tz.localize(datetime.combine(leave_start_day, datetime.min.time()))
@@ -292,11 +293,14 @@ class ResourceResource(models.Model):
         assert start.tzinfo and end.tzinfo
 
         start_day, end_day = start.date(), end.date()
-        week_start_date, week_end_date = start, end
         locale = babel_locale_parse(get_lang(self.env).code)
-        week_start_date = weekstart(locale, start)
-        week_end_date = weekend(locale, end)
-        end_year, end_week = weeknumber(locale, week_end_date)
+
+        week_start_day = int(get_lang(self.env).week_start) - 1
+        delta = relativedelta(weekday=weekdays[week_start_day](-1))
+        week_start_date = start + delta
+        week_end_date = end + delta + relativedelta(days=6)
+
+        end_year, end_week = weeknumber(locale, week_end_date, week_start_day)
 
         min_start_date = week_start_date + relativedelta(hour=0, minute=0, second=0, microsecond=0)
         max_end_date = week_end_date + relativedelta(days=1, hour=0, minute=0, second=0, microsecond=0)
@@ -334,7 +338,7 @@ class ResourceResource(models.Model):
                 if day >= start_day and day <= end_day:
                     resource_hours_per_day[resource.id][day] = day_working_hours
 
-                year_week = weeknumber(babel_locale_parse(locale), day)
+                year_week = weeknumber(babel_locale_parse(locale), day, week_start_day)
                 year, week = year_week
                 if (year < end_year) or (year == end_year and week <= end_week):
                     # cap weekly hours to the calendar's configured hours_per_week (not the
@@ -385,8 +389,9 @@ class ResourceResource(models.Model):
 
         work_hours = 0.0
         locale = get_lang(self.env).code
+        week_start_day = int(get_lang(self.env).week_start) - 1
         for day, hours in interval_duration_per_day.items():
-            week = weeknumber(babel_locale_parse(locale), day)
+            week = weeknumber(babel_locale_parse(locale), day, week_start_day)
             day_working_hours = max(0.0, min(
                 hours,
                 duration_per_day.get(day, 0.0),

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from collections import defaultdict
-from dateutil.relativedelta import relativedelta
+from dateutil.relativedelta import relativedelta, weekdays
 from datetime import datetime, timedelta, time
 from pytz import timezone
 
@@ -10,7 +10,7 @@ from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.tools import get_lang, babel_locale_parse
 from odoo.tools.intervals import Intervals
-from odoo.tools.date_utils import localized, sum_intervals, to_timezone, weeknumber, weekstart, weekend
+from odoo.tools.date_utils import localized, sum_intervals, to_timezone, weeknumber_with_first_week_day
 
 
 class ResourceResource(models.Model):
@@ -269,6 +269,7 @@ class ResourceResource(models.Model):
         leave_start_day = leave[0].date()
         leave_end_day = leave[1].date()
         tz = timezone(self.tz or self.env.user.tz)
+        week_start_day = int(get_lang(self.env).week_start) - 1
 
         while leave_start_day <= leave_end_day:
             if not self._is_fully_flexible():
@@ -276,7 +277,7 @@ class ResourceResource(models.Model):
                 # only days inside the original period
                 if leave_start_day >= start_day and leave_start_day <= end_day:
                     resource_hours_per_day[self.id][leave_start_day] -= hours
-                year_and_week = weeknumber(babel_locale_parse(locale), leave_start_day)
+                year_and_week = weeknumber_with_first_week_day(babel_locale_parse(locale), leave_start_day, week_start_day)
                 resource_hours_per_week[self.id][year_and_week] -= hours
 
             range_start_datetime = tz.localize(datetime.combine(leave_start_day, datetime.min.time()))
@@ -292,11 +293,13 @@ class ResourceResource(models.Model):
         assert start.tzinfo and end.tzinfo
 
         start_day, end_day = start.date(), end.date()
-        week_start_date, week_end_date = start, end
         locale = babel_locale_parse(get_lang(self.env).code)
-        week_start_date = weekstart(locale, start)
-        week_end_date = weekend(locale, end)
-        end_year, end_week = weeknumber(locale, week_end_date)
+
+        week_start_day = int(get_lang(self.env).week_start) - 1
+        week_start_date = start + relativedelta(weekday=weekdays[week_start_day](-1))
+        week_end_date = end + relativedelta(weekday=weekdays[week_start_day](-1)) + relativedelta(days=6)
+
+        end_year, end_week = weeknumber_with_first_week_day(locale, week_end_date, week_start_day)
 
         min_start_date = week_start_date + relativedelta(hour=0, minute=0, second=0, microsecond=0)
         max_end_date = week_end_date + relativedelta(days=1, hour=0, minute=0, second=0, microsecond=0)
@@ -334,7 +337,7 @@ class ResourceResource(models.Model):
                 if day >= start_day and day <= end_day:
                     resource_hours_per_day[resource.id][day] = day_working_hours
 
-                year_week = weeknumber(babel_locale_parse(locale), day)
+                year_week = weeknumber_with_first_week_day(babel_locale_parse(locale), day, week_start_day)
                 year, week = year_week
                 if (year < end_year) or (year == end_year and week <= end_week):
                     # cap weekly hours to the calendar's configured hours_per_week (not the
@@ -385,8 +388,9 @@ class ResourceResource(models.Model):
 
         work_hours = 0.0
         locale = get_lang(self.env).code
+        week_start_day = int(get_lang(self.env).week_start) - 1
         for day, hours in interval_duration_per_day.items():
-            week = weeknumber(babel_locale_parse(locale), day)
+            week = weeknumber_with_first_week_day(babel_locale_parse(locale), day, week_start_day)
             day_working_hours = max(0.0, min(
                 hours,
                 duration_per_day.get(day, 0.0),

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -151,6 +151,28 @@ class TestFlexibleResourceCalendar(TransactionCase):
                 (datetime(2025, 8, 31, 0, 0, tzinfo=UTC), datetime(2025, 8, 31, 17, 0, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
             ])
 
+    def test_flexible_resource_work_hours_first_week_day(self):
+        """
+        Check the case where the language's first day of the week is changed from
+        the language's default.
+        """
+        self.env['res.lang']._activate_lang(code='en_GB')
+        self.env['res.lang'].search([('code', '=', 'en_GB')]).week_start = "7"
+        self.flex_calendar.hours_per_week = 40
+
+        # Sunday to Saturday
+        start_dt = datetime(2026, 4, 12, 0, 0, 0).astimezone(UTC)
+        end_dt = datetime(2026, 4, 18, 23, 59, 59).astimezone(UTC)
+
+        flex_resource = self.flex_resource.with_context(lang='en_GB')
+        work_intervals, hours_per_day, hours_per_week = flex_resource._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        hours = flex_resource._get_flexible_resource_work_hours(
+            work_intervals[self.flex_resource.id],
+            hours_per_day[self.flex_resource.id],
+            hours_per_week[self.flex_resource.id],
+        )
+        self.assertAlmostEqual(hours, 40.0, 2)
+
     def test_hours_per_week_for_different_years(self):
         start_dt = datetime(2025, 12, 26).astimezone(UTC)
         end_dt = datetime(2026, 1, 1, 17).astimezone(UTC)

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -128,6 +128,28 @@ class TestFlexibleResourceCalendar(TransactionCase):
             (datetime(2025, 8, 4, 0, 0, tzinfo=UTC), datetime(2025, 8, 4, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
         ], "fully flex resource doesn't have a calendar, he should not follow the flex calendar public holiday, he follows holidays without a calendar")
 
+    def test_flexible_resource_work_hours_first_week_day(self):
+        """
+        Check the case where the language's first day of the week is changed from
+        the language's default.
+        """
+        self.env['res.lang']._activate_lang(code='en_GB')
+        self.env['res.lang'].search([('code', '=', 'en_GB')]).week_start = "7"
+        self.flex_calendar.hours_per_week = 40
+
+        # Sunday to Saturday
+        start_dt = datetime(2026, 4, 12, 0, 0, 0).astimezone(UTC)
+        end_dt = datetime(2026, 4, 18, 23, 59, 59).astimezone(UTC)
+
+        flex_resource = self.flex_resource.with_context(lang='en_GB')
+        work_intervals, hours_per_day, hours_per_week = flex_resource._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        hours = flex_resource._get_flexible_resource_work_hours(
+            work_intervals[self.flex_resource.id],
+            hours_per_day[self.flex_resource.id],
+            hours_per_week[self.flex_resource.id],
+        )
+        self.assertAlmostEqual(hours, 40.0, 2)
+
     def test_hours_per_week_for_different_years(self):
         start_dt = datetime(2025, 12, 26).astimezone(UTC)
         end_dt = datetime(2026, 1, 1, 17).astimezone(UTC)

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -425,7 +425,7 @@ def sum_intervals(intervals: Iterable[tuple[datetime, datetime, ...]]) -> float:
     )
 
 
-def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
+def weeknumber(locale: babel.Locale, date: date, first_week_day: int | None = None) -> tuple[int, int]:
     """Computes the year and weeknumber of `date`. The week number is 1-indexed
     (so the first week is week number 1).
 
@@ -443,23 +443,27 @@ def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
 
     An alternative is to split the week in two, so the week from December 27,
     2015 to January 2, 2016 would be *both* W53/2015 and W01/2016.
+
+    :param first_week_day: Optional override for the first day of the week
+        (0 = Monday, ..., 6 = Sunday). If None, derived from the locale.
     """
-    if locale.first_week_day == 0 and locale.min_week_days == 4:
+    if not first_week_day:
+        first_week_day = locale.first_week_day
+    if first_week_day == 0 and locale.min_week_days == 4:
         # woohoo nothing to do
         return date.isocalendar()[:2]
 
+    delta = relativedelta(weekday=weekdays[first_week_day](-1))
     # first find the first day of the first week of the next year, if the
     # reference date is after that then it must be in the first week of the next
     # year, remove this if we decide to implement split weeks instead
-    fdny = date.replace(year=date.year + 1, month=1, day=1) \
-       - relativedelta(weekday=weekdays[locale.first_week_day](-1))
+    fdny = date.replace(year=date.year + 1, month=1, day=1) - delta
     if date >= fdny:
         return date.year + 1, 1
 
     # otherwise get the number of periods of 7 days between the first day of the
     # first week and the reference
-    fdow = date.replace(month=1, day=1) \
-       - relativedelta(weekday=weekdays[locale.first_week_day](-1))
+    fdow = date.replace(month=1, day=1) - delta
     doy = (date - fdow).days
 
     return date.year, (doy // 7 + 1)

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -425,7 +425,7 @@ def sum_intervals(intervals: Iterable[tuple[datetime, datetime, ...]]) -> float:
     )
 
 
-def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
+def weeknumber_with_first_week_day(locale: babel.Locale, date: date, first_week_day: int | None = None) -> tuple[int, int]:
     """Computes the year and weeknumber of `date`. The week number is 1-indexed
     (so the first week is week number 1).
 
@@ -443,8 +443,12 @@ def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
 
     An alternative is to split the week in two, so the week from December 27,
     2015 to January 2, 2016 would be *both* W53/2015 and W01/2016.
+
+    :param first_week_day: Optional override for the first day of the week
+        (0 = Monday, ..., 6 = Sunday). If None, derived from the locale.
     """
-    if locale.first_week_day == 0 and locale.min_week_days == 4:
+    first_week_day = first_week_day if first_week_day is not None else locale.first_week_day
+    if first_week_day == 0 and locale.min_week_days == 4:
         # woohoo nothing to do
         return date.isocalendar()[:2]
 
@@ -452,17 +456,21 @@ def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
     # reference date is after that then it must be in the first week of the next
     # year, remove this if we decide to implement split weeks instead
     fdny = date.replace(year=date.year + 1, month=1, day=1) \
-       - relativedelta(weekday=weekdays[locale.first_week_day](-1))
+       - relativedelta(weekday=weekdays[first_week_day](-1))
     if date >= fdny:
         return date.year + 1, 1
 
     # otherwise get the number of periods of 7 days between the first day of the
     # first week and the reference
     fdow = date.replace(month=1, day=1) \
-       - relativedelta(weekday=weekdays[locale.first_week_day](-1))
+       - relativedelta(weekday=weekdays[first_week_day](-1))
     doy = (date - fdow).days
 
     return date.year, (doy // 7 + 1)
+
+
+def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
+    return weeknumber_with_first_week_day(locale, date)
 
 
 def weekstart(locale: babel.Locale, date: date):


### PR DESCRIPTION
**Steps to reproduce**
- Install planning
- Switch to English (UK) and change the "First day of the week" to Sunday in the technical settings
- Have an employee with a flexible schedule with a total of 40h/week, average 8h/day
- In the planning app, after creating a shift to display the employee in the gantt view, notice that when hovering over the progress bar on the left, 48 worked hours are expected for the current week, which is more than what is defined in the employee's calendar

**Cause**
The displayed week, starting on Sunday, could accumulate more hours than the weekly cap due to the Sunday being part of another week with the locale default first day (Monday).

opw-6110395