### PR TITLE
[FIX] pos_online_payment_self_order: enable frontend translations

### DIFF
--- a/addons/pos_online_payment_self_order/models/__init__.py
+++ b/addons/pos_online_payment_self_order/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_http
 from . import pos_config
 from . import pos_order
 from . import res_config_settings

--- a/addons/pos_online_payment_self_order/models/ir_http.py
+++ b/addons/pos_online_payment_self_order/models/ir_http.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ["pos_online_payment_self_order"]


### PR DESCRIPTION
Currently if you use an online payment with the kiosk, the payment page with the QR code is not translated.

Steps to reproduce:
-------------------
* Create an online payment method with demo
* Install any language, you don't need to switch
* Open kiosk configurations
* Set the online pm in the available payment methods
* Set the language istalled as the default language
* Make an order, go to payment page
> "Scan the QR code to pay" is written in english no matter the language

opw-6074194