### PR TITLE
[FIX] point_of_sale: shiplater COGS PoS

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -290,7 +290,13 @@ class PosOrder(models.Model):
         moves = self.mapped('picking_ids.move_ids')\
             .filtered(lambda m: m.is_valued and m.product_id.valuation == 'real_time' and m.product_id.id == product.id)\
             .sorted(lambda x: x.date)
-        return moves._get_price_unit()
+        if moves:
+            return moves._get_price_unit()
+        else:
+            if product.cost_method in ['standard', 'average']:
+                return product.standard_price
+            else:
+                return product._run_fifo(quantity) / quantity if quantity else 0
 
     name = fields.Char(string='Order Ref', required=True, readonly=True, copy=False, default='/')
     last_order_preparation_change = fields.Char(string='Last preparation change', help="Last printed state of the order")

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -123,6 +123,48 @@ class StockPicking(models.Model):
         pickings = self.filtered(lambda p: p.picking_type_id != p.picking_type_id.warehouse_id.pos_type_id)
         return super(StockPicking, pickings)._send_confirmation_email()
 
+    def _action_done(self):
+        res = super()._action_done()
+        for rec in self:
+            if rec.picking_type_id.code != 'outgoing':
+                continue
+            if rec.pos_order_id.shipping_date and not rec.pos_order_id.to_invoice:
+                cost_per_account = defaultdict(lambda: 0.0)
+                for line in rec.move_line_ids:
+                    if not line.product_id.is_storable or line.product_id.valuation != 'real_time':
+                        continue
+                    accounts = line.product_id._get_product_accounts()
+                    out = accounts['stock_valuation']
+                    exp = accounts['expense']
+                    line_cost = line.move_id.value * line.quantity_product_uom
+                    if line_cost != 0:
+                        cost_per_account[out, exp] += line_cost
+                move_vals = []
+                for (out_acc, exp_acc), cost in cost_per_account.items():
+                    move_vals.append({
+                        'journal_id': rec.pos_order_id.sale_journal.id,
+                        'date': rec.pos_order_id.date_order,
+                        'ref': 'pos_order_' + str(rec.pos_order_id.id),
+                        'partner_id': rec.pos_order_id.partner_id.id,
+                        'line_ids': [
+                            (0, 0, {
+                                'name': rec.pos_order_id.name,
+                                'account_id': exp_acc.id,
+                                'debit': cost,
+                                'credit': 0.0,
+                            }),
+                            (0, 0, {
+                                'name': rec.pos_order_id.name,
+                                'account_id': out_acc.id,
+                                'debit': 0.0,
+                                'credit': cost,
+                            }),
+                        ],
+                    })
+                move = self.env['account.move'].sudo().create(move_vals)
+                move.action_post()
+        return res
+
 
 class StockPickingType(models.Model):
     _name = 'stock.picking.type'

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -531,3 +531,57 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             {'product_id': self.product.id, 'credit': 20.0},
             {'product_id': product2.id, 'credit': 100.0},
         ])
+
+    def test_cogs_with_ship_later_invoicing(self):
+        # This test will check that the correct journal entries are created when an order use ship later and is invoiced
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        current_session.set_opening_control(0, None)
+
+        self.product = self.env['product.product'].create({
+            'name': 'New product 1',
+            'standard_price': 25,
+            'available_in_pos': True,
+            'is_storable': True,
+            'categ_id': self.category.id,
+        })
+
+        # I create a PoS order with 1 unit of New product at 450 EUR
+        self.pos_order_pos0 = self.PosOrder.create({
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'pricelist_id': self.company.partner_id.property_product_pricelist.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'to_invoice': False,
+            'shipping_date': '2023-01-01',
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product.id,
+                'price_unit': 100,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+            })],
+            'amount_total': 100,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'last_order_preparation_change': '{}'
+        })
+
+        # I make a payment to fully pay the order
+        context_make_payment = {"active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
+        self.pos_make_payment_0 = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 100.0,
+            'payment_method_id': self.cash_payment_method.id,
+        })
+        context_payment = {'active_id': self.pos_order_pos0.id}
+        self.pos_make_payment_0.with_context(context_payment).check()
+        self.pos_order_pos0._generate_pos_order_invoice()
+        self.pos_order_pos0
+        self.assertRecordValues(self.pos_order_pos0.account_move.line_ids,
+            [{'account_id': self.category.property_account_income_categ_id.id, 'balance': -100.0},
+            {'account_id': self.account.id, 'balance': 100.0},
+            {'account_id': self.category.property_stock_valuation_account_id.id, 'balance': -25.0},
+            {'account_id': self.category.property_account_expense_categ_id.id, 'balance': 25.0}])

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -264,7 +264,6 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(pos_order_pos0.account_move.journal_id, self.pos_config.invoice_journal_id)
         self.assertEqual(line.debit, 27, 'As it is a fifo product, the move\'s value should be 5*5 + 2*1')
 
-    @skip('Temporary to fast merge new valuation')
     def test_cogs_with_ship_later_no_invoicing(self):
         # This test will check that the correct journal entries are created when a product in real time valuation
         # is sold using the ship later option and no invoice is created in a company using anglo-saxon
@@ -324,25 +323,13 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         current_session.picking_ids.button_validate()
 
         # I test that the generated journal entries are correct.
-        account_output = self.category.property_stock_account_output_categ_id
+        account_output = self.category.property_stock_valuation_account_id
         expense_account = self.category.property_account_expense_categ_id
         aml = current_session._get_related_account_moves().line_ids
         aml_output = aml.filtered(lambda l: l.account_id.id == account_output.id)
         aml_expense = aml.filtered(lambda l: l.account_id.id == expense_account.id)
-
-        self.assertEqual(len(aml_output), 2, "There should be 2 output account move lines")
-        # 2 moves in POS journal (Pos order + manual entry at delivery)
-        self.assertEqual(len(aml_output.move_id.filtered(lambda l: l.journal_id == self.pos_config.journal_id)), 1)
-        # 1 move in stock journal (delivery from stock layers)
-        self.assertEqual(len(aml_output.move_id.filtered(lambda l: l.journal_id == self.category.property_stock_journal)), 1)
-        #Check the lines created after the picking validation
-        self.assertEqual(aml_output[1].credit, self.product.standard_price, "Cost of Good Sold entry missing or mismatching")
-        self.assertEqual(aml_output[1].debit, 0.0, "Cost of Good Sold entry missing or mismatching")
-        self.assertEqual(aml_expense[0].debit, self.product.standard_price, "Cost of Good Sold entry missing or mismatching")
-        self.assertEqual(aml_expense[0].credit, 0.0, "Cost of Good Sold entry missing or mismatching")
-        #Check the lines created by the PoS session
-        self.assertEqual(aml_output[0].debit, 100.0, "Cost of Good Sold entry missing or mismatching")
-        self.assertEqual(aml_output[0].credit, 0.0, "Cost of Good Sold entry missing or mismatching")
+        self.assertEqual(aml_expense.balance, 100)
+        self.assertEqual(aml_output.balance, -100)
 
     @skip('Temporary to fast merge new valuation')
     def test_action_pos_order_invoice(self):


### PR DESCRIPTION
When selling a product with the Ship Later option the COGS for the product were not recorded properly.

Steps to reproduce:
-------------------
* Create a product with fifo and real_time valuation
* Open PoS and add the product to the order
* Validate the order and set the Ship Later option
* Go to the backend and validate the picking of the order
* Go check the journal entries of the session
> Observation: It doesn't contain the COGS line.

Why the fix:
------------
Since the stock_valuation refactoring the COGS are not created anymore when validating the picking of the order.

opw-5965021