### PR TITLE
[FIX] crm: fair lead assignation

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -615,7 +615,7 @@ class Team(models.Model):
         for team, leads_to_assign_ids in leads_per_team.items():
             members_to_assign = list(team.crm_team_member_ids.filtered(lambda member:
                 not member.assignment_optout and quota_per_member.get(member, 0) > 0
-            ).sorted(key=lambda member: quota_per_member.get(member, 0), reverse=True))
+            ).sorted(key=lambda member: (quota_per_member.get(member, 0), random.random()), reverse=True))
             if not members_to_assign:
                 continue
             result_data.update({

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -3,8 +3,9 @@
 
 import random
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
@@ -553,3 +554,52 @@ class TestLeadAssign(TestLeadAssignCommon):
         members_data = sales_team_4._assign_and_convert_leads()
         self.assertFalse(members_data,
             "If team member has lead count greater than max assign,then do not assign any more")
+
+    def test_assign_fairness_member_order_bias(self):
+        """Make sure leads are distributed fairly across team members when all else is equal."""
+        random.seed(1000)
+
+        test_team = self.env['crm.team'].create({'name': 'Sales Team'})
+        senior = self.env['crm.team.member'].create({
+            'user_id': self.user_sales_leads.id,
+            'crm_team_id': test_team.id,
+            'assignment_max': 150,
+        })
+        junior = self.env['crm.team.member'].create({
+            'user_id': self.user_sales_salesman.id,
+            'crm_team_id': test_team.id,
+            'assignment_max': 150,
+        })
+        self.assertEqual(
+            (senior | junior).sorted().ids,
+            (senior | junior).ids,
+            "Senior should come before junior."
+        )
+
+        # Simulate the daily cron for 30 days. Each time there's 1 lead to be assigned.
+        base_time = datetime(2026, 1, 1, 8, 0, 0)
+        for run in range(30):
+            now = base_time + timedelta(hours=25) * run  # 25 hours to be outside of lead_day_count
+            with freeze_time(now), patch.object(self.env.cr, 'now', lambda: now):
+                self.env['crm.lead'].create({
+                    'name': f'TestLead_{run}',
+                    'type': 'lead',
+                    'user_id': False,
+                    'email_from': f'lead_{run}@example.com',
+                    'probability': 50,
+                    'team_id': test_team.id,
+                })
+                with mute_logger('odoo.addons.crm.models.crm_team'):
+                    test_team._assign_and_convert_leads()
+
+        senior_leads = self.env['crm.lead'].search_count([
+            ('user_id', '=', senior.user_id.id),
+            ('team_id', '=', test_team.id),
+        ])
+        junior_leads = self.env['crm.lead'].search_count([
+            ('user_id', '=', junior.user_id.id),
+            ('team_id', '=', test_team.id),
+        ])
+
+        self.assertEqual(senior_leads, 11)
+        self.assertEqual(junior_leads, 19)


### PR DESCRIPTION
_assign_and_convert_leads() is biased towards team members created earlier because they're ordered by create_date, id.

When members have equal quota, the round-robin order falls back to the order of the team members. If the amount of leads distributed across the team is not a multiple of the team size, then the oldest members will get more leads assigned. This advantage repeats each time the cron runs and can add up to a big difference, the provided test case ends up assigning all 30 leads to the more senior member without the fix.

Note that the lead_day_count field used in _get_assignment_quota() doesn't solve the problem. It helps to balance leads assigned in the same 24 hour window, but because the same senior person always goes first inside one of those windows, they will always get more leads assigned to them.

To fix it we break ties in the quota randomly.

task-6119168
