### PR TITLE
[FIX] account, sale: show section amount for combo products in invoice

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -352,6 +352,7 @@ class AccountMoveLine(models.Model):
         check_company=True,
         index=True,
     )
+    product_type = fields.Selection(related='product_id.type', depends=['product_id'])
     allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
     product_uom_id = fields.Many2one(
         comodel_name='uom.uom',

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -44,6 +44,7 @@ function hasPreviousSection(list, record) {
 
 function getRecordsUntilSection(list, record, asc, subSection) {
     const stopAtTypes = [DISPLAY_TYPES.SECTION];
+    const notStopAtProductTypes = record.data.product_type === 'combo' ? [] : ['combo'];
     if (subSection ?? record.data.display_type === DISPLAY_TYPES.SUBSECTION) {
         stopAtTypes.push(DISPLAY_TYPES.SUBSECTION);
     }
@@ -53,13 +54,18 @@ function getRecordsUntilSection(list, record, asc, subSection) {
     if (asc) {
         sectionRecords.push(list.records[index]);
         index++;
-        while (index < list.records.length && !stopAtTypes.includes(list.records[index].data.display_type)) {
+        while (
+            index < list.records.length &&
+            (!stopAtTypes.includes(list.records[index].data.display_type) ||
+            notStopAtProductTypes.includes(list.records[index].data.product_type))) {
             sectionRecords.push(list.records[index]);
             index++;
         }
     } else {
         index--;
-        while (index >= 0 && !stopAtTypes.includes(list.records[index].data.display_type)) {
+        while (index >= 0 &&
+            (!stopAtTypes.includes(list.records[index].data.display_type) ||
+            notStopAtProductTypes.includes(list.records[index].data.product_type))) {
             sectionRecords.unshift(list.records[index]);
             index--;
         }
@@ -599,6 +605,9 @@ export const sectionAndNoteText = {
 export const listSectionAndNoteText = {
     ...sectionAndNoteText,
     component: ListSectionAndNoteText,
+    fieldDependencies: [
+        { name: "product_type", type: "selection" },
+    ],
 };
 
 registry.category("fields").add("section_and_note_one2many", sectionAndNoteFieldOne2Many);

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1503,6 +1503,7 @@ class SaleOrderLine(models.Model):
                 'display_type': 'line_section',
                 'sequence': self.sequence,
                 'name': f'{self.product_id.name} x {qty_to_invoice}',
+                'product_id': self.product_id.id,
                 'product_uom_id': self.product_uom_id.id,
                 'quantity': self.qty_to_invoice,
                 'sale_line_ids': [Command.link(self.id)],

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -630,7 +630,7 @@ class TestSaleToInvoice(TestSaleCommon):
             {
                 'name': 'Meal Menu x 3',
                 'display_type': 'line_section',
-                'product_id': False,
+                'product_id': product_combo.id,
                 'quantity': 3,
                 'price_unit': 0,
                 'sequence': 0,


### PR DESCRIPTION
Issue:
---
Due to this issue, section amount is not taking combo products into
account in invoices.

### Steps to reproduce:
1- Create a SO.
2- Add a section, and add a combo product under section.
3- Confirm and create an invoice.

The section amount is not calculated correctly.

Cause:
---
This is because the `display_type` of a combo line is `line_section`,
as a result in invoice, the combo line is treated as a section line.
Hence, the combo line is not taken into account in calculation of
amount.

Fix:
---
To fix that, we need to differentiate the combo line from section line.
In sales app, it is handled by `product_type == combo`.
We can follow the same logic, by adding this field to
`account.move.line`.

opw-6112445