### PR TITLE
[FIX] Version bump Analytic Accounting to force views to update on Odoo.sh for Odoo 18.0

### DIFF
--- a/addons/analytic/__manifest__.py
+++ b/addons/analytic/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name' : 'Analytic Accounting',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Accounting/Accounting',
     'depends' : ['base', 'mail', 'uom'],
     'description': """

--- a/doc/cla/individual/movinglinguini.md
+++ b/doc/cla/individual/movinglinguini.md
@@ -1,0 +1,11 @@
+USA, 2026-04-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Luis Garcia luis.a.garcia01996@gmail.com https://github.com/movinglinguini


### PR DESCRIPTION
merge method: squash

Description of the issue/feature this PR addresses:

After the recent updates to Odoo enterprise, the error below pops up on new deployments of modules that depend on the `account_reports` Enterprise module in Odoo.sh.

I tracked down the issue to there being a mismatch between what is loaded in the DB and what the enterprise module is expecting. Specifically, the update to `enterprise/account_reports/views/account_move_views.xml` depends on there being an `analytic_distribution` field present in the arch in `analytic.view_account_analytic_line_tree` from `odoo/analytic/views/analytic_line_views.xml`. 

The `analytic_distribution` field was added to the [view 8 months ago](https://github.com/odoo/odoo/blame/37ee16be9e476bed74f53d3a440f2a4a621a6f28/addons/analytic/views/analytic_line_views.xml#L13), but the `analytic` module's version was not bumped since then (the last bump was 10 months ago).

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1366, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 129, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
                        ^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 228, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 662, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 733, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 648, in parse
    self._tag_root(de)
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 601, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo.tools.convert.ParseError: while parsing /home/odoo/src/enterprise/account_reports/views/account_move_views.xml:119
Error while parsing or validating view:

Element '<field name="analytic_distribution">' cannot be located in parent view

View error context:
{'file': '/home/odoo/src/enterprise/account_reports/views/account_move_views.xml',
 'line': 1,
 'name': 'account.analytic.coverage.analytic.line.tree',
 'view': ir.ui.view(4192,),
 'view.model': 'account.analytic.line',
 'view.parent': ir.ui.view(376,),
 'xmlid': 'view_analytic_line_tree'}
 ```



Current behavior before PR:

Upgrades crash if the module depends on Enterprise's `account_reports`.

Desired behavior after PR is merged:

Upgrades should not crash.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

