### PR TITLE
[FIX] web: pager button and scrollbar conflict

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -60,7 +60,8 @@ import { onMounted, onWillUnmount, status, xml } from "@odoo/owl";
 const DEFAULT_MIN_WIDTH = 80;
 const SELECTOR_WIDTH = 20;
 const OPEN_FORM_VIEW_BUTTON_WIDTH = 54;
-const DELETE_BUTTON_WIDTH = 12;
+const DELETE_BUTTON_WIDTH = 52;
+const COUNT_COLUMN_WIDTH = 105;
 let _dateWidths = null; // computed dynamically, lazily, see @computeOptimalDateWidths
 export const FIELD_WIDTHS = Object.freeze({
     boolean: [20, 100], // [minWidth, maxWidth]
@@ -235,13 +236,24 @@ function computeWidths(table, state, allowedWidth, startingWidths) {
     if (state.hasSelectors) {
         _columnWidths[0] = SELECTOR_WIDTH;
     }
-    if (state.hasOpenFormViewColumn) {
-        const index = _columnWidths.length - (state.hasActionsColumn ? 2 : 1);
-        _columnWidths[index] = OPEN_FORM_VIEW_BUTTON_WIDTH;
-    }
+
+    let trailingIndex = _columnWidths.length - 1;
+
     if (state.hasActionsColumn) {
-        _columnWidths[_columnWidths.length - 1] = DELETE_BUTTON_WIDTH;
+        _columnWidths[trailingIndex] = DELETE_BUTTON_WIDTH;
+        trailingIndex--;
     }
+
+    if (state.showCountColumn) {
+        _columnWidths[trailingIndex] = Math.max(COUNT_COLUMN_WIDTH, _columnWidths[trailingIndex]);
+        trailingIndex--;
+    }
+
+    if (state.hasOpenFormViewColumn) {
+        _columnWidths[trailingIndex] = OPEN_FORM_VIEW_BUTTON_WIDTH;
+        trailingIndex--;
+    }
+
     const columnWidthSpecs = getWidthSpecs(columns);
     const columnOffset = state.hasSelectors ? 1 : 0;
     for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -281,6 +281,7 @@ export class ListRenderer extends Component {
             hasSelectors: this.hasSelectors,
             hasOpenFormViewColumn: this.hasOpenFormViewColumn,
             hasActionsColumn: this.hasActionsColumn,
+            showCountColumn: this.showCountColumn,
         }));
 
         useExternalListener(window, "keydown", (ev) => {

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -74,6 +74,7 @@
 
             > tr > :last-child {
                 padding-right: var(--ListRenderer-table-padding-x);
+                padding-left: var(--ListRenderer-table-padding-x);
             }
         }
 
@@ -324,7 +325,7 @@
                     .o_pager_previous,
                     .o_pager_next {
                         padding: 0 !important;
-                        width: 16px !important;
+                        width: 18px !important;
                         height: 24px !important;
 
                         display: flex !important;
@@ -402,8 +403,8 @@
         }
 
         .o_list_actions_header {
-            width: 36px !important;
-            min-width: 36px;
+            width: 52px !important;
+            min-width: 52px;
             background-color: var(--ListRenderer-thead-bg-color);
         }
 

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -39,11 +39,13 @@
                                     <span
                                           class="o_resize position-absolute top-0 end-0 bottom-0 ps-1 bg-black-25 opacity-0 opacity-50-hover z-1"
                                           t-on-pointerdown.stop.prevent="this.columnWidths.onStartResize"
-                                          t-on-dblclick="this.columnWidths.resetWidths"/>
+                                          t-on-dblclick="this.columnWidths.resetWidths"
+                                        />
                                 </t>
                             </th>
                             <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{'o_list_button w-print-0 p-print-0': column.type === 'button_group'}"/>
                         </t>
+                        <th t-if="this.hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
                         <th
                             class="o_count_header opacity-trigger-hover w-print-auto"
                             t-att-class="this.getColumnClass(this.countColumn)"
@@ -57,13 +59,14 @@
                                 <i class="o_list_sortable_icon" t-att-class="this.getSortableIconClass(this.countColumn)"/>
                             </div>
                         </th>
-                        <th t-if="this.hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
-                        <th t-if="this.hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0 z-2 ps-2">
+                        <th t-if="this.hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0 z-2">
                             <div t-if="this.displayOptionalFields or this.hasOptionalOpenFormViewColumn" class="o_optional_columns_dropdown d-print-none text-center border-top-0">
                                 <Dropdown position="'bottom-end'" menuRef="this.optionalColumnsDropdownRef">
-                                    <button class="btn p-0" tabindex="-1" data-available-offline="">
-                                        <i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust"/>
-                                    </button>
+                                    <div class="d-flex justify-content-center w-100">
+                                        <button class="btn p-0" tabindex="-1" data-available-offline="">
+                                            <i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust"/>
+                                        </button>
+                                    </div>
 
                                     <t t-set-slot="content">
                                         <t t-foreach="this.optionalFieldGroups" t-as="group" t-key="group_index">
@@ -142,6 +145,7 @@
                             </span>
                         </td>
                         <td t-if="this.hasOpenFormViewColumn" class="w-print-0 p-print-0"/>
+                        <td t-if="this.showCountColumn" class="w-print-0 p-print-0"/>
                         <td t-if="this.displayOptionalFields or this.activeActions.onDelete" class="w-print-0 p-print-0" />
                     </tr>
                 </tfoot>
@@ -277,6 +281,7 @@
             </td>
             <t t-set="groupCellColspan" t-value="this.getGroupCellColspan(group)"/>
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-if="groupCellColspan > 0" t-att-colspan="groupCellColspan"/>
+            <th t-if="this.hasOpenFormViewColumn" class="w-print-0 p-print-0"/>
             <th class="o_count_column" t-if="this.showCountColumn">
                 <div class="d-flex justify-content-end align-items-center w-100 h-100">
                     <span t-if="!this.showGroupPager(group)" class="m-1" >
@@ -287,17 +292,19 @@
                     </div>
                 </div>
             </th>
-            <th class="px-1 position-sticky end-0 z-2" t-on-keydown="(ev) => this.onCellKeydown(ev, group)">
-                <div
-                    t-if="this.showGroupPager(group)"
-                    t-on-click.stop="" class="o_pager_cell_buttons"
-                >
-                    <Pager t-props="this.getGroupPagerProps(group)"/>
+            <th class="px-2 position-sticky end-0" t-on-keydown="(ev) => this.onCellKeydown(ev, group)">
+                <div class="d-flex justify-content-center w-100">
+                    <div
+                        t-if="this.showGroupPager(group)"
+                        t-on-click.stop="" class="o_pager_cell_buttons"
+                    >
+                        <Pager t-props="this.getGroupPagerProps(group)"/>
+                    </div>
+                    <GroupConfigMenu
+                        t-elif="this.showGroupConfigMenu(group)"
+                        t-props="this.getGroupConfigMenuProps(group)"
+                    />
                 </div>
-                <GroupConfigMenu
-                    t-elif="this.showGroupConfigMenu(group)"
-                    t-props="this.getGroupConfigMenuProps(group)"
-                />
             </th>
         </tr>
     </t>
@@ -378,14 +385,13 @@
                     >View</button>
                 </td>
             </t>
-
+            <td t-if="this.showCountColumn" tabindex="-1" class="w-print-0 p-print-0"/>
             <t t-set="useUnlink" t-value="'unlink' in this.activeActions" />
             <t t-set="hasX2ManyAction" t-value="this.isX2Many and (useUnlink ? this.activeActions.unlink : this.activeActions.delete)" />
-            <td t-if="this.showCountColumn" tabindex="-1" class="w-print-0 p-print-0"/>
             <t t-if="this.displayOptionalFields or this.props.list.isGrouped or hasX2ManyAction">
                 <t t-if="hasX2ManyAction">
                     <t t-set="hasDeleteButton" t-value="this.displayDeleteIcon(record)"/>
-                    <td class="o_list_record_remove w-print-0 p-print-0 text-center"
+                    <td class="o_list_record_remove o_list_actions_column_fixed w-print-0 p-print-0 text-center"
                         t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
                         t-on-click.stop="hasDeleteButton ? (ev) => this.onRemoveCellClicked(record, ev) : () => {}"
                         tabindex="-1"

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -259,7 +259,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 34, 64, 36]);
+    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 34, 64, 52]);
 });
 
 test(`width computation: with records, few fields`, async () => {
@@ -1245,20 +1245,20 @@ test(`freeze widths: toggle optional fields`, async () => {
         `,
     });
 
-    expectedColumnWidthsToBeCloseTo([40, 99, 436, 188, 36]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 427, 188, 52]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input:eq(0)").click();
-    expectedColumnWidthsToBeCloseTo([40, 99, 334, 102, 189, 36]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 325, 102, 189, 52]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 99, 522, 102, 36]);
+    expect(getColumnWidths()).toEqual([40, 99, 513, 102, 52]);
 
     await contains(".dropdown-item input:eq(2)").click();
-    expect(getColumnWidths()).toEqual([40, 99, 89, 102, 433, 36]);
+    expect(getColumnWidths()).toEqual([40, 99, 89, 102, 424, 52]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expectedColumnWidthsToBeCloseTo([40, 99, 89, 103, 189, 244, 36]);
+    expectedColumnWidthsToBeCloseTo([40, 99, 89, 103, 189, 235, 52]);
 });
 
 test(`freeze widths: x2many, add first record`, async () => {
@@ -1353,16 +1353,16 @@ test(`freeze widths: x2many, toggle optional field`, async () => {
             </form>`,
     });
 
-    expect(getColumnWidths()).toEqual([110, 622, 36]);
+    expect(getColumnWidths()).toEqual([110, 613, 52]);
 
     // create a record to store the current widths, but discard it directly to keep
     // the list empty (otherwise, the browser automatically computes the optimal widths)
     await contains(".o_field_x2many_list_row_add button").click();
-    expect(getColumnWidths()).toEqual([110, 622, 36]);
+    expect(getColumnWidths()).toEqual([110, 613, 52]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input").click();
-    expect(getColumnWidths()).toEqual([110, 541, 80, 36]);
+    expect(getColumnWidths()).toEqual([110, 532, 80, 52]);
 });
 
 // manually resize columns


### PR DESCRIPTION
In Firefox grouped list views, a visible scrollbar overlaps the group header's right pager button. This makes it difficult for users to click 'next'.

This commit fixes this by increasing the width of the pager buttons and column, and adjusting the padding accordingly.

Introduced by PR #255332