### PR TITLE
[FIX] runbot: fix noisy logs

### DIFF
--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import BaseCase, TransactionCase, tagged, BaseCase
-from odoo.tests.common import _logger as test_logger
+from odoo.tests.suite import _logger as test_logger
 
 import logging
 import inspect


### PR DESCRIPTION
While moving the logic from common to suite, the logger was changed from common._logger to suite._logger, but the monkeypatching was not updated, resulting in the "Retrying" logs not being downgraded to info and spamming the logs of the builds.