### PR TITLE
[FIX] sale: translate order line name

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -401,7 +401,7 @@ class SaleOrderLine(models.Model):
                 if ptav._origin not in valid_values:
                     line.product_no_variant_attribute_value_ids -= ptav
 
-    @api.depends('product_id', 'linked_line_id', 'linked_line_ids')
+    @api.depends('product_id', 'linked_line_id', 'linked_line_ids', 'order_partner_id.lang')
     def _compute_name(self):
         for line in self:
             if not line.product_id and not line.is_downpayment:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -793,6 +793,20 @@ class TestSaleOrder(SaleCommon):
             msg="price_total should be equal to expected_total",
         )
 
+    def test_sale_order_line_name_translation(self):
+        """Ensure the name of an order_line is translated to the partner's language."""
+        self.env['res.lang']._activate_lang('fr_FR')
+        self.product.update_field_translations('name', {'fr_FR': 'Produit Test'})
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+            })]
+        })
+        self.assertEqual(sale_order.order_line.name, "Test Product")
+        self.partner.lang = "fr_FR"
+        self.assertEqual(sale_order.order_line.name, "Produit Test")
+
 
 @tagged('post_install', '-at_install')
 class TestSaleOrderInvoicing(AccountTestInvoicingCommon, SaleCommon):


### PR DESCRIPTION
The description of an order line in the pdf generated for a sale order does not use partner's language if it has been changed after the order line creation

Steps to reproduce:
1. Install Sales
2. Go to Settings > Translations > Languages and activate language "French/Français"
3. Go to Sales and create a new quotation for partner "Acme Corporation" with product "Acoustic Bloc Screens"
4. Open the customer's form and change the language to "French/Français"
5. Go back to the quotation and print the quotation
6. The description of the order line is still in English

Solution:
Add a dependency to the partner's language on sale order line's name. This makes sure we recompute the order line name when the partner's language is modified

Issue:
The order line name is computed at its creation. Therefore, modifying the partner's name after the order line creation doesn't change the order line name to respect the partner's language

opw-6085804