### PR TITLE
[FIX] mail: fix emoji sequence rendering in Discuss

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -484,7 +484,38 @@ export function parseEmail(text) {
     return [text, false];
 }
 
-export const EMOJI_REGEX = /\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\u200d/gu;
+const r = String.raw;
+/**
+ * Match Country Subdivision Flags.
+ * Black Flag emoji + tag-encoded subdivision name + cancel tag
+ * Example:
+ * 🏴 + [B] + [E] + [W] + [A] + [L] + [CANCEL] = Flag for Wallonia (BE-WAL)
+ */
+const SUBDIVISION_FLAG = r`🏴[\u{E0020}-\u{E007E}]+\u{E007F}`;
+/**
+ * Match Keycaps (e.g., 5️⃣, #️⃣).
+ * Numpad character + Variation Selector-16 + Combining Enclosing Keycap
+ */
+const KEYCAP = r`[#*\d]\uFE0F\u20E3`;
+const EMOJI_WITH_SKIN_TONE = r`\p{Emoji_Modifier_Base}\p{Emoji_Modifier}`;
+/**
+ * Match "regular" emojis.
+ * iOS keyboard sometimes appends an extraneous Variation Selector-16, which the
+ * optional \uFE0F accounts for.
+ */
+const EMOJI_PRESENTATION = r`\p{Emoji_Presentation}\uFE0F?`;
+/**
+ * Match "text-default" emojis (☃, ♥, ☂) that are followed by a Variation
+ * Selector-16 (U+FE0F), enabling their emoji representation (☃ → ☃️).
+ * Negative lookahead prevents matching incomplete keycap sequences.
+ */
+const QUALIFIED_TEXT = r`(?![#*\d])\p{Emoji}\uFE0F`;
+const EMOJI = r`(?:${SUBDIVISION_FLAG}|${KEYCAP}|${EMOJI_WITH_SKIN_TONE}|${EMOJI_PRESENTATION}|${QUALIFIED_TEXT})`;
+export const EMOJI_REGEX = new RegExp(
+    r`\p{Regional_Indicator}{2}|` + // Regional Indicator pairs (e.g., 🇧🇪)
+        r`${EMOJI}(?:\u200D${EMOJI})*`, // Zero Width Joiner sequences (e.g., 👨‍👩‍👧‍👦)
+    "gu"
+);
 
 /**
  * Wrap emojis present in the given text with a title and return a safe HTML

--- a/addons/mail/static/tests/emoji/emoji_regex.test.js
+++ b/addons/mail/static/tests/emoji/emoji_regex.test.js
@@ -1,0 +1,30 @@
+import { EMOJI_REGEX } from "@mail/utils/common/format";
+
+import { expect, test } from "@odoo/hoot";
+
+test.tags("headless");
+test("EMOJI_REGEX correctly matches all types of emojis.", async () => {
+    const testCases = [
+        // Basic Emoji
+        ["👺", "👺"],
+        // Variation Selector-16
+        ["☃\u{fe0f}", "☃️"],
+        // Keycap Sequence
+        ["1\u{fe0f}\u{20e3}", "1️⃣"],
+        // Skin Tone Modifier
+        ["🧔" + "🏾", "🧔🏾"],
+        // ZWJ Sequence
+        ["👨\u{200d}👩\u{200d}👧\u{200d}👦", "👨‍👩‍👧‍👦"],
+        // Country Flag
+        ["🇻" + "🇨", "🇻🇨"],
+        // Subdivision Flag
+        ["🏴\u{e0062}\u{e0065}\u{e0077}\u{e0061}\u{e006c}\u{e007f}", "🏴󠁢󠁥󠁷󠁡󠁬󠁿"],
+        // Overqualified Emoji
+        ["⛄\u{fe0f}", "⛄️"],
+    ];
+    for (const [testCase, expected] of testCases) {
+        const match = testCase.match(EMOJI_REGEX);
+        expect(match).toHaveLength(1);
+        expect(match[0]).toBe(expected);
+    }
+});


### PR DESCRIPTION
Prior to this commit, emoji sequences were rendered incorrectly in Discuss. The existing regex failed to match multi-codepoint sequences, splitting complex emojis (like ❤️‍🔥) into separate individual emojis (❤️ and 🔥).

Steps to reproduce:
1. Post a message in Discuss containing "🤷‍♂️"
2. Notice the message displays "🤷♂" instead

This commit refines `EMOJI_REGEX` to match complete emoji sequences.

[Task-6128638](https://www.odoo.com/odoo/project/1519/tasks/6128638)