### PR TITLE
[FIX] microsoft_calendar: use correct timezone when syncing events to Outlook

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -525,11 +525,15 @@ class CalendarEvent(models.Model):
 
         if any(x in fields_to_sync for x in ['allday', 'start', 'date_end', 'stop']):
             if self.allday:
-                start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
-                end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
+                start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'UTC'}
+                end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'UTC'}
             else:
-                start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-                end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+                user_tz = self.user_id.tz or self.env.user.tz or 'UTC'
+                tz = pytz.timezone(user_tz)
+                start_local = pytz.utc.localize(self.start).astimezone(tz)
+                stop_local = pytz.utc.localize(self.stop).astimezone(tz)
+                start = {'dateTime': start_local.strftime('%Y-%m-%dT%H:%M:%S'), 'timeZone': user_tz}
+                end = {'dateTime': stop_local.strftime('%Y-%m-%dT%H:%M:%S'), 'timeZone': user_tz}
 
             values['start'] = start
             values['end'] = end
@@ -663,11 +667,15 @@ class CalendarEvent(models.Model):
         values['type'] = 'occurrence'
 
         if self.allday:
-            start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
-            end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
+            start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'UTC'}
+            end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'UTC'}
         else:
-            start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-            end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+            user_tz = self.user_id.tz or self.env.user.tz or 'UTC'
+            tz = pytz.timezone(user_tz)
+            start_local = pytz.utc.localize(self.start).astimezone(tz)
+            stop_local = pytz.utc.localize(self.stop).astimezone(tz)
+            start = {'dateTime': start_local.strftime('%Y-%m-%dT%H:%M:%S'), 'timeZone': user_tz}
+            end = {'dateTime': stop_local.strftime('%Y-%m-%dT%H:%M:%S'), 'timeZone': user_tz}
 
         values['start'] = start
         values['end'] = end

--- a/doc/cla/individual/qde-code.md
+++ b/doc/cla/individual/qde-code.md
@@ -1,0 +1,11 @@
+Belgium, 2026-04-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Quentin DELRÉE 88387774+qde-code@users.noreply.github.com https://github.com/qde-code


### PR DESCRIPTION
## Summary

When syncing calendar events from Odoo to Microsoft Outlook, the `_microsoft_values` and `_microsoft_values_occurence` methods send UTC datetimes (with `+00:00` offset) but label them with `Europe/London` as the timezone.

During DST periods (March-October), `Europe/London` becomes BST (`UTC+1`), creating an inconsistency between the offset and the timezone label. Microsoft Graph API then displays the events in **UTC** instead of converting them to the user's local timezone.

**Example:** An event at 16:00 Brussels time (14:00 UTC) appears as 14:00 UTC in Outlook instead of 16:00 Brussels.

## Fix

- For **timed events**: convert the UTC datetime to the event owner's timezone and send it without an offset, letting the `timeZone` field correctly identify the timezone
- For **all-day events**: use `UTC` as the timezone label since only dates are involved (no DST ambiguity)

## Steps to reproduce

1. Set user timezone to `Europe/Brussels` (or any non-UTC timezone)
2. Create a calendar event in Odoo at e.g. 16:00
3. Wait for Microsoft Calendar sync
4. Open the event in Outlook
5. **Expected:** Event shows 16:00 in user's timezone
6. **Actual:** Event shows 14:00 in UTC

## Affected methods

- `_microsoft_values()` in `addons/microsoft_calendar/models/calendar.py` (lines 528-532)
- `_microsoft_values_occurence()` in `addons/microsoft_calendar/models/calendar.py` (lines 666-670)