### PR TITLE
[FIX] mail: search for channel invite performance

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -2,7 +2,7 @@
 
 from odoo import api, fields, models
 from odoo.fields import Domain
-from odoo.tools import email_normalize, single_email_re, SQL
+from odoo.tools import email_normalize, single_email_re
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import AccessError
 
@@ -94,17 +94,14 @@ class ResPartner(models.Model):
             domain &= Domain("channel_ids", "not in", channel.id)
             if channel.group_public_id:
                 domain &= Domain("user_ids.all_group_ids", "in", channel.group_public_id.id)
-        query = self._search(domain, limit=limit)
-        # bypass lack of support for case insensitive order in search()
-        query.order = SQL('LOWER(%s), "res_partner"."id"', self._field_to_sql(self._table, "name"))
-        selectable_partners = self.env["res.partner"].browse(query)
+        selectable_partners = self.search(domain, limit=limit + 1, order="name, id")
         store.add(
             selectable_partners,
             "_store_channel_invite_fields",
             fields_params={"channel": channel},
         )
         return {
-            "count": self.env["res.partner"].search_count(domain),
+            "count": len(selectable_partners),
             "partner_ids": selectable_partners.ids,
         }
 

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -51,6 +51,10 @@ export class ChannelInvitation extends Component {
         });
     }
 
+    get searchLimit() {
+        return 15;
+    }
+
     get selectablePartners() {
         return this.props.state?.selectablePartners ?? this.state.selectablePartners;
     }
@@ -89,11 +93,8 @@ export class ChannelInvitation extends Component {
 
     get showingResultNarrowText() {
         return _t(
-            "Showing %(result_count)s results out of %(total_count)s. Narrow your search to see more choices.",
-            {
-                result_count: this.selectablePartners.length,
-                total_count: this.state.searchResultCount,
-            }
+            "Showing the first %(search_limit)s results. Narrow your search to see more choices.",
+            { search_limit: this.searchLimit }
         );
     }
 
@@ -106,10 +107,11 @@ export class ChannelInvitation extends Component {
 
     async fetchPartnersToInvite() {
         const results = await this.sequential(() =>
-            this.orm.call("res.partner", "search_for_channel_invite", [
-                this.searchStr,
-                this.props.channel?.id ?? false,
-            ])
+            this.orm.call("res.partner", "search_for_channel_invite", [], {
+                search_term: this.searchStr,
+                channel_id: this.props.channel?.id ?? false,
+                limit: this.searchLimit,
+            })
         );
         if (!results) {
             return;

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -23,7 +23,7 @@
                         <t t-if="props.channel">No one found to invite.</t>
                         <t t-else="">No user found.</t>
                     </div>
-                    <div t-if="state.searchResultCount > selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-esc="showingResultNarrowText"/>
+                    <div t-if="state.searchResultCount > this.searchLimit" class="smaller text-muted mx-1 mb-1 fst-italic" t-esc="showingResultNarrowText"/>
                     <t t-foreach="selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
                         <t t-call="discuss.ChannelInvitation-selectableItem">
                             <t t-set="selectableItemIndex" t-value="selectablePartner_index"/>


### PR DESCRIPTION
Since [1], the check in `search_for_channel_invite` that restricted the search to internal users was removed. As a result, the dataset to process has exploded and the query is very slow.

Moreover, the method is ordering on `LOWER(name)` which is not indexed, and another query is done to count the total results, which slows down the process even more.

This PR fixes those issues by:
- Removing the `LOWER` ordering. Ordering in a case sensitive fashion is not that big of a deal anyway.
- Removing the count query, fetching one more partner in the search is enough to know if there are more results, executing the same query twice is overkill.
- Reducing the number of partner returned: currently 30, but there isn't enough space to display them anyway.

task-4526176

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
