### PR TITLE
[REF] *: run rendering context migration script on checksum files

### DIFF
--- a/addons/html_editor/static/src/main/table/mobile_table_picker.xml
+++ b/addons/html_editor/static/src/main/table/mobile_table_picker.xml
@@ -1,12 +1,12 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.MobileTablePicker">
-        <div class="o-we-tablesizepopover d-flex bg-light overflow-auto shadow" t-on-keydown="onKeydown" role="dialog" aria-modal="true" aria-label="Table Size Popover">
-            <div class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
+        <div class="o-we-tablesizepopover d-flex bg-light overflow-auto shadow" t-on-keydown="this.onKeydown" role="dialog" aria-modal="true" aria-label="Table Size Popover">
+            <div class="container-fluid d-flex vertical-center p-2" t-custom-ref="editing-wrapper">
                 <div class="d-flex">
                     <div class="col p-2">
                         <div class="input-group mb-2">
                             <label for="rowCount">Row Count</label>
-                            <input id="rowCount" t-ref="rowCount"
+                            <input id="rowCount" t-custom-ref="rowCount"
                                 type="number" min="1" max="100"
                                 class="border-dark-subtle form-control form-control-sm"
                                 t-model="state.rowCount"
@@ -14,7 +14,7 @@
                                 placeholder="Number of rows"
                                 t-on-input="this.updateSize"/>
                             <label for="rowCount">Column Count</label>
-                            <input id="columnCount" t-ref="columnCount"
+                            <input id="columnCount" t-custom-ref="columnCount"
                                 type="number" min="1" max="12"
                                 class="border-dark-subtle form-control form-control-sm"
                                 t-model="state.columnCount"

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -3,22 +3,22 @@
 
     <t t-name="point_of_sale.Navbar">
         <div class="pos-topheader position-relative d-flex align-items-center justify-content-between gap-1 p-2 m-0 bg-view border-bottom">
-            <div class="pos-leftheader d-flex align-items-center flex-grow-1 overflow-auto min-w-0" t-att-class="{'d-none': ui.isSmall and state.searchBarOpen, 'mw-100': this.pos.getOrder()}">
-                <div class="d-flex flex-shrink-0 align-items-center gap-2 gap-lg-3 position-relative pe-2 min-w-0" t-att-class="{ 'w-100': !ui.isSmall }">
+            <div class="pos-leftheader d-flex align-items-center flex-grow-1 overflow-auto min-w-0" t-att-class="{'d-none': this.ui.isSmall and this.state.searchBarOpen, 'mw-100': this.pos.getOrder()}">
+                <div class="d-flex flex-shrink-0 align-items-center gap-2 gap-lg-3 position-relative pe-2 min-w-0" t-att-class="{ 'w-100': !this.ui.isSmall }">
                     <div class="navbar-menu btn-group" role="group" aria-label="Navigation Menu">
-                        <button class="register-label btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'register'}" t-on-click="() => this.onClickRegister()">
-                            <span t-if="!ui.isSmall">Register</span>
-                            <i t-else="" class="fa fa-fw fa-pencil" t-att-class="{'fa-lg' : !ui.isSmall}"/>
+                        <button class="register-label btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': this.mainButton === 'register'}" t-on-click="() => this.onClickRegister()">
+                            <span t-if="!this.ui.isSmall">Register</span>
+                            <i t-else="" class="fa fa-fw fa-pencil" t-att-class="{'fa-lg' : !this.ui.isSmall}"/>
                         </button>
-                        <button class="orders-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'order'}" t-on-click="() => this.onTicketButtonClick()">
-                            <t t-if="!ui.isSmall">
+                        <button class="orders-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': this.mainButton === 'order'}" t-on-click="() => this.onTicketButtonClick()">
+                            <t t-if="!this.ui.isSmall">
                                 <span>Orders</span>
                             </t>
-                            <i t-else="" class="fa fa-fw fa-book" t-att-class="{'fa-lg' : !ui.isSmall}"/>
+                            <i t-else="" class="fa fa-fw fa-book" t-att-class="{'fa-lg' : !this.ui.isSmall}"/>
                         </button>
                     </div>
-                    <OrderTabs orders="getOrderTabs()" class="'h-50'"/>
-                    <button class="btn btn-secondary d-flex align-items-center gap-1 h-100 ms-2 p-2 preset-time-btn" t-on-click="openPresetTiming" t-if="shouldDisplayPresetTime">
+                    <OrderTabs orders="this.getOrderTabs()" class="'h-50'"/>
+                    <button class="btn btn-secondary d-flex align-items-center gap-1 h-100 ms-2 p-2 preset-time-btn" t-on-click="this.openPresetTiming" t-if="this.shouldDisplayPresetTime">
                         <i class="fa fa-clock-o" aria-hidden="true"/>
                         <span class="fw-bolder lh-1" t-out="this.pos.getOrder()?.presetTime || '--:--'" />
                     </button>
@@ -34,27 +34,27 @@
                         <div t-if="this.pos.data.network.offline" class="fa fa-fw fa-chain-broken text-danger"/>
                         <div t-else="" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>
                     </div>
-                    <Input tModel="[pos, 'searchProductWord']"
-                    class="ui.isSmall ? 'p-0' : 'w-100 w-xl-50 me-0 me-lg-2'"
-                    isSmall="ui.isSmall"
+                    <Input tModel="[this.pos, 'searchProductWord']"
+                    class="this.ui.isSmall ? 'p-0' : 'w-100 w-xl-50 me-0 me-lg-2'"
+                    isSmall="this.ui.isSmall"
                     placeholder.translate="Search products..."
                     icon="{type: 'fa', value: 'fa-search fa-lg fa-fw'}"
                     debounceMillis="500"
                     getRef="(ref) => this.inputRef = ref"
-                    t-if="pos.showSearchButton()"
-                    isOpenCallback="(isOpen) => state.searchBarOpen = isOpen" />
-                    <button class="btn btn-light btn-lg lh-lg" t-if="isBarcodeScannerSupported() and ['ProductScreen', 'TicketScreen'].includes(this.pos.router.state.current) and !pos.config.module_pos_restaurant" t-on-click="onClickScan">
+                    t-if="this.pos.showSearchButton()"
+                    isOpenCallback="(isOpen) => this.state.searchBarOpen = isOpen" />
+                    <button class="btn btn-light btn-lg lh-lg" t-if="this.isBarcodeScannerSupported() and ['ProductScreen', 'TicketScreen'].includes(this.pos.router.state.current) and !this.pos.config.module_pos_restaurant" t-on-click="this.onClickScan">
                         <i class="fa fa-fw fa-lg fa-barcode" /><span t-if="this.pos.scanning" class="ms-1">Stop</span>
                     </button>
                     <!-- No need to show the cashier name on small screens -->
-                    <CashierName t-if="!ui.isSmall"/>
+                    <CashierName t-if="!this.ui.isSmall"/>
                     <Dropdown>
                         <button class="btn btn-light btn-lg lh-lg">
                             <i class="fa fa-fw fa-bars"/>
                         </button>
                         <t t-set-slot="content">
                             <div class="d-flex gap-2 p-2 border-bottom">
-                                <span t-on-click="openLnaPopup" role="button" t-attf-class="d-flex align-items-center justify-content-center py-1 btn btn-{{this.pos.lnaState.type}} w-100 text-center {{this.pos.config.use_iot_box ? 'flex-column' : '' }}" title="Local Network Access">
+                                <span t-on-click="this.openLnaPopup" role="button" t-attf-class="d-flex align-items-center justify-content-center py-1 btn btn-{{this.pos.lnaState.type}} w-100 text-center {{this.pos.config.use_iot_box ? 'flex-column' : '' }}" title="Local Network Access">
                                     <i class="fa fa-fw fa-wifi"/> LNA
                                 </span>
                             </div>
@@ -62,25 +62,25 @@
                                 <DropdownItem onSelected="() => this.openCustomerDisplay()">
                                     <i class="fa fa-fw fa-desktop" aria-hidden="true" /> Customer Display
                                 </DropdownItem>
-                                <DropdownItem t-if="!isDisplayStandalone and this.pos.cashier._role != 'minimal'" onSelected="() => window.open(this.appUrl)">
+                                <DropdownItem t-if="!this.isDisplayStandalone and this.pos.cashier._role != 'minimal'" onSelected="() => window.open(this.appUrl)">
                                     <i class="fa fa-fw fa-download" aria-hidden="true" /> Install App
                                 </DropdownItem>
-                                <DropdownItem t-if="showCashMoveButton and this.pos.cashier._role != 'minimal'" onSelected="() => this.pos.cashMove()">
+                                <DropdownItem t-if="this.showCashMoveButton and this.pos.cashier._role != 'minimal'" onSelected="() => this.pos.cashMove()">
                                     <i class="fa fa-fw fa-money" aria-hidden="true" /> Cash In/Out
                                 </DropdownItem>
                                 <DropdownItem t-if="!this.pos.data.network.offline" onSelected="() => this.reloadProducts()">
                                     <i class="fa fa-fw fa-refresh" aria-hidden="true" /> Reload Data
                                 </DropdownItem>
-                                <DropdownItem t-if="showCreateProductButton" onSelected="() => this.pos.editProduct()">
+                                <DropdownItem t-if="this.showCreateProductButton" onSelected="() => this.pos.editProduct()">
                                     <i class="fa fa-fw fa-plus" aria-hidden="true" /> Create Product
                                 </DropdownItem>
-                                <DropdownItem t-if="isBarcodeScannerSupported() and this.pos.router.state.current == 'ProductScreen' and ui.isSmall and !pos.config.module_pos_restaurant" onSelected="() => this.onClickScan()">
+                                <DropdownItem t-if="this.isBarcodeScannerSupported() and this.pos.router.state.current == 'ProductScreen' and this.ui.isSmall and !this.pos.config.module_pos_restaurant" onSelected="() => this.onClickScan()">
                                     <i class="fa fa-fw fa-barcode" aria-hidden="true" /> <t t-if="this.pos.scanning">Stop</t> Barcode Scanner
                                 </DropdownItem>
-                                <DropdownItem t-if="pos.ticketPrinter.hasReceiptPrinters" onSelected="() => this.showSaleDetails()">
+                                <DropdownItem t-if="this.pos.ticketPrinter.hasReceiptPrinters" onSelected="() => this.showSaleDetails()">
                                     <i class="fa fa-fw fa-print" aria-hidden="true" /> Print Report
                                 </DropdownItem>
-                                <DropdownItem onSelected="() => pos.closePos()">
+                                <DropdownItem onSelected="() => this.pos.closePos()">
                                     <i class="fa fa-fw fa-chevron-left" aria-hidden="true" /> Backend
                                 </DropdownItem>
                                 <DropdownItem onSelected="() => this.pos.closeSession()">

--- a/addons/pos_hr/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/app/components/navbar/navbar.xml
@@ -3,20 +3,20 @@
 
     <t t-name="pos_hr.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//DropdownItem/i[hasclass('fa-chevron-left')]/.." position="attributes">
-            <attribute name="t-if">showBackend</attribute>
+            <attribute name="t-if">this.showBackend</attribute>
         </xpath>
         <xpath expr="//DropdownItem/i[hasclass('fa-key')]/.." position="attributes">
             <attribute name="t-if">
-                !pos.config.module_pos_hr or pos.employeeIsAdmin or pos.getCashierUserId() === pos.session.user_id?.id
+                !this.pos.config.module_pos_hr or this.pos.employeeIsAdmin or this.pos.getCashierUserId() === this.pos.session.user_id?.id
             </attribute>
         </xpath>
         <xpath expr="//CashierName" position="after">
-            <button t-if="pos.config.module_pos_hr and !ui.isSmall" class="lock-screen btn btn-light btn-lg lh-lg" title="Lock" t-on-click="() => this.pos.showLoginScreen()">
+            <button t-if="this.pos.config.module_pos_hr and !this.ui.isSmall" class="lock-screen btn btn-light btn-lg lh-lg" title="Lock" t-on-click="() => this.pos.showLoginScreen()">
                 <i class="fa fa-fw fa-unlock"/>
             </button>
         </xpath>
         <xpath expr="//Dropdown//div[hasclass('pos-burger-menu-items')]" position="inside">
-            <DropdownItem t-if="pos.config.module_pos_hr and ui.isSmall" onSelected="() => this.pos.showLoginScreen()">
+            <DropdownItem t-if="this.pos.config.module_pos_hr and this.ui.isSmall" onSelected="() => this.pos.showLoginScreen()">
                 <i class="fa fa-fw fa-lock" aria-hidden="true" /> Lock
             </DropdownItem>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
@@ -2,39 +2,39 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
        <xpath expr="//div[hasclass('pos-topheader')]" position="after">
-           <FloorPlanEditorNavBar  t-if="floorPlanStore?.isEditToolbarVisible()"/>
+           <FloorPlanEditorNavBar  t-if="this.floorPlanStore?.isEditToolbarVisible()"/>
        </xpath>
         <xpath expr="//DropdownItem/i[hasclass('fa-chevron-left')]/.." position="before">
-            <t t-if="pos.router.state.current == 'FloorScreen' and ui.isSmall">
-                <DropdownItem t-if="showEditPlanButton and this.pos.config.floor_ids.length" onSelected="() => this.floorPlanStore.startEditMode()">
+            <t t-if="this.pos.router.state.current == 'FloorScreen' and this.ui.isSmall">
+                <DropdownItem t-if="this.showEditPlanButton and this.pos.config.floor_ids.length" onSelected="() => this.floorPlanStore.startEditMode()">
                     <i class="fa fa-fw fa-pencil-square-o" aria-hidden="true" /> Edit Plan
                 </DropdownItem>
             </t>
-            <DropdownItem t-if="pos.router.state.current == 'FloorScreen'" onSelected="() => this.onSwitchButtonClick()">
+            <DropdownItem t-if="this.pos.router.state.current == 'FloorScreen'" onSelected="() => this.onSwitchButtonClick()">
                 <i class="fa fa-fw fa-eye" aria-hidden="true" /> Switch Floor View
             </DropdownItem>
         </xpath>
         <xpath expr="//div[hasclass('pos-leftheader')]//OrderTabs" position="attributes">
-            <attribute name="t-if">!pos.config.module_pos_restaurant</attribute>
+            <attribute name="t-if">!this.pos.config.module_pos_restaurant</attribute>
         </xpath>
         <xpath expr="//div[hasclass('pos-leftheader')]//OrderTabs" position="after">
-            <span t-if="pos.config.module_pos_restaurant and pos.getOrder()" t-out="currentOrderName" class="badge rounded-pill bg-info-subtle border border-info py-2 fs-6 fw-bolder text-truncate"/>
+            <span t-if="this.pos.config.module_pos_restaurant and this.pos.getOrder()" t-out="this.currentOrderName" class="badge rounded-pill bg-info-subtle border border-info py-2 fs-6 fw-bolder text-truncate"/>
         </xpath>
         <xpath expr="//button[hasclass('register-label')]" position="before">
-            <button t-if="pos.config.module_pos_restaurant" class="table-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'table', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}" t-on-click="() => this.onClickPlanButton()">
-                <span t-if="!ui.isSmall">Tables</span>
+            <button t-if="this.pos.config.module_pos_restaurant" class="table-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': this.mainButton === 'table', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}" t-on-click="() => this.onClickPlanButton()">
+                <span t-if="!this.ui.isSmall">Tables</span>
                 <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" t-att-class="{'opacity-50': this.pos.getOrder()?.isFilledDirectSale}" alt="Floor Plan"/>
             </button>
         </xpath>
         <xpath expr="//div[hasclass('navbar-menu')]" position="after">
-            <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid">
+            <div class="d-flex align-items-center" t-if="this.pos.orderToTransferUuid">
                 <strong class="mx-2 text-warning">
                     Select table to transfer order
                 </strong>
             </div>
         </xpath>
         <xpath expr="//button[hasclass('orders-button')]" position="attributes">
-            <attribute name="t-att-class">{'active': mainButton === 'order', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}</attribute>
+            <attribute name="t-att-class">{'active': this.mainButton === 'order', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_self_order/static/src/overrides/components/navbar/navbar.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//DropdownItem/i[hasclass('fa-download')]/.." position="before">
-            <DropdownItem t-if="ui.isSmall and pos.config.module_pos_restaurant" onSelected="() => pos.redirectToQrForm()">
+            <DropdownItem t-if="this.ui.isSmall and this.pos.config.module_pos_restaurant" onSelected="() => this.pos.redirectToQrForm()">
                 <i class="fa fa-fw fa-qrcode" aria-hidden="true" /> Get QR Codes
             </DropdownItem>
         </xpath>

--- a/addons/test_translation_mode/static/src/translation_mode_side_panel.xml
+++ b/addons/test_translation_mode/static/src/translation_mode_side_panel.xml
@@ -7,7 +7,7 @@
         <aside
             class="o-translate-side-panel d-flex flex-column position-fixed top-0 end-0 bg-view shadow"
             data-translation-highlight="off"
-            t-ref="root"
+            t-custom-ref="root"
             t-translation="off"
         >
             <header class="d-flex flex-column p-2 gap-2">

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -29,7 +29,7 @@
             <div
                 class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1"
                 t-att-class="!hasEmojisFromSearch ? 'flex-column justify-content-center' : 'align-content-start'"
-                t-ref="emoji-grid"
+                t-custom-ref="emoji-grid"
                 t-on-scroll="this.highlightActiveCategory"
             >
                 <t t-if="searchTerm and !hasEmojisFromSearch" class="d-flex flex-column">
@@ -66,7 +66,7 @@
             <div
                 class="o-EmojiPicker-navbar d-flex flex-shrink-0 w-100 align-items-center justify-content-center overflow-auto px-1 gap-1 border-top border-secondary"
                 t-att-class="{ 'opacity-0': !this.state.emojiNavbarRepr }"
-                t-ref="navbar"
+                t-custom-ref="navbar"
             >
                 <t t-set="currentNavbarPanel" t-value="this.getCurrentNavbarPanel(_recentEmojis)" />
                 <t t-if="currentNavbarPanel">
@@ -165,8 +165,8 @@
     <input
         class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1"
         t-att-placeholder="this.placeholder"
-        t-model="localState.searchTerm"
-        t-ref="autofocus"
+        t-custom-model="localState.searchTerm"
+        t-custom-ref="autofocus"
         t-att-model="localState.searchTerm"
         t-att-tabindex="isMobileOS ? -1 : 0"
         t-on-input="() => this.state.activeEmojiIndex = 0"

--- a/odoo/upgrade_code/19.2-00-owl3-migration.py
+++ b/odoo/upgrade_code/19.2-00-owl3-migration.py
@@ -9,17 +9,6 @@ EXCLUDED_PATH = (
     'addons/web/static/lib/owl/owl.js',
 )
 
-CHECKSUM_FILES = (
-    'pos_blackbox_be/static/src/pos/overrides/navbar/navbar.xml',
-    'l10n_eu_iot_scale_cert/controllers/checksum.py',
-    'l10n_eu_iot_scale_cert/static/src/app/utils/scale/certified_iot_scale.js',
-    'l10n_eu_iot_scale_cert/static/src/pos_overrides/components/scale_screen/certified_scale_screen.js',
-    'l10n_eu_iot_scale_cert/static/src/pos_overrides/components/scale_screen/certified_scale_screen.xml',
-    'l10n_eu_iot_scale_cert/receipt/pos_order_receipt.xml',
-    'l10n_eu_iot_scale_cert/static/src/pos_overrides/components/orderline/certified_orderline.xml',
-    'iot_drivers/iot_handlers/drivers/serial_scale_driver.py',
-)
-
 
 class JSTooling:
     @staticmethod
@@ -227,7 +216,7 @@ class JSTooling:
         ]
 
     def get_template_files(file_manager):
-        excluded_path_pattern = re.compile('|'.join(EXCLUDED_PATH + CHECKSUM_FILES))
+        excluded_path_pattern = re.compile('|'.join(EXCLUDED_PATH))
         return [
             file for file in file_manager
             if '/static/src/' in file.path._str
@@ -475,7 +464,7 @@ def upgrade_tportal(file_manager, log_info, log_error):
 
 def upgrade_t_esc(file_manager, log_info, log_error):
     """Replaces the t-esc directive in xml templates with the t-out directive"""
-    excluded_path_pattern = re.compile('|'.join(EXCLUDED_PATH + CHECKSUM_FILES))
+    excluded_path_pattern = re.compile('|'.join(EXCLUDED_PATH))
     files = [
         file for file in file_manager
         if file.path.suffix in ['.xml', '.js'] and not re.search(excluded_path_pattern, file.path._str)


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

We had waited to run all the checksum file until the script was battle tested, which it now is. Note that the `this` migration which is not part of this script but in the below not yet merged PR was also run.

Script PR: #247965
Enterprise PR: odoo/enterprise#114152

task: OWL3 prep - add this. to template variables
