### PR TITLE
[IMP] store default in the database

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -150,12 +150,6 @@ class IrModelFields(models.Model):
         self.env.cr.execute('UPDATE ir_model_fields'
                          ' SET website_form_blacklisted=true'
                          ' WHERE website_form_blacklisted IS NULL')
-        # add an SQL-level default value on website_form_blacklisted to that
-        # pure-SQL ir.model.field creations (e.g. in _reflect) generate
-        # the right default value for a whitelist (aka fields should be
-        # blacklisted by default)
-        self.env.cr.execute('ALTER TABLE ir_model_fields '
-                         ' ALTER COLUMN website_form_blacklisted SET DEFAULT true')
 
     @api.ondelete(at_uninstall=False)
     def _check_if_used_in_website_form(self):

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1191,17 +1191,44 @@ class Field[T]:
             :param model: an instance of the field's model
             :param column: the column's configuration (dict) if it exists, or ``None``
         """
+        default = self._get_db_column_default(model)
         if not column:
             # the column does not exist, create it
-            sql.create_column(model.env.cr, model._table, self.name, self.column_type[1], self.string)
+            if callable(default):
+                default = None
+            sql.create_column(model.env.cr, model._table, self.name, self.column_type[1], comment=self.string, default=default)
             return
-        if column['udt_name'] == self.column_type[0]:
-            return
-        self._convert_db_column(model, column)
+        if column['udt_name'] != self.column_type[0]:
+            self._convert_db_column(model, column)
+            column['column_default'] = None  # conversion drops the default value
+        if not callable(default) and not (
+            default is None
+            if column['column_default'] is None else
+            column['column_default'] == str(default).lower()  # 'false'
+            if column['udt_name'] == 'bool' else
+            # in general the value is stored as a string with possible data cast
+            column['column_default'] == str(default)
+            or column['column_default'].startswith(repr(default) + ':')
+        ):
+            sql.update_column_default(model.env.cr, model._table, self.name, default)
 
     def _convert_db_column(self, model: BaseModel, column: dict[str, typing.Any]):
         """ Convert the given database column to the type of the field. """
         sql.convert_column(model.env.cr, model._table, self.name, self.column_type[1])
+
+    def _get_db_column_default(self, model: BaseModel):
+        """ Get the default value for the database.
+        This may return a callable in case there is a default, but should not be updated.
+        """
+        if self.company_dependent or not callable(self.default):
+            return None
+        if self.default.__module__ != Field.__module__:
+            # Not defined in _setup_attrs__
+            return self.default
+        default = self.default(model)
+        default = self.convert_to_write(default, model)
+        default = self.convert_to_column_insert(default, model, validate=False)
+        return default
 
     def update_db_notnull(self, model: BaseModel, column: dict[str, typing.Any]):
         """ Add or remove the NOT NULL constraint on ``self``.

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -60,6 +60,11 @@ class BaseString(Field[str | typing.Literal[False]]):
             return dep, ()
         return super().get_depends(model)
 
+    def _get_db_column_default(self, model):
+        if self.translate:
+            return None
+        return super()._get_db_column_default(model)
+
     def _convert_db_column(self, model, column):
         # specialized implementation for converting from/to translated fields
         if self.translate or column['udt_name'] == 'jsonb':

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -298,7 +298,7 @@ def table_columns(cr, tablename):
     # because specific access right restriction in the context of shared hosting (Heroku, OVH, ...)
     # might prevent a postgres user to read this field.
     cr.execute(SQL(
-        ''' SELECT column_name, udt_name, character_maximum_length, is_nullable
+        ''' SELECT column_name, udt_name, character_maximum_length, is_nullable, column_default
             FROM information_schema.columns WHERE table_name=%s
             AND table_schema = current_schema ''',
         tablename,
@@ -317,14 +317,16 @@ def column_exists(cr, tablename, columnname):
     return cr.rowcount
 
 
-def create_column(cr, tablename, columnname, columntype, comment=None):
+def create_column(cr, tablename, columnname, columntype, comment=None, default=None):
     """ Create a column with the given type. """
+    if default is None and columntype.upper() == 'BOOLEAN':
+        default = False
     sql = SQL(
         "ALTER TABLE %s ADD COLUMN %s %s %s",
         SQL.identifier(tablename),
         SQL.identifier(columnname),
         SQL(columntype),
-        SQL("DEFAULT false" if columntype.upper() == 'BOOLEAN' else ""),
+        SQL("DEFAULT %s", default),
     )
     if comment:
         sql = SQL("%s; %s", sql, SQL(
@@ -378,6 +380,15 @@ def _convert_column(cr, tablename, columnname, columntype, using: SQL):
         drop_depending_views(cr, tablename, columnname)
         cr.execute(query)
     _schema.debug("Table %r: column %r changed to type %s", tablename, columnname, columntype)
+
+
+def update_column_default(cr, tablename, columnname, default):
+    cr.execute(SQL(
+        "ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s",
+        SQL.identifier(tablename),
+        SQL.identifier(columnname),
+        default,
+    ))
 
 
 def drop_depending_views(cr, table, column):


### PR DESCRIPTION
When loading the database, at install tests or data load scripts may add new data in the database. However, required columns in modules not yet loaded are not known. Either we cannot add because of an existing NOT NULL constraint or we can add a value which will prevent the module from adding the not null constraint.
Add a default in the database, but do not rely on it inside the ORM.

task-5854589

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
