### PR TITLE
[FIX] stock: prevent traceback when confirming scrap after discard

### DIFF
--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6788,3 +6788,15 @@ class TestStockMove(TestStockCommon):
                 'packaging_quantity': 5.0,
                 'packaging_qty_ordered': 5.0,
             })
+
+    def test_scrap_unlink_behavior_on_discard_with_and_without_context(self):
+        """Check scrap deletion behavior when insufficient warning is discarded."""
+        scrap = self.env['stock.move'].create({
+            'is_scrap': True,
+            'product_id': self.productA.id,
+            'quantity': 5,
+        })
+        Form.from_action(self.env, scrap.with_context(not_unlink_on_discard=True).action_scrap()).save().action_cancel()
+        self.assertTrue(scrap.exists(), "The scrap move should not be deleted after discarding the warning.")
+        Form.from_action(self.env, scrap.action_scrap()).save().action_cancel()
+        self.assertFalse(scrap.exists(), "The scrap move should have been deleted after discarding the warning.")

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -328,7 +328,7 @@
                 <form string="Scrap Products">
                     <header invisible="context.get('from_order')">
                         <field name="state" widget="statusbar" statusbar_visible="draft,done"/>
-                        <button name="action_scrap" type="object" string="Confirm" class="btn-primary" invisible="state in ('done', 'cancel')"/>
+                        <button name="action_scrap" type="object" string="Confirm" class="btn-primary" invisible="state in ('done', 'cancel')" context="{'not_unlink_on_discard': True}"/>
                     </header>
                     <sheet>
                         <field name="is_scrap" invisible="1"/>

--- a/addons/stock/wizard/stock_warn_insufficient_qty.py
+++ b/addons/stock/wizard/stock_warn_insufficient_qty.py
@@ -46,4 +46,6 @@ class StockWarnInsufficientQtyScrap(models.TransientModel):
         return self.with_context(clean_context(self.env.context)).scrap_move_id._action_scrap()
 
     def action_cancel(self):
+        if self.env.context.get('not_unlink_on_discard'):
+            return True
         return self.scrap_move_id.sudo().unlink()


### PR DESCRIPTION
**Version:**
---------
- saas-19.2+

**Steps to reproduce:**
------------------------
* Install the *Inventory (stock)* module.
* Create a *storable product* with tracking enabled.
* Update the on-hand quantity to *5 units*.
* Navigate to *Inventory > Operations > Scrap* and create a new scrap
  record.
* Select the created product and set a quantity *greater than the
  available on-hand quantity (e.g. 6)*.
* Click on *Confirm*.
* An *insufficient quantity* wizard opens.
  * Click on *Discard*.
  * Then click again on *Confirm* in the wizard.

**Issue:**
---------
* A traceback occurs with the following error:
  `ValueError: Expected singleton: stock.move()`

**Cause:**
----------
* When clicking *Confirm*, button the insufficient quantity wizard is opened
  with a `scrap_move_id`.
https://github.com/odoo/odoo/blob/3206cd9bc0af33b047138fc6666a14f8d11da785/addons/stock/models/stock_move.py#L2747
https://github.com/odoo/odoo/blob/3206cd9bc0af33b047138fc6666a14f8d11da785/addons/stock/models/stock_move.py#L2742
* Clicking *Discard* button triggers `action_cancel`, which unlinks the
  associated `scrap_move_id`.
https://github.com/odoo/odoo/blob/3206cd9bc0af33b047138fc6666a14f8d11da785/addons/stock/wizard/stock_warn_insufficient_qty.py#L48-L49
* However, the wizard remains open, and clicking *Confirm* again
  triggers `action_done`, which calls:
https://github.com/odoo/odoo/blob/3206cd9bc0af33b047138fc6666a14f8d11da785/addons/stock/wizard/stock_warn_insufficient_qty.py#L46
* At this point, `scrap_move_id` no longer exists, leading to the
  singleton error.

- Before saas-19.2
This behavior was previously handled in:
https://github.com/odoo/odoo/commit/c361c3778ef4755b4760039a4fd8f9ed88294b64

Later in this commit https://github.com/odoo/odoo/commit/1c7d80a10b5d7db1c4163166bf52b3f3c77044ba
the condition was removed during refactoring, causing the scrap move is to be unlinked in all flows.

**Fix:**
------
* Add a context key to ensure that the scrap move is only unlinked
  during the `action_scrap` flow, preventing access to a deleted
  `scrap_move_id`.

---

opw-6128188


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
