### PR TITLE
[FIX] account: Get valid journal type from context

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -869,6 +869,9 @@ class AccountMove(models.Model):
             move.journal_id = move._search_default_journal()
 
     def _get_valid_journal_types(self):
+        journal_type = self.env.context.get("journal_type")
+        if journal_type:
+            return [journal_type]
         if self.is_sale_document(include_receipts=True):
             return ['sale']
         elif self.is_purchase_document(include_receipts=True):


### PR DESCRIPTION
When a account.bank.statement is created via a action where the journal_type is set in the context
this value isn't used to compute the right journal for the account.bank.statement.line/account.move





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
