### PR TITLE
[IMP] html_editor: force HTML field to readonly in list views

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -353,7 +353,7 @@ export const htmlField = {
     component: HtmlField,
     displayName: _t("Html"),
     supportedTypes: ["html"],
-    extractProps({ attrs, options }, dynamicInfo) {
+    extractProps({ attrs, options, viewType }) {
         const editorConfig = {
             mediaModalParams: {
                 useMediaLibrary: true,
@@ -399,7 +399,8 @@ export const htmlField = {
         if ("debounceHints" in options) {
             editorConfig.debounceHints = Boolean(options.debounceHints);
         }
-        return {
+
+        const props = {
             editorConfig,
             isCollaborative: options.collaborative,
             collaborativeTrigger: options.collaborative_trigger,
@@ -412,6 +413,12 @@ export const htmlField = {
             cssReadonlyAssetId: options.cssReadonly,
             codeview: Boolean(odoo.debug && options.codeview),
         };
+
+        if (viewType === "list") {
+            props.readonly = true;
+        }
+
+        return props;
     },
 };
 

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2903,3 +2903,19 @@ test("should not open icon toolbar when creating table of contents inside a list
     await advanceTime(200);
     await expectElementCount(".o-we-toolbar", 0);
 });
+
+test("html field is forced readonly in list views", async () => {
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `
+            <list>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </list>`,
+    });
+
+    expect(".odoo-editor-editable").toHaveCount(0);
+    expect(`[name="txt"] .o_readonly`).toHaveCount(2);
+    expect(queryAllTexts(`[name="txt"] .o_readonly`)).toEqual(["first", "second"]);
+});


### PR DESCRIPTION
Updates the HtmlField component's `extractProps` function to strictly enforce readonly mode whenever it is rendered inside a list view, to prevent unintended inline editing.

Task~6063804