### PR TITLE
[REF] *: rename get_formview_action to get_defaultview_action

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -996,7 +996,7 @@ class Meeting(models.Model):
 
     def action_open_calendar_event(self):
         if self.res_model and self.res_id:
-            return self.env[self.res_model].browse(self.res_id).get_formview_action()
+            return self.env[self.res_model].browse(self.res_id).get_defaultview_action()
         return False
 
     def action_sendmail(self):

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -142,8 +142,8 @@ class Department(models.Model):
             ])
         employees.write({'parent_id': manager_id})
 
-    def get_formview_action(self, access_uid=None):
-        res = super().get_formview_action(access_uid=access_uid)
+    def get_defaultview_action(self, access_uid=None):
+        res = super().get_defaultview_action(access_uid=access_uid)
         if (not self.env.user.has_group('hr.group_hr_user') and
            self.env.context.get('open_employees_kanban', False)):
             res.update({

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -419,9 +419,9 @@ We can redirect you to the public employee list."""
         # Hardcode the form view for public employee
         return self.env.ref('hr.hr_employee_public_view_form').id
 
-    def get_formview_action(self, access_uid=None):
+    def get_defaultview_action(self, access_uid=None):
         """ Override this method in order to redirect many2one towards the right model depending on access_uid """
-        res = super(HrEmployeePrivate, self).get_formview_action(access_uid=access_uid)
+        res = super().get_defaultview_action(access_uid=access_uid)
         user = self.env.user
         if access_uid:
             user = self.env['res.users'].browse(access_uid).sudo()

--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -28,7 +28,7 @@ export const patchAvatarCardPopover = {
     },
     async getProfileAction() {
         return this.user.employee_ids?.length > 0
-            ? this.orm.call("hr.employee", "get_formview_action", [this.user.employee_ids[0]])
+            ? this.orm.call("hr.employee", "get_defaultview_action", [this.user.employee_ids[0]])
             : super.getProfileAction(...arguments);
     },
 };

--- a/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
@@ -24,7 +24,7 @@ const patchAvatarCardResourcePopover = {
         return this.record.employee_id?.length > 0;
     },
     async getProfileAction() {
-        return await this.orm.call("hr.employee", "get_formview_action", [
+        return await this.orm.call("hr.employee", "get_defaultview_action", [
             this.record.employee_id[0],
         ]);
     },

--- a/addons/hr_org_chart/static/src/fields/hooks.js
+++ b/addons/hr_org_chart/static/src/fields/hooks.js
@@ -29,7 +29,7 @@ export function onEmployeeSubRedirect() {
             subordinates_type: type,
             context: user.context
         });
-        let action = await orm.call('hr.employee', 'get_formview_action', [employeeId]);
+        let action = await orm.call('hr.employee', 'get_defaultview_action', [employeeId]);
         action = {...action,
             name: _t('Team'),
             view_mode: 'kanban,list,form',

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -32,7 +32,7 @@ class HrOrgChartPopover extends Component {
      * @returns {Promise} action loaded
      */
     async _onEmployeeRedirect(employeeId) {
-        const action = await this.orm.call('hr.employee', 'get_formview_action', [employeeId]);
+        const action = await this.orm.call('hr.employee', 'get_defaultview_action', [employeeId]);
         this.actionService.doAction(action); 
     }
 }
@@ -118,7 +118,7 @@ export class HrOrgChart extends Component {
      * @returns {Promise} action loaded
      */
     async _onEmployeeRedirect(employeeId) {
-        const action = await this.orm.call('hr.employee', 'get_formview_action', [employeeId]);
+        const action = await this.orm.call('hr.employee', 'get_defaultview_action', [employeeId]);
         this.actionService.doAction(action); 
     }
 

--- a/addons/l10n_latam_check/views/account_payment_view.xml
+++ b/addons/l10n_latam_check/views/account_payment_view.xml
@@ -18,7 +18,7 @@
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="payment_date"/>
                                     <field name="amount" />
-                                    <button type="object" name="get_formview_action" icon="fa-pencil-square-o" title="open" help="Open" column_invisible="parent.state == 'draft'"/>
+                                    <button type="object" name="get_defaultview_action" icon="fa-pencil-square-o" title="open" help="Open" column_invisible="parent.state == 'draft'"/>
                                 </list>
                             </field>
                             <field name="l10n_latam_move_check_ids" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks']"
@@ -35,7 +35,7 @@
                                     <field name="issuer_vat" optional="hide"/>
                                     <field name="payment_date" optional="hide"/>
                                     <field name="amount"/>
-                                    <button type="object" name="get_formview_action" icon="fa-pencil-square-o" title="open" help="Open"/>
+                                    <button type="object" name="get_defaultview_action" icon="fa-pencil-square-o" title="open" help="Open"/>
                                 </list>
                             </field>
                         </group>

--- a/addons/purchase_requisition/static/src/widgets/purchase_order_alternatives_widget.js
+++ b/addons/purchase_requisition/static/src/widgets/purchase_order_alternatives_widget.js
@@ -37,7 +37,7 @@ export class FieldMany2ManyAltPOs extends X2ManyField {
     */
    async openRecord(record) {
       if (record.resId !== this.props.record.resId) {
-         const action = await this.orm.call(record.resModel, "get_formview_action", [[record.resId]], {
+         const action = await this.orm.call(record.resModel, "get_defaultview_action", [[record.resId]], {
                context: this.props.context,
          });
          await this.action.doAction(action);

--- a/addons/sale/static/src/js/sale_progressbar_field.js
+++ b/addons/sale/static/src/js/sale_progressbar_field.js
@@ -35,7 +35,7 @@ export class SaleProgressBarField extends KanbanProgressBarField {
      */
     async defineInvoicingTarget() {
         const { resId, resModel } = this.props.record;
-        const action = await this.orm.call(resModel, "get_formview_action", [[resId]]);
+        const action = await this.orm.call(resModel, "get_defaultview_action", [[resId]]);
         this.actionService.doAction(action, { props: { mode: "edit" } });
     }
 }

--- a/addons/sale/static/tests/sales_team_dashboard_tests.js
+++ b/addons/sale/static/tests/sales_team_dashboard_tests.js
@@ -41,7 +41,7 @@ QUnit.test("edit progressbar target", async (assert) => {
                         res_model: "crm.team",
                         target: "current",
                         type: "ir.actions.act_window",
-                        method: "get_formview_action",
+                        method: "get_defaultview_action",
                     },
                     "should trigger do_action with the correct args"
                 );
@@ -66,7 +66,7 @@ QUnit.test("edit progressbar target", async (assert) => {
             </kanban>`,
         resId: 1,
         async mockRPC(route, { method, model }) {
-            if (route === "/web/dataset/call_kw/crm.team/get_formview_action") {
+            if (route === "/web/dataset/call_kw/crm.team/get_defaultview_action") {
                 return {
                     method,
                     res_model: model,

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -171,7 +171,7 @@ def get_action(env, path_part):
                 ('res_model', '=', model)], limit=1)
             if not action:
                 action = env['ir.actions.act_window'].new(
-                    env[model].get_formview_action()
+                    env[model].get_defaultview_action()
                 )
         else:
             action = Actions

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -247,7 +247,7 @@ export class Many2OneField extends Component {
             [openActionContext || this.context, record.fields[name].context],
             record.evalContext
         );
-        const action = await this.orm.call(this.relation, "get_formview_action", [[this.resId]], {
+        const action = await this.orm.call(this.relation, "get_defaultview_action", [[this.resId]], {
             context,
         });
         await this.action.doAction(action);

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -345,7 +345,7 @@ export class PropertyValue extends Component {
      * @param {integer} recordId
      */
     async _openRecord(recordModel, recordId) {
-        const action = await this.orm.call(recordModel, "get_formview_action", [[recordId]], {
+        const action = await this.orm.call(recordModel, "get_defaultview_action", [[recordId]], {
             context: this.props.context,
         });
 

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -209,7 +209,7 @@ test("many2ones in form views", async () => {
             </form>`,
     };
 
-    onRpc("get_formview_action", function ({ args }) {
+    onRpc("get_defaultview_action", function ({ args }) {
         expect(args[0]).toEqual([4]);
         return {
             res_id: 17,
@@ -3642,8 +3642,8 @@ test("click on many2one link in list view", async () => {
                 <field name="product_id" widget="many2one" context="{'field': 'Yes'}"/>
             </list>`,
     };
-    onRpc("get_formview_action", (args) => {
-        expect.step("get_formview_action");
+    onRpc("get_defaultview_action", (args) => {
+        expect.step("get_defaultview_action");
         expect(args.kwargs.context.field).toBe("Yes");
         expect(args.kwargs.context).not.toInclude("global");
         return {
@@ -3669,7 +3669,7 @@ test("click on many2one link in list view", async () => {
     expect(".o_breadcrumb").toHaveCount(1);
 
     await contains("a.o_form_uri").click();
-    expect.verifySteps(["get_formview_action"]);
+    expect.verifySteps(["get_defaultview_action"]);
     expect(".breadcrumb-item").toHaveCount(1);
     expect(".o_breadcrumb").toHaveCount(1);
 });
@@ -3688,8 +3688,8 @@ test("external_button performs a doAction by default", async () => {
     Partner._views = {
         form: '<form><field name="trululu"/></form>',
     };
-    onRpc("get_formview_action", () => {
-        expect.step("get_formview_action");
+    onRpc("get_defaultview_action", () => {
+        expect.step("get_defaultview_action");
         return {
             type: "ir.actions.act_window",
             res_model: "partner",
@@ -3713,7 +3713,7 @@ test("external_button performs a doAction by default", async () => {
     expect(".o_field_widget .o_external_button.oi-arrow-right").toHaveCount(1);
     await contains(".o_field_widget .o_external_button", { visible: false }).click();
 
-    expect.verifySteps(["get_formview_action"]);
+    expect.verifySteps(["get_defaultview_action"]);
     expect(".breadcrumb").toHaveText("first record");
 });
 

--- a/addons/web/static/tests/views/fields/many2one_reference_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_reference_field.test.js
@@ -52,7 +52,7 @@ test("Many2OneReferenceField in form view", async () => {
         },
     });
 
-    onRpc("get_formview_action", ({ model, args }) => {
+    onRpc("get_defaultview_action", ({ model, args }) => {
         expect.step(`opening ${model} ${args[0][0]}`);
         return false;
     });

--- a/addons/web/static/tests/views/fields/reference_field.test.js
+++ b/addons/web/static/tests/views/fields/reference_field.test.js
@@ -285,9 +285,9 @@ test("reference in form view", async () => {
     `;
 
     onRpc(({ args, method, model }) => {
-        if (method === "get_formview_action") {
+        if (method === "get_defaultview_action") {
             expect(args[0]).toEqual([37], {
-                message: "should call get_formview_action with correct id",
+                message: "should call get_defaultview_action with correct id",
             });
             return {
                 res_id: 17,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -979,8 +979,8 @@ test(`Form and subview with _view_ref contexts`, async () => {
         expect(context.list_view_ref).toBe("some_other_tree_view");
         // "The correct _view_ref should have been sent to the server for the subview"
     });
-    onRpc("get_formview_action", ({ model, kwargs }) => {
-        expect.step("get_formview_action");
+    onRpc("get_defaultview_action", ({ model, kwargs }) => {
+        expect.step("get_defaultview_action");
         return {
             res_id: 1,
             type: "ir.actions.act_window",
@@ -1004,7 +1004,7 @@ test(`Form and subview with _view_ref contexts`, async () => {
     await contains(`.o_field_widget[name="product_id"] .o_external_button`, {
         visible: false,
     }).click();
-    expect.verifySteps(["get_formview_action", "product get_views", "partner.type get_views"]);
+    expect.verifySteps(["get_defaultview_action", "product get_views", "partner.type get_views"]);
 });
 
 test(`Form and subsubview with only _view_ref contexts`, async () => {

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -586,7 +586,7 @@ test("Props are updated and kept when switching/restoring views", async () => {
             </group>
         </form>`;
 
-    onRpc("get_formview_action", ({ args, model }) => ({
+    onRpc("get_defaultview_action", ({ args, model }) => ({
         res_id: args[0][0],
         res_model: model,
         type: "ir.actions.act_window",
@@ -1389,7 +1389,7 @@ test("can open a many2one external window", async () => {
         </form>`;
 
     stepAllNetworkCalls();
-    onRpc("get_formview_action", () => ({
+    onRpc("get_defaultview_action", () => ({
         name: "Partner",
         res_model: "partner",
         type: "ir.actions.act_window",
@@ -1410,7 +1410,7 @@ test("can open a many2one external window", async () => {
         "web_search_read",
         "has_group",
         "web_read",
-        "get_formview_action",
+        "get_defaultview_action",
         "get_views",
         "web_read",
     ]);
@@ -1897,7 +1897,7 @@ test("execute action from dirty, new record, and come back", async () => {
             <field name="bar" readonly="1"/>
         </form>`;
 
-    onRpc("get_formview_action", () => ({
+    onRpc("get_defaultview_action", () => ({
         res_id: 1,
         res_model: "partner",
         type: "ir.actions.act_window",
@@ -1936,7 +1936,7 @@ test("execute action from dirty, new record, and come back", async () => {
         "web_search_read",
         "has_group",
         "onchange",
-        "get_formview_action",
+        "get_defaultview_action",
         "web_save",
         "get_views",
         "web_read",
@@ -1998,7 +1998,7 @@ test("go back to action with form view as main view, and res_id", async () => {
     ]);
     Partner._views["form,44"] = '<form><field name="m2o"/></form>';
 
-    onRpc("get_formview_action", () => ({
+    onRpc("get_defaultview_action", () => ({
         res_id: 3,
         res_model: "partner",
         type: "ir.actions.act_window",
@@ -2036,7 +2036,7 @@ test("action with res_id, load another res_id, do new action, restore previous",
     defineActions([action]);
 
     Partner._views["form,44"] = '<form><field name="m2o"/></form>';
-    onRpc("get_formview_action", () => ({ ...action, res_id: 3 }));
+    onRpc("get_defaultview_action", () => ({ ...action, res_id: 3 }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(999, { props: { resIds: [1, 2] } });

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2421,7 +2421,7 @@ class Model(models.AbstractModel):
             on self. Used in overrides, notably with portal / website addons.
         """
         self.ensure_one()
-        return self.get_formview_action(access_uid=access_uid)
+        return self.get_defaultview_action(access_uid=access_uid)
 
     @api.model
     def get_empty_list_help(self, help_message):
@@ -2879,7 +2879,7 @@ class Model(models.AbstractModel):
         """
         return False
 
-    def get_formview_action(self, access_uid=None):
+    def get_defaultview_action(self, access_uid=None):
         """ Return an action to open the document ``self``. This method is meant
             to be overridden in addons that want to give specific view ids for
             example.


### PR DESCRIPTION
The method `get_formview_action` in `ir_ui_view.py` is primarily used by M2O UI fields to open views of a linked record. However, because it is frequently overridden across the codebase to open various other view types (such as kanban
 and list views), the original name is misleading.

Rename the method to `get_defaultview_action` to better reflect its actual behavior and prevent developer confusion.

task-6068437
