### PR TITLE
[FIX] website: failing auto hide menu tour

### DIFF
--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -1,3 +1,4 @@
+import { stepUtils } from "@web_tour/tour_utils";
 import {
     clickOnEditAndWaitEditMode,
     registerWebsitePreviewTour,
@@ -67,6 +68,7 @@ registerWebsitePreviewTour(
             content: "Check that modal has disappeared",
             trigger: "body:not(:has(.modal))",
         },
+        stepUtils.waitIframeIsReady(),
         {
             trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
         },


### PR DESCRIPTION
This commit fixes a non-deterministic problem of the tour by ensuring the iframe is ready before opening an edit mode.

runbot-240987
