### PR TITLE
[IMP] account: remove deprecated _check_tax_return_configuration method

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -1156,12 +1156,3 @@ class ResCompany(models.Model):
                     placeholder = _("%s, or / if not applicable", expected_vat)
 
             company.company_vat_placeholder = placeholder
-
-    # Deprecated, removed in master.
-    def _check_tax_return_configuration(self):
-        """
-        To override in localizations to check if the company is properly configured for tax returns.
-        or related modules are installed.
-        :raises RedirectWarning: if something is wrong configured.
-        """
-        return


### PR DESCRIPTION
- In this commit, removed _check_tax_return_configuration method, which was
  initially introduced for checking the company configuration before opening the
  tax return view.
- Which is not very useful, as there might be more than one type of return
  available, so not letting access to type A returns because the company
  configuration does not match for type B returns.

See this pr for more info: https://github.com/odoo/odoo/pull/247216

Related Ent PR: https://github.com/odoo/enterprise/pull/114346

no-task