### PR TITLE
[FIX] pos_safaricom: disable csrf on callback endpoints

### DIFF
--- a/addons/pos_safaricom/__init__.py
+++ b/addons/pos_safaricom/__init__.py
@@ -1,1 +1,1 @@
-from . import controllers, models
+from . import controllers, models, receipt

--- a/addons/pos_safaricom/__manifest__.py
+++ b/addons/pos_safaricom/__manifest__.py
@@ -6,6 +6,7 @@
     'data': [
         "views/pos_payment_method_views.xml",
         'security/ir.access.csv',
+        'receipt/pos_order_receipt.xml',
     ],
     "assets": {
         "point_of_sale._assets_pos": [

--- a/addons/pos_safaricom/controllers/main.py
+++ b/addons/pos_safaricom/controllers/main.py
@@ -6,7 +6,7 @@ from odoo.tools import verify_hash_signed
 
 class SafaricomController(http.Controller):
 
-    @http.route('/pos_safaricom/callback', type='http', auth='public', methods=['POST'])
+    @http.route('/pos_safaricom/callback', type='http', auth='public', methods=['POST'], csrf=False)
     def safaricom_callback(self, payload):
         """
         Handle M-Pesa STK Push callback
@@ -32,7 +32,7 @@ class SafaricomController(http.Controller):
         except ValueError:
             return request.make_json_response({"ResultCode": "1", "ResultDesc": "Error processing callback"})
 
-    @http.route('/c2b/validation/callback', type="http", auth='public', methods=['POST'])
+    @http.route('/c2b/validation/callback', type="http", auth='public', methods=['POST'], csrf=False)
     def c2b_validation_callback(self, payload):
         """
         Validate the payment before charging the customer
@@ -48,7 +48,7 @@ class SafaricomController(http.Controller):
         except ValueError:
             return request.make_json_response({"ResultCode": "C2B00011", "ResultDesc": "Rejected"})
 
-    @http.route('/c2b/confirmation/callback', type='http', auth='public', methods=['POST'])
+    @http.route('/c2b/confirmation/callback', type='http', auth='public', methods=['POST'], csrf=False)
     def c2b_confirmation_callback(self, payload):
         """
         Handle C2B payment confirmation via Lipa na M-PESA
@@ -61,7 +61,8 @@ class SafaricomController(http.Controller):
                 trans_id = data.get('TransID')
                 trans_amount = data.get('TransAmount')
                 msisdn = data.get('MSISDN')
-                name = data.get('FirstName')
+                nameParts = (data.get('FirstName'), data.get('MiddleName'), data.get('LastName'))
+                name = " ".join(p for p in nameParts if p)
 
                 payment_method = request.env['pos.payment.method'].sudo().search([
                         ('id', '=', decoded_payload.get('payment_method_id')),

--- a/addons/pos_safaricom/models/__init__.py
+++ b/addons/pos_safaricom/models/__init__.py
@@ -1,2 +1,3 @@
+from . import pos_payment
 from . import pos_payment_method
 from . import transaction_lipa_na_mpesa

--- a/addons/pos_safaricom/models/pos_payment.py
+++ b/addons/pos_safaricom/models/pos_payment.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class PosPayment(models.Model):
+    _inherit = 'pos.payment'
+
+    safaricom_transaction_id = fields.Char(string="Safaricom transaction id", required=False)

--- a/addons/pos_safaricom/models/pos_payment_method.py
+++ b/addons/pos_safaricom/models/pos_payment_method.py
@@ -1,12 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
-import re
 from datetime import datetime
 
 import requests
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo.tools import hash_sign
 
 TIMEOUT = 10
@@ -18,7 +17,9 @@ class PosPaymentMethod(models.Model):
     # Credentials from Mpesa
     consumer_key = fields.Char(string="Consumer Key")
     consumer_secret = fields.Char(string="Consumer Secret")
-    business_short_code = fields.Char(string="Business Short Code", help="The business short code and till number combination as 'shortcode-tillnumber' (ex: 123456-789012)")
+    business_short_code = fields.Char(string="Business Short Code")
+    safaricom_till_number = fields.Char(string="Till number")
+    safaricom_paybill_number = fields.Char(string="Paybill number")
     passkey = fields.Char(string="Passkey", help="The passkey is used to generate the password for the STK Push")
     safaricom_test_mode = fields.Boolean(string="Test Mode", default=True, help="Use sandbox environment")
     safaricom_payment_type = fields.Selection(
@@ -26,17 +27,14 @@ class PosPaymentMethod(models.Model):
         string="Payment Type",
         default='mpesa_express',
     )
+    safaricom_identifier_type = fields.Selection(
+        selection=[('paybill', 'Paybill number'), ('till', 'Till number')],
+        string="Identifier Type",
+        default='till',
+    )
 
     def _get_terminal_provider_selection(self):
         return super()._get_terminal_provider_selection() + [('safaricom', 'M-Pesa')]
-
-    @api.constrains('business_short_code')
-    def _check_business_short_code(self):
-        validation_error = "The business short code should contain both the short code and the till number seprated by a dash '-' (ex. 123456-789012)"
-        for record in self:
-            if record.business_short_code:
-                if not re.fullmatch(r'[0-9]+-[0-9]+', record.business_short_code):
-                    raise ValidationError(validation_error)
 
     def _get_business_shortcode(self):
         self.ensure_one()
@@ -84,11 +82,6 @@ class PosPaymentMethod(models.Model):
         if self.safaricom_test_mode:
             return 'https://sandbox.safaricom.co.ke/mpesa/qrcode/v1/generate'
         return 'https://api.safaricom.co.ke/mpesa/qrcode/v1/generate'
-
-    def _get_transaction_type(self):
-        if self.safaricom_test_mode:
-            return 'CustomerPayBillOnline'
-        return 'CustomerBuyGoodsOnline'
 
     def _get_bearer_token(self):
         """Get OAuth access token"""
@@ -146,14 +139,16 @@ class PosPaymentMethod(models.Model):
 
             signed_hash_payload = hash_sign(self.sudo().env, "pos_safaricom", {"payment_method_id": self.id}, expiration_hours=6)
 
+            transactionType, partyB = ('CustomerPayBillOnline', self.safaricom_paybill_number) if self.safaricom_identifier_type == 'paybill' else ('CustomerBuyGoodsOnline', self.safaricom_till_number)
+
             payload = {
                 'BusinessShortCode': self._get_business_shortcode(),
                 'Password': password,
                 'Timestamp': timestamp,
-                'TransactionType': self._get_transaction_type(),
+                'TransactionType': transactionType,
                 'Amount': int(data.get('amount', 0)),
                 'PartyA': phone_number,
-                'PartyB': self._get_till_number(),
+                'PartyB': partyB,
                 'PhoneNumber': phone_number,
                 'CallBackURL': f"{self.get_base_url()}/pos_safaricom/callback?payload={signed_hash_payload}",
                 'AccountReference': data.get('account_reference', 'POS Payment'),
@@ -244,9 +239,10 @@ class PosPaymentMethod(models.Model):
             }
 
             signed_hash_payload = hash_sign(self.sudo().env, "pos_safaricom", payload_hash, expiration_hours=6)
+            shortcode = self.safaricom_paybill_number if self.safaricom_identifier_type == 'paybill' else self.safaricom_till_number
 
             payload = {
-                'ShortCode': self._get_till_number(),
+                'ShortCode': shortcode,
                 'ResponseType': 'Completed',
                 'ValidationURL': f"{base_url}/c2b/validation/callback?payload={signed_hash_payload}",
                 'ConfirmationURL': f"{base_url}/c2b/confirmation/callback?payload={signed_hash_payload}",
@@ -303,12 +299,14 @@ class PosPaymentMethod(models.Model):
         try:
             access_token = self._get_bearer_token()
 
+            cpi = self.safaricom_paybill_number if self.safaricom_identifier_type == 'paybill' else self.safaricom_till_number
+
             body = {
                 'MerchantName': data.get('name', self.company_id.name),
                 'RefNo': data.get('ref', ''),
                 'Amount': int(data.get('amount', 0)),
                 'TrxCode': data.get('trxCode', 'BG'),
-                'CPI': data.get('cpi', self._get_till_number()),
+                'CPI': data.get('cpi', cpi),
                 'Size': data.get('size', '300'),
             }
 

--- a/addons/pos_safaricom/models/pos_payment_method.py
+++ b/addons/pos_safaricom/models/pos_payment_method.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
+import logging
 from datetime import datetime
 
 import requests
@@ -9,6 +10,7 @@ from odoo.exceptions import UserError
 from odoo.tools import hash_sign
 
 TIMEOUT = 10
+_logger = logging.getLogger(__name__)
 
 
 class PosPaymentMethod(models.Model):
@@ -18,12 +20,19 @@ class PosPaymentMethod(models.Model):
     consumer_key = fields.Char(string="Consumer Key")
     consumer_secret = fields.Char(string="Consumer Secret")
     business_short_code = fields.Char(string="Business Short Code")
+    safaricom_till_number = fields.Char(string="Till number")
+    safaricom_paybill_number = fields.Char(string="Paybill number")
     passkey = fields.Char(string="Passkey", help="The passkey is used to generate the password for the STK Push")
     safaricom_test_mode = fields.Boolean(string="Test Mode", default=True, help="Use sandbox environment")
     safaricom_payment_type = fields.Selection(
         selection=[('mpesa_express', 'M-PESA Express'), ('lipa_na_mpesa', 'Lipa na M-PESA')],
         string="Payment Type",
         default='mpesa_express',
+    )
+    safaricom_identifier_type = fields.Selection(
+        selection=[('paybill', 'Paybill number'), ('till', 'Till number')],
+        string="Identifier Type",
+        default='till',
     )
 
     def _get_terminal_provider_selection(self):
@@ -124,14 +133,16 @@ class PosPaymentMethod(models.Model):
 
             signed_hash_payload = hash_sign(self.sudo().env, "pos_safaricom", {"payment_method_id": self.id}, expiration_hours=6)
 
+            transactionType, partyB = ('CustomerPayBillOnline', self.safaricom_paybill_number) if self.safaricom_identifier_type == 'paybill' else ('CustomerBuyGoodsOnline', self.safaricom_till_number)
+
             payload = {
                 'BusinessShortCode': self.business_short_code,
                 'Password': password,
                 'Timestamp': timestamp,
-                'TransactionType': 'CustomerPayBillOnline',
+                'TransactionType': transactionType,
                 'Amount': int(data.get('amount', 0)),
                 'PartyA': phone_number,
-                'PartyB': self.business_short_code,
+                'PartyB': partyB,
                 'PhoneNumber': phone_number,
                 'CallBackURL': f"{self.get_base_url()}/pos_safaricom/callback?payload={signed_hash_payload}",
                 'AccountReference': data.get('account_reference', 'POS Payment'),
@@ -143,6 +154,7 @@ class PosPaymentMethod(models.Model):
                 'Content-Type': 'application/json',
             }
 
+            _logger.info('[safaricom] express send payment payload: %s', payload)
             response = requests.post(
                 self._get_express_stkpush_endpoint(),
                 json=payload,
@@ -151,6 +163,7 @@ class PosPaymentMethod(models.Model):
             )
 
             result = response.json()
+            _logger.info('[safaricom] express send payment response status: %s payload: %s', response, result)
 
             if result.get('ResponseCode') == '0':
                 return {
@@ -209,6 +222,12 @@ class PosPaymentMethod(models.Model):
         self.ensure_one()
 
         try:
+            base_url = self.get_base_url()
+            if base_url:
+                base_url = base_url.replace("http://", "https://")
+            else:
+                raise UserError(_("Could not find base url. Please set up web.base.url to a valid https address"))
+
             access_token = self._get_bearer_token()
 
             payload_hash = {
@@ -216,18 +235,21 @@ class PosPaymentMethod(models.Model):
             }
 
             signed_hash_payload = hash_sign(self.sudo().env, "pos_safaricom", payload_hash, expiration_hours=6)
+            shortcode = self.safaricom_paybill_number if self.safaricom_identifier_type == 'paybill' else self.safaricom_till_number
 
             payload = {
-                'ShortCode': self.business_short_code,
+                'ShortCode': shortcode,
                 'ResponseType': 'Completed',
-                'ValidationURL': f"{self.get_base_url()}/c2b/validation/callback?payload={signed_hash_payload}",
-                'ConfirmationURL': f"{self.get_base_url()}/c2b/confirmation/callback?payload={signed_hash_payload}",
+                'ValidationURL': f"{base_url}/c2b/validation/callback?payload={signed_hash_payload}",
+                'ConfirmationURL': f"{base_url}/c2b/confirmation/callback?payload={signed_hash_payload}",
             }
 
             headers = {
                 'Authorization': f'Bearer {access_token}',
                 'Content-Type': 'application/json',
             }
+
+            _logger.info('[safaricom] c2b register url: %s', payload)
 
             response = requests.post(
                 self._get_lipa_na_mpesa_register_endpoint(),
@@ -237,8 +259,10 @@ class PosPaymentMethod(models.Model):
             )
             result = response.json()
 
+            _logger.info('[safaricom] c2b register url response status: %s body: %s', response, result)
+
             if result.get('ResponseCode') != '00000000':
-                raise UserError(_("Failed to register URLs"))
+                raise UserError(_("Failed to register URLs: %s", result.get('errorMessage')))
 
         except (requests.exceptions.RequestException, ValueError):
             raise UserError(_("Failed to register URLs. Check your credentials and try again."))
@@ -275,12 +299,14 @@ class PosPaymentMethod(models.Model):
         try:
             access_token = self._get_bearer_token()
 
+            cpi = self.safaricom_paybill_number if self.safaricom_identifier_type == 'paybill' else self.safaricom_till_number
+
             body = {
                 'MerchantName': data.get('name', self.company_id.name),
                 'RefNo': data.get('ref', ''),
-                'Amount': data.get('amount', 0),
+                'Amount': int(data.get('amount', 0)),
                 'TrxCode': data.get('trxCode', 'BG'),
-                'CPI': data.get('cpi', self.business_short_code),
+                'CPI': data.get('cpi', cpi),
                 'Size': data.get('size', '300'),
             }
 
@@ -288,6 +314,8 @@ class PosPaymentMethod(models.Model):
                 'Authorization': f'Bearer {access_token}',
                 'Content-Type': 'application/json',
             }
+
+            _logger.info('[safaricom] c2b generate qr payload: %s', body)
 
             response = requests.post(
                 self._get_qr_code_endpoint(),
@@ -297,6 +325,8 @@ class PosPaymentMethod(models.Model):
             )
 
             result = response.json()
+
+            _logger.info('[safaricom] c2b generate qr status: %s body: %s', response, result)
 
             qr_code = result.get('QRCode')
             if not qr_code:

--- a/addons/pos_safaricom/receipt/__init__.py
+++ b/addons/pos_safaricom/receipt/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order_receipt

--- a/addons/pos_safaricom/receipt/pos_order_receipt.py
+++ b/addons/pos_safaricom/receipt/pos_order_receipt.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class PosOrderReceipt(models.AbstractModel):
+    _inherit = 'pos.order.receipt'
+
+    def _order_receipt_generate_payment_data(self):
+        payments = super()._order_receipt_generate_payment_data()
+        transaction_id_by_payment = {p.id: p.safaricom_transaction_id for p in self.payment_ids}
+        for payment in payments:
+            payment['safaricom_transaction_id'] = transaction_id_by_payment.get(payment['id']) or ''
+        return payments

--- a/addons/pos_safaricom/receipt/pos_order_receipt.xml
+++ b/addons/pos_safaricom/receipt/pos_order_receipt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="pos_safaricom.pos_order_receipt" inherit_id="point_of_sale.pos_order_receipt">
+            <xpath expr="//t[@name='payments']/tr" position="after">
+                <tr t-if="payment['safaricom_transaction_id']" class="payment-line">
+                    <td class="text-start w-70 text-small">Transaction ID:</td>
+                    <td class="text-end w-30 text-small font-monospace" t-out="payment['safaricom_transaction_id']"/>
+                </tr>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/pos_safaricom/static/src/app/components/popups/mpesa_transaction_popup.js
+++ b/addons/pos_safaricom/static/src/app/components/popups/mpesa_transaction_popup.js
@@ -41,6 +41,7 @@ export class MpesaTransactionPopup extends Component {
                     phone: r.number,
                     amount: r.amount,
                     received_at: r.received_at,
+                    trans_id: r.trans_id,
                 }))
                 .reverse();
         }
@@ -68,7 +69,8 @@ export class MpesaTransactionPopup extends Component {
         return this.state.transactions.filter(
             (transaction) =>
                 transaction.name.toLowerCase().includes(search.toLowerCase()) ||
-                transaction.phone.toLowerCase().includes(search.toLowerCase())
+                transaction.phone.toLowerCase().includes(search.toLowerCase()) ||
+                transaction.trans_id.toLowerCase().includes(search.toLowerCase())
         );
     }
 }

--- a/addons/pos_safaricom/static/src/app/components/popups/mpesa_transaction_popup.xml
+++ b/addons/pos_safaricom/static/src/app/components/popups/mpesa_transaction_popup.xml
@@ -31,16 +31,18 @@
                             <th>Phone</th>
                             <th>Amount</th>
                             <th>Arrived at</th>
+                            <th>ID</th>
                             <th></th>
                         </tr>
                     </thead>
                     <tbody>
                         <t t-if="this.transactions.length > 0" t-foreach="this.transactions" t-as="tx" t-key="tx.id">
                             <tr>
-                                <td><t t-out="tx.name"/></td>
-                                <td><t t-out="tx.phone"/></td>
-                                <td><t t-out="tx.amount"/></td>
-                                <td><t t-out="tx.received_at"/></td>
+                                <td><t t-esc="tx.name"/></td>
+                                <td><t t-esc="tx.phone"/></td>
+                                <td><t t-esc="tx.amount"/></td>
+                                <td><t t-esc="tx.received_at"/></td>
+                                <td><t t-esc="tx.trans_id"/></td>
                                 <td>
                                     <button class="btn btn-primary"
                                             t-on-click="() => this.confirm(tx)">

--- a/addons/pos_safaricom/static/src/app/models/pos_payment.js
+++ b/addons/pos_safaricom/static/src/app/models/pos_payment.js
@@ -1,0 +1,8 @@
+import { PosPayment } from "@point_of_sale/app/models/pos_payment";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPayment.prototype, {
+    get transId() {
+        return this.safaricom_transaction_id || "";
+    },
+});

--- a/addons/pos_safaricom/static/src/app/payment_safaricom.js
+++ b/addons/pos_safaricom/static/src/app/payment_safaricom.js
@@ -72,11 +72,16 @@ export class PaymentSafaricom extends PaymentInterface {
 
         line.setPaymentStatus("waitingCard");
 
+        // Ensure we have a valid account reference
+        const accountRef = order.name && order.name !== "/" ? order.name : order.uuid;
+        const transDesc =
+            order.name && order.name !== "/" ? `Payment for ${order.name}` : "POS Payment";
+
         const data = {
             amount: Math.round(line.amount),
             phone_number: phoneNumber,
-            account_reference: order.name || order.uuid,
-            transaction_desc: `Payment for ${order.name || "Order"}`,
+            account_reference: accountRef,
+            transaction_desc: transDesc,
             checkout_request_id: line.uuid,
         };
 
@@ -155,7 +160,7 @@ export class PaymentSafaricom extends PaymentInterface {
         line.setPaymentStatus("waitingCard");
 
         const qrData = {
-            ref: order.uuid,
+            ref: order.session_id.id + "-" + order.sequence_number,
             amount: line.amount.toString(),
         };
         const qrCode = await this._call_safaricom(qrData, "generate_qr_code");
@@ -193,6 +198,7 @@ export class PaymentSafaricom extends PaymentInterface {
             }
             line.setAmount(transaction.amount);
             line.transaction_id = transaction.id;
+            line.safaricom_transaction_id = transaction.trans_id;
             line.card_type = "M-Pesa";
             line.cardholder_name = transaction.phone;
             line.setPaymentStatus("done");

--- a/addons/pos_safaricom/static/src/app/payment_safaricom.js
+++ b/addons/pos_safaricom/static/src/app/payment_safaricom.js
@@ -198,6 +198,7 @@ export class PaymentSafaricom extends PaymentInterface {
             }
             line.setAmount(transaction.amount);
             line.transaction_id = transaction.id;
+            line.safaricom_transaction_id = transaction.trans_id;
             line.card_type = "M-Pesa";
             line.cardholder_name = transaction.phone;
             line.setPaymentStatus("done");

--- a/addons/pos_safaricom/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/pos_safaricom/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('paymentlines')]" position="inside">
+            <t t-if="line.safaricom_transaction_id">
+                <div class="text-start small">
+                    <span>Transaction ID: </span>
+                    <span t-out="line.safaricom_transaction_id"/>
+                </div>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_safaricom/static/src/app/services/pos_store.js
+++ b/addons/pos_safaricom/static/src/app/services/pos_store.js
@@ -23,6 +23,7 @@ patch(PosStore.prototype, {
             // Update payment status based on callback
             if (payload.success) {
                 paymentLine.transaction_id = payload.transaction_id;
+                paymentLine.safaricom_transaction_id = payload.transaction_id;
                 paymentLine.card_type = "M-Pesa";
                 if (payload.phone_number) {
                     paymentLine.cardholder_name = payload.phone_number;

--- a/addons/pos_safaricom/views/pos_payment_method_views.xml
+++ b/addons/pos_safaricom/views/pos_payment_method_views.xml
@@ -11,9 +11,12 @@
                         <group>
                             <field name="safaricom_test_mode" widget="boolean_toggle"/>
                             <field name="safaricom_payment_type" required="payment_provider == 'safaricom'"/>
+                            <field name="safaricom_identifier_type" required="payment_provider == 'safaricom'"/>
                             <field name="consumer_key" password="True" required="payment_provider == 'safaricom'"/>
                             <field name="consumer_secret" password="True" required="payment_provider == 'safaricom'"/>
                             <field name="business_short_code" required="payment_provider == 'safaricom'"/>
+                            <field name="safaricom_till_number" invisible="safaricom_identifier_type != 'till'" required="payment_provider == 'safaricom' and safaricom_identifier_type == 'till'"/>
+                            <field name="safaricom_paybill_number" invisible="safaricom_identifier_type != 'paybill'" required="payment_provider == 'safaricom' and safaricom_identifier_type == 'paybill'"/>
                             <field name="passkey" password="True" invisible="safaricom_payment_type != 'mpesa_express'" required="payment_provider == 'safaricom' and safaricom_payment_type == 'mpesa_express'"/>
                         </group>
                         <separator string="Lipa na M-PESA Configuration" invisible="safaricom_payment_type != 'lipa_na_mpesa'"/>


### PR DESCRIPTION
1. The `MPESA` payment method needs a callback url where it does a `POST` request with the transaction details. Since the call comes from safaricom, CSRF will block those requests. This commit will disable CSRF checks on the callback endpoints which are expected to be called from an external service
2. Sometimes the `web.base.url` parameter is automatically set to http. But safaricom expects https for all the urls. So we need to ensure that the urls we send on `lipa_na_mpesa_register_urls` use https, otherwise the registration fails with an `invalid url` error. Additionally, I added the error message in case of error
3. Added a safaricom_transaction_id to pos.payment which is used to identify safaricom transactions. It's the same value as what the payer receives on their phone and is printed on the receipt
4. Added support for till and paybill payments

Task-[6045833](https://www.odoo.com/odoo/project/1737/tasks/6045833)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
