### PR TITLE
[FIX] point_of_sale: prevent error when downloading pos order receipt

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -21,7 +21,7 @@ class PosController(PortalAccount):
         if not pos_order.exists():
             return request.not_found()
 
-        image = pos_order.sudo().order_receipt_generate_image()
+        image = pos_order.with_company(pos_order.company_id).sudo().order_receipt_generate_image()
         return request.make_response(image, [
             ('Content-Type', 'image/png'),
             ('Content-Length', len(image)),


### PR DESCRIPTION
When a user attempts to download a POS order receipt for an Indian company, a traceback is raised.

Steps to reproduce the error:
- Install ``l10n_in_pos`` module with demo data
- Switch to IN Company
- Open a PoS Session > Create an order > Payment > Validate
- Navigate to the backend
- Go to Orders > Open the created order > Download Receipt

Traceback:
```
QWebError: Error while rendering the template:
KeyError: 'l10n_in_hsn_code'
Template: point_of_sale.pos_orderline_receipt_information
```

https://github.com/odoo/odoo/blob/9fe02a4585ce139c2ea20e9d282bc92f37b7cad7/addons/point_of_sale/controllers/main.py#L24
Here, ``order_receipt_generate_image`` method is called using the current request
environment. As a result, the active company becomes the user's current company
instead of the POS order’s company.
Because of this mismatch, the condition that adds ``l10n_in_hsn_code`` to the
POS data fields (based on the company’s fiscal country) is not satisfied at [1].
Consequently, the field is missing from the receipt line data at [2],
and the template raises a KeyError when trying to access it.

[1]: https://github.com/odoo/odoo/blob/9fe02a4585ce139c2ea20e9d282bc92f37b7cad7/addons/l10n_in_pos/models/pos_order_line.py#L21-L24

[2]: https://github.com/odoo/odoo/blob/9fe02a4585ce139c2ea20e9d282bc92f37b7cad7/addons/point_of_sale/receipt/pos_order_receipt.py#L76

sentry-7417101015

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
