### PR TITLE
[IMP] expr_eval: allow attribute access

### DIFF
--- a/odoo/addons/test_tools/tests/test_safe_eval_expr.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval_expr.py
@@ -1,4 +1,4 @@
-from odoo.tests.common import BaseCase, tagged
+from odoo.tests.common import BaseCase, TransactionCase, tagged
 from odoo.tools.safe_eval import expr_eval
 
 
@@ -190,13 +190,18 @@ class TestExprEval(BaseCase):
         with self.assertRaises(KeyError):
             expr_eval('{}["x"]')
 
-    def test_invalid_syntax(self):
-        for expr in ('2 +', '* 3', 'import os', 'a.b'):
+    def test_invalid_expressions(self):
+        for expr, exc in (
+            ('2 +', SyntaxError),
+            ('* 3', SyntaxError),
+            ('import os', SyntaxError),
+            ('a.b', NameError),
+            ('unknown_func()', NameError),
+            ('a.b = c', SyntaxError),
+        ):
             with self.subTest(expr=expr):
-                with self.assertRaises((SyntaxError, TypeError)):
+                with self.assertRaises(exc):
                     expr_eval(expr)
-        with self.assertRaises(NameError):
-            expr_eval('unknown_func()')
 
     def test_unsupported_constants(self):
         for expr in ('...', '1j'):
@@ -216,3 +221,31 @@ class TestExprEval(BaseCase):
         mutable_ctx['a'][0] = 2
         res2 = expr_eval('a[0] + a[1]', mutable_ctx)
         self.assertEqual(res2, 4)
+
+
+class TestExprEvalAttribute(TransactionCase):
+    def test_attribute(self):
+        user = self.env.user
+        context = {
+            'user': user,
+            's': "hello",
+        }
+        cases = {
+            'user.id': user.id,
+            'user.ids': user.ids,
+            'user._name + s': user._name + "hello",
+            'user.login': user.login,
+            'user.company_ids[:1].name': user.company_ids[:1].name,
+        }
+        for expr, expected in cases.items():
+            with self.subTest(expr=expr):
+                self.assertEqual(expr_eval(expr, context=context), expected)
+
+        for expr in (
+            'user.login.islower',
+            'user.env',
+            'user.new()',
+            's.lower',
+        ):
+            with self.subTest(expr=expr), self.assertRaises(Exception):
+                expr_eval(expr, context=context)

--- a/odoo/tools/safe_eval/expression.py
+++ b/odoo/tools/safe_eval/expression.py
@@ -142,6 +142,28 @@ class _ExprEval(ast.NodeVisitor):
     def visit_IfExp(self, node):
         return self.visit(node.body) if self.visit(node.test) else self.visit(node.orelse)
 
+    def visit_Attribute(self, node):
+        from odoo.models import BaseModel  # noqa: PLC0415
+        if not isinstance(node.ctx, ast.Load):
+            raise SyntaxError("Only attribute loading is supported")  # noqa: TRY004
+
+        obj = self.visit(node.value)
+        if not isinstance(obj, BaseModel):
+            raise TypeError(
+                f"Attribute access is only supported on Odoo recordsets, got {type(obj).__name__!r} "
+                f"while accessing {node.attr!r}"
+            )
+
+        if field := obj._fields.get(node.attr):
+            return field.__get__(obj)
+
+        if node.attr == 'ids':
+            return obj.ids
+        if node.attr == '_name':
+            return obj._name
+
+        raise AttributeError(f"{obj._name!r} object has no field {node.attr!r}")
+
     def visit_Subscript(self, node):
         return self.visit(node.value)[self.visit(node.slice)]
 


### PR DESCRIPTION
This PR adds ability to access recordset attributes within expr_eval. This would allow to implement dynamic values in domains (krma task)

Replace safe eval of `('some_field', 'in', companies.ids)` with `('some_field', 'expr', 'companies')`.

task-4076815