### PR TITLE
[FIX] stock: set return_id on backorder return

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1575,6 +1575,7 @@ class Picking(models.Model):
             'move_ids': [],
             'move_line_ids': [],
             'backorder_id': self.id,
+            'return_id': self.return_id.id,
         })
 
     def _create_backorder(self, backorder_moves=None):

--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -241,6 +241,12 @@ class TestReturnPicking(TestStockCommon):
         self.assertListEqual(exchange_picking.move_line_ids.lot_id.ids, [])
         self.assertEqual(exchange_picking.move_ids.display_assign_serial, True)
 
+        # Return 1 unit and backorder, check that the backorder is part of the returns
+        return_picking.move_ids.quantity = 1
+        Form.from_action(self.env, return_picking.button_validate()).save().process()
+        return_backorder = return_picking.backorder_ids
+        self.assertEqual(original_picking.return_ids, return_picking | return_backorder)
+
     def test_stock_picking_report_has_return(self):
         """
         Ensures that only returned serialized products are marked as returned.


### PR DESCRIPTION
### Steps to reproduce:

- Create, confirm and validate a delivery for 2 units of a product A
- Click Return > Return All
- Validate the return for 1 unit and backorder
#### > The backorder does not belong to the return list of the delivery

### Cause of the issue:

Backorder pickings are created by copying the picking to backorder: https://github.com/odoo/odoo/blob/9ad995ff6b59a6a2fdfbbd6cf385fe27568dd3ea/addons/stock/models/stock_picking.py#L1580-L1593 https://github.com/odoo/odoo/blob/9ad995ff6b59a6a2fdfbbd6cf385fe27568dd3ea/addons/stock/models/stock_picking.py#L1571-L1578
However, the `return_id` is a `copy=False` field that is not manully set during this copy process:
https://github.com/odoo/odoo/blob/9ad995ff6b59a6a2fdfbbd6cf385fe27568dd3ea/addons/stock/models/stock_picking.py#L558

opw-6111544

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
