### PR TITLE
[FIX] stock_account: convert to local date before fiscal lock check

### DIFF
--- a/addons/stock_account/models/stock_picking.py
+++ b/addons/stock_account/models/stock_picking.py
@@ -26,9 +26,12 @@ class StockPicking(models.Model):
 
     def _is_date_in_lock_period(self):
         self.ensure_one()
+        tz = self.env.tz
         lock = []
         if self.state == "done":
-            lock += self.company_id._get_lock_date_violations(self.scheduled_date.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
+            local_date = self.scheduled_date.astimezone(tz).date()
+            lock += self.company_id._get_lock_date_violations(local_date, fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         if self.date_done:
-            lock += self.company_id._get_lock_date_violations(self.date_done.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
+            local_done = self.date_done.astimezone(tz).date()
+            lock += self.company_id._get_lock_date_violations(local_done, fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         return bool(lock)


### PR DESCRIPTION
opw-6050007

## Summary

When receipting goods where `scheduled_date` falls near a fiscal period boundary, `_is_date_in_lock_period` calls `.date()` on the UTC datetime without timezone conversion. For users in positive UTC offsets (e.g. NZST, UTC+12), a picking scheduled on April 1st local time is stored as March 31st UTC. The `.date()` call returns March 31st, which triggers the March lock period violation even though the user-visible date is in April.

## Steps to reproduce

1. Set user timezone to a positive UTC offset (e.g. Pacific/Auckland, UTC+12).
2. Set the fiscal year lock date to March 31st.
3. Create and receive a picking with `scheduled_date` of April 1st local time (before midday, so the UTC value falls on March 31st).
4. The lock date check fires and blocks the operation or adjusts `scheduled_date` to the 1st of the first unlocked period.

## Root cause

In `odoo/addons/stock_account/models/stock_picking.py`, `_is_date_in_lock_period` extracts the date with a naive `.date()` call on the UTC-stored datetime:

```python
lock += self.company_id._get_lock_date_violations(
    self.scheduled_date.date(), ...
)
```

`scheduled_date = 2026-03-31 14:00 UTC` corresponds to `2026-04-01 02:00 NZST`. The `.date()` call returns `2026-03-31` — inside the March lock period — but the user sees April 1st.

## Fix

Convert to the user-local date before comparing:

```python
tz = self.env.tz
local_date = self.scheduled_date.astimezone(tz).date()
lock += self.company_id._get_lock_date_violations(local_date, ...)
```

The same conversion is applied to `date_done`.

## Impact

Affects all users in timezones ahead of UTC when receipting goods within ~12 hours of a fiscal period boundary (e.g. end of month). The picking date appears correct in the UI but the lock check evaluates it as the previous day.
