### PR TITLE
[FIX] setup: nginx config fixes for Windows IoT

### DIFF
--- a/setup/win32/conf/nginx/nginx.conf
+++ b/setup/win32/conf/nginx/nginx.conf
@@ -4,13 +4,21 @@ events {
 
 http {
     server {
+        listen 80;
+        listen [::]:80;
         listen 443 ssl http2 default_server;
         listen [::]:443 ssl http2 default_server;
+
         server_name localhost;
         ssl_certificate      nginx-cert.crt;
         ssl_certificate_key  nginx-cert.key;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers HIGH:!aNULL:!MD5;
+
+        # Increase the allowed body size from 1MB to 10MB, this ensures
+        # large actions such as printing a long receipt will always work.
+        client_max_body_size 10M;
+
         location / {
             proxy_read_timeout 600s;
             proxy_pass http://127.0.0.1:8069;


### PR DESCRIPTION
Built installer for testing: https://drive.google.com/file/d/1wF7MCiQox3nAsW9CXg75wsV_Y5fF-5Rw/view?usp=sharing

This commit makes the following changes that bring the Windows IoT nginx config in line with the Raspberry Pi version:

- The `client_max_body_size` is set to 10MB. This prevents a 413 error from being received when sending large actions to the IoT (e.g. printing a large receipt).
- It now listens on regular HTTP as well as HTTPS. This fixes LNA not working with Virtual IoT.

opw-6106765, opw-6108700

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
