### PR TITLE
[FIX] uom: HALF-UP rounding method when computing quantity to same UoM

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -230,6 +230,7 @@ class UoM(models.Model):
 
         if self == to_unit:
             amount = qty
+            rounding_method = 'HALF-UP'  # If "converting" to the same unit, use the usual HALF-UP rounding method
         else:
             amount = qty / self.factor
             if to_unit:


### PR DESCRIPTION
This function is meant to compute the quantity from one UoM to another UoM, the rounding method parameter is meant to be used in that context.

If both UoM are the same, it should use the usual HALF-UP rounding method.

Explanations regarding the bug occurring in the related ticket:
- The OCR was matching a purchase order for which one of the lines had a quantity of exactly 6.
- When this PO was matched and imported on the vendor bill, the quantity of the related invoice line was rounded to 6.00000000000001. Under normal circumstances, the value would have stayed at 6 after rounding, but because the OCR runs within the context of a `_disable_discount_precision`, this kind of rounding discrepancy is possible.
- The billed quantity is then computed based on the quantity on the invoice line, 6.00000000000001. As it is rounded upwards to the nearest two decimals places, the final value is 6.01 instead of the expected 6.

opw-[6113387](https://www.odoo.com/odoo/my-support-tasks/6113387)