### PR TITLE
[FIX] spreadsheet: call askConfirmation cancel callback

### DIFF
--- a/addons/spreadsheet/static/src/hooks.js
+++ b/addons/spreadsheet/static/src/hooks.js
@@ -122,14 +122,18 @@ export function useSpreadsheetNotificationStore() {
      *
      * @param {string} body body content to display
      * @param {Function} confirm Callback if the user press 'Confirm'
+     * @param {Function} cancel Callback if the user press 'Cancel'
      */
-    function askConfirmation(body, confirm) {
+    function askConfirmation(body, confirm, cancel) {
+        const confirmLabel = cancel ? _t("Yes") : _t("Confirm");
+        const cancelLabel = cancel && _t("No");
         dialog.add(ConfirmationDialog, {
             title: _t("Odoo Spreadsheet"),
             body,
             confirm,
-            cancel: () => {}, // Must be defined to display the Cancel button
-            confirmLabel: _t("Confirm"),
+            cancel: cancel || (() => {}), // Must be defined to display the Cancel button
+            confirmLabel,
+            cancelLabel,
         });
     }
 


### PR DESCRIPTION
The `cancel` callback of the `env.askConfirmation` method was not called when the user clicked on the cancel button.

task-6074948

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
