### PR TITLE
[FIX] l10n_ar: special hiden characters

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -113,15 +113,11 @@ class ResPartner(models.Model):
                 raise ValidationError(repr(error))
 
     def _get_id_number_sanitize(self):
-        """ Sanitize the identification number. Return the digits/integer value of the identification number
-        If not vat number defined return 0 """
+        """Sanitize the identification number. Return the digits/integer value of the identification number
+        If not vat number defined return 0"""
         self.ensure_one()
         if not self.vat:
             return 0
-        if self.l10n_latam_identification_type_id.l10n_ar_afip_code in ['80', '86']:
-            # Compact is the number clean up, remove all separators leave only digits
-            res = int(stdnum.ar.cuit.compact(self.vat))
-        else:
-            id_number = re.sub('[^0-9]', '', self.vat)
-            res = id_number and int(id_number)
+        id_number = re.sub("[^0-9]", "", self.vat)
+        res = id_number and int(id_number)
         return res


### PR DESCRIPTION
Avoid traceback when there is special hidden characters on the VAT numer, compact() method from stdnum does not process it.

We use regex to get only the number part for all the doc types

### Description of the issue/feature this PR addresses:

1. Create new contact
2. add cuit value (in the vat field). This one is copy from an external program with special hidden characteres

### Current behavior before PR:

There is a traceback and the user can not create the contact

```
Traceback (most recent call last):
...
File "/home/odoo/src/odoo/addons/l10n_ar/models/res_partner.py", line 123, in _get_id_number_sanitize
res = int(stdnum.ar.cuit.compact(self.vat))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '\u206030717808599'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
RPC_ERROR
at makeErrorFromResponse (https://brunetti.adhoc.ar/web/assets/1/debug/web.assets_web.js:30061:19)
at XMLHttpRequest.<anonymous> (https://brunetti.adhoc.ar/web/assets/1/debug/web.assets_web.js:30124:27)
```
### Desired behavior after PR is merged:

Will let us to create the contact and validate the cuit no matter if it has or not an special character



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
