### PR TITLE
[FIX] web_editor: fix non-deterministic link popover test

### DIFF
--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -1107,6 +1107,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         // Wait for the popover to appear
         await nextTick();
         a.click();
+        setSelection(a, 0, a, 0); // Selection must be in the link otherwise the popover will close.
         await nextTick();
         // Click on the edit link icon
         document.querySelector("a.mx-1.o_we_edit_link.text-dark").click();


### PR DESCRIPTION
The popover opening is triggered through click, but there is a selectionchange handler on click that checks if the selection is outside of the link and, if it is, closes the popover.

In this case, the click method didn't set the selection inside the link properly because of the presence of \ufeff around the link. The test actually passes by mistake when the runbot was fast, but failed when the runbot was slow, as the selectionchange handler had the time to execute and close the popover.

This commit forces the selection to be inside the link after calling click, to be closer to what actually happens when a user click on a link, as opposed to a programmatic click.

runbot-161423
