### PR TITLE
[FIX] l10n_be: allow switch of fiscal localization of a Belgium company

### DIFF
--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -76,6 +76,23 @@ class AccountChartTemplate(models.AbstractModel):
         be_account = self.with_company(company).ref('a6560', raise_if_not_found=False)
         return be_account or super()._get_bank_fees_reco_account(company)
 
+    def _load(self, template_code, company, install_demo, force_create=True):
+        if template_code in ('be_comp', 'be_asso'):
+            self.env['account.cash.rounding'].search([
+                ('company_id', '=', company.id),
+                ('name', '=', 'Round to 0.05'),
+            ]).write({
+                'profit_account_id': False,
+                'loss_account_id': False,
+            })
+
+        return super()._load(
+            template_code,
+            company,
+            install_demo,
+            force_create=force_create,
+        )
+
     def _post_load_data(self, template_code, company, template_data):
         super()._post_load_data(template_code, company, template_data)
         if template_code in ('be_comp', 'be_asso') and \


### PR DESCRIPTION
### Issue before this commit:
Switching the fiscal localization of a Belgian company from "Companies" to "Associations and Foundations" caused a traceback during the chart reload process. The operation failed because some accounts from the previous localization could not be deleted.

### Steps to reproduce the issue:
1. Download Accounting
2. Create a new Belgian company
3. Switch to that company
4. Go into Settings -> Fiscal Localization
5. Switch to Associations and Foundations
6. Traceback: The operation cannot be completed: Another model is using the record you are trying to delete. The troublemaker is: 'Account Cash Rounding' (account.cash.rounding). Thanks to the following constraint: 'Profit Account' (profit_account_id). How about archiving the record instead?

### Cause of the issue:
The Belgian localization creates a default cash rounding method ("Round to 0.05") linked to specific profit and loss accounts. When switching localization, it was tried to delete the old chart of accounts, but these accounts are still referenced by account.cash.rounding through profit_account_id and loss_account_id, which use ondelete='restrict'. This prevents account deletion and blocks the localization change. Commit that caused the issue: https://github.com/odoo/odoo/commit/412fc9bed36645dd950c9a60d9b6ffdd9b4bce67

### Reason to introduce the fix:
Before reloading the Belgian chart template, the fix clears the profit_account_id and loss_account_id on the existing cash rounding records. This removes the blocking references, allows the old accounts to be deleted safely, and lets the fiscal localization switch complete successfully without affecting existing cash rounding configurations.

opw-6050537

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
