### PR TITLE
[IMP] l10n_be_reports: Add new VAT provision account

### DIFF
--- a/addons/l10n_be/data/template/account.account-be.csv
+++ b/addons/l10n_be/data/template/account.account-be.csv
@@ -163,6 +163,7 @@
 "a409","Trade Debtors - Write-Downs (-)","409","asset_current","","False","","Créances commerciales - Réductions de valeur (-)","Handelsvorderingen - Waardeverminderingen (-)","Forderungen aus Lieferungen und Leistungen - Wertminderungen (-)","","","","","",""
 "a411","VAT Recoverable","411","asset_current","","False","","TVA à récupérer","Terug te vorderen btw","Zurück zu erhaltende Mehrwertsteuer","","","","","",""
 "a4112","VAT Recoverable: VAT Current Account (C/A)","4112","asset_receivable","","True","True","TVA à récupérer : Compte courant TVA (C/C)","Terug te vorderen btw: Rekening-courant btw (RC)","Zurück zu erhaltende Mehrwertsteuer: Girokonto-MwSt","","","","","",""
+"a4118","Tax Provision Account","4118","asset_receivable","","True","True","Compte de provision TVA","Provisierekening btw","Rückstellungskontos MwSt","","","","","",""
 "a4125","Other Belgian Taxes to Be Recovered","4125","asset_current","","False","","Autres impôts et taxes belges à récupérer","Terug te vorderen andere Belgische belastingen","Zurück zu erhaltende sonstige belgische Steuern","","","","","",""
 "a4128","Foreign Taxes to Be Recovered","4128","asset_current","","False","","Impôts et taxes étrangers à récupérer","Terug te vorderen buitenlandse belastingen","Zurück zu erhaltende ausländische Steuern","","","","","",""
 "a414","Income Receivable","414","asset_current","","False","","Produits à recevoir","Te innen opbrengsten","Zu erhaltende Erträge","","","","","",""


### PR DESCRIPTION
[IMP] l10n_be_reports: Add new VAT provision account

Starting May 1st, in Belgium the VAT provision account will replace the current account for periodic returns
- Adding the new bank account
- Adding a new 'Tax Provision Account' 411800

task-6044017
