### PR TITLE
[FIX] l10n_in_ewaybill: use date instead of datetime for document_date

### DIFF
--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -40,7 +40,7 @@ class L10nInEwaybill(models.Model):
     account_move_id = fields.Many2one('account.move', copy=False, readonly=True)
 
     # Document details
-    document_date = fields.Datetime("Document Date", compute='_compute_ewaybill_document_details')
+    document_date = fields.Date("Document Date", compute='_compute_ewaybill_document_details')
     document_number = fields.Char("Document", compute='_compute_ewaybill_document_details')
     company_id = fields.Many2one("res.company", compute='_compute_ewaybill_company', store=True)
     company_currency_id = fields.Many2one(related='company_id.currency_id')

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -1,4 +1,5 @@
 import re
+import pytz
 from collections import defaultdict
 
 from odoo import _, api, fields, models
@@ -55,7 +56,9 @@ class L10nInEwaybill(models.Model):
         if picking_id := self.picking_id:
             return {
                 'document_number': picking_id.name,
-                'document_date': picking_id.date_done
+                'document_date': fields.Date.to_date(
+                    picking_id.date_done.astimezone(pytz.timezone('Asia/Kolkata')).strftime('%Y-%m-%d')
+                ) if picking_id.date_done else False,
             }
         return super()._get_ewaybill_document_details()
 


### PR DESCRIPTION
The e-waybill specification requires `document_date` to contain only the date component, but the field was previously defined as a datetime. Since the value is computed from the `account.move` date field, it defaulted to `00:00 UTC` (05:30 IST), introducing unnecessary time information.

This commit fixes the issue by:
* Changing the field type from datetime to date.
* Ensuring proper conversion when values originate from datetime fields (e.g., inventory flows), by converting to IST.

This prevents the inclusion of incorrect times and aligns the field with e-waybill requirements.

task-6128526