### PR TITLE
[FIX] web: Dont fully skip action button with no names

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1463,7 +1463,7 @@ export function makeActionManager(env, router = _router) {
      * @returns {Promise<void>}
      */
     async function doActionButton(params, { isEmbeddedAction, newWindow } = {}) {
-        if (!params.name) {
+        if (!params.name && !params.special) {
             return;
         }
         // determine the action to execute according to the params

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -463,3 +463,35 @@ test("test home client action", async () => {
     await animationFrame();
     expect.verifySteps(["/web/webclient/version_info", "assign /"]);
 });
+
+test("discarded dialogs has special=true in onClose params", async () => {
+    Partner._views = {
+        form: /* xml */ `
+            <form>
+                <footer>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        `,
+    };
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(
+        {
+            name: "Partners",
+            res_model: "partner",
+            views: [[false, "form"]],
+            target: "new",
+            type: "ir.actions.act_window",
+        },
+        {
+            onClose: (params) => {
+                expect.step(`special:${params?.special}`);
+            },
+        }
+    );
+
+    await contains(".modal footer .btn[special=cancel]").click();
+    expect(".modal .test_client_action").toHaveCount(0);
+    expect.verifySteps(["special:true"]);
+});


### PR DESCRIPTION
View buttons with no name cause onClosed to be called without any parameters even if special=true or dismiss=true.

This commit fixes that which allows to know if a close/discard button caused the action onClosed callback.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
