### PR TITLE
[FIX] hr: fix ACL error opening My Preferences for non-HR users

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -50,8 +50,7 @@ class HrEmployee(models.Model):
         ondelete='cascade',
         required=True,
         store=False,
-        compute_sudo=True,
-        groups="hr.group_hr_user")
+        compute_sudo=True)
     current_version_id = fields.Many2one(
         'hr.version',
         compute='_compute_current_version_id',

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -72,7 +72,7 @@
                     </h5>
                 </xpath>
                 <xpath expr="//group[@name='other_preferences']" position="inside">
-                    <field name="pin" string="Attendance PIN"/>
+                    <field name="pin" string="Attendance PIN" groups="hr.group_hr_user"/>
                 </xpath>
                 <xpath expr="//group[@name='other_calendar_preferences']" position="inside">
                     <field name="work_location_id" string="Main Work Location" options="{'no_create': True}"/>


### PR DESCRIPTION
Non-HR users could not open their own Preferences dialog because:
- The `pin` field was rendered in the view but restricted by `groups="hr.group_hr_user"` on the `hr.employee` model, causing a read access error.
- The `version_id` computed field had `groups="hr.group_hr_user"`, but it is loaded implicitly as a dependency of every `related='version_id.xxx'` field on `hr.employee`, making those fields unreadable for non-HR users as well.

## Fix
- Add `groups="hr.group_hr_user"` on the view element so non-HR users don't load the `pin` field at all.
- Remove `groups="hr.group_hr_user"` from `version_id`. It is a computed, non-stored pointer to `hr.version`; the individual sensitive fields accessed via `related='version_id.xxx'` keep their own ACL, so no data is leaked.

## Steps to reproduce
1. Fresh Odoo 19 with `hr` installed
2. Log in as a user with only `base.group_user` (no HR officer rights)
3. Click avatar (top-right) → **My Preferences**
4. Error: `You do not have enough rights to access the field "pin" on Employee (hr.employee)`
5. After resolving the `pin` issue, the same error appears for `version_id` via related fields

## Before / after
- **Before:** preferences dialog throws ACL error for non-HR users
- **After:** dialog opens cleanly; HR officers still see the PIN field, non-HR users do not
