### PR TITLE
[FIX] stock_account: use Odoo-configured date format

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/filters/filters.js
+++ b/addons/stock_account/static/src/stock_valuation/filters/filters.js
@@ -1,6 +1,7 @@
 import { Component, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
+import { formatDate } from "@web/core/l10n/dates";
 
 export class StockValuationReportFilters extends Component {
     static template = "stock_account.StockValuationReport.Filters";
@@ -37,6 +38,6 @@ export class StockValuationReportFilters extends Component {
     }
 
     get date() {
-        return this.env.controller.state.date.toLocaleString();
+        return formatDate(this.env.controller.state.date);
     }
 }

--- a/addons/stock_account/static/src/stock_valuation/filters/filters.js
+++ b/addons/stock_account/static/src/stock_valuation/filters/filters.js
@@ -1,6 +1,7 @@
 import { Component, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
+import { formatDate } from "@web/core/l10n/dates";
 
 export class StockValuationReportFilters extends Component {
     static template = "stock_account.StockValuationReport.Filters";
@@ -37,6 +38,6 @@ export class StockValuationReportFilters extends Component {
     }
 
     get date() {
-        return this.env.controller.state.date.toLocaleString();
+        return formatDate(this.env.controller.state.date)
     }
 }


### PR DESCRIPTION
Why this Commit:
---
toLocaleString() relies on the device's local format instead of the Odoo-configured format.

Since Odoo already defines a standard date format,the toLocaleString() usages should be replaced to ensure consistency.

After this commit:
---

<img width="1884" height="363" alt="image" src="https://github.com/user-attachments/assets/8cee2d86-10dc-48d7-8c3a-369ec257c101" />

date references consistently use the Odoo-configured date format. 

OPW: 6087341

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
