### PR TITLE
[IMP] hr_expense_stripe: archive expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -274,6 +274,7 @@ class HrExpense(models.Model):
         check_company=True,
         help="Both price-included and price-excluded taxes will behave as price-included taxes for expenses.",
     )
+    active = fields.Boolean(default=True)
 
     # Security fields
     is_editable = fields.Boolean(string="Is Editable By Current User", compute='_compute_is_editable', readonly=True)

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -454,6 +454,8 @@
                     <filter string="My Team" name="my_team_expenses" domain="[('employee_id.parent_id.user_id', '=', uid)]"
                             groups="hr_expense.group_hr_expense_team_approver" help="Expenses of Your Team Member"/>
                     <separator />
+                    <filter string="Action Required" name="action_required" domain="[('state', 'not in', ['paid', 'refused'])]"/>
+                    <separator />
                     <filter string="Paid by Company" name="by_company" domain="[('payment_mode', '=', 'company_account')]"/>
                     <filter string="Paid by Employee" name="by_employee" domain="[('payment_mode', '=', 'own_account')]"/>
                     <separator />
@@ -524,7 +526,7 @@
             <field name="res_model">hr.expense</field>
             <field name="view_mode">list,kanban,form,graph,pivot,activity</field>
             <field name="search_view_id" ref="hr_expense_view_search"/>
-            <field name="context">{'search_default_my_open_expenses': 1}</field>
+            <field name="context">{'search_default_my_open_expenses': 1, 'search_default_action_required': 1}</field>
             <field name="help" type="html">
                 <div class="o_view_nocontent_expense_receipt o_view_pink_overlay">
                     <p class="o_view_nocontent_expense_receipt_image"/>


### PR DESCRIPTION
Expenses cannot be deleted for audit reasons, which often leaves users
frustrated by a cluttered view filled with already processed records.
This change introduces a default search filter to handle it automatically.

How it functions:
-Adds an 'Action Required' filter to the base search view that excludes
terminal states ('paid' and 'refused').
-Updates the default window action context for "My Expenses" to apply
this filter automatically alongside the user's own expenses.
-This ensures users land on a clean view focused strictly on expenses
that still require their attention.

task: 5904913

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
