### PR TITLE
[FIX] orm: ordered query ids with where_clause

### DIFF
--- a/odoo/addons/base/tests/test_query.py
+++ b/odoo/addons/base/tests/test_query.py
@@ -65,6 +65,7 @@ class QueryTestCase(BaseCase):
         self.assertEqual(query.get_result_ids(), ())
         self.assertTrue(query.is_empty())
         self.assertIn('SELECT', query.subselect()._sql_tuple[0], "subselect must contain SELECT")
+        self.assertTrue(query.where_clause, "we have a restriction")
 
         query.add_where(SQL("x > 0"))
         self.assertTrue(query.is_empty(), "adding where clauses keeps the result empty")
@@ -74,6 +75,7 @@ class QueryTestCase(BaseCase):
         query.set_result_ids([1, 2, 3])
         self.assertEqual(query.get_result_ids(), (1, 2, 3))
         self.assertFalse(query.is_empty())
+        self.assertTrue(query.where_clause, "we have a restriction")
 
         query.add_where(SQL("x > 0"))
         self.assertIsNone(query._ids, "adding where clause resets the ids")

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -253,6 +253,7 @@ class Query:
             #   FROM "stuff"
             #   JOIN (SELECT * FROM unnest(%s) WITH ORDINALITY) AS "stuff__ids"
             #       ON ("stuff"."id" = "stuff__ids"."unnest")
+            #   WHERE 1=1  -- some code uses the fact there is a WHERE to detect restrictions
             #   ORDER BY "stuff__ids"."ordinality"
             table = self.table
             alias = table._make_alias('ids')
@@ -262,6 +263,7 @@ class Query:
                 SQL('(SELECT * FROM unnest(%s) WITH ORDINALITY)', list(ids)),
                 SQL('%s = %s', table.id, alias.unnest),
             )
+            self._where_clauses.append(SQL('1=1'))
             self.order = alias.ordinality
         else:
             self.add_where(SQL("%s IN %s", self.table.id, ids))


### PR DESCRIPTION
Some code uses `if query.where_clause` to detect if there are any restrictions on the table. When setting ordered result ids, we simply used a JOIN, so there is no detected where clause. To keep existing code working, we add a dummy 1=1 to the where clause.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
