### PR TITLE
[FIX] l10n_pl_edi_ksef: fix empty Email and Telefon tags in KSeF invoice XML

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2983,7 +2983,7 @@ class AccountMoveLine(models.Model):
 
         # ==== Create the move ====
         exchange_moves = self.env['account.move'].create(exchange_move_values_list)
-        exchange_moves._post(soft=False)
+        exchange_moves.with_context(validate_analytic=False)._post(soft=False)
 
         # ==== Reconcile ====
         reconciliation_plan = []

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -1161,3 +1161,38 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
         self.analytic_account_a.active = False
         with self.assertRaisesRegex(UserError, "archived analytic account"):
             invoice._post()
+
+    def test_exchange_move_with_mandatory_analytic_plan(self):
+        """ Ensure no mandatory analytic plan validation error is raised when an exchange move is auto-created."""
+
+        # Multi-currency setup
+        test_currency = self.setup_other_currency('CAD', rates=[('2016-01-01', 6.0), ('2017-01-01', 4.0)])
+
+        # Analytic plan setup
+        self.env['account.analytic.applicability'].create({
+            'business_domain': 'general',
+            'applicability': 'mandatory',
+            'analytic_plan_id': self.default_plan.id,
+        })
+
+        # Create an invoice in foreign currency
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': test_currency.id,
+            'invoice_date': '2016-01-01',
+            'invoice_line_ids': [Command.create({
+                'name': 'test line',
+                'quantity': 1,
+                'price_unit': 100,
+                'analytic_distribution': {self.analytic_account_a.id: 100},
+            })],
+        })
+        invoice.action_post()
+
+        # Create a credit note at a different rate
+        credit_note = invoice._reverse_moves([{'invoice_date': '2017-01-01'}])
+        # Post the credit note with the validate_analytic context key to mimic posting behavior from the form view.
+        credit_note.with_context(validate_analytic=True).action_post()
+
+        self.assertEqual(credit_note.state, 'posted')

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -170,11 +170,10 @@ test("Can set icon color", async () => {
     expect(getContent(el)).toBe(
         `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
     );
-    setContent(
-        el,
-        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</p>`
-    );
+    const fa = el.querySelector(".fa");
+    setSelection({ anchorNode: fa, anchorOffset: 0, focusNode: fa, focusOffset: 0 });
     await tick();
+    await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
     );
@@ -185,7 +184,7 @@ test("Can set icon color", async () => {
     const colorButton = await waitFor(".o_color_button[data-color='#6BADDE']");
     colorButton.click();
     await expectElementCount(".o_font_color_selector", 0); // selector closed
-    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6badde']", { timeout: 1500 });
+    await waitFor(".o-we-toolbar .o-select-color-foreground [style*='#6badde']");
     expect(getContent(el)).toBe(
         `<p>[<font style="color: rgb(107, 173, 222);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font>]</p>`
     );

--- a/addons/l10n_pl_edi/data/fa3_template.xml
+++ b/addons/l10n_pl_edi/data/fa3_template.xml
@@ -49,10 +49,10 @@
           <AdresL2 t-if="seller.street2" t-out="seller.street2"/>
         </Adres>
         <t t-if="seller.email or seller.phone">
-        <DaneKontaktowe>
-            <Email t-out="seller.email"/>
-            <Telefon t-out="seller.phone"/>
-        </DaneKontaktowe>
+          <DaneKontaktowe>
+            <Email t-if="seller.email" t-out="seller.email"/>
+            <Telefon t-if="seller.phone" t-out="seller.phone"/>
+          </DaneKontaktowe>
         </t>
       </Podmiot1>
 
@@ -100,10 +100,10 @@
           </Adres>
         </t>
         <t t-if="buyer.email or buyer.phone">
-        <DaneKontaktowe>
-            <Email t-out="buyer.email"/>
-            <Telefon t-out="buyer.phone"/>
-        </DaneKontaktowe>
+          <DaneKontaktowe>
+            <Email t-if="buyer.email" t-out="buyer.email"/>
+            <Telefon t-if="buyer.phone" t-out="buyer.phone"/>
+          </DaneKontaktowe>
         </t>
 
             <!-- JST flag: 1=subordinate local gov unit; 2=otherwise. If 1, complete Podmiot3 with NIP/IDWew and role=8 -->
@@ -184,10 +184,10 @@
           <!-- P_13_11: Total value of sales under the margin scheme referred to in Article 119 and Article 120 TO-CHECK -->
 
           <!-- P_15: Total gross amount of the invoice (including all taxes). -->
-        <P_15 t-out="float_repr(invoice.amount_total_in_currency_signed, 2)"/>
+        <P_15 t-out="float_repr(invoice.amount_total_signed, 2)"/>
 
           <!-- KursWalutyZ: Exchange rate of the currency to PLN on the invoice date. TO-CHECK -->
-          <KursWalutyZ t-out="float_repr(1 / (invoice.invoice_currency_rate or 1), 5)"/>
+          <KursWalutyZ t-out="float_repr(invoice.invoice_currency_rate, 3)"/>
         <!--
           ======================================================================
           Adnotacje (Annotations)

--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -496,6 +496,7 @@ class AccountMove(models.Model):
             if not is_allowance:
                 line.l10n_tw_edi_ecpay_item_sequence = index
 
+            # ItemRemark is in TW Chinese Characters because the official document uses TW Chinese Characters
             if self.l10n_tw_edi_is_b2b and is_allowance:
                 item_list.append({
                     "OriginalInvoiceNumber": self.l10n_tw_edi_ecpay_invoice_id,
@@ -515,6 +516,7 @@ class AccountMove(models.Model):
                     "ItemPrice": item_price,
                     "ItemTaxType": line.tax_ids[0].l10n_tw_edi_tax_type if tax_type != "4" and line.tax_ids else "",
                     "ItemAmount": item_amount,
+                    "ItemRemark": f"商品單位: {line.product_uom_id.name[:6]}" if line.product_uom_id else ""
                 })
             if self.l10n_tw_edi_is_b2b:
                 sale_amount += item_amount

--- a/addons/l10n_tw_edi_ecpay/tests/test_edi.py
+++ b/addons/l10n_tw_edi_ecpay/tests/test_edi.py
@@ -287,7 +287,8 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
                     'ItemWord': 'Units',
                     'ItemPrice': 1000.0,
                     'ItemTaxType': '1',
-                    'ItemAmount': 1000.0
+                    'ItemAmount': 1000.0,
+                    'ItemRemark': "商品單位: Units"
                 },
                 {
                     'ItemSeq': 2,
@@ -296,7 +297,8 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
                     'ItemWord': False,
                     'ItemPrice': -10.0,
                     'ItemTaxType': '1',
-                    'ItemAmount': -10.0
+                    'ItemAmount': -10.0,
+                    'ItemRemark': ""
                 },
             ],
         )


### PR DESCRIPTION
Before this commit: 
Steps
1. Create a Polish company
2. Create and send an invoice to KSeF where the buyer has no email or no phone number
3. KSeF rejects the invoice with error code 450 (semantic verification error) This happens because `Email` and `Telefon` elements are always rendered inside `DaneKontaktowe`, even when their values are empty, producing invalid empty tags.

After this commit: 
Add `t-if="buyer.email"` and `t-if="buyer.phone"` guards on each field so that `Email` and `Telefon` are only rendered when a value is present.

opw-6124187