### PR TITLE
[FIX] mail: opening channel from kanban opens chat window

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -348,7 +348,11 @@ export class DiscussChannel extends Record {
             if (this.channelNotifications === "no_notif") {
                 return 0;
             }
-            if (this.channelNotifications === "all" && !this.self_member_id?.mute_until_dt) {
+            if (
+                this.channelNotifications === "all" &&
+                this.self_member_id &&
+                !this.self_member_id.mute_until_dt
+            ) {
                 return this.self_member_id.message_unread_counter_ui;
             }
         }

--- a/addons/mail/static/tests/tours/create_channel_tour.js
+++ b/addons/mail/static/tests/tours/create_channel_tour.js
@@ -25,5 +25,9 @@ registry.category("web_tour.tours").add("can_create_channel_from_form_view", {
         {
             trigger: ".o-mail-DiscussSidebarChannel-itemName:contains('Test channel')",
         },
+        // clicking on the channel should open the chat window
+        { trigger: "button[title='View or join channels']:not(:visible)", run: "click" },
+        { trigger: "span:text('Sports')", run: "click" },
+        { trigger: ".o-mail-ChatWindow" },
     ],
 });

--- a/addons/mail/tests/discuss/test_ui.py
+++ b/addons/mail/tests/discuss/test_ui.py
@@ -51,4 +51,7 @@ class TestUi(HttpCaseWithUserDemo):
         )
 
     def test_05_can_create_channel_tour(self):
+        self.env["discuss.channel"].create({"name": "Sports"})
+        settings = self.user_demo.res_users_settings_id
+        settings.set_res_users_settings({"channel_notifications": "all"})
         self.start_tour("odoo/discuss", "can_create_channel_from_form_view", login="demo")


### PR DESCRIPTION
Steps to reproduce:

* Open Discuss
* Go to Configuration > Notifications
* Set it to `All Messages`
* Go to Channels menu
* Click on any record (not member)
    -> Traceback

This happens since [1] because it tries to read `message_unread_counter_ui` on `self_member_id` even when it is undefined.

This commit fixes the issue by opening the chat window instead.

[1]: https://github.com/odoo/odoo/pull/249755
Task-6128253


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
