### PR TITLE
[FIX] stock_picking_batch: only confirm draft picking

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -211,7 +211,7 @@ class StockPickingBatch(models.Model):
         self.ensure_one()
         if not self.picking_ids:
             raise UserError(_("You have to set some pickings to batch."))
-        self.picking_ids.action_confirm()
+        self.picking_ids.filtered(lambda picking: picking.state == 'draft').action_confirm()
         self._check_company()
         self.state = 'in_progress'
         return True


### PR DESCRIPTION
Before this change, picking that are already assigned could be changed by the `action_confirm`.
After this change only draft picking are being confirmed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
