### PR TITLE
[FIX] account_edi_ubl_cii: Fix co-contractant legal note

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -148,10 +148,10 @@ class AccountEdiCommon(models.AbstractModel):
         return find_xml_value(xpath, tree, nsmap)
 
     def _get_belgian_cocontractant_note(self, invoice, customer):
-        if customer.country_id and customer.country_id.code == 'BE' and invoice.country_code == 'BE':
+        if customer.country_id.code == 'BE' and invoice.country_code == 'BE':
             co_contractant = self.env['account.chart.template'].ref('fiscal_position_template_4', raise_if_not_found=False)
-            if co_contractant and customer.property_account_position_id == co_contractant:
-                note = html2plaintext(customer.property_account_position_id.note) if customer.property_account_position_id.note else ''
+            if co_contractant and invoice.fiscal_position_id == co_contractant:
+                note = html2plaintext(invoice.fiscal_position_id.note) if invoice.fiscal_position_id.note else ''
                 return note or COCONTRACTANT_DEFAULT_NOTE
         return ''
 

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -575,7 +575,7 @@ class TestBeExport(TestUblExportBis3BE):
             product_id=self.product_a,
             partner_id=self.partner_be,
         )
-        invoice.commercial_partner_id.property_account_position_id = co_contractant
+        invoice.fiscal_position_id = co_contractant
         invoice.action_post()
         xml_content = self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0]
         xml_tree = etree.fromstring(xml_content)


### PR DESCRIPTION
The decision to add a tax exemption reason for co-contractant fiscal position was being decided by the FP of the customer which could cause inconsistencies, instead, it is now tied to the FP of the invoice
related-task-id-5905176