### PR TITLE
[FIX] base_vat: prevent crash on invalid taiwan vat number

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -936,7 +936,7 @@ class ResPartner(models.Model):
         own validation to support these new valid UBNs.
         """
         vat = stdnum.util.get_cc_module("tw", "vat").compact(vat)
-        if len(vat) != 8:
+        if len(vat) != 8 or not vat.isdigit():
             return False  # The length is fixed, and we will expect it to be 8 in the following checks.
 
         logic_multiplier = [1, 2, 1, 2, 1, 2, 4, 1]  # This multiplier is set by the official validation logic.

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -181,7 +181,7 @@ class TestStructure(TransactionCase):
         for ubn in ['88117254', '12345601', '90183275']:
             test_partner.vat = ubn
 
-        for ubn in ['88117250', '12345600', '90183272']:
+        for ubn in ['88117250', '12345600', '90183272', '1234567A']:
             with self.assertRaises(ValidationError):
                 test_partner.vat = ubn
 


### PR DESCRIPTION
**Steps to reproduce:**

- Install the `base_vat` module.
- Navigate to Invoicing > Customers.
- Create a new contact and set the country to `Taiwan`.
- Enter `1234567A` as the `Tax ID` and try to `save`.

**Error:**
`ValueError: invalid literal for int() with base 10: 'A'`

**Root cause:**
At [1], `check_vat_tw` is missing validation to ensure that the 
VAT number (without the country code) contains only digits, which 
causes an error when calling the `int()` method on the VAT number.

**Fix:**
This commit prevents errors and ensures users receive a `clear warning message`.

[1]:
https://github.com/odoo/odoo/blob/23398d24e108875b2838715d4b366df265d53234/addons/base_vat/models/res_partner.py#L929-L958

**No task Id**