### PR TITLE
[FIX] purchase: Ask confirmation toggle display

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -237,15 +237,15 @@
                             <div name="date_planned_div">
                                 <field name="date_planned" readonly="state not in ('draft', 'sent', 'to approve', 'purchase')"/>
                             </div>
-                            <field name="receipt_reminder_email" string="Ask confirmation" widget="boolean_toggle" groups="purchase.group_send_reminder" />
-                            <label for="reminder_date_before_receipt" string="Days before confirmation" invisible="not receipt_reminder_email" groups="purchase.group_send_reminder" />
-                            <div name="reminder" class="d-flex"
-                                 invisible="not receipt_reminder_email" groups="purchase.group_send_reminder"
-                                 title="Automatically send a confirmation email to the vendor X days before the expected receipt date, asking him to confirm the exact date.">
-                                <field name="reminder_date_before_receipt" />
+                            <label for="receipt_reminder_email" string="Arrival Confirmation" groups="purchase.group_send_reminder"/>
+                            <div name="reminder" class="o_row" groups="purchase.group_send_reminder"
+                             title="Automatically send a confirmation email to the vendor X days before the expected receipt date, asking him to confirm the exact date.">
+                                <field name="receipt_reminder_email"/>
+                                <field name="reminder_date_before_receipt" class="mb-0" invisible="not receipt_reminder_email" style="max-width: 30px;"/>
+                                <span invisible="not receipt_reminder_email">day(s) before</span>
                                 <widget name="toaster_button" button_name="send_reminder_preview"
-                                        additionalClasses="o_external_button"
-                                        title="Preview the reminder email by sending it to yourself."  invisible="not id" />
+                                        additionalClasses="o_external_button py-0"
+                                        title="Preview the reminder email by sending it to yourself." invisible="not receipt_reminder_email or not id"/>
                             </div>
                             <label for="receipt_status" invisible="state !='purchase'"/>
                                 <div class="d-flex align-items-center" invisible="state !='purchase'">

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -42,6 +42,9 @@
             <xpath expr="//div[@name='reminder']" position="attributes">
                 <attribute name="invisible" add="effective_date" separator=" or "/>
             </xpath>
+            <xpath expr="//label[@for='receipt_reminder_email']" position="attributes">
+                <attribute name="invisible" add="effective_date" separator=" or "/>
+            </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
                 <field name="move_ids"/>
             </xpath>


### PR DESCRIPTION
- Go to Purchase
- Open a purchase => "Ask confirmation" should inside the "Expected Arrival" field and the x day before should be on the same line of the ask confirmation

task-6128288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
