### PR TITLE
[IMP] purchase_stock,product: improve replenishment vendor selection

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -2,6 +2,7 @@
 
 import re
 from collections import defaultdict
+from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
@@ -1158,6 +1159,10 @@ class ProductProduct(models.Model):
                 continue
             if seller.date_end and seller.date_end < date:
                 continue
+            if params and params.get('consider_lead') and date:
+                order_deadline = fields.Date.to_date(date) - relativedelta(days=seller.delay)
+                if order_deadline < fields.Date.context_today(self):
+                    continue
             if params and params.get('force_uom') and seller.uom_id != uom_id and seller.uom_id != self.uom_id:
                 continue
             if partner_id and seller.partner_id not in [partner_id, partner_id.parent_id]:

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -2,6 +2,7 @@
 
 import re
 from collections import defaultdict
+from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
@@ -1107,6 +1108,10 @@ class ProductProduct(models.Model):
                 continue
             if seller.date_end and seller.date_end < date:
                 continue
+            if params and params.get('consider_lead') and date:
+                order_deadline = fields.Date.to_date(date) - relativedelta(days=seller.delay)
+                if order_deadline < fields.Date.context_today(self):
+                    continue
             if params and params.get('force_uom') and seller.uom_id != uom_id and seller.uom_id != self.uom_id:
                 continue
             if partner_id and seller.partner_id not in [partner_id, partner_id.parent_id]:

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -182,9 +182,17 @@ class StockRule(models.Model):
         delays, delay_description = super()._get_lead_days(product, **values)
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
-        seller = 'supplierinfo' in values and values['supplierinfo'] or product.with_company(buy_rule.company_id)._select_seller(quantity=None)
         if not buy_rule:
             return delays, delay_description
+        if 'supplierinfo' in values:
+            seller = values['supplierinfo']
+        else:
+            ordered_by = values.get('supplier_order_by') or 'price_discounted'
+            seller = product.with_company(buy_rule.company_id)._select_seller(
+                partner_id=values.get('supplier_partner'),
+                quantity=None,
+                ordered_by=ordered_by,
+            )
         if not seller:
             delays['total_delay'] += 365
             delays['no_vendor_found_delay'] += 365
@@ -383,7 +391,10 @@ class StockRule(models.Model):
                 qty=procurement.product_qty,
                 uom=procurement.uom_id,
                 date=max(procurement_date_planned.date(), fields.Date.today()),
-                params={"force_uom": procurement.values.get('force_uom')},
+                params={
+                    "force_uom": procurement.values.get('force_uom'),
+                    "consider_lead": procurement.values.get('consider_lead'),
+                },
             )
 
         return supplier

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -383,7 +383,10 @@ class StockRule(models.Model):
                 qty=procurement.product_qty,
                 uom=procurement.uom_id,
                 date=max(procurement_date_planned.date(), fields.Date.today()),
-                params={"force_uom": procurement.values.get('force_uom')},
+                params={
+                    "force_uom": procurement.values.get('force_uom'),
+                    "consider_lead": procurement.values.get('consider_lead'),
+                },
             )
 
         return supplier

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -43,6 +43,7 @@ class ProductReplenish(models.TransientModel):
 
     def _prepare_run_values(self):
         res = super()._prepare_run_values()
+        res['consider_lead'] = True
         if self.partner_id:
             res['procurement_partner'] = self.partner_id
         return res

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -7,7 +7,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='route_id']" position="after">
                 <field name="partner_id"
-                    required="show_vendor"
                     invisible="not show_vendor"
                     context="{'product_id': product_id, 'highlight_supplier': 1}"
                     options="{'no_open': 1, 'no_create': 0, 'no_quick_create':1}"


### PR DESCRIPTION
The replenish wizard currently requires a vendor to be selected if the vendor field is visible. This is restrictive, as users may want to leave the supplier empty to let Odoo's standard selection logic choose the best vendor based on price or lead time when the RFQ is created.

This commit makes the supplier optional in the replenish wizard while preserving autofill behavior. It also introduces lead-time-aware filtering to ensure that vendors who cannot satisfy the scheduled delivery date are excluded from selection.

This commit's changes:
- Remove the "required" constraint from the partner_id field in the product.replenish wizard view.
- Update "_prepare_run_values" in the replenishment wizard to set a new "consider_lead" parameter in the procurement values.
- Update the "stock.rule" procurement logic to pass the "consider_lead" parameter to the supplier selection method.
- Implement lead-time filtering in "product.product" to ignore sellers whose delivery delay would cause the order deadline to fall in the past relative to the scheduled date.

task-6117625

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
