### PR TITLE
[FIX] website: allow full non-ascii title seo_name change


### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -414,8 +414,11 @@ export class OptimizeSEODialog extends Component {
             this.canEditSeo = this.data.can_edit_seo;
             this.canEditDescription = this.canEditSeo && 'website_meta_description' in this.data;
             this.canEditTitle = this.canEditSeo && 'website_meta_title' in this.data;
-            // The URL must not be customizable if it does not contain an editable slug.
-            const editableSlugPattern = new RegExp(`.*/(${this.data.seo_name || ""}|${this.data.seo_name_default || ""})-\\d+.*`);
+            const slug = this.data.seo_name || this.data.seo_name_default || "";
+            // The URL is possibly customizable if:
+            // - path contains the current slug
+            // - or there is no slug and path contains number only part (eg /1/)
+            const editableSlugPattern = slug ? new RegExp(`/${slug}-\\d+`) : /\/\d+(\/|$)/;
             this.canEditUrl = this.canEditSeo && Boolean(new URL(path).pathname.match(editableSlugPattern));
             seoContext.title = this.canEditTitle && this.data.website_meta_title;
 
@@ -494,9 +497,16 @@ export class OptimizeSEODialog extends Component {
         if (this.canEditKeywords) {
             data.website_meta_keywords = seoContext.keywords.join(',');
         }
+        let url = this.url;
         if (this.canEditUrl) {
             if (seoContext.seoName !== this.previousSeoName) {
-                data.seo_name = seoContext.seoName;
+                data.seo_name = seoContext.seoName.replace(/^-|-$/g, '');
+                if (data.seo_name) {
+                    url = url.replace(
+                        new RegExp(`/${this.previousSeoName || this.seoNameDefault}-(\\d+)`),
+                        `/${data.seo_name}-$1`
+                    );
+                }
             }
         }
         data.website_meta_og_img = seoContext.metaImage;
@@ -506,6 +516,6 @@ export class OptimizeSEODialog extends Component {
                 'website_id': this.website.currentWebsite.id,
             },
         });
-        this.website.goToWebsite({path: this.url.replace(this.previousSeoName || this.seoNameDefault, seoContext.seoName)});
+        this.website.goToWebsite({path: url});
     }
 }


### PR DESCRIPTION
Scenario:

- create blog or product on website with name кириллица
=> if python-slugify is not installed, all non-ascii are removed from
   the slug, so we are on an path without slug (eg: /1)
- open Editor > Site > Optimize SEO
- "Custom Url" is not shown

Cause: since 2042b2008e949bc10ae56b4c70de133e1a3294c4 we only show
"Custom Url" if the current slug is found in the URL. In the given case,
there is no slug (and only a /1 path) so "Custom Url" is never shown.

Fix: also show "Custom Url" if there is no seo_name/seo_default_name and
there is a /{number} part of the URL, this might catch false positive
(of an URL with seo_name but without slug) but would ensure that valid
cases will show "Custom Url". If we are in a case without slug, seo_name
will be set and if the "Custom Url" option will disappear.

Note: there is a similar issue in saas-18.3 and over, but it will need a
small adaptation because since 926e45aa93ffc3f74fe9bf4ae8f06642976c2ae5
special characters (eg. cyrillic) are allowed in URL.

Note: while fixing this, several issue discovered were corrected when
setting seo name:

- setting "-" => causes an error (redirect to /--1)
- setting empty seo_name when there is no default, redirects wrongly
  (eg. /a-1 becomes /-1)
- replacement simple odoo.com/odoo-1 if we replace odoo by google, we
  try to go to google.com/odoo-1 which redirect us to /

To fix these, this commit replace strip - in new seo name, and replace
the slug more precisely (replacing /{old-slug}-{number}) and just keep
current URL when switch not possible (eg. going from slug to noslug, or
from noslug to slug).

opw-6050521
opw-6055034