### PR TITLE
[FIX] orm: validate domain with SQL generation

### DIFF
--- a/addons/web/tests/test_domain.py
+++ b/addons/web/tests/test_domain.py
@@ -56,3 +56,17 @@ class DomainTest(HttpCaseWithUserDemo):
             data=json.dumps({'params': {'model': 'res.users', 'domain': [('accesses_count', '>', 10)]}}),
         )
         self.assertEqual(resp.json()['result'], False)
+
+        resp = self.url_open(
+            '/web/domain/validate',
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'params': {'model': 'res.currency', 'domain': [('iso_numeric', '=', 10)]}}),
+        )
+        self.assertEqual(resp.json()['result'], True)
+
+        resp = self.url_open(
+            '/web/domain/validate',
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'params': {'model': 'res.currency', 'domain': [('iso_numeric', '=', 'dfd')]}}),
+        )
+        self.assertEqual(resp.json()['result'], False)

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -405,7 +405,7 @@ class Domain:
     def validate(self, model: BaseModel) -> None:
         """Validates that the current domain is correct or raises an exception"""
         # just execute the optimization code that goes through all the fields
-        self._optimize(model, OptimizationLevel.FULL)
+        self._optimize(model, OptimizationLevel.FULL)._to_sql(Query(model).table)
 
     def _as_predicate(self, records: M) -> Callable[[M], bool]:
         """Return a predicate function from the domain (bound to records).


### PR DESCRIPTION
`Domain([('num_field', '=', 'dfd')]).validate(model)` should raise an exception because 'dfd' is not a valid number. Currently, the optimization does not check the data types for all operators, but these are checked during SQL generation. Let's generate the SQL to validate the domain.

task-6132976



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
