### PR TITLE
[FIX] hr: prevent traceback in departments hierarchy view

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
@@ -36,7 +36,7 @@ export class Many2OneAvatarEmployeeField extends Component {
     }
 
     get uniqueId() {
-        return this.props.record.data[this.props.name].write_date.toMillis();
+        return this.value?.write_date ? this.value.write_date.toMillis() : undefined;
     }
 }
 


### PR DESCRIPTION
## Issue
When opening the *Hierarchy* view of Employees > Departments, if at least one department has a manager set, a traceback appears before the view.

## Steps to reproduce
1. Install *Employees* (`hr`)
2. In Employees > Departments, add a manager to a department
3. Open the *Hierarchy* view
4. **A traceback appears:**

```
Caused by: TypeError: Cannot read properties of undefined (reading 'toMillis')
    at get uniqueId (http://localhost:8192/web/assets/cbd2032/web.assets_web.min.js:21370:74)
    at Many2OneAvatarEmployeeField.template (eval at compile (http://localhost:8192/web/assets/cbd2032/web.assets_web.min.js:1387:421), <anonymous>:25:122)
...
```

## Cause
The traceback is yielded from the `get uniqueId` getter from the `Many2OneAvatarEmployeeField` component:

https://github.com/odoo/odoo/blob/c3172d65db44c41f5619aef20532c3846494ea0e/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js#L38-L40

where `write_date` is undefined. This getter was added by https://github.com/odoo/odoo/commit/3732ca85b03bea9eabfb05cc306ce0bf5bac88d4, which handled the case of undefined `write_date` for the related Kanban component:

https://github.com/odoo/odoo/blob/c3172d65db44c41f5619aef20532c3846494ea0e/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.js#L49-L52

A similar solution is applied in this problematic getter.

opw-6128837