### PR TITLE
[FIX] website: prevent deletion of all websites

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -460,6 +460,9 @@ class Website(models.CachedModel):
         if default_website and default_website in self:
             raise UserError(_("You cannot delete default website %s. Try to change its settings instead", default_website.name))
 
+        if not default_website and not self.search_count([('id', 'not in', self.ids)], limit=1):
+            raise UserError(_('You must keep at least one website.'))
+
     def unlink(self):
         self._remove_attachments_on_website_unlink()
 


### PR DESCRIPTION
Currently an error occurs when the user unlinks all websites and tries
to access the frontend ( website).

Steps to produce an error:
- Install the website module
- Delete external identifier default_website
- Delete the My Website from Website > Configuration > Websites
- An error will occur when we try to access the website.

Error: `TypeError: expected string or bytes-like object, got 'bool'`

This issue was generated because while setting cookies to the Werkzeug
response, we got 'value' as a `False` at line [1], and the `value` is the
language code from the request (see line [2]) .

The language is determined by the `IrHttp` class through the `_get_default_lang`
method (see code line [3]). In the website module, this method is overridden
to return the language configured on the current website.

However, when all websites are deleted, no valid website record remains.
As a result, the method attempts to retrieve the language from an empty website,
which returns `False` (see code line [4]), leading to the issue.

This commit fixes the issue by preventing the deletion of all website records.

The method `_unlink_except_default_website` already ensures that the
default website (identified by the external ID `website.default_website`)
cannot be deleted. However, if this external identifier has been removed,
the safeguard no longer applies, allowing the default website to be deleted
without raising any error.

To address this, an additional check has been introduced: when the
`default_website` is not found, the system verifies whether any website records
remain using search_count. If no records are found, a `UserError` is raised to
prevent the deletion and ensure that at least one website always exists.

[1]: https://github.com/odoo/odoo/blob/cdf8aaec82ee387c8f29b8327efbc95fd17e2cb8/odoo/http.py#L1825
[2]: https://github.com/odoo/odoo/blob/cdf8aaec82ee387c8f29b8327efbc95fd17e2cb8/addons/http_routing/models/ir_http.py#L518
[3]: https://github.com/odoo/odoo/blob/cdf8aaec82ee387c8f29b8327efbc95fd17e2cb8/addons/http_routing/models/ir_http.py#L407-L411
[4]: https://github.com/odoo/odoo/blob/cdf8aaec82ee387c8f29b8327efbc95fd17e2cb8/addons/website/models/ir_http.py#L288

sentry-7413005338