### PR TITLE
[IMP] core: handle cancelling in `_wait_ready`

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1367,8 +1367,13 @@ class ChromeBrowser:
                 if not self._result.done():
                     del self.ws
                     self._result.set_exception(e)
-                    for f in self._responses.values():
-                        f.cancel()
+                    while True:
+                        try:
+                            _, f = self._responses.popitem()
+                        except KeyError:
+                            break
+                        else:
+                            f.cancel()
                 return
             except Exception as e:
                 if isinstance(e, ConnectionResetError) and self._result.done():
@@ -1690,10 +1695,16 @@ which leads to stray network requests and inconsistencies."""
             if taken > timeout:
                 break
 
-            result = self._websocket_request('Runtime.evaluate', params={
-                'expression': "try { %s } catch {}" % ready_code,
-                'awaitPromise': True,
-            }, timeout=timeout-taken)['result']
+            try:
+                result = self._websocket_request('Runtime.evaluate', params={
+                    'expression': "try { %s } catch {}" % ready_code,
+                    'awaitPromise': True,
+                }, timeout=timeout-taken)['result']
+            except CancelledError:
+                exc = self._result.done() and self._result.exception()
+                if exc:
+                    raise exc from None
+                result = "cancelled"
 
             if result == {'type': 'boolean', 'value': True}:
                 time_to_ready = time.time() - start_time
@@ -1701,6 +1712,9 @@ which leads to stray network requests and inconsistencies."""
                     self._logger.info('The ready code tooks too much time : %s', time_to_ready)
                 return True
 
+        exc = self._result.done() and self._result.exception()
+        if exc:
+            raise exc from None
         self.take_screenshot(prefix='sc_failed_ready_')
         self._logger.info('Ready code last try result: %s', result)
         return False


### PR DESCRIPTION
This case induces confusion in the ranks: when the WS connection fails, the result of the run is set to failure then every outstanding response is cancelled.

For `_wait_ready` specifically, because it's a blocking wait on a request it yield a confusing result as the run fails with `CancelledError` and the actual cause (the WS was closed) is lost.

One option would be to `set_exception` on the waiting responses, but I feel like this could create other confusing knock-on effects e.g. more evented waits which currently get ignored might start raising exceptions (although that seems unlikely as callbacks apparently do get called on cancel), and since issues with cancelling only seem to appear in `_wait_ready` that seems like overkill.

Instead have `_wait_ready` handle cancellation by first checking if the result is in error, and using that to raise the underlying error, otherwise retry (and ultimately timeout, probably). And while at it, before signaling a timeout check if the run is in failure and raise that immediately, just in case.

https://runbot.odoo.com/odoo/error/233738
