### PR TITLE
[FIX] web: support search_default_* for inner filters

### DIFF
--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -253,6 +253,14 @@ export class SearchArchParser {
                 this.optionsParams = { customOptions: [] };
                 visitChildren();
                 preSearchItem.optionsParams = this.optionsParams;
+                const defaultGeneratorIds = this.optionsParams.customOptions.flatMap((option) => {
+                    const name = option.id.replace("custom_", "");
+                    return name in this.searchDefaults ? [option.id] : [];
+                });
+                if (defaultGeneratorIds.length) {
+                    preSearchItem.isDefault = true;
+                    preSearchItem.defaultGeneratorIds = defaultGeneratorIds;
+                }
                 this.optionsParams = null;
             }
 

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -1153,3 +1153,29 @@ test(`Custom filter with "&"" as value`, async function () {
     expect(getFacetTexts()).toEqual([`Foo contains &`]);
     expect(searchBar.env.searchModel.domain).toEqual([["foo", "ilike", "&"]]);
 });
+
+test("search_default activates inner filter", async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "foo",
+        searchViewId: false,
+        searchMenuTypes: ["filter"],
+        searchViewArch: `
+            <search>
+                <filter string="Foo">
+                    <filter string="Abcd" name="abcd" domain="[('foo', '=', 'abcd')]"/>
+                    <filter string="Qsdf" name="qsdf" domain="[('foo', '=', 'qsdf')]"/>
+                </filter>
+            </search>
+        `,
+        context: {
+            search_default_abcd: 1,
+        },
+    });
+
+    await toggleSearchBarMenu();
+    await toggleMenuItem("Foo");
+    expect(searchBar.env.searchModel.domain).toEqual([["foo", "=", "abcd"]]);
+    expect(isItemSelected("Foo")).toBe(true);
+    expect(isOptionSelected("Foo", "Abcd")).toBe(true);
+    expect(getFacetTexts()).toEqual(["Abcd"]);
+});


### PR DESCRIPTION
Issue:
When using inner filters, passing `search_default_*` in the context did not activate the corresponding inner filter. As a result, parent filters containing inner filters were not applied.

Cause:
Inner filters are stored using generated `custom_*` ids, while `search_default_*` keys use the original filter names. The search parser did not resolve this mismatch, so parent filters were not marked as default when an
inner filter matched a search default.

Fix:
Update the search parser to detect inner filters that match `search_default_*` keys by mapping their `custom_*` ids back to the original filter names. When a match is found, mark the parent filter as default so that the corresponding inner filters are properly activated.

Task-6089715
