### PR TITLE
[FIX] mail: remove from suggested recepients upon clicking unfollow

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1892,6 +1892,8 @@ class MailThread(models.AbstractModel):
                 partner = self.env['res.partner'].sudo().browse([partner_info['partner_id']])[0]
         if email and email in [val[1] for val in result[self.ids[0]]]:  # already existing email -> skip
             return result
+        if partner and partner == self.env.user.partner_id:  # if current user (non-follower) -> skip
+            return result
         if partner and partner in self.message_partner_ids:  # recipient already in the followers -> skip
             return result
         if partner and partner.id in [val[0] for val in result[self.ids[0]]]:  # already existing partner ID -> skip

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -644,6 +644,19 @@ class RecipientsNotificationTest(MailCommon):
         )
 
     @users('employee')
+    def test_suggested_recipients_excludes_current_user_after_unfollow(self):
+        """Current user should not be suggested after they unsubscribe from a thread."""
+        test = self.env['mail.test.track'].create({
+            'name': 'Test Track',
+            'user_id': self.env.user.id,
+        })
+        test.message_unsubscribe([self.env.user.partner_id.id])
+        self.assertNotIn(
+            self.env.user.partner_id.id,
+            [partner_id for partner_id, *_ in test._message_get_suggested_recipients()[test.id]],
+        )
+
+    @users('employee')
     def test_notification_user_choice(self):
         """ Check fetching user information when notifying someone with multiple
         users (more complex use case). """


### PR DESCRIPTION
### Steps to reproduce:
- Open any mail thread in chatter
- Click the "Send To" button once
- Click "Unfollow"
- You will be a suggested recipient

### Cause of Issue:
The suggested recipient generation did not filter out the current user. After unsubscribing, the current user could still be returned by `_message_get_suggested_recipients` because the user is not on the following list.
https://github.com/odoo/odoo/blob/23398d24e108875b2838715d4b366df265d53234/addons/mail/models/mail_thread.py#L1881-L1907

### Fix:
Since followers are excluded from suggested recipient candidates in the mail thread, and the current user should be excluded when they unfollow, the current user is excluded altogether.

opw-6122351