### PR TITLE
[FIX] l10n_in_edi: save IRN number on invoice after EDI submission

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -191,7 +191,9 @@ class AccountMove(models.Model):
     def _get_l10n_in_edi_response_json(self):
         self.ensure_one()
         if self.l10n_in_edi_attachment_id:
-            return json.loads(self.l10n_in_edi_attachment_id.sudo().raw.decode("utf-8"))
+            json_data = json.loads(self.l10n_in_edi_attachment_id.sudo().raw.decode("utf-8"))
+            self.l10n_in_irn_number = json_data.get('Irn') if json_data.get('Irn') else ""
+            return json_data
         return {}
 
     def _l10n_in_lock_invoice(self):

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -1,6 +1,8 @@
+import json
+
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, _
 from odoo.tests import tagged
 from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
 
@@ -897,3 +899,24 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                   }
                 }
             )
+
+    def test_get_l10n_in_edi_response_json(self):
+        """Ensure EDI response JSON is returned and no IRN is set (no side-effect)."""
+        move = self.invoice
+        json_content = {
+            "Irn": "TEST_IRN_123",
+            "AckNo": "ACK_001"
+        }
+        attachment = self.env['ir.attachment'].create({
+            'name': 'edi_response.json',
+            'raw': json.dumps(json_content).encode('utf-8'),
+            'res_model': 'account.move',
+            'res_id': move.id,
+        })
+        move.l10n_in_edi_attachment_id = attachment
+        result = move._get_l10n_in_edi_response_json()
+        self.assertDictEqual(result, json_content)
+        self.assertFalse(move.l10n_in_irn_number, _("IRN should not be set by _get_l10n_in_edi_response_json anymore."))
+        move.l10n_in_edi_attachment_id = False
+        result_empty = move._get_l10n_in_edi_response_json()
+        self.assertEqual(result_empty, {})


### PR DESCRIPTION
**Steps to reproduce:**
* Install module *Indian E-Invoicing (l10n_in_edi)*.
* Configure *Indian integration* with required credentials
(E-Invoicing, E-Way bill, etc.).
* Save the settings.
* Create a *customer invoice*.
* Post the invoice.
* Send the invoice through *E-Invoicing (EDI)*.
* Open the generated *Invoice PDF* and the *form view*.

**Observed behavior:**
* The *IRN number* is correctly present in the *Invoice PDF*.
* However, it is *not saved/displayed* in the invoice form view.

**Cause:**
* No specific condition existed in the invoice flow to store the *IRN number* 
in the corresponding field, even though the value was available in the 
EDI response.

**Fix:**
* Update *_get_l10n_in_edi_response_json* to store the IRN number directly on 
the invoice when the response is received.
* This ensures the value is saved without impacting the existing EDI flow.

opw-6097923