### PR TITLE
[PERF] web: respect limit during onchange fetch

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 
 import babel.dates
 import base64
-import copy
 import itertools
 import json
 import pytz
@@ -1191,7 +1190,9 @@ class RecordSnapshot(dict):
             if 'context' in self.fields_spec[field_name]:
                 lines = lines.with_context(**self.fields_spec[field_name]['context'])
             sub_fields_spec = self.fields_spec[field_name].get('fields') or {}
-            self[field_name] = {line.id: RecordSnapshot(line, sub_fields_spec) for line in lines}
+            limit = self.fields_spec[field_name].get('limit')
+            limited_lines = lines[:limit] if limit else lines
+            self[field_name] = {line.id: RecordSnapshot(line, sub_fields_spec) for line in limited_lines}
         else:
             self[field_name] = self.record[field_name]
 


### PR DESCRIPTION
## Problem:
During an `onchange` call, if a field is defined in the `fields_spec` with a `limit` attribute, the `fetch` method doesn't respect it, and will fetch all records satisfying the domain. In certain circumstances, this leads to slow requests.

## Solution:
Enforce the `limit` when fetching if it is present.

## Steps to reproduce:
- Have a product with many quant records
1. Open a picking for this product in Barcode
2. Change the lot/serial

The frontend will send an `onchange` request that includes `product_stock_quant_ids` in the `fields_spec` (with default `limit` 40). Odoo will fetch all quants for this product regardless of the limit, and the request will take a while to resolve.

## Benchmark:
<table>
	<thead>
		<tr>
			<th># of quants</th>
			<th>Before</th>
			<th>After</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<td>17193</td>
			<td>~9s</td>
			<td>~400ms</td>
		</tr>
	</tbody>
</table>

opw-6041705