### PR TITLE
[FIX] point_of_sale: fix misleading Z report header

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -291,12 +291,13 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
             'precision': user_currency.decimal_places,
         }
 
+        order_sessions = orders.mapped('session_id')
         session_name = False
-        if len(sessions) == 1:
-            state = sessions[0].state
-            date_start = sessions[0].start_at
-            date_stop = sessions[0].stop_at
-            session_name = sessions[0].name
+        if len(order_sessions) == 1:
+            state = order_sessions[0].state
+            date_start = order_sessions[0].start_at
+            date_stop = order_sessions[0].stop_at
+            session_name = order_sessions[0].name
         else:
             state = "multiple"
 

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -436,3 +436,65 @@ class TestReportSession(TestPoSCommon):
         report = self.env['report.point_of_sale.report_saledetails'].get_sale_details()
         self.assertEqual(report["discount_amount"], 12.0, "Discount amount should be equal to 12.0")
         self.assertEqual(report["taxes_info"]["base_amount"], 90.0, "Base amount should be equal to 90.0")
+
+    def test_report_header_reflects_actual_order_sessions(self):
+        """A date-range report whose orders span multiple sessions (e.g. one
+        closed and one still open) must show state='multiple' rather than
+        displaying the closed session's name as if it were a single-session Z
+        report.
+        """
+        product = self.create_product('Test Product', self.categ_basic, 100)
+        order_vals = {
+            'company_id': self.env.company.id,
+            'pricelist_id': self.config.pricelist_id.id,
+            'partner_id': self.partner_a.id,
+            'lines': [(0, 0, {
+                'name': 'OL/0001',
+                'product_id': product.id,
+                'price_unit': 100,
+                'discount': 0,
+                'qty': 1,
+                'tax_ids': [],
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+            })],
+            'amount_paid': 100.0,
+            'amount_total': 100.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        }
+
+        # Session 1: open, create an order, close.
+        self.config.open_ui()
+        session1 = self.config.current_session_id
+        order1 = self.env['pos.order'].create({**order_vals, 'session_id': session1.id})
+        self.make_payment(order1, self.bank_pm1, 100)
+        session1.action_pos_session_closing_control()
+
+        # Session 2: open, create an order, intentionally leave open.
+        self.config.open_ui()
+        session2 = self.config.current_session_id
+        order2 = self.env['pos.order'].create({**order_vals, 'session_id': session2.id})
+        self.make_payment(order2, self.bank_pm1, 100)
+
+        # Run the report via date range (config_ids only, no session_ids).
+        # Both sessions' orders fall in the default date range (today).
+        report = self.env['report.point_of_sale.report_saledetails'].get_sale_details(
+            config_ids=self.config.ids,
+        )
+
+        self.assertEqual(report['state'], 'multiple',
+            "Header state must be 'multiple' when orders span more than one session")
+        self.assertFalse(report['session_name'],
+            "session_name must be False when orders come from multiple sessions")
+        self.assertEqual(report['nbr_orders'], 2,
+            "Both sessions' orders should be included in the report body")
+
+        session2.action_pos_session_closing_control()
+        report2 = self.env['report.point_of_sale.report_saledetails'].get_sale_details(
+            config_ids=self.config.ids,
+        )
+        self.assertEqual(report2['state'], 'multiple',
+            "Two closed sessions in range must still produce state='multiple'")
+        self.assertEqual(report2['nbr_orders'], 2)


### PR DESCRIPTION
Before this commit:

- When generating a Z report via date range (config_ids, no session_ids), the header's session name was derived from the closed-session if there was exactly one, which excludes open sessions (stop_at IS NULL).
- If an open session had completed orders (state='done') within the date range, those orders were included in the report body while the session itself was absent from the sessions list.
- This caused the header to display the closed session's name and title the report as a single-session Z report, even though it contained data from multiple sessions.

opw-6123054

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
