### PR TITLE
[FIX] hr_holidays : Remove approving multiple times in multi_allocations

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -115,14 +115,13 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
                 mail_notify_force_send=False,
                 mail_activity_automation_skip=True,
             ).create(vals_list)
-            allocations.filtered(lambda c: c.validation_type not in ('no_validation', 'hr')).action_approve()
             accrual_allocations = allocations.filtered(lambda a: a.allocation_type == 'accrual')
             for date_to, allocation in accrual_allocations.grouped('date_to').items():
                 date_to = min(date_to, date.today()) if date_to else False
                 allocation._process_accrual_plans(date_to)
+            allocations.filtered(lambda c: c.validation_type not in ('no_validation', 'hr')).action_approve()
             if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
                 allocations.filtered(lambda c: c.validation_type == 'hr').action_approve()
-            allocations.filtered(lambda c: c.validation_type != 'no_validation').action_approve()
 
             return {
                 'type': 'ir.actions.act_window',


### PR DESCRIPTION
Cause:
In this commit https://github.com/odoo/odoo/pull/258520/changes/1b6f3a1335302ca029ab62a25c7bcff0953b99be we accidently added a line to approve allocation which might already be approved.

Fix:
Remove this line and move the accrual filter right before the first action approve

opw-5888023