### PR TITLE
[FIX] website: activate input placeholder translation on searchbar

### DIFF
--- a/addons/website/static/src/builder/plugins/translation/options/attribute_translation_option.xml
+++ b/addons/website/static/src/builder/plugins/translation/options/attribute_translation_option.xml
@@ -18,10 +18,6 @@
         <translate_attribute_option
             t-att-selector="translateAttributeOptionSelector"
             editableOnly="false"/>
-        <translate_attribute_option
-            selector=".s_website_form_field"
-            t-att-applyTo="translateAttributeOptionSelector"
-            editableOnly="false"/>
     </xpath>
 </t>
 

--- a/addons/website/static/src/builder/plugins/translation/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/translation_plugin.js
@@ -226,6 +226,11 @@ export class TranslationPlugin extends Plugin {
                     filteredEditableEl.value = match[2];
                 }
                 filteredEditableEl.classList.add("o_translatable_attribute");
+                if (filteredEditableEl.matches("textarea, input")) {
+                    // We want those elements to be translated by the sidebar,
+                    // not by editing the input.
+                    filteredEditableEl.setAttribute("readonly", "");
+                }
             }
         }
         const textEditEls = editableEls.filter(
@@ -241,6 +246,9 @@ export class TranslationPlugin extends Plugin {
             // Update the text content of textarea too
             textEditEl.innerText = match[2];
             textEditEl.classList.add("o_translatable_text");
+            // We want those elements to be translated by the sidebar,
+            // not by editing the input.
+            textEditEl.setAttribute("readonly", "");
             textEditEl.classList.remove("o_text_content_invisible");
         }
     }

--- a/addons/website/static/src/builder/translate.edit.scss
+++ b/addons/website/static/src/builder/translate.edit.scss
@@ -15,12 +15,12 @@ html[lang] > body.editor_enable [data-oe-translation-state] {
 }
 
 .s_website_form, .s_searchbar_input, .js_subscribe, .s_group, .s_donation_form, .s_age_verification_popup {
-    input {
+    input:not(.o_translatable_attribute) {
         pointer-events: none;
     }
 }
 .s_website_form {
-    textarea {
+    textarea:not(.o_translatable_attribute):not(.o_translatable_text) {
         pointer-events: none;
     }
 }

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -260,6 +260,24 @@ test("translate attribute history", async () => {
     ).toHaveValue("title");
 });
 
+test("translate input of searchbar", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: `
+            <form method="get" class="o_searchbar_form s_searchbar_input " data-snippet="s_searchbar_input" data-name="Search Input">
+                <div role="search" class=" o_search_input_group input-group ">
+                    <input type="search" name="search" class="o_cc o_cc1 border search-query form-control oe_search_box o_savable_attribute" placeholder="&lt;span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;568&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;7f55382219f0202c1b4f56deb099e2fedcec87ee73fe2edb2105df5447323bc6&quot;&gt;Search...&lt;/span&gt;" data-search-type="all" data-limit="6" data-order-by="name asc" autocomplete="off">
+                </div>
+        </form>
+        `,
+        loadIframeBundles: true,
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    await contains(":iframe input").click();
+    expect(
+        "[data-action-id='translateAttribute'][data-action-param='placeholder'] input"
+    ).toHaveValue("Search...");
+});
+
 test("undo shortcut in translate", async () => {
     const { getEditor } = await setupSidebarBuilderForTranslation({
         websiteContent: `<h1>Homepage</h1>`,

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -489,7 +489,7 @@ export const websiteServiceInTranslateMode = {
 };
 
 export async function setupSidebarBuilderForTranslation(options) {
-    const { websiteContent } = options;
+    const { websiteContent, loadIframeBundles = false } = options;
     // Hack: configure the snippets menu as in translate mode when clicking
     // on the "Edit" button of the systray. The goal of this hack is to avoid
     // the handling of an extra reload of the action to arrive in translate
@@ -510,6 +510,7 @@ export async function setupSidebarBuilderForTranslation(options) {
             onIframeLoaded: (iframe) => {
                 websiteServiceInTranslateMode.pageDocument = iframe.contentDocument;
             },
+            loadIframeBundles,
         }
     );
     await getTranslatedElements();


### PR DESCRIPTION
[FIX] website: activate input placeholder translation on searchbar

Steps to reproduce:
- Add a "Search" snippet on the website.
- Add a second language on the website.
- Enter in translate mode.

-> The placeholder is not translatable

Since [1], all the `input` descendants of `.s_searchbar_input` have
`pointer-events: none`. As a result, clicking the input no longer shows
the translation option for the placeholder.
Note that the problem does not appear for the form inputs as
`TranslateAttributeOption` is also instantiated with
`.s_website_form_field` as selector and
`".o_translatable_text, .o_translatable_attribute"` as `applyTo`.
However, this logic can not be applied for all the inputs. For example,
the inputs of the 'Donation' snippet have the same issue. Since those
inputs share the same parent structure, the `selector`-`applyTo`
approach is not suitable here.

To solve the problem, this commit reverts the css rule modified by [1].
To prevent users from editing those fields while editing the page,
inputs with translatable attributes are now marked as `readonly`. Thanks
to it, the `selector`-`applyTo` approach is not needed anymore.

[1]: https://github.com/odoo/odoo/commit/b15c390b00b1c7fab5f5fe773738e254172d699c

task-6132330