### PR TITLE
[FIX] l10n_in_withholding: require aggregate_period when aggregate set

### DIFF
--- a/addons/l10n_in_withholding/views/l10n_in_section_alert_views.xml
+++ b/addons/l10n_in_withholding/views/l10n_in_section_alert_views.xml
@@ -37,7 +37,7 @@
                         <div>
                             <field class="w-25" name="is_aggregate_limit" widget="boolean_toggle"/>
                             <field class="w-25 text-center oe_inline" name="aggregate_limit" invisible="not is_aggregate_limit"/>
-                            <field class="w-25" name="aggregate_period" invisible="not is_aggregate_limit"/>
+                            <field class="w-25" name="aggregate_period" invisible="not is_aggregate_limit" required="is_aggregate_limit"/>
                         </div>
                     </group>
                 </sheet>


### PR DESCRIPTION
Previously, if `is_aggregate_limit` was set to True while `aggregate_period` was left empty, it would raise a traceback during invoice creation. Although `aggregate_period` has a default value, it can still be manually cleared.

With this commit, `aggregate_period` is enforced as mandatory whenever `is_aggregate_limit` is enabled, preventing such errors.

