### PR TITLE
[FIX] mail: add missing picture-in-picture action in call menu

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -77,7 +77,6 @@
         'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
         'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and !action.tags.includes('PRIMARY') and !action.tags.includes('CALL_LAYOUT'),
         'bg-transparent': store.shouldSimulateDarkTheme(this) and action.tags.includes('CALL_LAYOUT'),
-        'opacity-75 opacity-100-hover': action.tags.includes('CALL_LAYOUT'),
     })"/>
     <t t-set="attrs" t-value="{ 'aria-label': action.name, 'disabled': action.disabledCondition, 'name': action.id, 'data-sequence': action.sequence, 'data-sequence-group': action.sequenceGroup, 'data-sequence-quick': action.sequenceQuick }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -41,6 +41,13 @@
     }
 }
 
+.o-discuss-Call-layoutActions button {
+    opacity: 75%;
+    &:hover {
+        opacity: 100%;
+    }
+}
+
 .o-discuss-Call-sidebar {
     width: 120px;
     min-width: 120px;

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -219,11 +219,7 @@ registerCallAction("fullscreen", {
     tags: ACTION_TAGS.CALL_LAYOUT,
 });
 registerCallAction("picture-in-picture", {
-    condition: ({ owner, store, thread }) =>
-        !owner.env.inCallMenu &&
-        thread?.isSelfInCall &&
-        store.env.services["discuss.pip_service"] &&
-        !store.env?.isSmall,
+    condition: ({ owner, store, thread }) => thread?.isSelfInCall && !store.env?.isSmall,
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
         store.rtc?.state.isPipMode ? _t("Exit Picture in Picture") : _t("Picture in Picture"),

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -495,6 +495,24 @@ test("Systray icon shows latest action", async () => {
     await contains(".o-discuss-CallMenu-buttonContent .fa-hand-paper-o");
 });
 
+test("Can use Call actions in Call Systray Menu", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click(".o-discuss-CallMenu-dropdownMore");
+    await contains(".o-dropdown-item", { count: 8 });
+    await contains(".o-dropdown-item:has(:text('Mute'))");
+    await contains(".o-dropdown-item:has(:text('Deafen'))");
+    await contains(".o-dropdown-item:has(:text('Turn camera on'))");
+    await contains(".o-dropdown-item:has(:text('Share Screen'))");
+    await contains(".o-dropdown-item:has(:text('Raise Hand'))");
+    await contains(".o-dropdown-item:has(:text('Picture in Picture'))");
+    await contains(".o-dropdown-item:has(:text('Fullscreen'))");
+    await contains(".o-dropdown-item:has(:text('Disconnect'))");
+});
+
 test("Systray icon keeps track of earlier actions", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Before this commit, Call Menu did not have the "Picture-in-Picture" action. This is unfortunate because this is one of the most valuable action to have it available there, as a frequent usage of Discuss is to join a call, switch to another conversation or chatter, and then wanting to keep an overlay of the call.

Without the "Picture-in-Picture" in Call Menu, this forces user to access the Discuss conversation again and then click on "Picture-in-Picture" there, when clicking on the call menu would be faster.

This commit adds the "Picture-in-Picture" action in the call menu to ease using this feature.

Also fixes an issue where "Fullscreen" and "Picture-in-Picture" actions have reduced opacity in the Call Menu. This comes from opacity hover effect that should be limited to their inline visual in the Call view but was mistakenly also present in the dropdown.

Before / After
<img width="440" height="369" alt="Screenshot 2026-04-17 at 14 15 58" src="https://github.com/user-attachments/assets/2accb779-28f5-4930-a101-db5e52b029b7" />
