### PR TITLE
[FIX] test_discuss_full: correct query count

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -133,7 +133,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - _compute_message_unread
     #       - fetch im_livechat_channel
     #   1: _get_last_messages
-    #   24: store add message:
+    #   23: store add message:
     #       - fetch mail_message
     #       - search mail_message (_compute_linked_message_ids)
     #       - fetch mail_message (_compute_linked_message_ids)
@@ -146,7 +146,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search_fetch mail_poll (_compute_has_poll end_message_id)
     #       - search mail_message_link_preview
     #       - search mail_notification
-    #       - search mail_tracking_value
     #       - search rating_rating
     #       - fetch mail_notification
     #       - search discuss_call_history
@@ -158,7 +157,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch user (author)
     #       - fetch discuss_call_history
     #       - select the current db snapshot
-    _query_count_discuss_channels = 62
+    _query_count_discuss_channels = 61
 
     def setUp(self):
         super().setUp()

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -24,7 +24,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search mail_notification
         #       - fetch mail_notification
         #   - search bus_bus (_bus_last_id)
-        #   30 store add message:
+        #   29 store add message:
         #       - fetch mail_message (_records_by_model_name/prefetch)
         #       - search mail_message_schedule
         #       - search mail_followers
@@ -42,7 +42,6 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #       - search mail_poll (end_message_id)
         #       - search mail_message_link_preview
         #       - fetch mail_notification
-        #       - search mail_tracking_value
         #       2 _compute_rating_id:
         #           - search rating_rating
         #           - fetch rating_rating
@@ -78,5 +77,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(38):
+        with self.assertQueryCount(37):
             self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})


### PR DESCRIPTION
since PR #235719 the query relating to `mail_tracking_value` has been removed. This change corrects the query count accordingly.
