### PR TITLE
[IMP] hr_livechat: access rights issue for users without payroll access

### DIFF
--- a/addons/hr_livechat/views/discuss_channel_views.xml
+++ b/addons/hr_livechat/views/discuss_channel_views.xml
@@ -9,7 +9,7 @@
                 <xpath expr="//*[@name='filter_my_sessions']" position="after">
                     <filter
                        name="filter_my_team"
-                       domain="['|', ('channel_member_ids.partner_id.user_ids', '=', uid), ('channel_member_ids.partner_id.employee_ids.parent_id.user_id', '=', uid)]"
+                       domain="['|', ('channel_member_ids.partner_id.user_ids', '=', uid), ('channel_member_ids.partner_id.user_ids.employee_public_ids.parent_id.user_id', '=', uid)]"
                        string="My Team"
                     />
                 </xpath>

--- a/addons/hr_livechat/views/im_livechat_report_channel_views.xml
+++ b/addons/hr_livechat/views/im_livechat_report_channel_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="im_livechat.im_livechat_report_channel_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//*[@name='my_session']" position="after">
-                <filter name="my_team" domain="['|', ('partner_id.user_ids', '=', uid), ('partner_id.employee_ids.parent_id.user_id', '=', uid)]" string="My Team"/>
+                <filter name="my_team" domain="['|', ('partner_id.user_ids', '=', uid), ('partner_id.user_ids.employee_public_ids.parent_id.user_id', '=', uid)]" string="My Team"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Some users have access to livechat but not to payroll, which leads to access errors when fetching employee-related data.

To avoid this issue, employee public IDs are used instead, as they are accessible to all internal users without requiring payroll access.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
