### PR TITLE
[FIX] website_sale: missed normalize_handlers into processors

### DIFF
--- a/addons/website_sale/static/src/website_builder/editable_button_plugin.js
+++ b/addons/website_sale/static/src/website_builder/editable_button_plugin.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 class EditableButtonPlugin extends Plugin {
     static id = "editableButton";
     resources = {
-        normalize_handlers: this.wrapEditableButtons.bind(this),
+        normalize_processors: this.wrapEditableButtons.bind(this),
     };
 
     /**


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Commit [1] changed normalize_handlers into processors but an occurrence of normalize_handler was missed to updated. Most probably missed during forward port.

[1]: https://github.com/odoo/odoo/commit/37c898a81dabd91914367f7172fc091da625e803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
