### PR TITLE
[IMP] pos_mollie: remove blocking validation error

### DIFF
--- a/addons/pos_mollie/models/pos_payment_method.py
+++ b/addons/pos_mollie/models/pos_payment_method.py
@@ -1,4 +1,4 @@
-from odoo import fields, models, api, _
+from odoo import fields, models
 from odoo.exceptions import ValidationError
 from odoo.addons.payment_mollie import const
 
@@ -14,19 +14,11 @@ class PosPaymentMethod(models.Model):
     mollie_terminal_id = fields.Char("Mollie Terminal ID", copy=False)
     mollie_payment_provider_id = fields.Many2one("payment.provider", domain=[("code", "=", "mollie")])
 
-    @api.constrains('mollie_payment_provider_id')
-    def _check_mollie_payment_provider_id(self):
-        for payment_method in self:
-            if not payment_method.mollie_payment_provider_id:
-                continue
-            if not payment_method.mollie_payment_provider_id.mollie_api_key:
-                raise ValidationError(_(
-                    'Please set the Mollie API Key field on the %s payment provider.',
-                    payment_method.mollie_payment_provider_id.name
-                ))
-
     def mollie_create_payment(self, amount: float, payment_uuid: str, pos_session_id: int):
         self.ensure_one()
+
+        if not self.mollie_payment_provider_id.mollie_api_key:
+            raise ValidationError(self.env._("Please set the API key on the Mollie payment provider before making a payment."))
 
         user_lang = self.env.context.get("lang")
         currency = self.journal_id.currency_id or self.company_id.currency_id


### PR DESCRIPTION
Before this commit, when configuring the Mollie payment method in POS, a validation error would be raised if the associated payment provider did not have the API key set. While this makes sense given that it needs to be set in order for payments to work, it resulted in this unintuitive UX:

1. User fills in all the fields in the Mollie POS payment method form.
2. The user tries to save, but hits the validation error.
3. The user uses the internal link to go to the payment provider and fill in the API key.
4. The user returns to the POS payment method form, but because the form couldn't save they have to fill in everything *again*.

This commit removes the validation error, allowing everything to be filled in just once. There will still be an error if trying to make a payment without an API key set.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
