### PR TITLE
[FIX] web: realign x2many cache filtering in web_read

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -14,7 +14,7 @@ from odoo.models import BaseModel, NewId
 from odoo.osv.expression import AND, TRUE_DOMAIN, normalize_domain
 from odoo.tools import date_utils, unique
 from odoo.tools.misc import OrderedSet, get_lang
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from collections import defaultdict
 
 SEARCH_PANEL_ERROR_MESSAGE = _lt("Too many items to display.")
@@ -136,14 +136,42 @@ class Base(models.AbstractModel):
 
                 field_spec_order = field_spec.get('order')
                 field_spec_has_fields = 'fields' in field_spec
+                has_co_records = any(co_records.ids)
+                has_model_read_access = (
+                    has_co_records
+                    and co_records.env['ir.model.access'].check(
+                        co_records._name, 'read', raise_exception=False,
+                    )
+                )
 
-                if field_spec_order or field_spec_has_fields:
-                    # Re-search the records to apply read record rules
-                    # (cache may contain inaccessible ids after write/read) and apply order.
-                    co_records = co_records.with_context(active_test=False).search(
-                        [('id', 'in', co_records.ids)], order=field_spec_order,
-                    ).with_context(co_records.env.context)  # Reapply previous context
+                # Filter out co-records the user cannot read (cache may keep
+                # inaccessible ids after a sudo write/read).
+                if field_spec_order and has_co_records:
+                    if not has_model_read_access:
+                        # If the comodel is not readable, keep the x2many empty.
+                        co_records = co_records.browse()
+                    else:
+                        try:
+                            co_records = co_records.with_context(active_test=False).search(
+                                [('id', 'in', co_records.ids)], order=field_spec_order,
+                            ).with_context(co_records.env.context)  # Reapply previous context
+                        # Keep UserError if the model does not accept the search
+                        # (e.g. account.code.mapping).
+                        except (AccessError, UserError):
+                            co_records = co_records.browse()
 
+                elif field_spec_has_fields and has_model_read_access:
+                    # Filter co-records only if the user can read the comodel.
+                    # Some x2many fields have models that are not directly
+                    # readable by the user (e.g. hr.employee from hr.appraisal for a
+                    # base.group_user). In that case, keep the relation ids unchanged.
+                    co_records = co_records.with_context(
+                        active_test=False,
+                    )._filter_access_rules('read').with_context(
+                        co_records.env.context
+                    )
+
+                if has_co_records and (field_spec_order or field_spec_has_fields):
                     co_records_ids = set(co_records.ids)
 
                     for values in values_list:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This is a follow-up to #250904.

The original 17.0 fix filtered inaccessible x2many records reused from cache during web_read. However, while forward-porting the fix to 18.0, additional issues were revealed.

The original issue is still cache pollution: web_read may reuse cached x2many ids that are not accessible anymore with the current record rules/context, and should neither expose them nor crash when formatting the result.

The 18.0 investigation showed that the first approach was not enough in all cases:

* using search([('id', 'in', ...)]) to filter x2many records is not always safe, as some models can override search() and raise errors
* using _filtered_access('read') unconditionally can also be too aggressive when the current user has no general read access on the comodel, as it may remove valid x2many values and break existing flows.

This PR backports the adjusted logic from the 18.0 forward-port to 17.0, so that 17.0 stays aligned with the later versions.

Current behavior before PR:
Even after the previous fix, web_read can still mishandle polluted cached x2many values in some cases, either by crashing while trying to filter/order the records, or by over-filtering them when the user has no general read access on the comodel.

Desired behavior after PR is merged:
web_read should keep filtering polluted x2many values when the user has read access on the comodel, while avoiding regressions for fields whose comodel is not generally readable by the current user.

The x2many values are therefore filtered in a safer way, aligned with the logic introduced in the 18.0 forward-port.

Backport-Of: #257517

X-original-commit: 05ded3eda89fb8ff9aafa62f314a9d5d4677d292 (cherry picked from commit 7eec72aadc294b1c2780e601e81636cffcc4965d)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
