### PR TITLE
[FIX] stock_landed_costs: fix landed cost calculation with currency rate

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['expense'].id,
-                'price_unit': sign * l.company_currency_id.round(l.price_subtotal * l.currency_rate),
+                'price_unit': sign * l.company_currency_id.round(l.price_subtotal / l.currency_rate),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -926,7 +926,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         ])
         landed_cost_amls = landed_cost.account_move_id.line_ids.sorted('credit')
         self.assertRecordValues(landed_cost_amls, [
-            {'account_id': lc_stock_valuation_account.id, 'debit':  35.0,   'credit':  0.0},
-            {'account_id': lc_expense_account.id,         'debit':   0.0,   'credit': 35.0},
+            {'account_id': lc_stock_valuation_account.id, 'debit':  140.0,   'credit':  0.0},
+            {'account_id': lc_expense_account.id,         'debit':   0.0,   'credit': 140.0},
         ])
-        self.assertEqual(bill.landed_costs_ids.cost_lines.price_unit, 50)
+        self.assertEqual(bill.landed_costs_ids.cost_lines.price_unit, 200)


### PR DESCRIPTION
Issue introduced by commit daf196e365f481ffcc8b56664fa361fa9c9bbda9

Steps to reproduce:
- Enable two currencies (e.g., USD and EUR)
  - Set exchange rate: 2 EUR = 1 USD
- Set current company currency to USD
- Create a service product "Landed Cost":
  - Purchase tab:
    - Mark as "Is a Landed Cost"
    - Cost: $10
- Create a bill:
  - Vendor: any vendor
  - Currency: EUR
  - Add 1 unit of "Landed Cost" → correctly shows 20 EUR
- Click the "Create Landed Cost" button

Expected behavior:
Landed cost should be calculated as $10

Actual behavior:
Landed cost is incorrectly calculated as $40, because the AML (Account Move Line) price subtotal is multiplied by the currency exchange rate (2) instead of dividing.

opw-6121706
opw-6121407
Opw-6124771
Opw-6123193