### PR TITLE
[FIX] account_edi_proxy_client: Fix errors display when creating new user.

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -192,7 +192,7 @@ class AccountEdiProxyClientUser(models.Model):
             except AccountEdiProxyError as e:
                 raise UserError(e.message)
             if 'error' in response:
-                raise UserError(response['error'])
+                raise UserError(response['error']['subject'])
 
         return self.create({
             'id_client': response['id_client'],


### PR DESCRIPTION
Bug reason : We were attempting to display the whole error python dict as a string.
This commit fixes this bug by displaying the readable error value instead of the whole python dict.

task-6139095

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
