### PR TITLE
[FIX] website: show translation state of filename over alert background

### DIFF
--- a/addons/website/static/src/builder/plugins/translation/repeat_translation_state_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/repeat_translation_state_plugin.js
@@ -15,6 +15,7 @@ export class RepeatTranslationStatePlugin extends Plugin {
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
+        force_background_translation_state_selectors: ".alert > .o_file_name_container",
         // lower sequence than the default to run before FeffPlugin's handler
         normalize_handlers: withSequence(5, (root) => {
             const cursors = this.dependencies.selection.preserveSelection();


### PR DESCRIPTION
Commit cbb2eb2edfeecbc21a70c1a3cba81ad0a7ac9c75 added a resource to repeat the background color of the translation state inside elements, for the cases where an element has a background color that hides the translation state.

This commit uses the resource for file's names (added by typing `/file`)

Steps to reproduce:
- Open website builder
- Type `/file` and add a file
- Add a language
- Open in translate mode
- Bug: the translation state is not show on the file name

task-6038029
