### PR TITLE
[IMP] website: replace `s_video` preview link with a SVG

### DIFF
--- a/addons/website/views/snippets/s_video.xml
+++ b/addons/website/views/snippets/s_video.xml
@@ -2,11 +2,10 @@
 <odoo>
 
 <template id="s_video" name="Video">
-    <div class="media_iframe_video o_snippet_drop_in_only" data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0">
-        <div class="css_editable_mode_display"></div>
-        <div class="media_iframe_video_size"></div>
-        <iframe src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"
-            frameborder="0" allowfullscreen="allowfullscreen" aria-label="Video"></iframe>
+    <div class="s_video media_iframe_video o_snippet_drop_in_only rounded border d-inline-flex justify-content-center align-items-center bg-100 opacity-50 w-100 ratio ratio-16x9" style="max-width: 50vw">
+        <svg xmlns="http://www.w3.org/2000/svg" width="4em" height="4em" viewBox="-420 -1380 1800 1800" fill="none">
+            <path d="m380-300 280-180-280-180v360ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" opacity="0.4" fill="currentColor"/>
+        </svg>
     </div>
 </template>
 


### PR DESCRIPTION
Prior to this PR, the `s_video` inner snippet was using a video as placeholder, which implied maintenance to ensure the video is always available.

To avoid maintenance and ensuring long term effectiveness, we replace this video with a `SVG` placeholder, similarly to what has been done for the `s_image`.

task-5441285

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
