### PR TITLE
[IMP] orm: template_code is not an ormcache

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1020,14 +1020,16 @@ class IrQweb(models.AbstractModel):
 
         view_hash = hash(document)
         cache_key = tuple(self.env.context.get(k) or False for k in self._get_template_cache_keys())
-        return self._generate_code_cached_memo(ref, memo_key=(view_hash, cache_key))
 
-    @tools.conditional(
-        'xml' not in tools.config['dev_mode'],
-        tools.ormcache('ref', 'memo_key', cache='template_code'),
-    )
-    def _generate_code_cached_memo(self, ref: int, memo_key):
-        return self._generate_code_uncached(ref)
+        if 'xml' in tools.config['dev_mode']:
+            return self._generate_code_uncached(ref)
+        memo_key = (ref, view_hash, cache_key)
+        cache = self.env.registry._template_code__
+        code = cache.get(memo_key)
+        if code is None:
+            code = self._generate_code_uncached(ref)
+            cache[memo_key] = code
+        return code
 
     def _generate_code_uncached(self, template: int | str | etree._Element):
         assert isinstance(self, IrQweb)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -55,7 +55,6 @@ _REGISTRY_CACHES = {
     'assets': 512,
     'stable': 1024,
     'templates': 1024,
-    'template_code': 1024,
     'routing': 1024,  # 2 entries per website
     'routing.rewrites': 8192,  # url_rewrite entries
     'templates.cached_values': 2048, # arbitrary
@@ -283,6 +282,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self._ordinary_tables: set[str] | None = None  # cached names of regular tables
         self._constraint_queue: dict[typing.Any, Callable[[BaseCursor], None]] = {}  # queue of functions to call on finalization of constraints
         self.__caches: dict[str, LRU] = {cache_name: LRU(cache_size) for cache_name, cache_size in _REGISTRY_CACHES.items()}
+        self._template_code__ = LRU(_REGISTRY_CACHES['templates'])  # memo for code templates
 
         # update context during loading modules
         self.loaded_xmlids: set[str] = set()           # loaded xmlids for IrModelData._process_end()


### PR DESCRIPTION
"template_code" ormcache cannot be invalidated as it has no corresponding table for sequences. It is not a real `ormcache`. We create an independent cache on the registry for it.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
