### PR TITLE
[FIX] hr_recruitment: Do not override employee work email with company email

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -679,7 +679,7 @@ class Applicant(models.Model):
             'lang': address_sudo.lang,
             'department_id': self.department_id.id,
             'address_id': self.company_id.partner_id.id,
-            'work_email': self.department_id.company_id.email or self.email_from, # To have a valid email address by default
+            'work_email': False,
             'work_phone': self.department_id.company_id.phone,
             'applicant_id': self.ids,
             'private_phone': self.partner_phone or self.partner_mobile

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -679,7 +679,7 @@ class Applicant(models.Model):
             'lang': address_sudo.lang,
             'department_id': self.department_id.id,
             'address_id': self.company_id.partner_id.id,
-            'work_email': self.department_id.company_id.email or self.email_from, # To have a valid email address by default
+            'work_email': self.email_from,
             'work_phone': self.department_id.company_id.phone,
             'applicant_id': self.ids,
             'private_phone': self.partner_phone or self.partner_mobile

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -121,3 +121,34 @@ class TestRecruitment(TransactionCase):
         self.env['hr.applicant'].create(applicant_data)
         partner_count = self.env['res.partner'].search_count([('email', '=', 'test@thisisatest.com')])
         self.assertEqual(partner_count, 1)
+
+    def test_default_employee_email_after_direct_contract_sign(self):
+        """
+        When an applicant moved to hired stage and when an employee is created,
+        the employee email should not be set.
+        """
+        self.env.company.email = 'mycompany@info.com'
+        job = self.env['hr.job'].create({
+            'name': 'Test Job',
+            'no_of_recruitment': 5,
+            'department_id': self.env['hr.department'].create({'name': 'Test Department'}).id,
+        })
+        applicant = self.env['hr.applicant'].create({
+            'name': 'Test Applicant',
+            'partner_name': 'Test Applicant',
+            'job_id': job.id,
+            'email_from': 'applicant@example.com',
+        })
+        _, stage_hired = self.env['hr.recruitment.stage'].create([{
+            'name': 'New',
+            'sequence': 0,
+        }, {
+            'name': 'Hired',
+            'sequence': 1,
+            'hired_stage': True,
+        }])
+        applicant.stage_id = stage_hired
+
+        action = applicant.create_employee_from_applicant()
+        employee = self.env['hr.employee'].browse(action['res_id'])
+        self.assertFalse(employee.work_email)

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -119,3 +119,43 @@ class TestRecruitment(TransactionCase):
         self.env['hr.applicant'].create(applicant_data)
         partner_count = self.env['res.partner'].search_count([('email', '=', 'test@thisisatest.com')])
         self.assertEqual(partner_count, 1)
+
+    def test_default_employee_email_after_direct_contract_sign(self):
+        """
+        When an applicant moved to hired stage and when an employee is created,
+        the employee email should be set with the applicant email. If no email is available set it to False by default.
+        """
+        self.env.company.email = 'mycompany@info.com'
+        job = self.env['hr.job'].create({
+            'name': 'Test Job',
+            'no_of_recruitment': 5,
+            'department_id': self.env['hr.department'].create({'name': 'Test Department'}).id,
+        })
+        applicant1, applicant2 = self.env['hr.applicant'].create([{
+            'name': 'Test Applicant1',
+            'partner_name': 'Test Applicant1',
+            'job_id': job.id,
+            'email_from': 'applicant1@example.com',
+        }, {
+            'name': 'Test Applicant2',
+            'partner_name': 'Test Applicant2',
+            'job_id': job.id,
+        }])
+        _, stage_hired = self.env['hr.recruitment.stage'].create([{
+            'name': 'New',
+            'sequence': 0,
+        }, {
+            'name': 'Hired',
+            'sequence': 1,
+            'hired_stage': True,
+        }])
+        applicant1.stage_id = stage_hired
+        applicant2.stage_id = stage_hired
+
+        action1 = applicant1.create_employee_from_applicant()
+        employee1 = self.env['hr.employee'].browse(action1['res_id'])
+        self.assertEqual(employee1.work_email, applicant1.email_from, 'Employee email should be the same as applicant email')
+
+        action2 = applicant2.create_employee_from_applicant()
+        employee2 = self.env['hr.employee'].browse(action2['res_id'])
+        self.assertFalse(employee2.work_email, 'Employee email should be False when applicant email is not set')


### PR DESCRIPTION
### Steps to Reproduce:
- Create an applicant (with or without an email address).
- Move the applicant to the *Hired* stage.
- Create an employee from the applicant.
- The employee’s work email is automatically being set to the company email.

### Fix:
- Explicitly set work_email to False.
- work_email=False is required as we have this compute method:
  https://github.com/odoo/odoo/blob/d84196003012d68b63b8a1564deb43e43c9ebd68/addons/hr/models/hr_employee_base.py#L200-L204
  here work_email and partner's email is being sync.

Task: 6124112

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
