### PR TITLE
[FIX] project: prevent crash when deleting an empty kanban column

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -21,7 +21,7 @@ export class ProjectTaskKanbanDynamicGroupList extends RelationalModel.DynamicGr
                 });
             });
         }
-        return super._unlinkGroups();
+        return super._unlinkGroups(groups);
     }
 }
 


### PR DESCRIPTION
Currently, an error occurs when deleting a kanban column that is empty in the To-do app

### **Steps to reproduce:**
1) Open To-do app.
2) In Kanban, create or locate an empty column (no tasks). 
3) Click the column gear icon and choose Delete.

### **Error:**
TypeError: Cannot read properties of undefined (reading 'map')

### **Root Cause**
The `ProjectTaskKanbanDynamicGroupList` override of `_unlinkGroups` did not forward the `groups` argument to `super._unlinkGroups()` at [1], so the superclass received undefined and attempted to call groups.map(), causing the Error.

[1]- https://github.com/odoo/odoo/blob/9468ff7a47d78447b66a4cdf1d33f8c21f51c309/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js#L24

### **Fix:**
This commit prevents error by ensuring the `groups` argument is passed to super method.

**opw-6129664**