### PR TITLE
[FIX] core: implement __reversed__ for OrderedSet

### DIFF
--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
@@ -1149,3 +1149,36 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             {"balance": 1000.0,     "tax_tag_ids": []},
             {"balance": -1000.0,    "tax_tag_ids": base_tag.ids},
         ])
+
+    def test_payment_register_non_withholding_tax(self):
+        """ Test the flow of registering a payment on an invoice with non-withholding taxes. """
+        tax_a = self.percent_tax(
+            -5,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            type_tax_use='purchase',
+        )
+        tax_b = self.percent_tax(12, type_tax_use='purchase')
+        tax_c = self.percent_tax(-10, type_tax_use='purchase')
+
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2024-01-01',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 1000.0,
+                'tax_ids': [Command.set((tax_a | tax_b | tax_c).ids)],
+            })],
+        })
+        bill.action_post()
+
+        # Clear ORM cache so field access triggers the prefetch traversal.
+        self.env.flush_all()
+        self.env.invalidate_all()
+
+        payment_register = self.env['account.payment.register']\
+            .with_context(active_model='account.move', active_ids=bill.ids)\
+            .create({})
+
+        self.assertRecordValues(payment_register, [{'amount': 1020.0, 'withholding_net_amount': 970.0}])

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1004,6 +1004,9 @@ class OrderedSet[T](MutableSet[T]):
     def __iter__(self):
         return iter(self._map)
 
+    def __reversed__(self):
+        return reversed(self._map)
+
     def __len__(self):
         return len(self._map)
 


### PR DESCRIPTION
The issue originates from `_get_batches` in `account_payment_register`, where a prefetch collection is built using `OrderedSet`. After an ORM cache invalidation, accessing fields on the resulting records could raise an error because `with_prefetch()` expects the iterable of IDs to be reversible, which `OrderedSet` does not support.

This commit implements `__reversed__` on it, making it compatible with `with_prefetch()` while preserving its intended behavior.

A unit test is also added in `l10n_account_withholding_tax` to cover the prefetch traversal scenario.

task-[6108453](https://www.odoo.com/odoo/project/967/tasks/6108453)