### PR TITLE
[FIX] web: support filename in pdf viewer field

### DIFF
--- a/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
+++ b/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
@@ -14,6 +14,7 @@ export class PdfViewerField extends Component {
     };
     static props = {
         ...standardFieldProps,
+        fileNameField: { type: String, optional: true },
     };
 
     setup() {
@@ -45,8 +46,13 @@ export class PdfViewerField extends Component {
         return `/web/static/lib/pdfjs/web/viewer.html?file=${file}#page=${page}`;
     }
 
-    update({ data }) {
-        const changes = { [this.props.name]: data || false };
+    update({ name, data }) {
+        const changes = {
+            [this.props.name]: data || false,
+        };
+        if (this.props.fileNameField && this.props.record.data[this.props.fileNameField] !== name) {
+            changes[this.props.fileNameField] = name || false;
+        }
         return this.props.record.update(changes);
     }
 
@@ -55,10 +61,10 @@ export class PdfViewerField extends Component {
         this.update({});
     }
 
-    onFileUploaded({ data, objectUrl }) {
+    onFileUploaded({ name, data, objectUrl }) {
         this.state.isValid = true;
         this.state.objectUrl = objectUrl;
-        this.update({ data });
+        this.update({ name, data });
     }
 
     onLoadFailed() {
@@ -81,6 +87,7 @@ export const pdfViewerField = {
         },
     ],
     supportedTypes: ["binary"],
+    extractProps: ({ attrs }) => ({ fileNameField: attrs.filename }),
 };
 
 registry.category("fields").add("pdf_viewer", pdfViewerField);

--- a/addons/web/static/tests/views/fields/pdf_viewer_field.test.js
+++ b/addons/web/static/tests/views/fields/pdf_viewer_field.test.js
@@ -18,9 +18,11 @@ const getIframeViewerParams = () =>
 
 class Partner extends models.Model {
     document = fields.Binary({ string: "Binary" });
+    document_name = fields.Char({ string: "Filename" });
     _records = [
         {
             document: "coucou==\n",
+            document_name: "test.pdf",
         },
     ];
 }
@@ -75,4 +77,31 @@ test("PdfViewerField: upload rendering", async () => {
     expect(getIframeProtocol()).toBe("blob");
     await clickSave();
     expect(getIframeProtocol()).toBe("blob");
+});
+
+test("PdfViewerField: upload also sets filename", async () => {
+    expect.assertions(1);
+
+    onRpc("web_save", ({ args }) => {
+        expect(args[1]).toEqual({
+            document: btoa("test"),
+            document_name: "test.pdf",
+        });
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="document" widget="pdf_viewer" filename="document_name"/>
+            </form>
+        `,
+    });
+
+    const file = new File(["test"], "test.pdf", { type: "application/pdf" });
+    await click(".o_field_pdf_viewer input[type=file]");
+    await setInputFiles(file);
+    await waitFor("iframe.o_pdfview_iframe");
+    await clickSave();
 });


### PR DESCRIPTION
When uploading a file using the PDF viewer field, the filename was not 
stored in the corresponding filename field.

This commit updates the PdfViewerField to support a filename field via 
the `filename` attribute.

task-4825728

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
