### PR TITLE
[PERF] mail: optimize complexity of messages grouping

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -11,6 +11,7 @@ from odoo import _, api, Command, fields, models, modules, tools
 from odoo.exceptions import AccessError, MissingError
 from odoo.osv import expression
 from odoo.tools import clean_context, groupby as tools_groupby, SQL
+from odoo.tools.misc import OrderedSet
 
 _logger = logging.getLogger(__name__)
 _image_dataurl = re.compile(r'(data:image/[a-z]+?);base64,([a-z0-9+/\n]{3,}=*)\n*([\'"])(?: data-filename="([^"]*)")?', re.I)
@@ -354,16 +355,17 @@ class Message(models.Model):
         allowed, based on '_get_mail_message_access' behavior and potential
         model override. """
         DocumentModel = self.env[doc_model].with_context(active_test=False).with_prefetch(doc_res_ids)
-        documents_per_operation = defaultdict(self.env[doc_model].browse)
+        documents_ids_per_operation = defaultdict(OrderedSet)
         for document in DocumentModel.browse(doc_res_ids):
             if hasattr(document, '_get_mail_message_access'):
                 doc_operation = DocumentModel._get_mail_message_access(document.ids, operation)  # why not giving model here?
             else:
                 doc_operation = self.env['mail.thread']._get_mail_message_access(document.ids, operation, model_name=document._name)
-            documents_per_operation[doc_operation] |= document
+            documents_ids_per_operation[doc_operation].add(document.id)
 
         allowed = self.env[doc_model]
-        for record_operation, records in documents_per_operation.items():
+        for record_operation, documents_ids in documents_ids_per_operation.items():
+            records = self.env[doc_model].browse(documents_ids)
             operation_allowed = records.check_access_rights(record_operation, raise_exception=False)
             if operation_allowed:
                 filter_method = records._filter_access_rules_python if filter_python else records._filter_access_rules

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -354,16 +354,17 @@ class Message(models.Model):
         allowed, based on '_get_mail_message_access' behavior and potential
         model override. """
         DocumentModel = self.env[doc_model].with_context(active_test=False).with_prefetch(doc_res_ids)
-        documents_per_operation = defaultdict(self.env[doc_model].browse)
+        documents_ids_per_operation = defaultdict(list)
         for document in DocumentModel.browse(doc_res_ids):
             if hasattr(document, '_get_mail_message_access'):
                 doc_operation = DocumentModel._get_mail_message_access(document.ids, operation)  # why not giving model here?
             else:
                 doc_operation = self.env['mail.thread']._get_mail_message_access(document.ids, operation, model_name=document._name)
-            documents_per_operation[doc_operation] |= document
+            documents_ids_per_operation[doc_operation].append(document.id)
 
         allowed = self.env[doc_model]
-        for record_operation, records in documents_per_operation.items():
+        for record_operation, documents_ids in documents_ids_per_operation.items():
+            records = DocumentModel.browse(documents_ids)
             operation_allowed = records.check_access_rights(record_operation, raise_exception=False)
             if operation_allowed:
                 filter_method = records._filter_access_rules_python if filter_python else records._filter_access_rules


### PR DESCRIPTION
## The Problem
When grouping messages, the code was accumulating recordsets using the `|=` union operator inside a loop. Since each union call internally builds an `OrderedSet` over all previously accumulated IDs, the performance degraded quadratically relative to the number of document records. This caused bottlenecks on databases with large message volumes.

## The Solution
* Replaced the `|=` recordset accumulation with a plain Python dictionary of ordered sets to store IDs per operation, while keeping same behavior.
* Deferred the `browse()` call until after the loop is complete.
* Reduced the overall complexity from **$O(N^2)$** to **$O(N)$**.

---

## Benchmarks
*Tested on a customer database grouping by "Created By" and "Created On":*

| Record Count | Before | After | Improvement |
| :--- | :--- | :--- | :--- |
| **300k records** | 83.00s | **1.00s** | **-99%** |
| **30k records** | 0.60s | 0.25s | (Minor) |

**Note:** The performance gains become exponentially more significant as the record count grows.

**OPW-6123758**