### PR TITLE
[FIX] l10n_pl_edi: handles gross unit price on import

### DIFF
--- a/addons/l10n_pl_edi/models/account_move.py
+++ b/addons/l10n_pl_edi/models/account_move.py
@@ -479,16 +479,33 @@ class AccountMove(models.Model):
             currency_code = get_value(invoice_node, '{*}KodWaluty')
             move_line_nodes = invoice_node.findall("{*}FaWiersz")
 
-            lines = [
-                {
-                    'name': get_value(line_node, '{*}P_7') or '/',
-                    'uom_name': get_value(line_node, '{*}P_8A') or '',
-                    'quantity': float(get_value(line_node, '{*}P_8B') or 0.0),
-                    'price_unit': float(get_value(line_node, '{*}P_9A') or 0.0),
-                    'tax_name': get_value(line_node, '{*}P_12') or '',
-                }
-                for line_node in move_line_nodes
-            ]
+            lines = []
+            for line_node in move_line_nodes:
+                name = get_value(line_node, '{*}P_7') or '/'
+                tax_name = get_value(line_node, '{*}P_12') or ''
+
+                if P_9A := get_value(line_node, '{*}P_9A'):
+                    price_unit = float(P_9A)
+                elif P_9B := get_value(line_node, '{*}P_9B'):
+                    if xml_id := p12_to_tax_xml_id_map.get(tax_name):
+                        if tax := self.env['account.chart.template'].ref(xml_id, raise_if_not_found=False):
+                            price_unit = float(P_9B) * (1 - tax.amount / (100 + tax.amount))
+                        else:
+                            raise UserError(self.env._("Purchase tax corresponding to '%s' required for the KSeF import was not found in the system.", tax_name))
+                    else:
+                        raise UserError(self.env._("Tax corresponding to '%s' required to derive the net unit price from gross price during KSeF import was not found in the mapping.", tax_name))
+                else:
+                    raise UserError(self.env._("No net or gross unit price found in the FA (3) for the line with product '%s'.", name))
+
+                lines.append(
+                    {
+                        'name': name,
+                        'uom_name': get_value(line_node, '{*}P_8A') or '',
+                        'quantity': float(get_value(line_node, '{*}P_8B') or 0.0),
+                        'price_unit': price_unit,
+                        'tax_name': tax_name,
+                    }
+                )
 
             return {
                 'vendor_nip': vendor_nip,

--- a/addons/l10n_pl_edi/tests/import_xmls/invoice_with_net_and_gross_unit_price.xml
+++ b/addons/l10n_pl_edi/tests/import_xmls/invoice_with_net_and_gross_unit_price.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/"
+         xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-10T10:50:29Z</DataWytworzeniaFa>
+        <SystemInfo>Odoo</SystemInfo>
+    </Naglowek>
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>7492091229</NIP>
+            <Nazwa>HADRON FOR BUSINESS SP Z O O</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>250 Executive Park Blvd, Suite 3400 94134 Kędzierzyn-Koźle Polska</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>it@hadron.eu.com</Email>
+            <Telefon>112</Telefon>
+        </DaneKontaktowe>
+    </Podmiot1>
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>5795955811</NIP>
+            <Nazwa>PL Company</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1> 47-400 Racibórz Polska</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>info@company.plexample.com</Email>
+            <Telefon>+48 512 345 678</Telefon>
+        </DaneKontaktowe>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-10</P_1>
+        <P_1M>Kędzierzyn-Koźle</P_1M>
+        <P_2>FV/2026/00001-demo-test-005</P_2>
+        <P_13_1>3.19</P_13_1>
+        <P_14_1>0.73</P_14_1>
+        <P_15>38.42</P_15>
+        <KursWalutyZ>1.0</KursWalutyZ>
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+        <RodzajFaktury>VAT</RodzajFaktury>
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>[FURN_0006] Podstawka pod monitor</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1.0</P_8B>
+            <P_9A>3.19</P_9A>
+            <P_11>3.19</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>2</NrWierszaFa>
+            <P_7>[FOOD_0001] Chleb pszenny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2.5</P_8B>
+            <P_9A>5.00</P_9A>
+            <P_11>12.50</P_11>
+            <P_12>8</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>3</NrWierszaFa>
+            <P_7>[BOOK_0001] Podręcznik szkolny</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>4.0</P_8B>
+            <P_9B>5.25</P_9B>
+            <P_11A>21.00</P_11A>
+            <P_12>5</P_12>
+        </FaWiersz>
+        <Platnosc>
+            <TerminPlatnosci>
+                <Termin>2026-02-10</Termin>
+            </TerminPlatnosci>
+        </Platnosc>
+    </Fa>
+</Faktura>

--- a/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
+++ b/addons/l10n_pl_edi/tests/test_l10n_pl_edi.py
@@ -122,6 +122,16 @@ class TestL10nPlEdi(AccountTestInvoicingCommon, CronMixinCase):
             ae.args = (ae.args[0] + f"\nFile used for comparison: {filename}", )
             raise
 
+    def _assert_import_invoice(self, filename, expected_values):
+        path = f'l10n_pl_edi/tests/import_xmls/{filename}'
+        with tools.file_open(path, mode='rb') as fd:
+            invoice = self.env['account.move'].create(self.env['account.move'].l10n_pl_edi_get_ksef_bill_vals_from_xml(fd.read()))
+        try:
+            self.assertRecordValues(invoice.invoice_line_ids, expected_values)
+        except AssertionError as ae:
+            ae.args = (ae.args[0] + f"\nFile used for comparison: {filename}", )
+            raise
+
     @freeze_time('2026-01-23')
     def test_ksef_fa3_standard_vat(self):
         """
@@ -638,3 +648,25 @@ class TestL10nPlEdi(AccountTestInvoicingCommon, CronMixinCase):
         self.assertEqual(len(capt.records), cron_runs_before + 1)
         self.assertGreaterEqual(capt.records[-1].call_at, start + timedelta(seconds=120))
         self.assertLessEqual(capt.records[-1].call_at, start + timedelta(seconds=240))
+
+    def test_import_invoice_with_net_and_gross_unit_price(self):
+        self._assert_import_invoice('invoice_with_net_and_gross_unit_price.xml', [
+            {
+                'name': '[FURN_0006] Podstawka pod monitor',
+                'price_unit': 3.19,
+                'price_total': 3.92,
+                'tax_ids': self.env['account.chart.template'].ref('vz_kraj_23').ids,
+            },
+            {
+                'name': '[FOOD_0001] Chleb pszenny',
+                'price_unit': 5.0,
+                'price_total': 13.5,
+                'tax_ids': self.env['account.chart.template'].ref('vz_kraj_8').ids,
+            },
+            {
+                'name': '[BOOK_0001] Podręcznik szkolny',
+                'price_unit': 5.0,
+                'price_total': 21.0,
+                'tax_ids': self.env['account.chart.template'].ref('vz_kraj_5').ids,
+            },
+        ])


### PR DESCRIPTION
**PROBLEM**
When receiving bills from KSeF, we don't handle gross unit price and default to a price_unit of 0.0. Leading to an incorrect invoice.
When generating the bill, the vendor can choose to report the net unit price (P_9A) or gross unit price (P_9B). We need to handle both cases.

opw-6066027
