### PR TITLE
[FIX] account_edi_ubl_cii: fix test ensure_installed module

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_invoice_be_down_payment.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_invoice_be_down_payment.py
@@ -13,6 +13,8 @@ class TestUblExportBis3InvoiceBEDownPayment(TestUblExportBis3BE):
 
     @classmethod
     def get_default_groups(cls):
+        # This runs during the super.setUpClass() call, we didn't make sure (yet) that the module exists.
+        cls.ensure_installed('sale')
         groups = super().get_default_groups()
         return groups | cls.env.ref('sales_team.group_sale_manager')
 


### PR DESCRIPTION
The `get_default_groups` call happens during super.setUpClass(), therefore we have not checked (yet) if the module in which the security group is in is installed, and we end up with an Exception.

task-none