### PR TITLE
[FIX] web: form: border color for required fields

### DIFF
--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -3,16 +3,12 @@
 .o_form_view {
     @include media-breakpoint-down(md) {
         --field-spacing-unit: 8px;
-        --o-box-border-size: 1px;
+        --o-field-box-border-color: var(--gray-200);
 
         %-o-field-box {
             border-radius: calc(.5 * var(--field-spacing-unit));
-            border: var(--o-box-border-size) solid var(--o-input-border-color);
+            border: 1px solid var(--o-field-box-border-color);
             padding: var(--field-spacing-unit) calc(1.5 * var(--field-spacing-unit));
-
-            &:focus-within {
-                @include print-variable(o-input-border-color, $o-action);
-            }
 
             .o_input {
                 border-width: 0;
@@ -22,21 +18,24 @@
                 all: unset;
             }
 
-            &:has(.o_required_modifier:not(.o_readonly_modifier)) {
-                --o-box-border-size: 2px;
-            }
+            &:focus-within {
+                --o-field-box-border-color: #{$o-action};
 
-            &:has(.o_field_widget.o_readonly_modifier):not(:has(.o_field_widget:not(.o_readonly_modifier))) {
-                background: rgba($body-color, .04);
             }
-
+            &:has(.o_required_modifier) {
+                --o-field-box-border-color: var(--gray-400);
+            }
             &:has(.o_field_invalid) {
-                --o-input-border-color: #{o-text-color('danger')};
+                --o-field-box-border-color: #{o-text-color('danger')};
                 background: #{$o-input-invalid-bg};
 
                 .o_field_invalid {
                     --o-input-background-color: transparent;
                 }
+            }
+            &:has(.o_field_widget.o_readonly_modifier):not(:has(.o_field_widget:not(.o_readonly_modifier))) {
+                --o-field-box-border-color: var(--gray-200);
+                background: rgba($body-color, .04);
             }
         }
 
@@ -92,7 +91,7 @@
                 }
 
                 &:has(+ * .o_required_modifier:not(.o_readonly_modifier)) {
-                    --o-box-border-size: 2px;
+                    --o-field-box-border-color: var(--gray-400);
                 }
 
                 &:has(+ *:focus-within) .o_form_label {


### PR DESCRIPTION
This commit fixes the input border color for required fields on small screens.

The border width is now consistent, while the border color differs depending on whether the field is readonly, required, or invalid.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
