### PR TITLE
[FIX] web: prevent reset value when rendering

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -146,6 +146,7 @@ export class SelectMenu extends Component {
             }
             const searchString = ev.target.value;
             this.state.searchValue = searchString;
+            delete this.pendingValue;
             this.onInput(searchString);
         }, DEBOUNCED_DELAY);
         this.dropdownState = useDropdownState();
@@ -197,7 +198,15 @@ export class SelectMenu extends Component {
         };
     }
 
+    handleInputDebounced(ev) {
+        this.pendingValue = ev.target.value;
+        this.debouncedOnInput(ev);
+    }
+
     get displayValue() {
+        if (this.pendingValue) {
+            return this.pendingValue;
+        }
         return this.state.searchValue === null
             ? this.selectedChoice?.label || ""
             : this.state.searchValue;

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -11,7 +11,7 @@
             type="text"
             t-attf-class="o_input {{inputClass}}"
             t-custom-ref="inputRef"
-            t-on-input="this.debouncedOnInput"
+            t-on-input="this.handleInputDebounced"
             t-on-focus="this.onInputFocus"
             t-on-blur="this.onInputBlur"
             t-att-placeholder="this.placeholderValue"

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1415,3 +1415,41 @@ test("prevent glitch on open or focusout", async () => {
     expect(queryOne(".o_select_menu_searchbox input")).toBe(searchInput);
     expect(searchInput.placeholder).toBe("searchPlaceholder");
 });
+
+test("Prevents loss of value due to debounce when changing state (rendering)", async () => {
+    class MyParent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+        <SelectMenu
+            choices="this.choices"
+            value="this.state.value"
+            placeholder="this.state.placeholder"
+            searchPlaceholder="this.state.searchPlaceholder"
+        />
+    `;
+        setup() {
+            this.choices = [
+                { label: "Harry Kane", value: "kane" },
+                { label: "Michael Olise", value: "olise" },
+                { label: "Vincent Kompany", value: "Kompany" },
+            ];
+            this.state = useState({
+                value: "",
+                placeholder: "brol",
+                searchPlaceholder: "search",
+            });
+        }
+    }
+    const machin = await mountSingleApp(MyParent);
+    expect(".o_select_menu_toggler").toHaveAttribute("placeholder", "brol");
+    await open();
+    expect(".o_select_menu_toggler").toHaveAttribute("placeholder", "search");
+    await contains(".o_select_menu_input").edit("Michael", { confirm: false });
+    machin.state.searchPlaceholder = "player";
+    await animationFrame();
+    machin.choices.push({ label: "Michael Owen", value: "owen" });
+    expect(".o_select_menu_input").toHaveValue("Michael");
+    await runAllTimers();
+    expect(".o_select_menu-choices .o-dropdown-item").toHaveCount(2);
+});


### PR DESCRIPTION
This commit prevents the SelectMenu input value from being reset due to debounce when the state updates during rendering.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
