### PR TITLE
[FIX] mail: correctly mention roles in full composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -5,7 +5,7 @@ import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzo
 import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { MAIL_PLUGINS, MAIL_SMALL_UI_PLUGINS } from "@mail/core/common/plugin/plugin_sets";
-import { useSuggestion } from "@mail/core/common/suggestion_hook";
+import { mapSuggestionsToOptions, useSuggestion } from "@mail/core/common/suggestion_hook";
 import { useSelection } from "@mail/utils/common/hooks";
 import { trimEmptyBlocksAround } from "@mail/utils/common/format";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
@@ -460,82 +460,14 @@ export class Composer extends Component {
         if (!this.hasSuggestions) {
             return props;
         }
-        const suggestions = this.suggestion.state.items.suggestions;
-        switch (this.suggestion.state.items.type) {
-            case "Partner":
-                return {
-                    ...props,
-                    optionTemplate: "mail.Composer.suggestionPartner",
-                    options: suggestions.map((suggestion) => {
-                        if (suggestion.isSpecial) {
-                            return {
-                                ...suggestion,
-                                group: 1,
-                                optionTemplate: "mail.Composer.suggestionSpecial",
-                                classList: "o-mail-Composer-suggestion",
-                            };
-                        } else if (suggestion.Model.getName() === "res.role") {
-                            return {
-                                label: suggestion.name,
-                                role: suggestion,
-                                thread: this.thread,
-                                optionTemplate: "mail.Composer.suggestionRole",
-                                classList: "o-mail-Composer-suggestion",
-                            };
-                        } else {
-                            return {
-                                label: this.thread?.getPersonaName(suggestion) ?? suggestion.name,
-                                thread: this.thread,
-                                partner: suggestion,
-                                classList: "o-mail-Composer-suggestion",
-                            };
-                        }
-                    }),
-                };
-            case "Thread":
-                return {
-                    ...props,
-                    optionTemplate: "mail.Composer.suggestionThread",
-                    options: suggestions.map((suggestion) => ({
-                        label: suggestion.fullNameWithParent,
-                        thread: suggestion,
-                        classList: "o-mail-Composer-suggestion",
-                    })),
-                };
-            case "ChannelCommand":
-                return {
-                    ...props,
-                    optionTemplate: "mail.Composer.suggestionChannelCommand",
-                    options: suggestions.map((suggestion) => ({
-                        label: suggestion.name,
-                        help: suggestion.help,
-                        classList: "o-mail-Composer-suggestion",
-                    })),
-                };
-            case "mail.canned.response":
-                return {
-                    ...props,
-                    optionTemplate: "mail.Composer.suggestionCannedResponse",
-                    options: suggestions.map((suggestion) => ({
-                        cannedResponse: suggestion,
-                        label: suggestion.substitution,
-                        source: suggestion.source,
-                        title: suggestion.substitution,
-                        classList: "o-mail-Composer-suggestion",
-                    })),
-                };
-            case "emoji":
-                return {
-                    ...props,
-                    optionTemplate: "mail.Composer.suggestionEmoji",
-                    options: suggestions.map((suggestion) => ({
-                        emoji: suggestion,
-                        label: suggestion.codepoints,
-                    })),
-                };
-            default:
-                return props;
-        }
+        return {
+            ...props,
+            ...mapSuggestionsToOptions(
+                this.suggestion.state.items.type,
+                this.suggestion.state.items.suggestions,
+                { thread: this.thread }
+            ),
+        };
     }
 
     onDropFile(ev) {

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -10,7 +10,33 @@ import { status, useComponent, useEffect, useState } from "@odoo/owl";
 import { ConnectionAbortedError } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
-import { createTextNode } from "@web/core/utils/xml";
+
+/**
+ * @typedef {Object} Option
+ * @property {string} [buttonClass]
+ * @property {string} [classList]
+ * @property {number} [group]
+ * @property {string} [label]
+ * @property {string} [optionTemplate]
+ * @property {string} [title]
+ * @property {boolean} [unselectable]
+ * @property {import("models").ResRole} [role]
+ * @property {import("models").ResPartner} [partner]
+ * @property {import("models").Thread} [thread]
+ * @property {import("models").CannedResponse} [cannedResponse]
+ * @property {import("@web/core/emoji_picker/emoji_picker").Emoji} [emoji]
+ * @property {string} [help]
+ * @property {string} [source]
+ */
+
+/**
+ * @typedef {import("models").ResPartner
+ *   | import("models").ResRole
+ *   | import("models").Thread
+ *   | import("models").CannedResponse
+ *   | import("@web/core/emoji_picker/emoji_picker").Emoji
+ *   | import("@mail/core/common/store_service").SpecialMention} Suggestion
+ */
 
 export const DELAY_FETCH = 250;
 
@@ -210,18 +236,7 @@ export class UseSuggestion {
             this.composer.cannedResponses.push(option.cannedResponse);
         }
         if (this.comp.composerService.htmlEnabled) {
-            let inlineElement;
-            if (option.partner) {
-                inlineElement = generatePartnerMentionElement(option.partner, this.thread);
-            } else if (option.isSpecial) {
-                inlineElement = generateSpecialMentionElement(option.label);
-            } else if (option.role) {
-                inlineElement = generateRoleMentionElement(option.role);
-            } else if (option.thread) {
-                inlineElement = generateThreadMentionElement(option.thread);
-            } else {
-                inlineElement = createTextNode(option.label);
-            }
+            const inlineElement = makeMentionFromOption(option, { thread: this.thread });
             this.comp.editor.shared.dom.insert(inlineElement);
             const [anchorNode, anchorOffset] = rightPos(inlineElement);
             this.comp.editor.shared.selection.setSelection({ anchorNode, anchorOffset });
@@ -295,4 +310,111 @@ export class UseSuggestion {
 
 export function useSuggestion() {
     return new UseSuggestion(useComponent());
+}
+
+/**
+ * Maps raw suggestion records to navigable list option objects for all suggestion types.
+ *
+ * @param {string} type
+ * @param {Suggestion[]} suggestions
+ * @param {Object} [params]
+ * @param {import("models").Thread} [params.thread] The thread where the suggestion is being
+ *   composed. Used e.g. to resolve partner display names in context and stored on the resulting
+ *   Option so that consumers (insertion handlers, mention templates) can access it.
+ * @returns {{ optionTemplate?: string, options: Option[] }}
+ */
+export function mapSuggestionsToOptions(type, suggestions, { thread } = {}) {
+    const classList = "o-mail-Composer-suggestion";
+    switch (type) {
+        case "Partner":
+            return {
+                optionTemplate: "mail.Composer.suggestionPartner",
+                options: suggestions.map((suggestion) => {
+                    if (suggestion.isSpecial) {
+                        return {
+                            ...suggestion,
+                            group: 1,
+                            optionTemplate: "mail.Composer.suggestionSpecial",
+                            classList,
+                        };
+                    }
+                    if (suggestion?.Model?.getName?.() === "res.role") {
+                        return {
+                            label: suggestion.name,
+                            role: suggestion,
+                            thread,
+                            optionTemplate: "mail.Composer.suggestionRole",
+                            classList,
+                        };
+                    }
+                    return {
+                        label: thread?.getPersonaName(suggestion) ?? suggestion.name,
+                        partner: suggestion,
+                        thread,
+                        classList,
+                    };
+                }),
+            };
+        case "Thread":
+            return {
+                optionTemplate: "mail.Composer.suggestionThread",
+                options: suggestions.map((suggestion) => ({
+                    label: suggestion.fullNameWithParent,
+                    thread: suggestion,
+                    classList,
+                })),
+            };
+        case "ChannelCommand":
+            return {
+                optionTemplate: "mail.Composer.suggestionChannelCommand",
+                options: suggestions.map((suggestion) => ({
+                    label: suggestion.name,
+                    help: suggestion.help,
+                    classList,
+                })),
+            };
+        case "mail.canned.response":
+            return {
+                optionTemplate: "mail.Composer.suggestionCannedResponse",
+                options: suggestions.map((suggestion) => ({
+                    cannedResponse: suggestion,
+                    label: suggestion.substitution,
+                    source: suggestion.source,
+                    title: suggestion.substitution,
+                    classList,
+                })),
+            };
+        case "emoji":
+            return {
+                optionTemplate: "mail.Composer.suggestionEmoji",
+                options: suggestions.map((suggestion) => ({
+                    emoji: suggestion,
+                    label: suggestion.codepoints,
+                })),
+            };
+        default:
+            return { options: [] };
+    }
+}
+
+/**
+ * @param {Option} option
+ * @param {Object} [params]
+ * @param {import("models").Thread} [params.thread] The thread being viewed by the
+ *   user, needed to generate mention links that point back to the right record.
+ */
+export function makeMentionFromOption(option, { thread } = {}) {
+    let inlineElement;
+    if (option.partner) {
+        inlineElement = generatePartnerMentionElement(option.partner, thread);
+    } else if (option.isSpecial) {
+        inlineElement = generateSpecialMentionElement(option.label);
+    } else if (option.role) {
+        inlineElement = generateRoleMentionElement(option.role);
+    } else if (option.thread) {
+        inlineElement = generateThreadMentionElement(option.thread);
+    } else {
+        inlineElement = document.createTextNode(option.label);
+    }
+    return inlineElement;
 }

--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -3,6 +3,7 @@ import { Component, useEffect, useState } from "@odoo/owl";
 import { useService, useAutofocus } from "@web/core/utils/hooks";
 
 import { NavigableList } from "@mail/core/common/navigable_list";
+import { mapSuggestionsToOptions } from "@mail/core/common/suggestion_hook";
 import { useSequential } from "@mail/utils/common/hooks";
 
 export class MentionList extends Component {
@@ -56,7 +57,7 @@ export class MentionList extends Component {
             },
             () => [
                 this.state.searchTerm,
-                this.props.type === "partner" ? "@" : "#",
+                this.props.type === "Partner" ? "@" : "#",
                 this.props.thread,
             ]
         );
@@ -64,9 +65,9 @@ export class MentionList extends Component {
 
     get placeholder() {
         switch (this.props.type) {
-            case "channel":
+            case "Thread":
                 return _t("Search for a channel...");
-            case "partner":
+            case "Partner":
                 return _t("Search for a user...");
             default:
                 return _t("Search...");
@@ -74,7 +75,7 @@ export class MentionList extends Component {
     }
 
     get navigableListProps() {
-        const props = {
+        return {
             anchorRef: this.ref.el,
             position: "bottom-fit",
             isLoading: !!this.state.searchTerm && this.state.isFetching,
@@ -82,32 +83,10 @@ export class MentionList extends Component {
                 this.props.onSelect(...args);
                 this.props.close();
             },
-            options: [],
+            ...mapSuggestionsToOptions(this.props.type, this.state.options, {
+                thread: this.props.thread,
+            }),
         };
-        switch (this.props.type) {
-            case "partner":
-                props.optionTemplate = "mail.Composer.suggestionPartner";
-                props.options = this.state.options.map((suggestion) => {
-                    return {
-                        label: suggestion.name,
-                        partner: suggestion,
-                        classList: "o-mail-Composer-suggestion",
-                    };
-                });
-                break;
-            case "channel":
-                props.optionTemplate = "mail.Composer.suggestionThread";
-                props.options = this.state.options.map((suggestion) => {
-                    return {
-                        label: suggestion.displayName,
-                        thread: suggestion,
-                        channel: suggestion,
-                        classList: "o-mail-Composer-suggestion",
-                    };
-                });
-                break;
-        }
-        return props;
     }
 
     onKeydown(ev) {

--- a/addons/mail/static/src/core/web/mention_list.xml
+++ b/addons/mail/static/src/core/web/mention_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
+    <!--deprecated as of saas-19.0-->
     <t t-name="mail.Wysiwyg.mentionLink">
         <a
             t-att-href="href"

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -1,8 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { MentionList } from "@mail/core/web/mention_list";
-import { router } from "@web/core/browser/router";
-import { renderToElement } from "@web/core/utils/render";
-import { url } from "@web/core/utils/urls";
+import { makeMentionFromOption } from "@mail/core/common/suggestion_hook";
 
 export class MentionPlugin extends Plugin {
     static id = "mention";
@@ -21,19 +19,10 @@ export class MentionPlugin extends Plugin {
 
     onSelect(ev, option) {
         this.dependencies.selection.focusEditable();
-        const mentionBlock = renderToElement("mail.Wysiwyg.mentionLink", {
-            option,
-            href: url(
-                router.stateToUrl({
-                    model: option.partner ? "res.partner" : "discuss.channel",
-                    resId: option.partner ? option.partner.id : option.channel.id,
-                })
-            ),
-        });
-        const nameNode = this.document.createTextNode(
-            `${option.partner ? "@" : "#"}${option.label}`
-        );
-        mentionBlock.appendChild(nameNode);
+        const mentionBlock = makeMentionFromOption(option, { thread: this.config.thread });
+        if (!mentionBlock) {
+            return;
+        }
         this.historySavePointRestore();
         this.dependencies.dom.insert(mentionBlock);
         this.dependencies.history.addStep();
@@ -46,7 +35,7 @@ export class MentionPlugin extends Plugin {
                 props: {
                     onSelect: this.onSelect.bind(this),
                     thread: this.config.thread,
-                    type: ev.data === "@" ? "partner" : "channel",
+                    type: ev.data === "@" ? "Partner" : "Thread",
                     close: () => {
                         this.mentionList.close();
                     },

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -185,7 +185,7 @@ test("mention a partner", async () => {
     await press("enter");
     expect("[name='body'] .odoo-editor-editable").toHaveInnerHTML(`
     <p>
-        <a target="_blank" data-oe-protected="true" contenteditable="false" href="https://www.hoot.test/odoo/res.partner/17" class="o_mail_redirect" data-oe-id="17" data-oe-model="res.partner">
+        <a href="/odoo/res.partner/17" class="o_mail_redirect" data-oe-id="17" data-oe-model="res.partner" target="_blank" contenteditable="false">
             @Mitchell Admin
         </a>
     </p>`);


### PR DESCRIPTION
There is an issue when tagging a role using the full composer:
1. Emails are sent to the wrong address or sometimes no address at all
2. The displayed URL is not correct

This commit fixes the issue by correctly rendering the mention block for roles in the full composer, using the correct configuration.

task-6139162


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
