### PR TITLE
[FIX] web: keep the property editor usable on an invalid domain

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.js
@@ -40,6 +40,9 @@ export class ModelFieldSelector extends Component {
             onClose: async () => {
                 if (this.newPath !== null) {
                     const fieldInfo = await loadFieldInfo(this.props.resModel, this.newPath);
+                    if (["properties", "properties_definition"].includes(fieldInfo.fieldDef?.type)) {
+                        return;
+                    }
                     this.props.update(this.newPath, fieldInfo);
                 }
             },

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -357,19 +357,20 @@ export class PropertyDefinition extends Component {
      * Update the number of records that match the current domain.
      */
     async _updateMatchingRecordsCount() {
+        let matchingRecordsCount;
         if (this.state.resModel && this.state.resModel.length) {
             const domainList = new Domain(this.state.propertyDefinition.domain || "[]").toList();
-
-            const result = await this.orm.call(
-                this.state.propertyDefinition.comodel,
-                "search_count",
-                [domainList]
-            );
-
-            this.state.matchingRecordsCount = result;
-        } else {
-            this.state.matchingRecordsCount = undefined;
+            try {
+                matchingRecordsCount = await this.orm.call(
+                    this.state.propertyDefinition.comodel,
+                    "search_count",
+                    [domainList]
+                );
+            } catch {
+                // An invalid domain shows no record count.
+            }
         }
+        this.state.matchingRecordsCount = matchingRecordsCount;
     }
 
     /**

--- a/addons/web/static/tests/core/model_field_selector_tests.js
+++ b/addons/web/static/tests/core/model_field_selector_tests.js
@@ -886,6 +886,81 @@ QUnit.module("Components", (hooks) => {
         assert.containsNone(target, ".o_model_field_selector_warning");
     });
 
+    QUnit.test(
+        "prevent update of properties(_definition) without sub-fields with X2Many",
+        async (assert) => {
+            addProperties();
+            serverData.models.partner.fields.partner_ids = {
+                string: "Partners (m2m)",
+                type: "many2many",
+                relation: "partner",
+                searchable: true,
+            };
+            serverData.models.partner.fields.child_ids = {
+                string: "Children (o2m)",
+                type: "one2many",
+                relation: "partner",
+                searchable: true,
+            };
+
+            class Parent extends Component {
+                static components = { ModelFieldSelector };
+                static template = xml`
+                    <ModelFieldSelector
+                        readonly="false"
+                        resModel="'partner'"
+                        path="path"
+                        update="(path) => this.onUpdate(path)"
+                    />
+                `;
+                setup() {
+                    this.path = "foo";
+                }
+                onUpdate(path) {
+                    this.path = path;
+                    assert.step(path);
+                    this.render();
+                }
+            }
+
+            await mountComponent(Parent);
+
+            await openModelFieldSelectorPopover(target);
+            await click(
+                target,
+                ".o_model_field_selector_popover_item[data-name='properties'] .o_model_field_selector_popover_relation_icon"
+            );
+            await nextTick();
+            await click(target, ".o_model_field_selector_popover_close");
+
+            await openModelFieldSelectorPopover(target);
+            await click(
+                target,
+                ".o_model_field_selector_popover_item[data-name='partner_ids'] .o_model_field_selector_popover_relation_icon"
+            );
+            await click(
+                target,
+                ".o_model_field_selector_popover_item[data-name='properties'] .o_model_field_selector_popover_relation_icon"
+            );
+            await nextTick();
+            await click(target, ".o_model_field_selector_popover_close");
+
+            await openModelFieldSelectorPopover(target);
+            await click(
+                target,
+                ".o_model_field_selector_popover_item[data-name='child_ids'] .o_model_field_selector_popover_relation_icon"
+            );
+            await click(
+                target,
+                ".o_model_field_selector_popover_item[data-name='properties'] .o_model_field_selector_popover_relation_icon"
+            );
+            await nextTick();
+            await click(target, ".o_model_field_selector_popover_close");
+
+            assert.verifySteps([]);
+        }
+    );
+
     QUnit.test("search on field string and name in debug mode", async (assert) => {
         patchWithCleanup(browser, { setTimeout: (fn) => fn() }); // for debouncedSearchFields
         serverData.models.partner.fields.ucit = {

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -18,6 +18,7 @@ import { toggleActionMenu } from "@web/../tests/search/helpers";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { makeServerError } from "@web/../tests/helpers/mock_server";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { browser } from "@web/core/browser/browser";
 import {
@@ -1094,6 +1095,57 @@ QUnit.module("Fields", (hooks) => {
             "Should have created a new user"
         );
     });
+
+    QUnit.test(
+        "properties: a relational property with an unevaluable domain shows no record count",
+        async function (assert) {
+            async function mockRPC(route, { method, model }) {
+                if (["check_access_rights", "check_access_rule"].includes(method)) {
+                    return true;
+                } else if (method === "get_available_models" && model === "ir.model") {
+                    return [{ model: "res.users", display_name: "User" }];
+                } else if (method === "fields_get" && model === "res.users") {
+                    return { name: { searchable: true, string: "Name", type: "char" } };
+                } else if (method === "search_count" && model === "res.users") {
+                    throw makeServerError({ message: "Wrong path" });
+                }
+            }
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 2,
+                serverData,
+                arch: `
+                    <form>
+                        <sheet>
+                            <group>
+                                <field name="company_id"/>
+                                <field name="properties"/>
+                            </group>
+                        </sheet>
+                    </form>`,
+                mockRPC,
+            });
+
+            const popover = () => target.querySelector(".o_property_field_popover");
+            for (const propertyType of ["many2one", "many2many"]) {
+                await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+                await changeType(target, propertyType);
+                // Selecting the model triggers the matching-records count, which fails here.
+                await click(popover(), ".o_field_property_definition_model input");
+                await click(popover(), ".o_field_property_definition_model .ui-menu-item:first-child");
+
+                assert.ok(popover(), `the ${propertyType} property editor stays open`);
+                assert.strictEqual(
+                    popover().textContent.includes("record(s)"),
+                    false,
+                    "no matching record count is shown when the domain cannot be evaluated"
+                );
+                await closePopover(target);
+            }
+        }
+    );
 
     /**
      * Test the properties many2many


### PR DESCRIPTION
When a relational property has a domain the server cannot evaluate, opening its definition editor crashes. The editor calls search_count on that domain to show how many records match, both when it opens and on every later render. The server raises a ValueError and the call has no error handling, so the whole editor goes down. The bad domain stays saved on the property, so reopening the editor fails the same way and the property can no longer be edited or deleted.

Wrap the search_count call in _updateMatchingRecordsCount (property_definition.js) in a try/catch and show no count when it fails. This is the only place the editor counts matching records, so guarding it here handles a bad domain from any source, the field selector or the code editor. The field selector still shows its warning on the invalid path, so the user can fix or delete the property.

Steps to reproduce:
1. On a model that has a Properties field, add a Many2one property and set its Model to a model that itself has a Properties field.
2. Open the property Domain and click New Rule.
3. In the field selector pick the Properties entry, then close the selector.

=> An error dialog appears and the property can no longer be edited or deleted.

Ticket [link](https://www.odoo.com/odoo/project.task/6101311)
opw-6101311

