### PR TITLE
[FIX] website_sale: provide missing render context for product tags

### DIFF
--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -2,6 +2,9 @@
 
 from odoo.http import Controller, request, route
 
+from odoo.addons.website.controllers.main import QueryURL
+from odoo.addons.website_sale.const import SHOP_PATH
+
 
 class WebsiteSaleVariantController(Controller):
     @route(
@@ -66,7 +69,11 @@ class WebsiteSaleVariantController(Controller):
             all_tags = product.all_product_tag_ids if product else product_template.product_tag_ids
             combination_info["product_tags"] = request.env["ir.ui.view"]._render_template(
                 "website_sale.product_tags",
-                values={"all_product_tags": all_tags.filtered("visible_to_customers")},
+                values={
+                    "all_product_tags": all_tags.filtered("visible_to_customers"),
+                    "keep": QueryURL(SHOP_PATH),
+                    "shop_path": SHOP_PATH,
+                },
             )
 
         combination_info["packaging_selector"] = request.env["ir.ui.view"]._render_template(


### PR DESCRIPTION
**Steps to reproduce**
- Have a product with tags assigned at the variant level.
- Open the product page and switch to the variant carrying the tags.
- A KeyError on `keep` is raised when rendering the `product_tags` template.

**Cause**
Commit 44e36f4 made the `product_tags` template reference `keep` and `shop_path` to build clickable tag links to the shop. The full product page render supplies these values, but the variant combination RPC in `variant.py` re-renders the same template without them.

**Change**
Pass `keep` and `shop_path` into the render values of the `product_tags` template call in `variant.py`.

opw-6127823

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
