### PR TITLE
[REF] im_livechat: remove _to_store of im_livechat discuss.channel

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -494,7 +494,6 @@ class DiscussChannel(models.Model):
 
     def _store_channel_fields(self, res: Store.FieldList):
         super()._store_channel_fields(res)
-        res.attr("chatbot_current_step")
         res.one("country_id", ["code", "name"], predicate=is_livechat_channel)
         res.attr("livechat_end_dt", predicate=is_livechat_channel)
         # sudo - visitor can access to the channel member history of an accessible channel
@@ -514,15 +513,11 @@ class DiscussChannel(models.Model):
             res.attr("livechat_looking_for_help_since_dt", predicate=is_livechat_channel)
             res.many("livechat_expertise_ids", ["name", "color"], predicate=is_livechat_channel)
 
-    def _to_store(self, store: Store, res: Store.FieldList):
-        """Extends the channel header by adding the livechat operator and the 'anonymous' profile"""
-        if add_current_step := "chatbot_current_step" in res:
-            res.remove("chatbot_current_step")
-        super()._to_store(store, res)
-        if not add_current_step:
-            return
         lang = self.env["chatbot.script"]._get_chatbot_language()
-        for channel in self.filtered(lambda channel: channel.chatbot_current_step_id):
+
+        def chatbot_data(channel):
+            if not channel.chatbot_current_step_id:
+                return False
             # sudo: chatbot.script.step - returning the current script/step of the channel
             current_step_sudo = channel.chatbot_current_step_id.sudo().with_context(lang=lang)
             chatbot_script = current_step_sudo.chatbot_script_id
@@ -539,14 +534,21 @@ class DiscussChannel(models.Model):
                 # sudo: discuss.channel - visitors/guests can check if an operator exists
                 and bool(channel.sudo().livechat_agent_partner_ids),
             }
-            store.add(current_step_sudo, "_store_script_step_fields")
-            store.add(chatbot_script, "_store_script_fields")
-            chatbot_data = {
+            return {
                 "script": chatbot_script.id,
                 "steps": [current_step],
                 "currentStep": current_step,
             }
-            store.add(channel, {"chatbot": chatbot_data})
+        res.attr("chatbot", chatbot_data, predicate=is_livechat_channel)
+        res.one(
+            "chatbot_current_step_id",
+            lambda res: (
+                res.from_method("_store_script_step_fields"),
+                res.one("chatbot_script_id", "_store_script_fields"),
+            ),
+            value=lambda c: c.chatbot_current_step_id.sudo().with_context(lang=lang),
+            predicate=is_livechat_channel,
+        )
 
     @api.autovacuum
     def _gc_empty_livechat_sessions(self):

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -31,6 +31,7 @@ declare module "models" {
     }
     export interface DiscussChannel {
         chatbot: Chatbot;
+        chatbot_current_step_id: ChatbotScriptStep;
         country_id: Country;
         livechat_agent_history_ids: LivechatChannelMemberHistory[];
         livechat_bot_history_ids: LivechatChannelMemberHistory[];

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -12,6 +12,7 @@ const discussChannelPatch = {
     setup() {
         super.setup(...arguments);
         this.chatbot = fields.One("Chatbot", { inverse: "channel_id" });
+        this.chatbot_current_step_id = fields.One("chatbot.script.step");
         this.country_id = fields.One("res.country");
         this.livechat_agent_history_ids = fields.Many("im_livechat.channel.member.history", {
             inverse: "channelAsAgentHistory",

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -928,6 +928,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "ai_agent_id": False,
                 "channel_type": "livechat",
+                "chatbot": False,
+                "chatbot_current_step_id": False,
                 "country_id": self.env.ref("base.in").id,
                 "create_uid": self.users[1].id,
                 "default_display_mode": False,
@@ -958,6 +960,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "ai_agent_id": False,
                 "channel_type": "livechat",
+                "chatbot": False,
+                "chatbot_current_step_id": False,
                 "country_id": self.env.ref("base.be").id,
                 "create_uid": self.env.ref("base.public_user").id,
                 "default_display_mode": False,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -169,6 +169,8 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     {
                         "ai_agent_id": False,
                         "channel_type": "livechat",
+                        "chatbot": False,
+                        "chatbot_current_step_id": False,
                         "country_id": False,
                         "create_uid": self.user_public.id,
                         "default_display_mode": False,
@@ -344,6 +346,8 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 {
                     "ai_agent_id": False,
                     "channel_type": "livechat",
+                    "chatbot": False,
+                    "chatbot_current_step_id": False,
                     "country_id": False,
                     "create_uid": self.user_public.id,
                     "default_display_mode": False,


### PR DESCRIPTION
This commit removes the `_to_store` override of `discuss.channel` in the `im_livechat` module.
The `_to_store` pattern will eventually be deprecated with all data coming from their respective ORM models.
This commit also in particulars removes the "fake" compute `operatorFound` by replacing it with the real data necessary to establish an operator been found (step_type and
livechat_agent_partner_ids).

task-4676435