### PR TITLE
[FIX] mail: non deterministic channel member test

### DIFF
--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -208,7 +208,6 @@ test("should show a button to load more members if they are not all loaded", asy
 });
 
 test("Load more button should load more members", async () => {
-    // Test assumes at most 100 members are loaded at once.
     const pyEnv = await startServer();
     const channel_member_ids = [];
     for (let i = 0; i < 101; i++) {
@@ -219,10 +218,10 @@ test("Load more button should load more members", async () => {
         name: "TestChannel",
         channel_type: "channel",
     });
+    pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-ChannelMember");
-    pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
+    await contains(".o-discuss-ChannelMember", { count: 101 });
     await click(
         ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) [title='Load more']"
     );


### PR DESCRIPTION
Before this commit, the `Load more button should load more members` test was sometimes failing. When the click on the "load more" button happens before the initial fetch of the members, the last member is not loaded.

fixes runbot-242684

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
