### PR TITLE
[FIX] modules: Fix migration compare for same version

### DIFF
--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -154,14 +154,17 @@ class MigrationManager(object):
 
             full_version = convert_version(version)
             majorless_version = (version != full_version)
-
+            parsed_full_version = parse_version(full_version)
             if majorless_version:
                 # We should not re-execute major-less scripts when upgrading to new Odoo version
                 # a module in `9.0.2.0` should not re-execute a `2.0` script when upgrading to `10.0.2.0`.
                 # In which case we must compare just the module version
                 return parsed_installed_version[2:] < parse_version(full_version)[2:] <= current_version[2:]
-
-            return parsed_installed_version < parse_version(full_version) <= current_version
+            if not (parsed_installed_version < parsed_full_version <= current_version):
+                return False
+            if parsed_installed_version[0] == parsed_full_version[0] and parsed_installed_version[1] <= parsed_full_version[1]:
+                return False  # Skip same-major version scripts with module version difference e.g. 2.2, 2.3
+            return True
 
         versions = _get_migration_versions(pkg, stage)
         for version in versions:


### PR DESCRIPTION
Migration scripts from version 18.0.2.3 were incorrectly executed during the upgrade to 19.0, although it should only run during the 17.0 → 18.0 upgrade.

Steps to reproduce:
- Create a database on 18.0 with l10n_mx module version 18.0.2.2  here is change (https://github.com/odoo/odoo/pull/204742)
- Add a migration script in version 18.0.2.3
- Upgrade to 19.0 → the 18.0.2.3 script is executed

This happens because the condition:
   ``parse_installed_version < full_version
evaluates to True (18.0.2.2 < 18.0.2.3) `` , causing the script to run even during later upgrades.

To prevent this, an additional check on the saas version is added to ensure that migration scripts are executed only in their intended upgrade path (means in 19.0 version).

**Note**: I found during testing with my upgrade PR https://github.com/odoo/upgrade/pull/9845/files
