### PR TITLE
[IMP] microsoft_calendar: allow editing recurring events from Odoo

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -53,11 +53,6 @@ class CalendarEvent(models.Model):
             )
             event.microsoft_sync_active = sync_active
 
-    @api.depends('microsoft_sync_active', 'recurrency')
-    def _compute_user_can_edit(self):
-        super()._compute_user_can_edit()
-        self.filtered(lambda e: e.microsoft_sync_active and e.recurrency).user_can_edit = False
-
     def _get_organizer(self):
         return self.user_id
 
@@ -93,11 +88,6 @@ class CalendarEvent(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         notify_context = self.env.context.get('dont_notify', False)
-
-        # Forbid recurrence creation in Odoo, suggest its creation in Outlook due to the spam limitation.
-        recurrency_in_batch = any(vals.get('recurrency') for vals in vals_list)
-        if self._check_microsoft_sync_status() and not notify_context and recurrency_in_batch:
-            self._forbid_recurrence_creation()
 
         vals_check_organizer = self._check_organizer_validation_conditions(vals_list)
         for vals in [vals for vals, check_organizer in zip(vals_list, vals_check_organizer) if check_organizer]:
@@ -165,43 +155,10 @@ class CalendarEvent(models.Model):
 
         return (event_start, event_stop) == (start, stop)
 
-    def _forbid_recurrence_update(self):
-        """
-        Suggest user to update recurrences in Outlook due to the Outlook Calendar spam limitation.
-        """
-        error_msg = _("Due to an Outlook Calendar limitation, recurrence updates must be done directly in Outlook Calendar.")
-        if any(not record.ms_universal_event_id for record in self):
-            # If any event is not synced, suggest deleting it in Odoo and recreating it in Outlook.
-            error_msg = _(
-                "Due to an Outlook Calendar limitation, recurrence updates must be done directly in Outlook Calendar.\n"
-                "If this recurrence is not shown in Outlook Calendar, you must delete it in Odoo Calendar and recreate it in Outlook Calendar.")
-
-        raise UserError(error_msg)
-
-    def _forbid_recurrence_creation(self):
-        """
-        Suggest user to update recurrences in Outlook due to the Outlook Calendar spam limitation.
-        """
-        raise UserError(_("Due to an Outlook Calendar limitation, recurrent events must be created directly in Outlook Calendar."))
-
     def write(self, vals):
         values = vals
         recurrence_update_setting = values.get('recurrence_update')
         notify_context = self.env.context.get('dont_notify', False)
-
-        # Forbid recurrence updates through Odoo and suggest user to update it in Outlook.
-        if not notify_context:
-            recurrency_in_batch = self.filtered(lambda ev: ev.recurrency)
-            recurrence_update_attempt = recurrence_update_setting or 'recurrency' in values or recurrency_in_batch and len(recurrency_in_batch) > 0
-            # Check if this is an Outlook recurring event with active sync
-            if recurrence_update_attempt and 'active' not in values:
-                recurring_events = self.filtered('microsoft_recurrence_master_id')
-                if recurring_events and any(
-                    event.with_user(organizer)._check_microsoft_sync_status()
-                    for event in recurring_events
-                    if (organizer := event._get_organizer())
-                ):
-                    self._forbid_recurrence_update()
 
         # When changing the organizer, check its sync status and verify if the user is listed as attendee.
         # Updates from Microsoft must skip this check since changing the organizer on their side is not possible.
@@ -230,6 +187,31 @@ class CalendarEvent(models.Model):
                     event.microsoft_id = False
                     event.ms_universal_event_id = False
 
+        # Capture recurrence state before super() so we can issue the correct Microsoft API calls
+        # afterwards. The recurrence record may be deleted and recreated by _rewrite_recurrence,
+        # so scalar IDs must be saved now — accessing old_rec.field after super() risks MissingError.
+        old_rec = self.recurrence_id if len(self) == 1 else self.env['calendar.recurrence']
+        old_microsoft_id = old_rec.microsoft_id
+        old_ms_universal_event_id = old_rec.ms_universal_event_id
+        ms_base_event = (
+            (old_rec.base_event_id or old_rec._get_first_event(include_outliers=False))
+            if old_rec else self.env['calendar.event']
+        )
+
+        # Block 'future_events' for Microsoft-synced recurring events: the split requires 2 API
+        # calls (truncate + insert), which is not supported in the current sync implementation.
+        if not notify_context and recurrence_update_setting == 'future_events' \
+                and old_microsoft_id and self.microsoft_sync_active:
+            raise UserError(_(
+                "Editing 'This and following events' is not supported when Outlook Calendar sync "
+                "is active. Please use 'This event' or 'All events' instead.",
+            ))
+
+        # For all_events: pass need_sync_m=False so individual events are not
+        # PATCHed during the internal rewrite. The series master PATCH is issued below.
+        if recurrence_update_setting == 'all_events' and len(self) == 1:
+            values = dict(values, need_sync_m=False)
+
         deactivated_events = self.browse(deactivated_events_ids)
         # Update attendee status before 'values' variable is overridden in super.
         attendee_ids = values.get('attendee_ids')
@@ -242,19 +224,72 @@ class CalendarEvent(models.Model):
         if deactivated_events:
             res |= super(CalendarEvent, deactivated_events.with_context(dont_notify=notify_context)).write({**values, 'active': False})
 
-        if recurrence_update_setting in ('all_events',) and len(self) == 1 \
-           and values.keys() & self._get_microsoft_synced_fields():
-            self.recurrence_id.need_sync_m = True
+        # Trigger the correct Microsoft Graph API call(s) for series-level changes.
+        if old_microsoft_id and not notify_context and self._check_microsoft_sync_status():
+            if recurrence_update_setting == 'all_events':
+                # 1 PATCH to the series master propagates changes to all occurrences.
+                new_rec = ms_base_event.recurrence_id or self.recurrence_id
+                if new_rec:
+                    if not new_rec.microsoft_id:
+                        # _rewrite_recurrence destroyed and recreated the recurrence (time/rrule
+                        # change). Restore the Microsoft series master ID so the PATCH goes to
+                        # the correct Outlook series.
+                        new_rec.with_context(dont_notify=True).write({
+                            'microsoft_id': old_microsoft_id,
+                            'ms_universal_event_id': old_ms_universal_event_id,
+                            'need_sync_m': False,
+                        })
+                    ms_values = new_rec._microsoft_values(new_rec._get_microsoft_synced_fields())
+                    if ms_values:
+                        new_rec._microsoft_patch(
+                            new_rec._get_organizer(), old_microsoft_id, ms_values)
         return res
 
+    @api.model
+    def _get_archive_values(self):
+        """Prevent individual occurrence DELETEs during a series rewrite.
+        The series master is updated via a single PATCH by the outer write() instead."""
+        return {**super()._get_archive_values(), 'need_sync_m': False}
+
+    def _rewrite_recurrence(self, values, time_values, recurrence_values):
+        """Override to preserve Microsoft series master ID through Odoo's destroy+recreate cycle.
+
+        The base implementation may delete and recreate the calendar.recurrence record when
+        time fields or rrule parameters change. We save the Microsoft IDs beforehand and
+        restore them on the new recurrence so that the outer write() can issue a single PATCH
+        to the existing Outlook series instead of deleting and recreating it.
+        """
+        if not self._check_microsoft_sync_status():
+            return super()._rewrite_recurrence(values, time_values, recurrence_values)
+
+        old_rec = self.recurrence_id
+        old_microsoft_id = old_rec.microsoft_id
+        old_ms_universal_event_id = old_rec.ms_universal_event_id
+        ms_base_event = old_rec.base_event_id or old_rec._get_first_event(include_outliers=False)
+
+        # Use no_calendar_sync=True so that @after_commit Microsoft API calls scheduled
+        # inside the base _rewrite_recurrence (archive events, unlink recurrence, recreate)
+        # are silently dropped — the outer write() issues the single correct PATCH instead.
+        super(CalendarEvent, self.with_context(no_calendar_sync=True))._rewrite_recurrence(
+            values, time_values, recurrence_values)
+
+        if not old_microsoft_id:
+            return None
+
+        # If the recurrence was recreated (IF branch: time/rrule changes), ms_base_event
+        # now points to the new recurrence. Restore the Microsoft IDs so the PATCH lands
+        # on the correct Outlook series.
+        new_rec = ms_base_event.recurrence_id or self.recurrence_id
+        if new_rec and not new_rec.microsoft_id:
+            new_rec.with_context(dont_notify=True).write({
+                'microsoft_id': old_microsoft_id,
+                'ms_universal_event_id': old_ms_universal_event_id,
+                'need_sync_m': False,
+            })
+
+        return None
+
     def unlink(self):
-        # Forbid recurrent events unlinking from calendar list view with sync active.
-        if self and self._check_microsoft_sync_status():
-            synced_events = self._get_synced_events()
-            change_from_microsoft = self.env.context.get('dont_notify', False)
-            recurrence_deletion = any(ev.recurrency and ev.recurrence_id and ev.follow_recurrence for ev in synced_events)
-            if not change_from_microsoft and recurrence_deletion:
-                self._forbid_recurrence_update()
         return super().unlink()
 
     def _recreate_event_different_organizer(self, values, sender_user):
@@ -297,10 +332,7 @@ class CalendarEvent(models.Model):
                 attendee.state = state_update
 
     def action_mass_archive(self, recurrence_update_setting):
-        # Do not allow archiving if recurrence is synced with Outlook. Suggest updating directly from Outlook.
         self.ensure_one()
-        if self._check_microsoft_sync_status() and self.microsoft_id:
-            self._forbid_recurrence_update()
         super().action_mass_archive(recurrence_update_setting)
 
     def _get_microsoft_sync_domain(self):

--- a/addons/microsoft_calendar/models/calendar_attendee.py
+++ b/addons/microsoft_calendar/models/calendar_attendee.py
@@ -32,6 +32,4 @@ class CalendarAttendee(models.Model):
         linked_events = self.event_id._get_synced_events()
         for event in linked_events:
             if event._check_microsoft_sync_status() and self.env.user != event.user_id and self.env.user.partner_id in event.partner_ids:
-                if event.recurrency:
-                    event._forbid_recurrence_update()
                 event._microsoft_attendee_answer(answer, params)

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -49,13 +49,28 @@ class CalendarRecurrence(models.Model):
                 event._microsoft_delete(event.user_id, event.microsoft_id)
                 event.ms_universal_event_id = False
         self.env['calendar.event'].with_context(skip_contact_description=True).create(vals)
+
+        # Insert new recurrences to Microsoft. Skipped when syncing from Microsoft (dont_notify)
+        # or when no_calendar_sync is set (e.g. during _rewrite_recurrence), which the
+        # @after_commit decorator in _microsoft_insert already enforces.
+        if not self.env.context.get('dont_notify'):
+            for recurrence in self:
+                if not recurrence.microsoft_id:
+                    base_event = recurrence.base_event_id or recurrence._get_first_event()
+                    if base_event and base_event._check_microsoft_sync_status():
+                        sender_user = recurrence._get_event_user_m()
+                        if not recurrence._is_microsoft_insertion_blocked(sender_user):
+                            ms_values = recurrence._microsoft_values(recurrence._get_microsoft_synced_fields())
+                            if ms_values:
+                                recurrence._microsoft_insert(ms_values)
+
         self.calendar_event_ids.need_sync_m = False
         return detached_events
 
     def _write_events(self, values, dtstart=None):
-        # If only some events are updated, sync those events.
-        # If all events are updated, sync the recurrence instead.
-        values['need_sync_m'] = bool(dtstart) or values.get("need_sync_m", True)
+        # Events within a recurrence are never synced individually.
+        # Series-level changes are handled by a single PATCH to the series master.
+        values['need_sync_m'] = False
         return super()._write_events(values, dtstart=dtstart)
 
     def _get_organizer(self):

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_form_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_form_controller.js
@@ -1,0 +1,18 @@
+import { RadioField, radioField } from "@web/views/fields/radio/radio_field";
+import { registry } from "@web/core/registry";
+
+class MicrosoftRecurrenceUpdateField extends RadioField {
+    get items() {
+        const items = super.items;
+        if (this.props.record.data.microsoft_sync_active) {
+            return items.filter(([value]) => value !== "future_events");
+        }
+        return items;
+    }
+}
+
+registry.category("fields").add("microsoft_recurrence_update", {
+    ...radioField,
+    component: MicrosoftRecurrenceUpdateField,
+    additionalClasses: ["o_field_radio"],
+});

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -480,8 +480,7 @@ class TestCommon(HttpCase):
         )
         already_created = self.recurrent_base_event
 
-        # Currently, it is forbidden to create recurrences in Odoo. A trick for deactivating the checking
-        # is needed below in this test setup: deactivating the synchronization during recurrences creation.
+        # Create the recurrence with sync paused so no Microsoft API calls are made during test setup.
         sync_previous_state = self.env.user.microsoft_synchronization_stopped
         self.env.user.microsoft_synchronization_stopped = False
 

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -11,7 +11,7 @@ from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCal
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.models.res_users import ResUsers
 from odoo.addons.microsoft_calendar.tests.common import TestCommon, mock_get_token, _modified_date_in_the_future
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import ValidationError
 from odoo.tests.common import tagged
 
 
@@ -297,22 +297,32 @@ class TestCreateEvents(TestCommon):
             self.assert_odoo_event(e, self.expected_odoo_recurrency_events_from_outlook[i])
 
     @patch.object(MicrosoftCalendarService, 'insert')
-    def test_forbid_recurrences_creation_synced_outlook_calendar(self, mock_insert):
+    def test_create_recurrence_synced_outlook_calendar(self, mock_insert):
         """
-        Forbids new recurrences creation in Odoo due to Outlook spam limitation of updating recurrent events.
+        Creating a recurrence in Odoo while synced with Outlook is now allowed.
+        The series must be pushed to Outlook as a seriesMaster event.
         """
-        # Set custom calendar token validity to simulate real scenario.
-        self.env.user.microsoft_calendar_token_validity = datetime.now() + timedelta(minutes=5)
+        # Set token and validity to simulate an active Outlook connection.
+        self.env.user.sudo().write({
+            'microsoft_calendar_token': 'test_token',
+            'microsoft_calendar_token_validity': datetime.now() + timedelta(minutes=5),
+        })
 
         # Assert that synchronization with Outlook is active.
         self.assertFalse(self.env.user.microsoft_synchronization_stopped)
 
-        with self.assertRaises(UserError):
-            self.env["calendar.event"].create(
-                self.recurrent_event_values
-            )
-        # Assert that no insert call was made.
-        mock_insert.assert_not_called()
+        mock_insert.return_value = ('ms_event_id_123', 'ms_uid_456')
+
+        event = self.env["calendar.event"].create(self.recurrent_event_values)
+        self.call_post_commit_hooks()
+
+        # Assert that the event was created successfully.
+        self.assertTrue(event.exists())
+
+        # Assert that the series was inserted into Outlook as a seriesMaster.
+        mock_insert.assert_called_once()
+        ms_values = mock_insert.call_args[0][0]
+        self.assertEqual(ms_values.get('type'), 'seriesMaster', "Recurring event must be sent to Outlook as a seriesMaster")
 
     @patch.object(MicrosoftCalendarService, 'insert')
     def test_create_event_with_sync_config_paused(self, mock_insert):

--- a/addons/microsoft_calendar/tests/test_delete_events.py
+++ b/addons/microsoft_calendar/tests/test_delete_events.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 
 from odoo import fields
 
-from odoo.exceptions import UserError
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.models.res_users import ResUsers
@@ -336,27 +335,26 @@ class TestDeleteEvents(TestCommon):
         idx = 0
         self.organizer_user.microsoft_calendar_token_validity = fields.Datetime.now() + timedelta(hours=1)
 
-        # Act: try to delete a recurrent event that was already synced.
-        with self.assertRaises(UserError):
-            self.recurrent_events[idx].with_user(self.organizer_user).action_mass_archive('all_events')
-            self.call_post_commit_hooks()
+        # Act: archiving a synced recurrent event is now allowed.
+        self.recurrent_events[idx].with_user(self.organizer_user).action_mass_archive('all_events')
+        self.call_post_commit_hooks()
 
-        # Ensure that event remains undeleted after deletion attempt and delete method wasn't called.
+        # Ensure that sync is active and the event is now archived.
         self.assertTrue(self.recurrent_events[idx].with_user(self.organizer_user)._check_microsoft_sync_status())
-        self.assertTrue(self.recurrent_events[idx].active)
-        mock_delete.assert_not_called()
+        self.assertFalse(self.recurrent_events[idx].active)
 
-    def test_forbid_recurrence_unlinking_list_view(self):
-        # Forbid recurrence unlinking from list view with sync on.
+    def test_recurrence_unlinking_list_view(self):
+        # Recurrence unlinking from list view is now allowed even with sync on.
         self.assertTrue(self.env['calendar.event'].with_user(self.organizer_user)._check_microsoft_sync_status())
-        with self.assertRaises(UserError):
-            self.recurrent_events.unlink()
+        first_event = self.recurrent_events[0]
+        first_event.unlink()
+        self.assertFalse(first_event.exists(), "Recurrent event must be deleted after unlink.")
 
-        # Allow recurrence unlinking when update comes from Microsoft (dont_notify=True).
+        # Recurrence unlinking when update comes from Microsoft (dont_notify=True) also works.
         self.recurrent_events[2:].with_context(dont_notify=True).unlink()
         self.assertTrue(all(not event.exists() for event in self.recurrent_events[2:]), "Recurrent event must be deleted after unlink from Microsoft.")
 
-        # Allow unlinking recurrence when sync is off for the current user.
+        # Recurrence unlinking when sync is off for the current user also works.
         self.organizer_user.microsoft_synchronization_stopped = True
         self.assertFalse(self.env['calendar.event'].with_user(self.organizer_user)._check_microsoft_sync_status())
         self.recurrent_events[1].with_user(self.organizer_user).unlink()

--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -4,7 +4,6 @@ from datetime import datetime, UTC
 
 from dateutil.relativedelta import relativedelta
 
-from odoo.exceptions import UserError
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.tests import tagged
 
@@ -38,11 +37,10 @@ class TestMicrosoftEvent(TestCommon):
         self.assertEqual(len(mapped._events), 1)
         self.assertEqual(mapped._events[event_id]["_odoo_id"], self.simple_event.id)
 
-    def test_forbid_edit_outlook_recurring_event(self):
+    def test_edit_outlook_recurring_event(self):
         """
-        Test that no user can edit a recurring event imported from Outlook
-        (identified by microsoft_recurrence_master_id), but that the sync
-        mechanism itself can still write through via dont_notify context.
+        Test that users can now edit recurring events imported from Outlook,
+        and that the sync mechanism itself can also write through via dont_notify context.
         """
         # Give the organizer user a Microsoft token
         self.organizer_user.microsoft_calendar_token = "fake_token"
@@ -71,26 +69,21 @@ class TestMicrosoftEvent(TestCommon):
             },
         ])
 
-        # No user should be able to edit the Outlook event through Odoo
-        for user in [self.attendee_user, self.organizer_user]:
-            with self.assertRaises(UserError):
-                outlook_recurring_event.with_user(user).with_context(dont_notify=False).write({
-                    'name': 'Trying to change name',
-                    'recurrence_update': 'future_events',
-                })
-        self.assertEqual(outlook_recurring_event.name, 'Outlook Recurring Event')
+        # Users can now edit Outlook-imported recurring events through Odoo
+        outlook_recurring_event.with_user(self.organizer_user).with_context(dont_notify=False).write({
+            'name': 'Changed by organizer',
+            'recurrence_update': 'self_only',
+        })
+        self.assertEqual(outlook_recurring_event.name, 'Changed by organizer')
 
-        # But changes from Microsoft sync itself should still work
+        # Changes from Microsoft sync itself should also work
         outlook_recurring_event.with_context(dont_notify=True).write({
             'name': 'Updated from Outlook',
-            'recurrence_update': 'future_events'
+            'recurrence_update': 'self_only'
         })
         self.assertEqual(outlook_recurring_event.name, 'Updated from Outlook')
 
-        # Remove token: organizer is no longer synced to Outlook
-        self.organizer_user.microsoft_calendar_token = False
-
-        # Any user should be able to edit a non-Outlook recurring event
+        # Any user should be able to edit a non-Outlook recurring event (all modes, including future_events)
         for user in [self.attendee_user, self.organizer_user]:
             recurring_event.with_user(user).with_context(dont_notify=False).write({
                 'name': f'Changed by {user.name}',

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -241,263 +241,56 @@ class TestUpdateEvents(TestCommon):
 
     # ------ One and future events in a recurrence ------
 
-    @patch.object(MicrosoftCalendarService, 'delete')
-    @patch.object(MicrosoftCalendarService, 'insert')
-    @patch.object(MicrosoftCalendarService, 'patch')
-    def test_update_name_of_one_and_future_events_of_recurrence_from_odoo(
-        self, mock_patch, _mock_insert, _mock_delete
-    ):
+    def test_update_name_of_one_and_future_events_of_recurrence_from_odoo(self):
         """
-        Update a Odoo event name and future events from a recurrence from the organizer calendar.
+        'future_events' mode is blocked for Microsoft-synced recurring events.
         """
         if not self.sync_odoo_recurrences_with_outlook_feature():
             return
-        # arrange
-        new_name = "my specific event in recurrence"
-        modified_event_id = 4
+        with self.assertRaises(UserError):
+            self.recurrent_events[4].with_user(self.organizer_user).write({
+                "recurrence_update": "future_events",
+                "name": "my specific event in recurrence",
+            })
 
-        # act
-        res = self.recurrent_events[modified_event_id].with_user(self.organizer_user).write({
-            "recurrence_update": "future_events",
-            "name": new_name,
-        })
-        self.call_post_commit_hooks()
-        self.recurrent_events.invalidate_recordset()
-
-        # assert
-        self.assertTrue(res)
-        self.assertEqual(mock_patch.call_count, self.recurrent_events_count - modified_event_id)
-        for i in range(modified_event_id, self.recurrent_events_count):
-            mock_patch.assert_any_call(
-                self.recurrent_events[i].microsoft_id,
-                {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name},
-                token=mock_get_token(self.organizer_user),
-                timeout=ANY,
-            )
-        for i in range(modified_event_id, self.recurrent_events_count):
-            self.assertEqual(self.recurrent_events[i].name, new_name)
-            self.assertEqual(self.recurrent_events[i].follow_recurrence, True)
-
-        for i in range(modified_event_id):
-            self.assertNotEqual(self.recurrent_events[i].name, new_name)
-
-    @patch.object(MicrosoftCalendarService, 'delete')
-    @patch.object(MicrosoftCalendarService, 'insert')
-    @patch.object(MicrosoftCalendarService, 'patch')
-    def test_update_start_of_one_and_future_events_of_recurrence_from_odoo(
-        self, mock_patch, _mock_insert, mock_delete
-    ):
+    def test_update_start_of_one_and_future_events_of_recurrence_from_odoo(self):
         """
-        Update a Odoo event start date and future events from a recurrence from the organizer calendar.
+        'future_events' mode is blocked for Microsoft-synced recurring events.
         """
         if not self.sync_odoo_recurrences_with_outlook_feature():
             return
-        # When a time-related field is changed, the event does not follow the recurrence scheme anymore.
-        # With Outlook, another constraint is that the new start of the event cannot overlap/cross the start
-        # date of another event of the recurrence (see microsoft_calendar/models/calendar.py
-        # _check_recurrence_overlapping() for more explanation)
-        #
-        # In this case, as we also update future events, the recurrence should be splitted into 2 parts:
-        #  - the original recurrence should end just before the first updated event
-        #  - a second recurrence should start at the first updated event
-
-        # arrange
         new_date = datetime(2021, 9, 29, 10, 0, 0)
-        modified_event_id = 4
-        existing_recurrences = self.env["calendar.recurrence"].search([])
+        with self.assertRaises(UserError):
+            self.recurrent_events[4].with_user(self.organizer_user).write({
+                "recurrence_update": "future_events",
+                "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
+            })
 
-        expected_deleted_event_ids = [
-            r.microsoft_id
-            for i, r in enumerate(self.recurrent_events)
-            if i in range(modified_event_id + 1, self.recurrent_events_count)
-        ]
-
-        # act
-        res = self.recurrent_events[modified_event_id].with_user(self.organizer_user).write({
-            "recurrence_update": "future_events",
-            "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
-        })
-        self.call_post_commit_hooks()
-        self.recurrent_events.invalidate_recordset()
-
-        # assert
-        new_recurrences = self.env["calendar.recurrence"].search([]) - existing_recurrences
-
-        self.assertTrue(res)
-
-        # a new recurrence should be created from the modified event to the end
-        self.assertEqual(len(new_recurrences), 1)
-        self.assertEqual(new_recurrences.base_event_id.start, new_date)
-        self.assertEqual(len(new_recurrences.calendar_event_ids), self.recurrent_events_count - modified_event_id)
-
-        # future events of the old recurrence should have been removed
-        for e_id in expected_deleted_event_ids:
-            mock_delete.assert_any_call(
-                e_id,
-                token=mock_get_token(self.organizer_user),
-                timeout=ANY,
-            )
-
-        # the base event should have been modified
-        mock_patch.assert_called_once_with(
-            self.recurrent_events[modified_event_id].microsoft_id,
-            {
-                'seriesMasterId': 'REC123',
-                'type': 'exception',
-                'start': {
-                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'end': {
-                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'isAllDay': False
-            },
-            token=mock_get_token(self.organizer_user),
-            timeout=ANY,
-        )
-
-    @patch.object(MicrosoftCalendarService, 'delete')
-    @patch.object(MicrosoftCalendarService, 'insert')
-    @patch.object(MicrosoftCalendarService, 'patch')
-    def test_update_start_of_one_and_future_events_of_recurrence_from_odoo_with_overlap(
-        self, mock_patch, _mock_insert, mock_delete
-    ):
+    def test_update_start_of_one_and_future_events_of_recurrence_from_odoo_with_overlap(self):
         """
-        Update a Odoo event start date and future events from a recurrence from the organizer calendar,
-        overlapping an existing event.
+        'future_events' mode is blocked for Microsoft-synced recurring events.
         """
         if not self.sync_odoo_recurrences_with_outlook_feature():
             return
-        # arrange
         new_date = datetime(2021, 9, 27, 10, 0, 0)
-        modified_event_id = 4
-        existing_recurrences = self.env["calendar.recurrence"].search([])
+        with self.assertRaises(UserError):
+            self.recurrent_events[4].with_user(self.organizer_user).write({
+                "recurrence_update": "future_events",
+                "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
+            })
 
-        expected_deleted_event_ids = [
-            r.microsoft_id
-            for i, r in enumerate(self.recurrent_events)
-            if i in range(modified_event_id + 1, self.recurrent_events_count)
-        ]
-
-        # as the test overlap the previous event of the updated event, this previous event
-        # should be removed too
-        expected_deleted_event_ids += [self.recurrent_events[modified_event_id - 1].microsoft_id]
-
-        # act
-        res = self.recurrent_events[modified_event_id].with_user(self.organizer_user).write({
-            "recurrence_update": "future_events",
-            "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
-        })
-        self.call_post_commit_hooks()
-        self.recurrent_events.invalidate_recordset()
-
-        # assert
-        new_recurrences = self.env["calendar.recurrence"].search([]) - existing_recurrences
-
-        self.assertTrue(res)
-
-        # a new recurrence should be created from the modified event to the end
-        self.assertEqual(len(new_recurrences), 1)
-        self.assertEqual(new_recurrences.base_event_id.start, new_date)
-        self.assertEqual(len(new_recurrences.calendar_event_ids), self.recurrent_events_count - modified_event_id + 1)
-
-        # future events of the old recurrence should have been removed + the overlapped event
-        for e_id in expected_deleted_event_ids:
-            mock_delete.assert_any_call(
-                e_id,
-                token=mock_get_token(self.organizer_user),
-                timeout=ANY,
-            )
-
-        # the base event should have been modified
-        mock_patch.assert_called_once_with(
-            self.recurrent_events[modified_event_id].microsoft_id,
-            {
-                'seriesMasterId': 'REC123',
-                'type': 'exception',
-                'start': {
-                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'end': {
-                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'isAllDay': False
-            },
-            token=mock_get_token(self.organizer_user),
-            timeout=ANY,
-        )
-
-    @patch.object(MicrosoftCalendarService, 'delete')
-    @patch.object(MicrosoftCalendarService, 'insert')
-    @patch.object(MicrosoftCalendarService, 'patch')
-    def test_update_one_and_future_events_of_recurrence_from_odoo_attendee_calendar(
-        self, mock_patch, _mock_insert, mock_delete
-    ):
+    def test_update_one_and_future_events_of_recurrence_from_odoo_attendee_calendar(self):
         """
-        Update a Odoo event name and future events from a recurrence from the attendee calendar.
+        'future_events' mode is blocked for Microsoft-synced recurring events (attendee calendar).
         """
         if not self.sync_odoo_recurrences_with_outlook_feature():
             return
-        # arrange
         new_date = datetime(2021, 9, 29, 10, 0, 0)
-        modified_event_id = 4
-        existing_recurrences = self.env["calendar.recurrence"].search([])
-
-        expected_deleted_event_ids = [
-            r.microsoft_id
-            for i, r in enumerate(self.recurrent_events)
-            if i in range(modified_event_id + 1, self.recurrent_events_count)
-        ]
-
-        # act
-        res = self.recurrent_events[modified_event_id].with_user(self.attendee_user).write({
-            "recurrence_update": "future_events",
-            "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
-        })
-        self.call_post_commit_hooks()
-        self.recurrent_events.invalidate_recordset()
-
-        # assert
-        new_recurrences = self.env["calendar.recurrence"].search([]) - existing_recurrences
-
-        self.assertTrue(res)
-
-        # a new recurrence should be created from the modified event to the end
-        self.assertEqual(len(new_recurrences), 1)
-        self.assertEqual(new_recurrences.base_event_id.start, new_date)
-        self.assertEqual(len(new_recurrences.calendar_event_ids), self.recurrent_events_count - modified_event_id)
-
-        # future events of the old recurrence should have been removed
-        for e_id in expected_deleted_event_ids:
-            mock_delete.assert_any_call(
-                e_id,
-                token=mock_get_token(self.organizer_user),
-                timeout=ANY,
-            )
-
-        # the base event should have been modified
-        mock_patch.assert_called_once_with(
-            self.recurrent_events[modified_event_id].microsoft_id,
-            {
-                'seriesMasterId': 'REC123',
-                'type': 'exception',
-                'start': {
-                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'end': {
-                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
-                    'timeZone': 'Europe/London'
-                },
-                'isAllDay': False
-            },
-            token=mock_get_token(self.organizer_user),
-            timeout=ANY,
-        )
+        with self.assertRaises(UserError):
+            self.recurrent_events[4].with_user(self.attendee_user).write({
+                "recurrence_update": "future_events",
+                "start": new_date.strftime("%Y-%m-%d %H:%M:%S"),
+            })
 
     # ------ All events in a recurrence ------
 
@@ -1300,9 +1093,9 @@ class TestUpdateEvents(TestCommon):
             )
 
     @patch.object(MicrosoftCalendarService, 'patch')
-    def test_forbid_simple_event_become_recurrence_sync_on(self, mock_patch):
+    def test_simple_event_become_recurrence_sync_on(self, mock_patch):
         """
-        Forbid in Odoo simple event becoming a recurrence when Outlook Calendar sync is active.
+        A simple event can now become a recurrence even when Outlook Calendar sync is active.
         """
         # Set custom calendar token validity to simulate real scenario.
         self.env.user.microsoft_calendar_token_validity = datetime.now() + timedelta(minutes=5)
@@ -1310,25 +1103,23 @@ class TestUpdateEvents(TestCommon):
         # Assert that synchronization with Outlook Calendar is active.
         self.assertFalse(self.env.user.microsoft_synchronization_stopped)
 
-        # Simulate upgrade of a simple event to recurrent event (forbidden).
+        # A simple event can now be upgraded to a recurrent event.
         simple_event = self.env['calendar.event'].with_user(self.organizer_user).create(self.simple_event_values)
-        with self.assertRaises(UserError):
-            simple_event.write({
-                'recurrency': True,
-                'rrule_type': 'weekly',
-                'event_tz': 'America/Sao_Paulo',
-                'end_type': 'count',
-                'interval': 1,
-                'count': 1,
-                'fri': True,
-                'month_by': 'date',
-                'day': 1,
-                'weekday': 'FRI',
-                'byday': '2'
-            })
-
-        # Assert that no patch call was made due to the recurrence update forbiddance.
-        mock_patch.assert_not_called()
+        simple_event.write({
+            'recurrency': True,
+            'rrule_type': 'weekly',
+            'event_tz': 'America/Sao_Paulo',
+            'end_type': 'count',
+            'interval': 1,
+            'count': 1,
+            'fri': True,
+            'month_by': 'date',
+            'day': 1,
+            'weekday': 'FRI',
+            'byday': '2'
+        })
+        # Assert that the event is now recurrent.
+        self.assertTrue(simple_event.recurrency)
 
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_synced_event_with_sync_config_paused(self, mock_patch):

--- a/addons/microsoft_calendar/views/microsoft_calendar_views.xml
+++ b/addons/microsoft_calendar/views/microsoft_calendar_views.xml
@@ -16,32 +16,12 @@
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
         <field name="arch" type="xml">
-            <xpath
-                expr="//div[./field[@name='recurrence_update']][@role='status']"
-                position="attributes">
-                <attribute name="invisible" add="microsoft_sync_active" separator="or"/>
-            </xpath>
-
-            <xpath
-                expr="//div[./field[@name='recurrence_update']][@role='status']"
-                position="after">
-                <div invisible="not (microsoft_sync_active and recurrency)" class="alert alert-info"
-                    role="alert">
-                    Recurring events can only be edited from Outlook.
-                </div>
-            </xpath>
-
-            <xpath expr="//field[@name='recurrency']" position="attributes">
-                <attribute name="readonly" add="microsoft_sync_active" separator="or"/>
-            </xpath>
-
-            <xpath expr="//field[@name='recurrency']" position="after">
-                <div invisible="recurrency or not microsoft_sync_active"
-                    class="alert alert-info" role="alert"
-                    colspan="2">
-                    Recurring events must be created directly in Outlook Calendar.
-                </div>
-            </xpath>
+            <field name="active" position="after">
+                <field name="microsoft_sync_active" invisible="1"/>
+            </field>
+            <field name="recurrence_update" widget="radio" position="replace">
+                <field name="recurrence_update" widget="microsoft_recurrence_update" options="{'horizontal': True}"/>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When editing a recurring event synced with Outlook, Odoo was issuing one PATCH request per occurrence. Each PATCH caused Microsoft to send a calendar notification email to every attendee, flooding inboxes when a recurrence had many events. The original workaround was to block all recurring event edits from Odoo and redirect users to Outlook Calendar.

Microsoft Graph supports series-level PATCH calls targeting the series master (seriesMasterId), which updates all occurrences in a single request and triggers only one notification. This removes the original spam concern and makes it safe to lift the restrictions.

"This and following events" (future_events) is still blocked because it requires splitting a series into two separate API calls — truncating the original and POSTing a new one — which is harder to make atomic and is left for a future improvement.