### PR TITLE
[IMP] point_of_sale, pos_self_order: improve real-time order sync and stability

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -232,8 +232,9 @@ class PosConfig(models.Model):
         static_records = {}
 
         for model, ids in records.items():
-            records = self.env[model].browse(ids).exists()
-            static_records[model] = self.env[model]._load_pos_data_read(records, self)
+            record_set = self.env[model].browse(ids).exists()
+            if record_set:
+                static_records[model] = self.env[model]._load_pos_data_read(record_set, self)
 
         self._notify('SYNCHRONISATION', {
             'static_records': static_records,

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1196,6 +1196,14 @@ class PosOrder(models.Model):
     def _get_order_log_representation(order):
         return dict((k, order.get(k)) for k in ("name", "uuid"))
 
+    def _get_sync_records(self):
+            return {
+            'pos.order': self.ids,
+            'pos.order.line': self.lines.ids,
+            'pos.payment': self.payment_ids.ids,
+            'product.attribute.custom.value': self.lines.custom_attribute_value_ids.ids,
+        }
+
     @api.model
     def sync_from_ui(self, orders):
         """ Create and update Orders from the frontend PoS application.
@@ -1245,10 +1253,12 @@ class PosOrder(models.Model):
         pos_order_ids = self.env['pos.order'].browse(order_ids)
         config = pos_order_ids.config_id[0] if pos_order_ids else False
 
-        for order in pos_order_ids:
-            order._ensure_access_token()
-            if not self.env.context.get('preparation'):
-                order.config_id.notify_synchronisation(order.config_id.current_session_id.id, self.env.context.get('device_identifier', 0))
+        for config, config_orders in pos_order_ids.grouped('config_id').items():
+            records = config_orders._get_sync_records()
+            for order in config_orders:
+                order._ensure_access_token()
+                if not self.env.context.get('preparation'):
+                    order.config_id.notify_synchronisation(order.config_id.current_session_id.id, self.env.context.get('device_identifier', 0), records=records)
 
         _logger.info("PoS synchronisation #%d finished", sync_token)
         return pos_order_ids.read_pos_data(orders, config)

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -62,6 +62,10 @@ export class PosOrder extends PosOrderAccounting {
         if (!this.config_id) {
             this.config_id = this.config;
         }
+
+        if (this.uiState) {
+            this.uiState.displayed = this.state !== "cancel" && this.uiState.displayed;
+        }
     }
 
     initState() {
@@ -71,7 +75,7 @@ export class PosOrder extends PosOrderAccounting {
             unmerge: {},
             lastPrints: [],
             lineToRefund: {},
-            displayed: this.state !== "cancel",
+            displayed: true,
             booked: false,
             screen_data: {},
             selected_orderline_uuid: undefined,

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -62,28 +62,46 @@ export default class DevicesSynchronisation {
      * @param {Object} data.static_records - Records data that need to be synchronized.
      */
     async collect(data) {
-        const { static_records, deleted_record_ids, session_id, device_identifier } = data;
-        const isSameDevice = isSamePosDevice(session_id, device_identifier, this.pos);
-
-        logPosMessage(
-            "Synchronisation",
-            "collect",
-            `Incoming synchronization from ${isSameDevice ? "this" : "another"} device`,
-            CONSOLE_COLOR
-        );
+        const {
+            static_records,
+            deleted_record_ids,
+            deleted_records,
+            session_id,
+            device_identifier,
+            login_number,
+        } = data;
+        const deviceId = device_identifier || login_number;
+        const isSameDevice = isSamePosDevice(session_id, deviceId, this.pos);
 
         if (isSameDevice) {
             return;
         }
 
-        if (Object.keys(static_records).length) {
-            this.processStaticRecords(static_records);
-        }
-        if (deleted_record_ids && Object.keys(deleted_record_ids).length) {
-            this.processDeletedRecords(deleted_record_ids);
+        // `static_records` contains fully read data objects — `records` only contains raw IDs.
+        const incomingRecords = static_records || {};
+        const incomingDeleted = { ...(deleted_record_ids || {}), ...(deleted_records || {}) };
+        const hasRecords = Object.keys(incomingRecords).length > 0;
+        const hasDeleted = Object.keys(incomingDeleted).length > 0;
+
+        if (!hasRecords && !hasDeleted) {
+            return await this.readDataFromServer();
         }
 
-        return await this.readDataFromServer();
+        if (hasRecords) {
+            const missing = await this.pos.data.missingRecursive(incomingRecords);
+            const { dynamicR, staticR } = this._sortRecordsByModelType(missing);
+
+            this._decorateOrderRecords(dynamicR["pos.order"]);
+
+            this.processStaticRecords(staticR);
+            await this.processDynamicRecords(dynamicR);
+        }
+
+        if (hasDeleted) {
+            this.processDeletedRecords(incomingDeleted);
+        }
+
+        await this._triggerUIRefresh();
     }
 
     /**
@@ -113,34 +131,18 @@ export default class DevicesSynchronisation {
 
         if (Object.keys(response.dynamic_records).length) {
             const missing = await this.pos.data.missingRecursive(response.dynamic_records);
-            const { dynamicR, staticR } = Object.entries(missing).reduce(
-                (acc, [model, records]) => {
-                    if (this.dynamicModels.has(model)) {
-                        acc.dynamicR[model] = records;
-                    } else if (this.staticModels.has(model)) {
-                        acc.staticR[model] = records;
-                    }
-                    return acc;
-                },
-                { dynamicR: {}, staticR: {} }
-            );
+            const { dynamicR, staticR } = this._sortRecordsByModelType(missing);
 
+            this._decorateOrderRecords(dynamicR["pos.order"]);
             this.processStaticRecords(staticR);
-            const res = await this.processDynamicRecords(dynamicR);
-            if (res && res["pos.order"].length > 0) {
-                const config = this.pos.config;
-                const session = this.pos.session;
-
-                for (const order of res["pos.order"]) {
-                    order.config_id = config;
-                    order.session_id = session;
-                }
-            }
+            await this.processDynamicRecords(dynamicR);
         }
 
         if (Object.keys(response.deleted_record_ids).length) {
             this.processDeletedRecords(response.deleted_record_ids);
         }
+
+        await this._triggerUIRefresh();
     }
 
     /**
@@ -169,7 +171,7 @@ export default class DevicesSynchronisation {
     processDeletedRecords(deletedRecords) {
         for (const [model, ids] of Object.entries(deletedRecords)) {
             const records = this.models[model].readMany(ids);
-            this.models[model].deleteMany(records.filter(Boolean), { silent: true });
+            this.models[model].deleteMany(records.filter(Boolean));
         }
     }
 
@@ -242,8 +244,54 @@ export default class DevicesSynchronisation {
 
         return { domain: domainByModel, recordIds: recordIdsByModel };
     }
+    /**
+     * Sort records into dynamic and static categories based on model type.
+     */
+    _sortRecordsByModelType(records) {
+        const dynamicR = {};
+        const staticR = {};
+
+        for (const [model, data] of Object.entries(records)) {
+            if (this.dynamicModels.has(model)) {
+                dynamicR[model] = data;
+            } else {
+                staticR[model] = data;
+            }
+        }
+
+        return { dynamicR, staticR };
+    }
+
+    /**
+     * Inject current session and config into order records so they
+     * are recognized by the Ticket Screen's filtering logic.
+     */
+    _decorateOrderRecords(orders) {
+        if (!orders?.length) {
+            return;
+        }
+        const { id: configId } = this.pos.config;
+        const { id: sessionId } = this.pos.session;
+        for (const order of orders) {
+            order.config_id = configId;
+            order.session_id = sessionId;
+        }
+    }
+
+    /**
+     * Toggle loading state to force Owl to re-render the UI.
+     */
+    async _triggerUIRefresh() {
+        this.pos.loadingOrderState = true;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        this.pos.loadingOrderState = false;
+    }
 }
 
 export function isSamePosDevice(session_id, device_identifier, posStore) {
-    return odoo.pos_session_id != session_id || device_identifier == posStore.device.identifier;
+    if (device_identifier === "0" || device_identifier === 0) {
+        return false;
+    }
+
+    return device_identifier === posStore.device.identifier;
 }

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -25,3 +25,8 @@ class PosOrder(models.Model):
         result = super().read_pos_data(data, config)
         result['restaurant.order.course'] = self.env['restaurant.order.course']._load_pos_data_read(self.course_ids, config)
         return result
+
+    def _get_sync_records(self):
+        records = super()._get_sync_records()
+        records['restaurant.order.course'] = self.course_ids.ids
+        return records

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -54,10 +54,26 @@ class PosOrder(models.Model):
         self._send_notification(self)
 
     def _send_notification(self, order_ids):
-        config_ids = order_ids.config_id
-        for config in config_ids:
-            config.notify_synchronisation(config.current_session_id.id, self.env.context.get('device_identifier', 0))
+        for config, orders in order_ids.grouped('config_id').items():
+            records = orders._get_sync_records()
+            # Remove empty lists from records to prevent backend crashes in `_load_pos_data_read`
+            records = {k: v for k, v in records.items() if v}
+
+            session_id = config.current_session_id.id
+            device_id = self.env.context.get('device_identifier', 0)
+
+            config.notify_synchronisation(session_id, device_id, records=records)
             config._notify('ORDER_STATE_CHANGED', {})
+
+            # Broadcast to all active restaurant POS in the same company for real-time Kiosk sync
+            restaurants = self.env['pos.config'].search([
+                ('company_id', '=', config.company_id.id),
+                ('module_pos_restaurant', '=', True),
+                ('id', '!=', config.id),
+                ('session_ids.state', '=', 'opened'),
+            ])
+            for resto in restaurants:
+                resto.notify_synchronisation(resto.current_session_id.id, 0, records)
 
     def _send_self_order_receipt(self):
         self.ensure_one()

--- a/addons/pos_stock/models/pos_order.py
+++ b/addons/pos_stock/models/pos_order.py
@@ -22,6 +22,11 @@ class PosOrder(models.Model):
         pos_data['pos.pack.operation.lot'] = self.env['pos.pack.operation.lot']._load_pos_data_read(self.lines.pack_lot_ids, config) if config else []
         return pos_data
 
+    def _get_sync_records(self):
+        records = super()._get_sync_records()
+        records['pos.pack.operation.lot'] = self.lines.pack_lot_ids.ids
+        return records
+
     def _create_order_picking(self):
         self.ensure_one()
         if self.picking_ids:


### PR DESCRIPTION
This update enhances the responsiveness and reliability of order synchronization between Kiosks and POS terminals.
Functional improvements:
- Instant synchronization: Removed artificial delays to ensure Kiosk orders appear on the ticket screen immediately upon validation.
- Enhanced stability: Fixed backend errors that could occur when syncing complex orders (e.g., products with serial numbers or multi-course meals).
- Optimized performance: Improved the way the system tracks active devices to maintain high speed, even in large installations with many points of sale.
- Modular reliability: Simplified the communication logic to ensure all order details are transmitted accurately between devices.

Task-ID: 6030785

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
