### PR TITLE
[FIX] l10n_in_ewaybill_stock: show only date in document_date for e-waybill

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -593,7 +593,7 @@ class Ewaybill(models.Model):
                 ),
                 "transDistance": str(self.distance),
                 "docNo": self.document_number,
-                "docDate": (self.document_date or fields.Datetime.now()).strftime("%d/%m/%Y"),
+                "docDate": fields.Date.context_today(self.with_context(tz='Asia/Kolkata'), self.document_date).strftime("%d/%m/%Y"),
                 # bill details
                 **prepare_details(
                     key_paired_function={

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -43,7 +43,7 @@
                         <group>
                             <field name="ewaybill_date" invisible="not ewaybill_date"/>
                             <field name="document_number"/>
-                            <field name="document_date" invisible="picking_type_code == 'incoming'" readonly="1"/>
+                            <field name="document_date" invisible="picking_type_code == 'incoming'" readonly="1" widget="datetime" options="{'show_time': false}"/>
                         </group>
                     </group>
                     <group name="partners" string="Address Details">


### PR DESCRIPTION
The `document_date` field in e-waybill form view previously included both date and time, which is not as per the expected format.

This fix ensures that only the date is shown, hiding the time component.
