### PR TITLE
[FIX] product: fix CSV and XLSX pricelist reports with UoM-based rules

### DIFF
--- a/addons/product/controllers/pricelist_report.py
+++ b/addons/product/controllers/pricelist_report.py
@@ -35,13 +35,23 @@ class ProductPricelistExportController(Controller):
         for product in products:
             variants = product.get('variants', [product])
             for variant in variants:
-                row = [
-                    variant['name'],
-                    variant['default_code'] or '',
-                    variant['barcode'] or '',
-                    variant['uom'],
-                ] + [variant['price'].get(qty, 0.0) for qty in quantities]
-                rows.append(row)
+                uoms = variant.get('uoms', [])
+
+                for uom in uoms:
+                    row = [
+                        variant['name'],
+                        variant.get('default_code') or '',
+                        variant.get('barcode') or '',
+                        uom['name'],
+                    ]
+
+                    # Add prices per quantity for this UoM
+                    for qty in quantities:
+                        price = variant['price'].get(uom['id'], {}).get(qty, 0.0)
+                        row.append(price)
+
+                    rows.append(row)
+
         return rows
 
     def _generate_csv(self, pricelist_name, quantities, products, headers, date):

--- a/addons/product/tests/test_pricelist_report.py
+++ b/addons/product/tests/test_pricelist_report.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
+import json
+
+from odoo.tests import HttpCase, tagged
 
 from odoo.addons.product.tests.common import ProductCommon
 
@@ -36,3 +38,50 @@ class TestPricelistReport(ProductCommon):
         self.env['report.product.report_pricelist'].get_html(data={
             'active_ids': self.env['product.template'].search([]).ids,
         })
+
+
+@tagged('post_install', '-at_install')
+class TestPricelistReportController(ProductCommon, HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pricelist = cls._enable_pricelists()
+
+    def test_csv_export(self):
+        self.authenticate('admin', 'admin')
+        response = self.url_open(
+            "/product/export/pricelist/",
+            data={
+                "report_data": json.dumps({
+                    "active_model": "product.template",
+                    "active_ids": list(self.env['product.template']._search([], limit=10)),
+                    "display_pricelist_title": "",
+                    "pricelist_id": self.pricelist.id,
+                    "quantities": [1, 5, 10],
+                    "date": "2026-04-20",
+                }),
+                "export_format": "csv",
+                "csrf_token": self.csrf_token(),
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_xlsx_export(self):
+        self.authenticate('admin', 'admin')
+        response = self.url_open(
+            "/product/export/pricelist/",
+            data={
+                "report_data": json.dumps({
+                    "active_model": "product.template",
+                    "active_ids": list(self.env['product.template']._search([], limit=10)),
+                    "display_pricelist_title": "",
+                    "pricelist_id": self.pricelist.id,
+                    "quantities": [1, 5, 10],
+                    "date": "2026-04-20",
+                }),
+                "export_format": "xlsx",
+                "csrf_token": self.csrf_token(),
+            },
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Since the introduction of packaging/UoM-based rules in pricelists, the report data structure was updated to include prices per UoM. However, CSV and XLSX exports were not adapted to this change and were still assuming a single UoM, leading to error during export.

This commit updates the export logic to iterate over UoMs and fetch prices using the new `price[uom_id][qty]` structure, aligning it with the PDF report and backend view.

Follow-up of: https://github.com/odoo/odoo/pull/234935#discussion_r3101116828