### PR TITLE
[FIX] mail: filter VOIP-only presence test fields

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2030,6 +2030,7 @@ class MailCommon(MailCase):
         if "has_active_call" not in self.env["res.users"]._fields:
             for data in users_data:
                 data.pop("has_active_call", None)
+                data.pop("should_display_in_call_im_status", None)
         return list(users_data)
 
     def _filter_threads_fields(self, /, *threads_data):

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -74,17 +74,15 @@ class TestMailPresence(WebsocketCase, MailCommon):
     def test_manual_im_status(self):
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
         session = self.authenticate(bob.login, bob.login)
-        expected_payload = {}
-        if "has_active_call" in self.env["res.users"]._fields:
-            expected_payload["res.users"] = [
+        expected_payload = {
+            "res.users": self._filter_users_fields(
                 {
                     "should_display_in_call_im_status": False,
                     "id": bob.id,
                     "im_status": "offline",
                 },
-            ]
-        else:
-            expected_payload["res.users"] = [{"id": bob.id, "im_status": "offline"}]
+            ),
+        }
 
         with self.assertBus(
             BusResult((bob, "presence"), "mail.record/insert", expected_payload),


### PR DESCRIPTION
Commit [1] added expected `should_display_in_call_im_status` values to shared mail test payloads, but this field is only provided by enterprise VOIP through `has_active_call`.

Strip that VOIP-only field from community expectations when `has_active_call` is unavailable, and reuse the common user-field filter for the manual IM status test payload.

[1]: https://github.com/odoo/odoo/commit/600b50cc26fd4c516a0f3dcdb9a1df846dc4f56a

runbot-242689
