### PR TITLE
[IMP] l10n_ar: Add support for VAT zero base amount.

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -343,6 +343,7 @@ class AccountMove(models.Model):
             'vat_amount': 0,
             'vat_taxable_amount': 0,
             'vat_exempt_base_amount': 0,
+            'vat_zero_base_amount': 0,
             'vat_untaxed_base_amount': 0,
             'not_vat_taxes_amount': 0,
             'iibb_perc_amount': 0,
@@ -367,6 +368,8 @@ class AccountMove(models.Model):
         for grouping_key, values in vat_afip_code_aggregated_tax_details.items():
             if grouping_key['vat_afip_code'] == '2':
                 res['vat_exempt_base_amount'] = values['base_amount_currency']
+            elif grouping_key['vat_afip_code'] == '3':
+                res['vat_zero_base_amount'] = values['base_amount_currency']
             elif grouping_key['vat_afip_code'] == '1':
                 res['vat_untaxed_base_amount'] = values['base_amount_currency']
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: 
When uploading the digital VAT book txt file to ARCA, the operation code must be reported when the VAT rate is zero. Validation file: https://www.afip.gob.ar/iva/documentos/Libro-IVA-Digital-Especificaciones.pdf page 10, "Campo 20: Código de operación." Specification: https://www.afip.gob.ar/iva/documentos/libro-iva-digital-diseno-registros.pdf (page 4 "Diseño de Registro Compras e Importación de Bienes- Cabecera").

**Current behavior before PR**:
The operation code is not being reported in the digital VAT book txt file when the VAT rate is zero.

**Desired behavior after PR is merged**:
The operation code is being reported in the digital VAT book txt file when the VAT rate is zero.

Task Adhoc side: 55146
Task latam side: 1357



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
