### PR TITLE
[FIX] hr_attendance: Fix missing attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -191,28 +191,9 @@ class HrAttendance(models.Model):
             between check_in and check_out, without taking into account the lunch_interval"""
         for attendance in self:
             if attendance.check_out and attendance.check_in and attendance.employee_id:
-                attendance.worked_hours = attendance._get_worked_hours_in_range(attendance.check_in, attendance.check_out)
+                attendance.worked_hours = (attendance.check_out - attendance.check_in).total_seconds() / 3600
             else:
                 attendance.worked_hours = False
-
-    def _get_worked_hours_in_range(self, start_dt, end_dt):
-        """Returns the amount of hours worked because of this attendance during the
-        interval defined by [start_dt, end_dt]
-
-        :param start_dt: datetime starting the interval.
-        :param end_dt: datetime ending the interval.
-        :returns: float, hours worked
-        """
-        self.ensure_one()
-        tz = ZoneInfo(self.employee_id._get_tz(self.check_in))
-        start_dt_tz = max(self.check_in, start_dt).replace(tzinfo=UTC).astimezone(tz)
-        end_dt_tz = min(self.check_out, end_dt).replace(tzinfo=UTC).astimezone(tz)
-
-        if end_dt_tz < start_dt_tz:
-            return 0.0
-
-        attendance_intervals = Intervals([(start_dt_tz, end_dt_tz, self)])
-        return sum_intervals(attendance_intervals)
 
     @api.constrains('check_in', 'check_out')
     def _check_validity_check_in_check_out(self):

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
+from datetime import time
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
@@ -127,6 +128,7 @@ class HrEmployee(models.Model):
         for employee in self:
             employee.total_overtime = mapped_validated_overtimes.get(employee, 0)
 
+    @api.depends('attendance_ids', 'attendance_ids.check_in', 'attendance_ids.check_out', 'attendance_ids.worked_hours', 'attendance_ids.validated_overtime_hours')
     def _compute_hours_last_month(self):
         """
         Compute hours and overtime hours in the current month, if we are the 15th of october, will compute from 1 oct to 15 oct
@@ -138,7 +140,7 @@ class HrEmployee(models.Model):
             now_tz = now_utc.astimezone(tz)
             start_tz = now_tz.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             start_naive = start_tz.astimezone(datetime.UTC).replace(tzinfo=None)
-            end_tz = now_tz
+            end_tz = datetime.datetime.combine(now_tz + relativedelta(day=31), time.max, tzinfo=now_tz.tzinfo)
             end_naive = end_tz.astimezone(datetime.UTC).replace(tzinfo=None)
 
             for employee in employees:
@@ -152,14 +154,9 @@ class HrEmployee(models.Model):
                     overtime_hours += att.validated_overtime_hours or 0
                 employee.hours_last_month = round(hours, 2)
                 employee.hours_last_month_display = "%g" % employee.hours_last_month
-                # overtime_adjustments = sum(
-                #     ot.duration or 0
-                #     for ot in employee.overtime_ids.filtered(
-                #         lambda ot: ot.date >= start_tz.date() and ot.date <= end_tz.date() and ot.adjustment
-                #     )
-                # )
                 employee.hours_last_month_overtime = round(overtime_hours, 2)
 
+    @api.depends('attendance_ids', 'attendance_ids.check_in', 'attendance_ids.check_out')
     def _compute_hours_today(self):
         now = fields.Datetime.now()
         now_utc = now.replace(tzinfo=datetime.UTC)

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -131,7 +131,7 @@ class HrEmployee(models.Model):
             now_tz = now_utc.astimezone(tz)
             start_tz = now_tz.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             start_naive = start_tz.astimezone(datetime.UTC).replace(tzinfo=None)
-            end_tz = now_tz
+            end_tz = now_tz.replace(hour=23, minute=59, second=59)
             end_naive = end_tz.astimezone(datetime.UTC).replace(tzinfo=None)
 
             for employee in employees:

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 from odoo.fields import Domain
+from odoo.tools.date_utils import sum_intervals
+from odoo.tools.intervals import Intervals
 
 
 class HrLeaveAllocation(models.Model):
@@ -78,8 +80,9 @@ class HrLeaveAllocation(models.Model):
             ('check_out', '>', start_dt),
         ])
 
-        total_worked_hours = 0.0
-        for attendance in attendances:
-            total_worked_hours += attendance._get_worked_hours_in_range(start_dt, end_dt)
+        attendance_intervals = []
+        for att in attendances:
+            attendance_intervals.append((att.check_in, att.check_out, att))
 
-        return total_worked_hours
+        worked_interval = Intervals(attendance_intervals) & Intervals([(start_dt, end_dt, self.env['hr.attendance'])])
+        return sum_intervals(worked_interval)


### PR DESCRIPTION
Issue
===========
If you mark an attendance for an employee that ends after the timestamp at which you created it,
it's not captured, as monthly hours are computed based on employee attendances inside the range
[start of today, timestamp at the time of creation].

Fix
===========
- Instead of filtering attendances starting from the current day's first hour and ending
at the exact moment of the attendance creation, we extend the filter's upper bound to the
end of the current month (at 23:59), to be able to count hours from all attendances of the
current month, even before they happen.

TaskID-6121547