### PR TITLE
[FIX] mrp,mrp_subcontracting_purchase: fix product replenishment route

### DIFF
--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -47,6 +47,6 @@ class ProductReplenish(models.TransientModel):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
         manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)]).route_id
-        if manufacture_route and product_tmpl_id.bom_ids:
+        if manufacture_route and product_tmpl_id.bom_ids.filtered(lambda b: b.type == 'normal'):
             domain = Domain.OR([domain, Domain('id', 'in', manufacture_route.ids)])
         return domain

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -1092,3 +1092,15 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
             {'product_id': self.comp3.id, 'product_uom_qty': 1.0},
             {'product_id': self.comp4.id, 'product_uom_qty': 1.0},
         ])
+
+    def test_replenish_with_subcontracting_bom(self):
+        """ Checks that a subcontracting bom cannot trigger a 'Manufacture' replenish.
+        """
+        self.assertEqual(self.finished.bom_ids.type, 'subcontract')
+        replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=self.finished.product_tmpl_id.id).create({
+            'product_id': self.finished.id,
+        })
+        buy_routes = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', self.company.id)]).route_id
+        self.assertIn(replenish_wizard.route_id, buy_routes)
+        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', self.company.id)]).route_id
+        self.assertNotIn(manufacture_route, replenish_wizard.allowed_route_ids)

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -1087,3 +1087,15 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
             {'product_id': self.comp3.id, 'product_uom_qty': 1.0},
             {'product_id': self.comp4.id, 'product_uom_qty': 1.0},
         ])
+
+    def test_replenish_with_subcontracting_bom(self):
+        """ Checks that a subcontracting bom cannot trigger a 'Manufacture' replenish.
+        """
+        self.assertEqual(self.finished.bom_ids.type, 'subcontract')
+        replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=self.finished.product_tmpl_id.id).create({
+            'product_id': self.finished.id,
+        })
+        buy_routes = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', self.company.id)]).route_id
+        self.assertIn(replenish_wizard.route_id, buy_routes)
+        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', self.company.id)]).route_id
+        self.assertNotIn(manufacture_route, replenish_wizard.allowed_route_ids)


### PR DESCRIPTION
'product.replenish' default_get/_get_route_domain wrongly states that a manufacturing order can be created from a non-'normal' bill of material.

This prevents the 'Manufacture' route from being proposed to subcontracted-only products.

task: 6132290
