### PR TITLE
[FIX] account,purchase: make purchase move view work with old version

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -636,6 +636,7 @@ class AccountMove(models.Model):
         check_company=True,
         help="Auto-complete from a previous bill or refund.",
     )
+    show_invoice_vendor_bill = fields.Boolean(compute="_compute_show_invoice_vendor_bill")
     invoice_source_email = fields.Char(string='Source Email', tracking=True)
     invoice_partner_display_name = fields.Char(compute='_compute_invoice_partner_display_info', store=True)
     is_manually_modified = fields.Boolean()
@@ -1912,6 +1913,11 @@ class AccountMove(models.Model):
     def _compute_need_cancel_request(self):
         for move in self:
             move.need_cancel_request = move._need_cancel_request()
+
+    @api.depends('state', 'move_type')
+    def _compute_show_invoice_vendor_bill(self):
+        for move in self:
+            move.show_invoice_vendor_bill = move.state == 'draft' and move.move_type in ('in_invoice', 'in_refund')
 
     @api.depends('partner_id', 'invoice_source_email', 'partner_id.display_name')
     def _compute_invoice_partner_display_info(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1099,7 +1099,7 @@
                                 <field name="invoice_vendor_bill_id"
                                        string="Auto-Complete"
                                        class="oe_edit_only"
-                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"
+                                       invisible="not show_invoice_vendor_bill"
                                        domain="([('partner_id', 'child_of', [partner_id])] if partner_id else []) + [
                                            ('company_id', '=', company_id),
                                            ('move_type', '=', move_type)

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -162,6 +162,14 @@ class AccountMove(models.Model):
                     warnings.add(product.display_name + ' - ' + product_msg)
             move.purchase_warning_text = '\n'.join(warnings)
 
+    @api.depends_context('uid')
+    def _compute_show_invoice_vendor_bill(self):
+        super()._compute_show_invoice_vendor_bill()
+        # If the user doesn't have purchase access, `invoice_vendor_bill_id` is displayed,
+        # as the user doesn't have access to `purchase_vendor_bill_id`.
+        for move in self:
+            move.show_invoice_vendor_bill &= not self.env.user.has_group('purchase.group_purchase_user')
+
     def action_purchase_matching(self):
         self.ensure_one()
         return {

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <!-- Auto-complete could be done from either a bill either a purchase order -->
-            <field name="invoice_vendor_bill_id" position="after">
+            <field name="tax_cash_basis_origin_move_id" position="after">
                 <t groups="purchase.group_purchase_user">
                     <field name="purchase_id" invisible="1" readonly="state != 'draft'"/>
                     <field name="purchase_vendor_bill_id"
@@ -19,9 +19,6 @@
                         context="{'show_total_amount': True}"
                         options="{'no_create': True, 'no_open': True}"/>
                 </t>
-            </field>
-            <field name="invoice_vendor_bill_id" position="attributes">
-                <attribute name="groups">!purchase.group_purchase_user</attribute>
             </field>
             <!-- Add link to purchase_line_id to account.move.line -->
             <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='company_id']" position="after">


### PR DESCRIPTION
c5ac4867fb708c56aa74e38508347660f1875dd3 added back the computed fields `invoice_vendor_bill_id` and `purchase_vendor_bill_id` on `account.move` in stable.

The issue is that the view on purchase expects the view on account to have `invoice_vendor_bill_id` in it.
But if a user already had `account` installed before the commit, then install `purchase` after, the purchase view will raise an exception as it expects `invoice_vendor_bill_id` in the view of account.

The fix here is to not reference `invoice_vendor_bill_id` in the purchase view and compute its visibility with a non-stored computed field.