### PR TITLE
[FIX] html_editor: fix setting color on icon

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -63,13 +63,14 @@ export class IconPlugin extends Plugin {
                     return;
                 }
                 const isIconInTargetedNodes = targetedNodes.some(isIconElement);
-                // All nodes should be icons or their ZWS children.
+                // All nodes should be icons, their ZWS children, or their ancestors.
                 // FEFF nodes are only considered valid if an icon is selected and the
                 // FEFF is directly adjacent to it.
                 const isIconRelatedNode = (node) => {
                     if (
                         node.classList?.contains("fa") ||
-                        node.parentElement?.classList.contains("fa")
+                        node.parentElement?.classList.contains("fa") ||
+                        (node.querySelector?.(":scope > .fa") && node.isContentEditable !== false)
                     ) {
                         return true;
                     }

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1,4 +1,5 @@
 import {
+    advanceTime,
     animationFrame,
     click,
     describe,
@@ -1368,6 +1369,9 @@ test("Should not close the color picker on icon color change", async () => {
     await waitFor('[data-color="o-color-1"]');
     await hover('[data-color="o-color-1"]');
     expectElementCount('[data-color="o-color-1"]', 1);
+    await advanceTime(200);
+    await animationFrame();
+    await waitFor('.o_font_color_selector [data-color="o-color-2"]');
     await hover('[data-color="o-color-2"]');
     // Color picker should stay open
     expectElementCount('[data-color="o-color-2"]', 1);


### PR DESCRIPTION
Commit [1] did already fix this problem, but commit [2] broke it again.

This commit restores the condition that was removed by [2] but adapts it slightly in order to only take into account the direct children of the node, instead of any sub-node when checking for the presence of icons.

Steps to reproduce:
- Go to a "To do" note
- Insert an icon with /media
- Select the icon
- Open the color picker
- Hover a color

=> Color picker closed right away

[1]: https://github.com/odoo/odoo/commit/1adfd9b9daf09c26ad642faf411574123110b9be
[2]: https://github.com/odoo/odoo/commit/85688ffd11a3a988bf32c8c923a4628a89b57f87

task-6128069
