### PR TITLE
[FIX] tests: update current_test on retry

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -870,7 +870,7 @@ class BaseCase(case.TestCase):
 
     def assertCanOpenTestCursor(self):
         """ Asserts that we can currently open a test cursor. """
-        if odoo.modules.module.current_test != self:
+        if odoo.modules.module.current_test is not self:
             message = f"Trying to open a test cursor for {self.canonical_tag} while already in a test {odoo.modules.module.current_test.canonical_tag}"
             _logger.runbot(message)
             raise BadRequest(message)

--- a/odoo/tests/suite.py
+++ b/odoo/tests/suite.py
@@ -67,6 +67,7 @@ class TestSuite(BaseTestSuite):
                         if not (result.had_failure or quiet_log.had_error_log):
                             break
                         test = test.__class__(test._testMethodName)  # re-create the test to reset its state
+                        odoo.modules.module.current_test = test
                     else:  # last try
                         test(result)
                         if not result.wasSuccessful() and default_tests_run_count != 1:


### PR DESCRIPTION
When a test is retried, the current_test variable was not updated to the new test instance, which could lead to issues when opening a test cursor. This commit ensures that current_test is updated on each retry attempt.

While there update the condition to have a stronger check in this specific case since test equality only uses test name