### PR TITLE
[FIX] *: Keep mo quantity when a quality check failed

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -136,7 +136,7 @@ class StockMove(models.Model):
         subcontract order to the new quantity.
         """
         self._check_access_if_subcontractor(values)
-        if 'product_uom_qty' in values and self.env.context.get('cancel_backorder') is not False and not self._context.get('extra_move_mode'):
+        if 'product_uom_qty' in values and self.env.context.get('cancel_backorder') is not False and not self._context.get('extra_move_mode') and not self.env.context.get('do_not_unreserve'):
             self.filtered(
                 lambda m: m.is_subcontract and m.state not in ['draft', 'cancel', 'done']
                 and float_compare(m.product_uom_qty, values['product_uom_qty'], precision_rounding=m.product_uom.rounding) != 0
@@ -327,12 +327,8 @@ class StockMove(models.Model):
                 'product_qty': wip_production.product_qty + quantity_to_remove
             }).change_prod_qty()
 
-        productions = productions - wip_production
-        if self.env.context.get('failed_quality'):
-            productions = productions.sorted(lambda p: (p.lot_producing_id.id != self.env.context.get('failed_lot_id'), not p.subcontracting_has_been_recorded))
-
         # Cancel productions until reach new_quantity
-        for production in productions:
+        for production in (productions - wip_production):
             if float_compare(quantity_to_remove, production.product_qty, precision_rounding=production.product_uom_id.rounding) >= 0:
                 if len(productions + wip_production) == 1:
                     production.qty_producing = 0


### PR DESCRIPTION
*:mrp_subcontracting{,_quality}, quality_control
**Issue**:
In subcontracting, if a quality check of type quantity failed, the associated mo quantity produced is reduced. This is an issue since it will, by extension, reduce the consumption of the component. Therefore, the stock of the component become incorrect.

**Steps to reproduce**:
- Create two tracked products (final and component)
- Create a BoM for the final product using the component (1:1 ratio), with subcontracting
- Create a quality check for that product:
	- Control per quantity
	- Operations type: receipts
- Create a PO for the final product:
	- With a quantity of 10
	- With the associated partner be the one mentioned in the subcontracting BOM
	- Confirm it
- Open the associated receipt
- Perform the quality check and fail 4 products
- Validate the receipt by creating a backorder
- Confirm the backorder
- Check move history -> The move associated to the component will have a quantity of 6 instead of 10.

**Cause**:
While failing a quality check:
https://github.com/odoo/enterprise/blob/8cd7fffde3c9e73fa95080a82c5750d1a74370cb/quality_mrp/models/quality.py#L56 https://github.com/odoo/enterprise/blob/8cd7fffde3c9e73fa95080a82c5750d1a74370cb/quality_control/models/quality.py#L471

The `product_uom_qty` of the move of the po will be reduced. Therefore, the subcontracting mo quantity is reduced too: https://github.com/odoo/odoo/blob/ca01e606928a7704c6b2e4f430710f895be2653d/addons/mrp_subcontracting/models/stock_move.py#L140-L143 https://github.com/odoo/odoo/blob/ca01e606928a7704c6b2e4f430710f895be2653d/addons/mrp_subcontracting/models/stock_move.py#L116-L119

And ultimately reduces the raw move quantity:
https://github.com/odoo/odoo/blob/ca01e606928a7704c6b2e4f430710f895be2653d/addons/mrp/wizard/change_production_qty.py#L65

**Additional note**:
This commit also reverts the fix of 05ebbc27e37eaeff13dd0af2a8cdd7fa28209595 since it ensured the correct production was reduced. However, this commit ensures that production is not reduced at all, making the previous fix obsolete.

opw-5427873
