### PR TITLE
[IMP] l10n_ph: enhance payment voucher report

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -21,7 +21,7 @@
                             </t>
                             <t t-else="o.partner_type == 'supplier'">
                                 Vendor:
-                            </t><span t-field="o.partner_id" data-oe-demo="Marc Demo"/>
+                            </t> <span t-field="o.partner_id" data-oe-demo="Marc Demo"/>
                         </div>
                         <div name="payment_method"
                              t-if="values['display_payment_method'] and o.payment_method_id"

--- a/addons/l10n_ph/__manifest__.py
+++ b/addons/l10n_ph/__manifest__.py
@@ -21,6 +21,7 @@
         'views/res_company_views.xml',
         'views/res_partner_views.xml',
         'views/report_disbursement_voucher_template.xml',
+        'views/report_disbursement_voucher_internal_template.xml',
         'views/account_report.xml',
         'views/report_templates.xml',
     ],

--- a/addons/l10n_ph/models/__init__.py
+++ b/addons/l10n_ph/models/__init__.py
@@ -3,3 +3,4 @@ from . import template_ph
 from . import res_partner
 from . import account_tax
 from . import res_company
+from . import account_payment

--- a/addons/l10n_ph/models/__init__.py
+++ b/addons/l10n_ph/models/__init__.py
@@ -2,6 +2,7 @@
 from . import template_ph
 from . import res_partner
 from . import account_move
+from . import account_move_line
 from . import account_payment
 from . import account_tax
 from . import res_company

--- a/addons/l10n_ph/models/account_move_line.py
+++ b/addons/l10n_ph/models/account_move_line.py
@@ -1,0 +1,105 @@
+"""Payment voucher helpers for account move lines."""
+
+from odoo import models
+from odoo.tools.float_utils import float_round
+from odoo.tools.misc import formatLang, get_lang
+
+
+class AccountMoveLine(models.Model):
+    """Extend journal items with report-friendly analytic distribution formatting."""
+
+    _inherit = "account.move.line"
+
+    def _get_analytic_distribution_plan_summaries(self):
+        self.ensure_one()
+
+        if not self.analytic_distribution:
+            return []
+
+        analytic_distribution = self.analytic_distribution
+        analytic_keys = [key for key in analytic_distribution if key != '__update__']
+        analytic_account_ids = sorted({
+            int(account_id)
+            for account_ids in analytic_keys
+            for account_id in account_ids.split(',')
+            if account_id.isdigit()
+        })
+
+        analytic_accounts = self.env['account.analytic.account'].with_context(active_test=False)
+        accounts_by_id = {
+            account.id: account
+            for account in analytic_accounts.browse(analytic_account_ids).exists()
+        }
+        plans_summary = {}
+
+        for account_ids, distribution in analytic_distribution.items():
+            if account_ids == '__update__':
+                continue
+            valid_account_ids = [
+                int(account_id)
+                for account_id in account_ids.split(',')
+                if account_id.isdigit()
+            ]
+            for account_id in valid_account_ids:
+                account = accounts_by_id.get(account_id)
+                if not account:
+                    continue
+
+                plan = account.root_plan_id
+                plan_summary = plans_summary.setdefault(plan.id, {
+                    'plan': plan,
+                    'accounts': {},
+                })
+                account_summary = plan_summary['accounts'].setdefault(account.id, {
+                    'account': account,
+                    'total': 0.0,
+                })
+                account_summary['total'] += float(distribution or 0.0)
+
+        return [plans_summary[plan_id] for plan_id in sorted(plans_summary)]
+
+    def _format_analytic_distribution_percentage(self, value, precision):
+        decimal_point = get_lang(self.env).decimal_point
+        formatted = formatLang(
+            self.env,
+            float_round(value, precision_digits=precision),
+            digits=precision,
+            grouping=False,
+        )
+        if precision:
+            formatted = formatted.rstrip('0').rstrip(decimal_point)
+        return f"{formatted}%"
+
+    def _is_analytic_distribution_complete(self, total, precision):
+        return float_round(total, precision_digits=precision) == 100
+
+    def _get_analytic_distribution_plain_text(self):
+        self.ensure_one()
+        plan_summaries = self._get_analytic_distribution_plan_summaries()
+        if not plan_summaries:
+            return ""
+
+        precision = self.analytic_precision or self.env[
+            'decimal.precision'
+        ].precision_get('Percentage Analytic')
+        plan_texts = []
+        for plan_summary in plan_summaries:
+            account_summaries = [
+                plan_summary['accounts'][account_id]
+                for account_id in sorted(plan_summary['accounts'])
+            ]
+            account_texts = []
+            for account_summary in account_summaries:
+                if self._is_analytic_distribution_complete(account_summary['total'], precision):
+                    account_texts.append(account_summary['account'].display_name)
+                else:
+                    percentage_text = self._format_analytic_distribution_percentage(
+                        account_summary['total'],
+                        precision,
+                    )
+                    account_texts.append(
+                        f"{percentage_text} "
+                        f"{account_summary['account'].display_name}"
+                    )
+            plan_texts.append(", ".join(account_texts))
+        return '\n'.join(plan_texts)

--- a/addons/l10n_ph/models/account_payment.py
+++ b/addons/l10n_ph/models/account_payment.py
@@ -1,0 +1,52 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    def _get_aggregated_bill_lines_with_totals(self):
+        self.ensure_one()
+
+        aggregated = {}
+        total_debit = 0.0
+        total_credit = 0.0
+        currency_round = self.company_id.currency_id.round
+
+        for line in self.reconciled_bill_ids.line_ids:
+            key = (line.account_id.id, line.move_name)
+            if key not in aggregated:
+                aggregated[key] = {
+                    'account_id': line.account_id,
+                    'move_name': line.move_name,
+                    'debit': 0.0,
+                    'credit': 0.0,
+                }
+            aggregated[key]['debit'] = currency_round(aggregated[key]['debit'] + line.debit)
+            aggregated[key]['credit'] = currency_round(aggregated[key]['credit'] + line.credit)
+            total_debit = currency_round(total_debit + line.debit)
+            total_credit = currency_round(total_credit + line.credit)
+
+        return {
+            'lines': list(aggregated.values()),
+            'total_debit': total_debit,
+            'total_credit': total_credit,
+        }
+
+    def _get_payment_journal_entries_with_totals(self):
+        self.ensure_one()
+
+        if not self.move_id or self.move_id.move_type != 'entry':
+            return {'lines': [], 'total_debit': 0.0, 'total_credit': 0.0}
+
+        currency_round = self.company_id.currency_id.round
+        lines = self.move_id.line_ids
+        total_debit = currency_round(sum(lines.mapped('debit')))
+        total_credit = currency_round(sum(lines.mapped('credit')))
+
+        return {
+            'lines': lines,
+            'total_debit': total_debit,
+            'total_credit': total_credit,
+        }

--- a/addons/l10n_ph/tests/__init__.py
+++ b/addons/l10n_ph/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import common
 from . import test_bir_2307_generation
+from . import test_payment_voucher

--- a/addons/l10n_ph/tests/test_payment_voucher.py
+++ b/addons/l10n_ph/tests/test_payment_voucher.py
@@ -1,0 +1,92 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ph.tests.common import TestPhCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestPaymentVoucher(TestPhCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        project_plan, _other_plans = cls.env['account.analytic.plan']._get_all_plans()
+        department_plan = cls.env['account.analytic.plan'].create({
+            'name': 'Department',
+        })
+        cls.project_account = cls.env['account.analytic.account'].create({
+            'name': 'Project Alpha',
+            'plan_id': project_plan.id,
+        })
+        cls.second_project_account = cls.env['account.analytic.account'].create({
+            'name': 'Project Beta',
+            'plan_id': project_plan.id,
+        })
+        cls.department_account_a = cls.env['account.analytic.account'].create({
+            'name': 'Department A',
+            'plan_id': department_plan.id,
+        })
+        cls.department_account_b = cls.env['account.analytic.account'].create({
+            'name': 'Department B',
+            'plan_id': department_plan.id,
+        })
+
+    def test_01_plain_text_analytic_distribution_summary(self):
+        """Ensure plain text rendering groups totals by analytic plan."""
+        bill = self.init_invoice(
+            move_type='in_invoice',
+            amounts=[100.0],
+            partner=self.partner_a,
+        )
+        line = bill.invoice_line_ids
+        line.analytic_distribution = {
+            f'{self.project_account.id},{self.department_account_a.id}': 20.0,
+            f'{self.project_account.id},{self.department_account_b.id}': 80.0,
+        }
+
+        text_lines = line._get_analytic_distribution_plain_text().splitlines()
+        self.assertEqual(text_lines[0], self.project_account.display_name)
+        self.assertEqual(
+            text_lines[1],
+            f'20% {self.department_account_a.display_name}, 80% {self.department_account_b.display_name}',
+        )
+
+    def test_02_plain_text_analytic_distribution_aggregates_combinations(self):
+        """Ensure percentages are accumulated across analytic account combinations."""
+        bill = self.init_invoice(
+            move_type='in_invoice',
+            amounts=[100.0],
+            partner=self.partner_a,
+        )
+        line = bill.invoice_line_ids
+        line.analytic_distribution = {
+            f'{self.project_account.id},{self.department_account_a.id}': 20.0,
+            f'{self.project_account.id},{self.department_account_b.id}': 30.0,
+            f'{self.second_project_account.id},{self.department_account_a.id}': 50.0,
+        }
+
+        self.assertEqual(
+            line._get_analytic_distribution_plain_text(),
+            f'50% {self.project_account.display_name}, 50% {self.second_project_account.display_name}\n'
+            f'70% {self.department_account_a.display_name}, 30% {self.department_account_b.display_name}',
+        )
+
+    def test_03_plain_text_analytic_distribution_includes_inactive_account(self):
+        """Ensure inactive analytic accounts are still resolved in the plain text output."""
+        self.department_account_b.active = False
+
+        bill = self.init_invoice(
+            move_type='in_invoice',
+            amounts=[100.0],
+            partner=self.partner_a,
+        )
+        line = bill.invoice_line_ids
+        line.analytic_distribution = {
+            f'{self.project_account.id},{self.department_account_b.id}': 100.0,
+        }
+
+        self.assertEqual(
+            line._get_analytic_distribution_plain_text(),
+            f'{self.project_account.display_name}\n{self.department_account_b.display_name}',
+        )

--- a/addons/l10n_ph/views/account_report.xml
+++ b/addons/l10n_ph/views/account_report.xml
@@ -1,12 +1,23 @@
 <odoo>
     <record id="action_report_disbursement_voucher_ph" model="ir.actions.report">
-        <field name="name">Philippines : Disbursement Voucher</field>
+        <field name="name">Disbursement Voucher</field>
         <field name="model">account.payment</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">l10n_ph.report_disbursement_voucher</field>
         <field name="report_file">l10n_ph.report_disbursement_voucher</field>
         <field name="binding_model_id" ref="account.model_account_payment"/>
         <field name="binding_type">report</field>
-        <field name="domain" eval="[('company_id.country_code', '=', 'PH')]"/>
+        <field name="domain">[('company_id.country_code', '=', 'PH')]</field>
+    </record>
+
+    <record id="action_report_disbursement_voucher_internal_ph" model="ir.actions.report">
+        <field name="name">Internal Disbursement Voucher</field>
+        <field name="model">account.payment</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_ph.report_disbursement_voucher_internal</field>
+        <field name="report_file">l10n_ph.report_disbursement_voucher_internal</field>
+        <field name="binding_model_id" ref="account.model_account_payment"/>
+        <field name="binding_type">report</field>
+        <field name="domain">[('company_id.country_code', '=', 'PH'), ('reconciled_bill_ids', '!=', False)]</field>
     </record>
 </odoo>

--- a/addons/l10n_ph/views/report_disbursement_voucher_internal_template.xml
+++ b/addons/l10n_ph/views/report_disbursement_voucher_internal_template.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template inherit_id="l10n_ph.report_disbursement_voucher_document" id="report_disbursement_voucher_internal_document" primary="True">
+        <xpath expr="//t[@name='voucher_title']" position="replace">
+            <t name="voucher_title">Disbursement Voucher: Internal</t>
+        </xpath>
+
+        <xpath expr="//div[table[@name='invoices']]" position="after">
+            <t t-if="o.reconciled_bill_ids">
+                <h5 class="mt-3 mb-2"><strong>Related Vendor Bill</strong></h5>
+                <table name="vendor_bill_journal_entries"
+                       class="table table-borderless"
+                       style="page-break-inside: avoid;">
+                    <thead>
+                        <tr>
+                            <th class="col-4"><span>Account</span></th>
+                            <th class="col-4"><span>Number</span></th>
+                            <th class="text-end col-2"><span>Debit</span></th>
+                            <th class="text-end col-2"><span>Credit</span></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-set="bill_data" t-value="o._get_aggregated_bill_lines_with_totals()"/>
+                        <t t-foreach="bill_data['lines']" t-as="agg_line">
+                            <tr>
+                                <td><span t-out="agg_line['account_id'].code"/> - <span t-out="agg_line['account_id'].name"/></td>
+                                <td><span t-out="agg_line['move_name']"/></td>
+                                <td class="text-end">
+                                    <span t-out="agg_line['debit']" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </td>
+                                <td class="text-end">
+                                    <span t-out="agg_line['credit']" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </td>
+                            </tr>
+                        </t>
+                        <tr>
+                            <td><strong>Totals</strong></td>
+                            <td/>
+                            <td class="text-end">
+                                <strong>
+                                    <span t-out="bill_data['total_debit']"
+                                          t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </strong>
+                            </td>
+                            <td class="text-end">
+                                <strong>
+                                    <span t-out="bill_data['total_credit']"
+                                          t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </strong>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="report_disbursement_voucher_internal">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
+                <t t-call="l10n_ph.report_disbursement_voucher_internal_document" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/addons/l10n_ph/views/report_disbursement_voucher_template.xml
+++ b/addons/l10n_ph/views/report_disbursement_voucher_template.xml
@@ -2,7 +2,8 @@
 <odoo>
     <template id="l10n_ph.minimal_layout" inherit_id="web.minimal_layout">
         <xpath expr="//script[@t-if='subst']" position="after">
-        <t t-if="report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph'">
+        <t t-set="is_l10n_ph_voucher_report" t-value="report_xml_id in ('l10n_ph.action_report_disbursement_voucher_ph', 'l10n_ph.action_report_disbursement_voucher_internal_ph')"/>
+        <t t-if="is_l10n_ph_voucher_report">
             <script>
                 function display_footer_on_last_page_only() {
                     var vars = {};
@@ -21,7 +22,7 @@
         </t>
         </xpath>
         <xpath expr="//body" position="attributes">
-            <attribute name="t-att-onload">(subst and 'subst();' or '') + (report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph' and 'display_footer_on_last_page_only()' or '')</attribute>
+            <attribute name="t-att-onload">(subst and 'subst();' or '') + (is_l10n_ph_voucher_report and 'display_footer_on_last_page_only()' or '')</attribute>
         </xpath>
     </template>
 
@@ -48,68 +49,90 @@
         </div>
     </template>
 
-    <template inherit_id="account.report_payment_receipt_document" id="report_disbursement_voucher_document">
+    <template inherit_id="account.report_payment_receipt_document" id="report_disbursement_voucher_document" primary="True">
+        <xpath expr="//t[@t-call='web.external_layout']" position="before">
+            <t t-set="l10n_ph_voucher_footer" t-value="True"/>
+        </xpath>
+
         <xpath expr="//span[@t-field='o.payment_receipt_title']" position="replace">
-            <t t-if="is_l10n_ph_disbursement_voucher">
-                Disbursement Voucher:
-            </t>
-            <t t-else="">
-                <span t-field="o.payment_receipt_title">Payment Receipt</span>:
-            </t>
+            <t name="voucher_title">Disbursement Voucher:</t>
         </xpath>
 
         <xpath expr="//div[hasclass('row')][div[hasclass('col-6')][@t-if='o.memo']]" position="after">
-            <t t-if="is_l10n_ph_disbursement_voucher">
+            <t t-if="o.payment_method_id.code == 'check_printing'">
                 <div class="row">
-                    <div class="col-6 offset-6" t-if="o.check_number">
+                    <div class="col-6" t-if="o.date">
+                        Check Date: <span t-field="o.date"/>
+                    </div>
+                    <div class="col-6" t-if="o.check_number">
                         Check Number: <span t-field="o.check_number"/>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-6" t-if="o.journal_id">
+                        Journal: <span t-field="o.journal_id"/>
+                    </div>
+                    <div class="col-6" t-if="o.check_amount_in_words">
+                        Amount in Words: <span t-field="o.check_amount_in_words"/>
                     </div>
                 </div>
             </t>
         </xpath>
 
         <xpath expr="//table[@name='invoices']" position="attributes">
-            <attribute name="t-if">
-                ('is_l10n_ph_disbursement_voucher' and (o.reconciled_invoice_ids or o.reconciled_bill_ids))
-                or (values['display_invoices'] and not is_l10n_ph_disbursement_voucher)
-            </attribute>
+            <attribute name="t-if">o.reconciled_invoice_ids or o.reconciled_bill_ids</attribute>
         </xpath>
 
         <xpath expr="//div[table[@name='invoices']]" position="after">
-            <t t-if="is_l10n_ph_disbursement_voucher">
-                <table name="journal_entries"
-                    t-if="o.move_id and o.move_id.move_type == 'entry'"
-                    class="table table-borderless"
-                    style="page-break-inside: avoid;">
-                    <thead>
-                        <tr>
-                            <th class="col-8"><span>Account</span></th>
-                            <th class="text-end col-2"><span>Debit</span></th>
-                            <th class="text-end col-2"><span>Credit</span></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <t t-foreach="o.move_id.line_ids" t-as="line">
-                        <tr>
-                            <td><span t-field="line.account_id.name"/></td>
-                            <td class="text-end">
-                                <span t-field="line.debit" t-options="{'widget': 'monetary', 'display_currency': line.company_currency_id}"/>
-                            </td>
-                            <td class="text-end">
-                                <span t-field="line.credit" t-options="{'widget': 'monetary', 'display_currency': line.company_currency_id}"/>
-                            </td>
-                        </tr>
-                        </t>
-                    </tbody>
-                </table>
-            </t>
+            <t t-set="payment_data" t-value="o._get_payment_journal_entries_with_totals()"/>
+            <h5 class="mt-4 mb-2" t-if="payment_data['lines']"><strong>Payment</strong></h5>
+            <table name="journal_entries"
+                   t-if="payment_data['lines']"
+                class="table table-borderless"
+                style="page-break-inside: avoid;">
+                <thead>
+                    <tr>
+                        <th class="col-4"><span>Account</span></th>
+                        <th class="col-4"><span>Label</span></th>
+                        <th class="text-end col-2"><span>Debit</span></th>
+                        <th class="text-end col-2"><span>Credit</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr t-foreach="payment_data['lines']" t-as="line">
+                        <td><span t-field="line.account_id"/></td>
+                        <td><span t-field="line.name"/></td>
+                        <td class="text-end">
+                            <span t-field="line.debit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                        </td>
+                        <td class="text-end">
+                            <span t-field="line.credit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><strong>Totals</strong></td>
+                        <td/>
+                        <td class="text-end">
+                            <strong>
+                                <span t-out="payment_data['total_debit']"
+                                      t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                            </strong>
+                        </td>
+                        <td class="text-end">
+                            <strong>
+                                <span t-out="payment_data['total_credit']"
+                                      t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                            </strong>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </xpath>
     </template>
 
     <template id="report_disbursement_voucher">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-set="is_l10n_ph_disbursement_voucher" t-value="True"/>
                 <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
                 <t t-call="l10n_ph.report_disbursement_voucher_document" t-lang="lang"/>
             </t>

--- a/addons/l10n_ph/views/report_disbursement_voucher_template.xml
+++ b/addons/l10n_ph/views/report_disbursement_voucher_template.xml
@@ -2,26 +2,28 @@
 <odoo>
     <template id="l10n_ph.minimal_layout" inherit_id="web.minimal_layout">
         <xpath expr="//script[@t-if='subst']" position="after">
-        <t t-if="report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph'">
-            <script>
-                function display_footer_on_last_page_only() {
+            <t t-if="report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph'">
+                <script>
+                    function display_footer_on_last_page_only() {
                     var vars = {};
                     var x = document.location.search.substring(1).split('&amp;');
                     for (var i in x) {
-                        var z = x[i].split('=', 2);
-                        vars[z[0]] = unescape(z[1]);
+                    var z = x[i].split('=', 2);
+                    vars[z[0]] = unescape(z[1]);
                     }
                     var elements = document.getElementsByClassName('last-page');
                     var isLastPage = vars.sitepage === vars.sitepages;
                     for (var i = 0; i&lt;elements.length; i++) {
-                        elements[i].style.display = isLastPage ? 'inherit' : 'none';
+                    elements[i].style.display = isLastPage ? 'inherit' : 'none';
                     }
-                }
-            </script>
-        </t>
+                    }
+                </script>
+            </t>
         </xpath>
         <xpath expr="//body" position="attributes">
-            <attribute name="t-att-onload">(subst and 'subst();' or '') + (report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph' and 'display_footer_on_last_page_only()' or '')</attribute>
+            <attribute name="t-att-onload">(subst and 'subst();' or '') + (report_xml_id == 'l10n_ph.action_report_disbursement_voucher_ph' and
+                'display_footer_on_last_page_only()' or '')
+            </attribute>
         </xpath>
     </template>
 
@@ -29,7 +31,8 @@
         <div class="last-page text-start">
             <div class="row">
                 <div class="col-8">
-                    Prepared By: <span t-out="user.name"/>
+                    Prepared By:
+                    <span t-out="user.name"/>
                 </div>
                 <div class="col-4">
                     Approved By:
@@ -59,10 +62,25 @@
         </xpath>
 
         <xpath expr="//div[hasclass('row')][div[hasclass('col-6')][@t-if='o.memo']]" position="after">
-            <t t-if="is_l10n_ph_disbursement_voucher">
+            <t t-if="is_l10n_ph_disbursement_voucher and o.payment_method_id.code == 'check_printing'">
                 <div class="row">
-                    <div class="col-6 offset-6" t-if="o.check_number">
-                        Check Number: <span t-field="o.check_number"/>
+                    <div class="col-6" t-if="o.date">
+                        Check Date:
+                        <span t-field="o.date"/>
+                    </div>
+                    <div class="col-6" t-if="o.check_number">
+                        Check Number:
+                        <span t-field="o.check_number"/>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-6" t-if="o.journal_id">
+                        Bank:
+                        <span t-field="o.journal_id"/>
+                    </div>
+                    <div class="col-6" t-if="o.check_amount_in_words">
+                        Amount in Words:
+                        <span t-field="o.check_amount_in_words"/>
                     </div>
                 </div>
             </t>
@@ -77,31 +95,160 @@
 
         <xpath expr="//div[table[@name='invoices']]" position="after">
             <t t-if="is_l10n_ph_disbursement_voucher">
-                <table name="journal_entries"
-                    t-if="o.move_id and o.move_id.move_type == 'entry'"
-                    class="table table-borderless"
-                    style="page-break-inside: avoid;">
-                    <thead>
-                        <tr>
-                            <th class="col-8"><span>Account</span></th>
-                            <th class="text-end col-2"><span>Debit</span></th>
-                            <th class="text-end col-2"><span>Credit</span></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <t t-foreach="o.move_id.line_ids" t-as="line">
-                        <tr>
-                            <td><span t-field="line.account_id.name"/></td>
-                            <td class="text-end">
-                                <span t-field="line.debit" t-options="{'widget': 'monetary', 'display_currency': line.company_currency_id}"/>
-                            </td>
-                            <td class="text-end">
-                                <span t-field="line.credit" t-options="{'widget': 'monetary', 'display_currency': line.company_currency_id}"/>
-                            </td>
-                        </tr>
-                        </t>
-                    </tbody>
-                </table>
+                <t t-set="show_source_bill" t-value="len(o.reconciled_bill_ids) &gt; 1"/>
+
+                <t t-if="o.reconciled_bill_ids">
+                    <h5 class="mt-3 mb-2">
+                        <strong>Related Vendor Bill</strong>
+                    </h5>
+                    <table name="vendor_bill_journal_entries"
+                           class="table table-borderless"
+                           style="page-break-inside: avoid;">
+                        <thead>
+                            <tr>
+                                <th class="col-2">
+                                    <span>Account</span>
+                                </th>
+                                <th class="col-3">
+                                    <span>Number</span>
+                                </th>
+                                <th t-if="show_source_bill" class="col-2">
+                                    <span>Source Vendor Bill</span>
+                                </th>
+                                <th groups="analytic.group_analytic_accounting" class="col-3">
+                                    <span>Analytic Distribution</span>
+                                </th>
+                                <th class="text-end col-1">
+                                    <span>Debit</span>
+                                </th>
+                                <th class="text-end col-1">
+                                    <span>Credit</span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-set="related_bill_debit_total" t-value="0.0"/>
+                            <t t-set="related_bill_credit_total" t-value="0.0"/>
+                            <t t-foreach="o.reconciled_bill_ids" t-as="bill">
+                                <tr t-foreach="bill.line_ids" t-as="line">
+                                    <t t-set="related_bill_debit_total" t-value="related_bill_debit_total + line.debit"/>
+                                    <t t-set="related_bill_credit_total" t-value="related_bill_credit_total + line.credit"/>
+                                    <td>
+                                        <span t-out="line.account_id.display_name"/>
+                                    </td>
+                                    <td>
+                                        <span t-out="line.move_name"/>
+                                    </td>
+                                    <td t-if="show_source_bill">
+                                        <span t-field="bill.name"/>
+                                    </td>
+                                    <td groups="analytic.group_analytic_accounting">
+                                        <span t-out="line._get_analytic_distribution_plain_text() or '-'"
+                                              style="white-space: pre-line;"/>
+                                    </td>
+                                    <td class="text-end">
+                                        <span t-field="line.debit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </td>
+                                    <td class="text-end">
+                                        <span t-field="line.credit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </td>
+                                </tr>
+                            </t>
+                            <tr>
+                                <td>
+                                    <strong>Totals</strong>
+                                </td>
+                                <td/>
+                                <td t-if="show_source_bill"/>
+                                <td groups="analytic.group_analytic_accounting"/>
+                                <td class="text-end">
+                                    <strong>
+                                        <span t-out="related_bill_debit_total"
+                                              t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </strong>
+                                </td>
+                                <td class="text-end">
+                                    <strong>
+                                        <span t-out="related_bill_credit_total"
+                                              t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </strong>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </t>
+
+                <t t-if="o.move_id and o.move_id.move_type == 'entry'">
+                    <h5 class="mt-4 mb-2">
+                        <strong>Payment</strong>
+                    </h5>
+                    <table name="payment_journal_entries"
+                           class="table table-borderless"
+                           style="page-break-inside: avoid;">
+                        <thead>
+                            <tr>
+                                <th class="col-3">
+                                    <span>Account</span>
+                                </th>
+                                <th class="col-3">
+                                    <span>Label</span>
+                                </th>
+                                <th groups="analytic.group_analytic_accounting" class="col-3">
+                                    <span>Analytic Distribution</span>
+                                </th>
+                                <th class="text-end col-2">
+                                    <span>Debit</span>
+                                </th>
+                                <th class="text-end col-2">
+                                    <span>Credit</span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-set="payment_debit_total" t-value="0.0"/>
+                            <t t-set="payment_credit_total" t-value="0.0"/>
+                            <tr t-foreach="o.move_id.line_ids" t-as="line">
+                                <t t-set="payment_debit_total" t-value="payment_debit_total + line.debit"/>
+                                <t t-set="payment_credit_total" t-value="payment_credit_total + line.credit"/>
+                                <td>
+                                    <span t-field="line.account_id"/>
+                                </td>
+                                <td>
+                                    <span t-field="line.name"/>
+                                </td>
+                                <td groups="analytic.group_analytic_accounting">
+                                    <span t-out="line._get_analytic_distribution_plain_text() or '-'"
+                                          style="white-space: pre-line;"/>
+                                </td>
+                                <td class="text-end">
+                                    <span t-field="line.debit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </td>
+                                <td class="text-end">
+                                    <span t-field="line.credit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <strong>Totals</strong>
+                                </td>
+                                <td/>
+                                <td groups="analytic.group_analytic_accounting"/>
+                                <td class="text-end">
+                                    <strong>
+                                        <span t-out="payment_debit_total"
+                                              t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </strong>
+                                </td>
+                                <td class="text-end">
+                                    <strong>
+                                        <span t-out="payment_credit_total"
+                                              t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
+                                    </strong>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </t>
             </t>
         </xpath>
     </template>

--- a/addons/l10n_ph/views/report_templates.xml
+++ b/addons/l10n_ph/views/report_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="l10n_ph.external_layout_footer_content" inherit_id="web.external_layout_footer_content">
         <xpath expr="//div[@t-field='company.report_footer']" position="before">
-            <t t-if="is_l10n_ph_disbursement_voucher">
+            <t t-if="l10n_ph_voucher_footer">
                 <t t-call="l10n_ph.report_disbursement_voucher_document_footer"/>
             </t>
         </xpath>


### PR DESCRIPTION
This commit introduces a new "Disbursement Voucher: Internal" PDF report
for the Philippines localization and enhances the main voucher report with
expanded check details.

Key changes include:
- **Internal Voucher Report**: Added a new internal PDF report that displays
  related Vendor Bills (aggregated by account and move name) and Payment
  journal entries, alongside their respective debit/credit totals.
- **Check Details Expansion**: The check printing details block now displays
  Check Date, Bank, and Amount in Words. This applies to both the standard
  and internal reports when the payment method is check printing.
- **Logic Extraction**: Moved the data aggregation and total calculation
  logic out of QWeb and into Python (`_get_aggregated_bill_lines_with_totals`
  and `_get_payment_journal_entries_with_totals` in `account.payment`).
  This significantly cleans up the XML templates and improves maintainability.
- **Footer Integration**: Reused the existing signature footer logic for
  the new internal report to maintain consistent internal routing and approvals.

Task-5971773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
