### PR TITLE
[FIX] account: Replace dynamicFilters with context for search more

### DIFF
--- a/addons/account/static/src/components/many2one_account_account/many2one_account_account.js
+++ b/addons/account/static/src/components/many2one_account_account/many2one_account_account.js
@@ -11,20 +11,13 @@ export class Many2XAccountAccountAutocomplete extends Many2XAutocomplete {
 
     async onSearchMore(request) {
         const { getDomain, context, fieldString } = this.props;
-        let dynamicFilters = [];
         if (request.length) {
-            dynamicFilters = [
-                {
-                    description: _t("Quick search: %s", request),
-                    domain: [["name", "ilike", request]],
-                },
-            ];
+            context["search_default_name"] = request;
         }
         const title = _t("Search: %s", fieldString);
         this.selectCreate({
             domain: getDomain(),
             context,
-            filters: dynamicFilters,
             title,
         });
     }

--- a/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
+++ b/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
@@ -28,21 +28,14 @@ export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
         const { getDomain, context, fieldString } = this.props;
 
         const domain = getDomain();
-        let dynamicFilters = [];
         if (request.length) {
-            dynamicFilters = [
-                {
-                    description: _t("Quick search: %s", request),
-                    domain: [["name", "ilike", request]],
-                },
-            ];
+            context["search_default_name"] = request;
         }
 
         const title = _t("Search: %s", fieldString);
         this.selectCreate({
             domain,
             context,
-            filters: dynamicFilters,
             title,
         });
     }


### PR DESCRIPTION
This commit replaces the use of creating dynamicFilters while doing "Search More" in the account and tax widget.
It now simply updates the context to search default name instead of creating a filter domain manually for that.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
