### PR TITLE
[FIX] resource: recompute duration_hours after change in day_period

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -74,7 +74,7 @@ class ResourceCalendarAttendance(models.Model):
         # some years have 53 weeks. Therefore, two consecutive odd week number follow each other (53 --> 1).
         return int(math.floor((date.toordinal() - 1) / 7) % 2)
 
-    @api.depends('hour_from', 'hour_to')
+    @api.depends('hour_from', 'hour_to', 'day_period')
     def _compute_duration_hours(self):
         for attendance in self.filtered('hour_to'):
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0


### PR DESCRIPTION
Since #217895, `duration_hours` is now stored and needs to be recomputed when we change the attendance's `day_period` from lunch to morning/afternoon/full_day otherwise we will run into division by 0 in `_get_attendance_intervals_days_data`.

### Steps to reproduce
1. Change the day period of one of the working hours of a working schedule from Lunch to Morning.
2. Open the attendance overview including the attendances of an employee that has the working schedule from step 1.

opw-6129881