### PR TITLE
[FIX] hr_attendance: check out on employee archive

### DIFF
--- a/addons/hr_attendance/__init__.py
+++ b/addons/hr_attendance/__init__.py
@@ -3,3 +3,4 @@
 
 from . import controllers
 from . import models
+from . import wizard

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -25,7 +25,8 @@ actions(Check in/Check out) performed by them.
         'views/hr_department_view.xml',
         'views/hr_employee_view.xml',
         'views/res_config_settings_views.xml',
-        'views/hr_attendance_kiosk_templates.xml'
+        'views/hr_attendance_kiosk_templates.xml',
+        'wizard/hr_employee_departure_wizard_views.xml'
     ],
     'demo': [
         'data/hr_attendance_demo.xml'

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -78,12 +78,13 @@ class HrEmployee(models.Model):
 
     def action_archive(self):
         super().action_archive()
-        self.env['hr.attendance'].search([
-            ('employee_id', 'in', self.ids),
-            ('check_out', '=', False),
-        ]).write({
-            'check_out': fields.Datetime.now(),
-        })
+        if not self.env.context.get('no_wizard'):
+            self.env['hr.attendance'].sudo().search([
+                ('employee_id', 'in', self.ids),
+                ('check_out', '=', False),
+            ]).write({
+                'check_out': fields.Datetime.now(),
+            })
 
     @api.depends('overtime_ids.duration', 'attendance_ids')
     def _compute_total_overtime(self):

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -28,6 +28,14 @@ class TestHrAttendance(TransactionCase):
             'name': "Machiavel",
             'pin': '5678',
         })
+        cls.hr_user = cls.env['res.users'].create({
+            'name': 'HR Officer',
+            'login': 'hr_officer',
+            'groups_id': [(6, 0, [
+                cls.env.ref('hr.group_hr_user').id,
+                # Explicitly NOT adding: hr_attendance.group_hr_attendance_user
+            ])]
+        })
 
     def setUp(self):
         super().setUp()
@@ -75,3 +83,16 @@ class TestHrAttendance(TransactionCase):
             self.test_employee.action_archive()
             self.assertEqual(test_attendance.check_out, fields.Datetime.now())
             self.assertEqual(test_attendance.worked_hours, 8.0)
+
+    def test_attendance_checkout_while_employee_archived_without_rights(self):
+        """Test that archiving employee by HR user closes attendance even if lacks of attendance permissions"""
+
+        test_attendance = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': '2024-01-15 08:00:00',
+        })
+
+        with freeze_time("2024-01-15 17:00:00"):
+            self.test_employee.with_user(self.hr_user).action_archive()
+            self.assertTrue(not self.test_employee.active, "Employee should be archived successfully with sudo()")
+            self.assertEqual(test_attendance.check_out, fields.Datetime.now(), "Attendance should be checked out at the time of archiving")

--- a/addons/hr_attendance/wizard/__init__.py
+++ b/addons/hr_attendance/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee_departure_wizard

--- a/addons/hr_attendance/wizard/hr_employee_departure_wizard.py
+++ b/addons/hr_attendance/wizard/hr_employee_departure_wizard.py
@@ -1,0 +1,82 @@
+from odoo import api, fields, models
+
+
+class HrDepartureWizard(models.TransientModel):
+    _inherit = 'hr.departure.wizard'
+
+    has_ongoing_attendance = fields.Boolean(
+        string='Has Ongoing Attendance',
+        compute='_compute_attendance_info'
+    )
+    has_multiple_attendances = fields.Boolean(
+        string='Has Multiple Ongoing Attendances',
+        compute='_compute_attendance_info'
+    )
+    attendance_id = fields.Many2one(
+        'hr.attendance',
+        string='Ongoing Attendance',
+        compute='_compute_attendance_id',
+        store=True,
+        readonly=False
+    )
+    attendance_check_in = fields.Datetime(
+        string='Check In',
+        related='attendance_id.check_in',
+        readonly=True
+    )
+    attendance_worked_hours = fields.Float(
+        string='Hours Since Check-in',
+        compute='_compute_worked_hours',
+        digits=(16, 2)
+    )
+    attendance_action = fields.Selection([
+        ('checkout', 'Check out now'),
+        ('delete', 'Delete attendance'),
+    ], string='Action', default='checkout')
+
+    @api.depends('employee_id')
+    def _compute_attendance_info(self):
+        for wizard in self:
+            if wizard.employee_id:
+                attendances = self.env['hr.attendance'].sudo().search([
+                    ('employee_id', '=', wizard.employee_id.id),
+                    ('check_out', '=', False),
+                ])
+
+                wizard.has_ongoing_attendance = len(attendances) > 0
+                wizard.has_multiple_attendances = len(attendances) > 1
+            else:
+                wizard.has_ongoing_attendance = False
+                wizard.has_multiple_attendances = False
+
+    @api.depends('employee_id')
+    def _compute_attendance_id(self):
+        for wizard in self:
+            if wizard.employee_id:
+                attendances = self.env['hr.attendance'].sudo().search([
+                    ('employee_id', '=', wizard.employee_id.id),
+                    ('check_out', '=', False),
+                ])
+                wizard.attendance_id = attendances[0] if len(attendances) == 1 else False
+            else:
+                wizard.attendance_id = False
+
+    @api.depends('attendance_id', 'attendance_id.check_in')
+    def _compute_worked_hours(self):
+        for wizard in self:
+            if wizard.attendance_id and wizard.attendance_id.check_in:
+                delta = fields.Datetime.now() - wizard.attendance_id.check_in
+                wizard.attendance_worked_hours = delta.total_seconds() / 3600
+            else:
+                wizard.attendance_worked_hours = 0.0
+
+    def action_register_departure(self):
+        if self.attendance_id and self.attendance_action:
+            if self.attendance_action == 'checkout':
+                self.attendance_id.sudo().write({
+                    'check_out': fields.Datetime.now(),
+                })
+            elif self.attendance_action == 'delete':
+                self.attendance_id.sudo().unlink()
+
+        return super().action_register_departure()

--- a/addons/hr_attendance/wizard/hr_employee_departure_wizard_views.xml
+++ b/addons/hr_attendance/wizard/hr_employee_departure_wizard_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_departure_wizard_view_form_inherit_attendance" model="ir.ui.view">
+        <field name="name">hr.departure.wizard.view.form.inherit.attendance</field>
+        <field name="model">hr.departure.wizard</field>
+        <field name="inherit_id" ref="hr.hr_departure_wizard_view_form"/>
+        <field name="arch" type="xml">
+
+            <sheet position="inside">
+                <field name="has_ongoing_attendance" invisible="1"/>
+                <field name="has_multiple_attendances" invisible="1"/>
+
+                <div class="alert alert-warning" role="alert" invisible="not has_ongoing_attendance or has_multiple_attendances">
+                    <h5 class="alert-heading mb-2" role="alert">Ongoing Attendance Detected</h5>
+                    <p class="">This employee is currently checked in. Please choose how to handle the attendance:</p>
+                    <group class="mb-2">
+                        <group>
+                            <label for="attendance_check_in" string="Checked In At"/>
+                            <field name="attendance_check_in" readonly="1" nolabel="1"/>
+                            <label for="attendance_worked_hours" string="Hours Since Check-in"/>
+                            <field name="attendance_worked_hours" readonly="1" nolabel="1" widget="float_time"/>
+                        </group>
+                        <group>
+                            <field name="attendance_action" widget="radio" 
+                                required="has_ongoing_attendance and not has_multiple_attendances"/>
+                        </group>
+                    </group>
+                </div>
+
+                <div class="alert alert-warning" role="alert" invisible="not has_multiple_attendances">
+                    <h5 class="alert-heading mb-2" role="alert">Multiple Ongoing Attendances Detected</h5>
+                    <p class="mb-0">
+                        This employee has multiple ongoing attendances. 
+                        Please handle them manually in the Attendances app before archiving this employee.
+                    </p>
+                </div>
+
+            </sheet>
+            
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Step to reproduce: with attendance installed and an employee checked in, archive that employee by HR user. If missing attendance rights, the employee will be archived but not checked out from its ongoing attendance.
- Cause: if no role set for Attendance (default), no permission to update the employee attendance while archiving.
- Solution: using sudo method so that any user with sufficient rights to archive an employee, can trigger check out of the corresponding attendance. Inheriting from employee departure wizard and adding a warning if ongoing attendance so the hr user can choose to checkout or delete the attendance.

Task: 6131692
