### PR TITLE
[FIX] point_of_sale: undefined printer ids

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -54,14 +54,14 @@ export class Navbar extends Component {
 
     async openLnaPopup() {
         let localPrinterIp;
-        if (isPrivateIp(this.pos.config.epson_printer_ip)) {
-            localPrinterIp = this.pos.config.epson_printer_ip;
-        }
-        if (!localPrinterIp) {
-            for (const printer of this.pos.config.printer_ids) {
-                if (isPrivateIp(printer.epson_printer_ip)) {
-                    localPrinterIp = printer.epson_printer_ip;
-                }
+        const printerIds = new Set([
+            ...this.pos.config.receipt_printer_ids,
+            ...this.pos.config.preparation_printer_ids,
+        ]);
+        for (const printer of printerIds) {
+            if (isPrivateIp(printer.epson_printer_ip)) {
+                localPrinterIp = printer.epson_printer_ip;
+                break;
             }
         }
         if (localPrinterIp) {


### PR DESCRIPTION
We were looping over non existing `config.printer_ids`. It's either `config.receipt_printer_ids` or
`config.preparation_printer_ids`.

We now loop over a set containing values of both.