### PR TITLE
[FIX] mail: allow deleting attachments

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -182,6 +182,32 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertIn("o-mail-Message-edited", message.body)
         message.sudo().unlink()
 
+        # Test attachment can be removed if message type is "notification"
+        attachment = self.env["ir.attachment"].create({
+            "name": "an attachment",
+            "res_model": "res.partner",
+            "res_id": self.partner_a.id,
+        })
+        attachment.flush_recordset()
+        message = self.env['mail.message'].create({
+            'attachment_ids': [(6, 0, attachment.ids)],
+            "model": "res.partner",
+            "res_id": self.partner_a.id,
+            "message_type": "notification"
+        })
+        res = self.url_open(
+            url=f'{self.invoice_base_url}/mail/attachment/delete',
+            json={
+                'params': {
+                    'attachment_id': attachment.id,
+                    "access_token": attachment._get_ownership_token(),
+                },
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(attachment.exists())
+        message.sudo().unlink()
+
         # Test attachment can't be associated if no attachment token.
         attachment = self.env['ir.attachment'].create({
             'name': 'an attachment',

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -94,7 +94,7 @@ class AttachmentController(ThreadController):
             raise NotFound()
         message = request.env["mail.message"].sudo().search(
             [("attachment_ids", "in", attachment.ids)], limit=1)
-        if message:
+        if message and message.message_type == 'comment':
             thread = request.env[message.model].browse(message.res_id)
             thread._message_update_content(message, body=message.body)  # marks the message edited
         # sudo: ir.attachment: access is validated with _has_attachments_ownership


### PR DESCRIPTION
Step to reproduce:
- install purchase
- create a RFQ, confirm it. a PO will be created
- click on "upload bill" , upload a documnet, you will be sent for vendor bill
- confirm the bill
- try to delete the attachment from "paper-clip" icon

Observation:
- Error message:
```Only messages type comment can have their content updated ```

Cause:
- commit [1] introduced a feature which adds "edited" tag in message body if
attachment is removed, but that is only applicable for message with
type == 'comment'

https://github.com/odoo/odoo/blob/c3172d65db44c41f5619aef20532c3846494ea0e/addons/mail/models/mail_thread.py#L521-L531

- As this attachment is attached to record at time of creation,
its type is "notification", and hence we are not able to delete this

[1] https://github.com/odoo/odoo/commit/7c8971f2e2870fee19f55f971f3b8c8e553959c3
Fix:
- we now limit the feature introduced by commit [1] only for message type
"comment"

opw-6055206


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
