### PR TITLE
[FIX] hr_holidays: prevent test failing during weekend

### DIFF
--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -283,6 +283,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                         'request_date_to': date.today() + relativedelta(day=10),
                     })
 
+    @freeze_time("2023-03-15")
     def test_manager_can_approve_from_leave_report_calendar(self):
         """Check if an approval user that has not additional access rights for Time Off can approve a leave for an employee."""
 


### PR DESCRIPTION
### Issue before this commit:
The test test_manager_can_approve_from_leave_report_calendar is unstable and fails depending on the execution date or existing demo data.

### Cause of the issue:
The test lacks temporal isolation. Odoo's constraint logic triggers a ValidationError when a leave is requested on a non-working day or overlaps with existing records:
odoo.exceptions.ValidationError: The following employees are not supposed to work during that period: David Employee. Commit that caused the error: https://github.com/odoo/odoo/commit/83d5c84fa0ead1557fbb6eff6855f77ee4771dc4

### Reason to introduce the fix:
To ensure test determinism by using @freeze_time. Freezing the date to a known working weekday prevents intermittent failures caused by the real-time calendar and ensures the focus remains on validating the manager's approval flow.

runbot-242574

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
