### PR TITLE
[FIX] sale: show promised delivery in sale order list

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -132,6 +132,7 @@
                 <field name="delivery_date" string="Delivery Date" optional="hide"
                     decoration-muted="not commitment_date"
                     decoration-danger="(commitment_date and (expected_date &lt; commitment_date or commitment_date &lt; context_today().strftime('%Y-%m-%d'))) and state in ['draft', 'sent']"/>
+                <field name="commitment_date" readonly="1" optional="hide"/>
                 <field name="partner_id" readonly="1"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show"/>
                 <field name="activity_ids" widget="list_activity" optional="show"/>


### PR DESCRIPTION
Version:
---
19.1+

Issue:
---
it's not possible to sort sale order list using `delivery date` anymore.

After 30b895e3bd93ab3f0c0a86c3fcfd0fc0c3b6fb89, a `delivery_field` field is introduced, and `commitment_date`'s string is renamed to `promised delivery`.
The new `delivery_date` is a compute field, hence it isn't sortable.

The propostion here is to add `commitment_date` to the list view, in case users want to sort the list using `Promised delivery date`.

opw-6112037
