### PR TITLE
[FIX] account: parent in company domain of account.payment.method.line

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -96,6 +96,7 @@ class AccountPaymentMethodLine(models.Model):
     _name = 'account.payment.method.line'
     _description = "Payment Methods"
     _order = 'sequence, id'
+    _check_company_domain = models.check_company_domain_parent_of
 
     # == Business fields ==
     name = fields.Char(compute='_compute_name', readonly=False, store=True)

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1542,12 +1542,12 @@
                                         <field name="secured" groups="account.group_account_secured,base.group_no_one"/>
                                         <field name="preferred_payment_method_line_id"
                                                string="Payment Method"
-                                               domain="[('payment_type', '=', 'inbound'), ('company_id', '=', company_id)]"
+                                               domain="[('payment_type', '=', 'inbound'), ('company_id', 'parent_of', company_id)]"
                                                invisible="move_type in ('in_invoice', 'in_refund', 'in_receipt')"
                                         />
                                         <field name="preferred_payment_method_line_id"
                                                string="Payment Method"
-                                               domain="[('payment_type', '=', 'outbound'), ('company_id', '=', company_id)]"
+                                               domain="[('payment_type', '=', 'outbound'), ('company_id', 'parent_of', company_id)]"
                                                invisible="move_type in ('out_invoice', 'out_refund', 'out_receipt')"
                                         />
                                         <field name="invoice_cash_rounding_id" groups="account.group_cash_rounding" readonly="state != 'draft'"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Contacts and Accounting
- Create a branch company
- Switch to the branch company

**Issue:**
In the partner form, "Payment Method" field doesn't propose the methods coming from the parent company.
Same issue on the account move form.
However, in the payment wizard opened from an invoice, the payment methods from the parent company are available.
The behavior should be consistent.
The payment methods from the parent company should be available from a branch company

opw-6001573




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
