### PR TITLE
[FIX] core: avoid leaking custom fields in field_setup_dependents

### DIFF
--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -305,6 +305,32 @@ class TestIrModelEdition(TransactionCase):
         fnames = [str(field) for field in self.registry.field_depends]
         self.assertEqual(len(fnames), len(set(fnames)), "registry.field_depends contains duplicates")
 
+    def test_setup_model_with_manual_related_fields(self):
+        model = self.env['ir.model'].create({
+            'name': 'Bananas',
+            'model': 'x_bananas',
+        })
+        self.env['ir.model.fields'].create({
+            'name': 'x_partner_id',
+            'field_description': 'Partner',
+            'ttype': 'many2one',
+            'relation': 'res.partner',
+            'model_id': model.id,
+            'state': 'manual',
+        })
+        self.env['ir.model.fields'].create({
+            'name': 'x_name_related',
+            'field_description': 'Name Related',
+            'ttype': 'char',
+            'related': 'x_partner_id.name',
+            'model_id': model.id,
+            'state': 'manual',
+        })
+        # check that registry setup doesn't introduce duplicates in registry.field_setup_dependents
+        self.registry._setup_models__(self.env.cr, [])
+        res_partner_name = self.env['res.partner']._fields['name']
+        fnames = [str(field) for field in self.registry.field_setup_dependents[res_partner_name]]
+        self.assertEqual(len(fnames), len(set(fnames)), "registry.field_setup_dependents contains duplicates")
 
 @tagged('test_eval_context')
 class TestEvalContext(TransactionCase):

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -535,13 +535,18 @@ def _setup_fields(model_cls: type[BaseModel], env: Environment):
 def _add_manual_models(env: Environment):
     """ Add extra models to the registry. """
     # clean up registry first
+    removed_fields = OrderedSet()
     for name, model_cls in list(env.registry.items()):
         if model_cls._custom:
+            removed_fields.update(model_cls._fields.values())
             del env.registry.models[name]
             # remove the model's name from its parents' _inherit_children
             for parent_cls in model_cls.__bases__:
                 if hasattr(parent_cls, 'pool'):
                     parent_cls._inherit_children.discard(name)
+
+    if removed_fields:
+        env.registry._discard_fields(list(removed_fields))
 
     # we cannot use self._fields to determine translated fields, as it has not been set up yet
     env.cr.execute("SELECT *, name->>'en_US' AS name FROM ir_model WHERE state = 'manual'")

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -594,7 +594,10 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self._is_modifying_relations.clear()
 
         # discard fields from field inverses
-        self.field_inverses.discard_keys_and_values(fields)
+        if 'field_inverses' in vars(self):
+            self.field_inverses.discard_keys_and_values(fields)
+
+        self.field_setup_dependents.discard_keys_and_values(fields)
 
     def get_field_trigger_tree(self, field: Field) -> TriggerTree:
         """ Return the trigger tree of a field by computing it from the transitive


### PR DESCRIPTION
When a custom (manual) field is related to a base field, it is added to
`registry.field_setup_dependents`. However, these custom fields were not
being cleaned up correctly, causing them to duplicate and leak during
each model setup.

This fix explicitly cleans these manual fields from `field_setup_dependents`
inside `_add_manual_models()` when manual models are removed from the registry
and the registry is being reloaded.

Similar to https://github.com/odoo/odoo/pull/253377.