### PR TITLE
[FIX] web: input border color for required field

### DIFF
--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -28,7 +28,7 @@
     @include print-variable(o-caret-color, $input-color);
 }
 
-.o_required_modifier:not(:focus-within, :hover) {
+.o_required_modifier {
     @include print-variable(o-input-border-color, $o-input-border-required);
     @include print-variable(o-caret-color, $o-input-border-required);
 }

--- a/addons/web/static/src/views/form/form_controller_m3.scss
+++ b/addons/web/static/src/views/form/form_controller_m3.scss
@@ -3,7 +3,7 @@
 .o_form_view {
     @include media-breakpoint-down(md) {
         --field-spacing-unit: 8px;
-        --o-field-box-border-color: var(--gray-200);
+        --o-field-box-border-color: var(--o-input-border-color);
 
         %-o-field-box {
             border-radius: calc(.5 * var(--field-spacing-unit));
@@ -34,7 +34,7 @@
                 }
             }
             &:has(.o_field_widget.o_readonly_modifier):not(:has(.o_field_widget:not(.o_readonly_modifier))) {
-                --o-field-box-border-color: var(--gray-200);
+                --o-field-box-border-color: var(--o-input-border-color);
                 background: rgba($body-color, .04);
             }
         }
@@ -117,7 +117,6 @@
                 display: contents;
 
                 .o_property_field_value {
-                    @include print-variable(o-input-border-color, $o-form-lightsecondary);
                     @extend %-o-field-box;
                     margin-bottom: map-get($spacers, 3);
                 }


### PR DESCRIPTION
Before this commit, hovering over the label changed the input border color to a darker shade, but hovering over the input field itself did not.

This inconsistency was caused by a missed revert from a previous "m3 input boxes" update.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
