### PR TITLE
[FIX] product: catalog sample record traceback

### DIFF
--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -9,7 +9,7 @@ export class ProductCatalogOrderLine extends Component {
         quantity: Number,
         price: Number,
         productType: String,
-        uomId: Number,
+        uomId: { type: Number, optional: true },
         uomDisplayName: { type: String, optional: true },
         productUomFactor: { type: Number, optional: true },
         productUomDisplayName: { type: String, optional: true },


### PR DESCRIPTION
Issue
=====
When sample records are shown in product's catalog, the user encounters some tracebacks.

How to reproduce
================
1. Install Purchase without demo data;
2. Create a new quotation (which requires at least one vendor);
3. Click on "Catalog" => The catalog is opened but multiple tracebacks happen.

Explanation
===========
When there are no products to show by default (the catalog's products are filtered to show vendor's products in Purchase Order), samples are shown instead. The issue is: in `_getSampleOrderLineInfo` which generate props for sample records, there is no `uomId` prop, but `ProductCatalogOrderLine` expects one.

Fix
===
The `uomId` prop is now optional, as it doesn't make sense to have one for sample data.
