### PR TITLE
[FIX] sale_stock,stock_account: compute correct return cogs 2 steps

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1659,3 +1659,41 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
             {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 10.0},
             {'account_id': self.account_expense.id, 'debit': 10.0, 'credit': 0.0},
         ])
+
+    def test_fifo_multi_steps_return_credit_note_cogs(self):
+        """ Check that when a credit note is confirmed after a return of a fifo product
+        in a multiple step receipt warehouse, the cogs are corret.
+        """
+        self.warehouse.reception_steps = 'two_steps'
+        self.product_fifo_auto.invoice_policy = 'delivery'
+
+        # SO for 2: 1@10 and 1@20
+        self._make_in_move(self.product_fifo_auto, 1, 10)
+        self._make_in_move(self.product_fifo_auto, 1, 20)
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 1)
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        cogs_aml = invoice.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(cogs_aml, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 30.0},
+            {'account_id': self.account_expense.id, 'debit': 30.0, 'credit': 0.0},
+        ])
+
+        # return 1 quantity
+        ctx = {'active_id': sale_order.picking_ids[0].id, 'active_model': 'stock.picking'}
+        return_wizard = Form(self.env['stock.return.picking'].with_context(ctx)).save()
+        return_wizard.product_return_moves.quantity = 1
+        return_picking = return_wizard._create_return()
+        return_picking.move_ids.write({'quantity': 1, 'picked': True})
+        return_picking.button_validate()
+        return_picking_2 = sale_order.picking_ids[2]
+        return_picking_2.button_validate()
+
+        # confirm credit note and check cogs
+        credit_note = sale_order._create_invoices(final=True)
+        credit_note.action_post()
+        credit_note_cogs_aml = credit_note.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(credit_note_cogs_aml, [
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 15.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 15.0, 'credit': 0.0},
+        ])

--- a/addons/stock_account/wizard/stock_picking_return.py
+++ b/addons/stock_account/wizard/stock_picking_return.py
@@ -13,4 +13,5 @@ class StockReturnPickingLine(models.TransientModel):
     def _prepare_move_default_values(self, new_picking):
         vals = super()._prepare_move_default_values(new_picking)
         vals['to_refund'] = self.to_refund
+        vals['value'] = 0
         return vals


### PR DESCRIPTION
**Steps to reproduce:**
- set the warehouse as 2 steps receipt
- create a storable product with fifo perpetual 
- set the invoicing policy as 'delivered quantity' 
- set a cost of 10 and a quantity of 2
- create a SO for a quantity of 2
- validate delivery and confirm invoice
- return 1 quantity on the delivery 
- validate both picking
- from the SO click on 'create invoice'
- confirm the credit note

**Current behavior:**
The cogs on the credit note have a value 
of 30

**Expected behavior:**
The cogs on the credit not should have a 
value of 10

**Cause of the issue:**
Inside _get_cogs_price_unit() if the product 
is fifo, the compution is : 
sum of the moves' values / valued quantity
https://github.com/odoo/odoo/blob/b5069328734e623c12b0de50a177d501f7f0c995/addons/stock_account/models/stock_move.py#L261-L263
When there is a chain of moves (in multi-steps 
deliveries or multi-steps receives) only one move 
should have a value (the last one for deliveries, the 
first one for receipts). 
Indeed, inside _action_done, _set_value() is only 
called on moves for which either _is_out() is true 
or is_in is true (i.e not internal moves). 
https://github.com/odoo/odoo/blob/b5069328734e623c12b0de50a177d501f7f0c995/addons/stock_account/models/stock_move.py#L168-L176

The problem here is that, when we create the return, 
the values are copied from the original move 
including the value. 
https://github.com/odoo/odoo/blob/b5069328734e623c12b0de50a177d501f7f0c995/addons/stock/wizard/stock_picking_return.py#L53
So the first move is created with a value (of 20 in our steps)
before it is validated. 
The second return move of the chain is created via a copy 
of the first return move so it will also have a value of 20.
https://github.com/odoo/odoo/blob/942cbbbf243ff28f84fdaa40ed73b6572e0032a6/addons/stock/models/stock_rule.py#L245-L246
So both move have a value. 

For the first move it will be changed to the correct value 
(20/2 = 10) when _set_value() is called at the end of _action_done() 
in stock_account.
https://github.com/odoo/odoo/blob/942cbbbf243ff28f84fdaa40ed73b6572e0032a6/addons/stock_account/models/stock_move.py#L176-L177
But the second move of the chain is internal so 
set_value will never be called and the value will stay 20. 

So when _get_cogs_price_unit() is called the computation 
will be wrong.
https://github.com/odoo/odoo/blob/b5069328734e623c12b0de50a177d501f7f0c995/addons/stock_account/models/stock_move.py#L261-L263

opw-6046902