### PR TITLE
[IMP] stock: improve on-hand updates after traceability change

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -903,8 +903,8 @@ class ProductTemplate(models.Model):
     def _compute_show_qty_update_button(self):
         for product in self:
             product.show_qty_update_button = (
-                product._should_open_product_quants()
-                or product.product_variant_count > 1
+                product.product_variant_count > 1
+                or product._should_open_product_quants()
             )
 
     @api.depends(
@@ -1135,8 +1135,9 @@ class ProductTemplate(models.Model):
             'stock.group_tracking_lot',
         ]
         return (
-            any(self.env.user.has_group(g) for g in advanced_option_groups)
-            or self.tracking != "none"
+            self.tracking != 'none'
+            or any(self.env.user.has_group(g) for g in advanced_option_groups)
+            or any(qty > 0 for qty in self.product_variant_ids.stock_quant_ids.lot_id.mapped('product_qty'))
         )
 
     # Be aware that the exact same function exists in product.product

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1121,7 +1121,8 @@ class ProductTemplate(models.Model):
         ]
         return (
             any(self.env.user.has_group(g) for g in advanced_option_groups)
-            or self.tracking != "none"
+            or self.tracking != 'none'
+            or self.product_variant_ids.stock_quant_ids.lot_id
         )
 
     # Be aware that the exact same function exists in product.product


### PR DESCRIPTION
Keep On-Hand quantity read-only when quants with lot/serial having quantity exist and
tracking is changed from lot/serial to by quantity, even if other conditions
do not enforce read-only. Make the field clickable to open quants and
avoid inconsistent on-hand updates.

Also, check the simple condition first to avoid unnecessary
calls to the more complex logic, and slightly improve performance.

TaskId-5721185