### PR TITLE
[FIX] web: increase query count in test_load_menus_perf

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -56,8 +56,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 62
-        with self.assertQueryCount(62):
+        # - All modules 63
+        with self.assertQueryCount(63):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache:
@@ -72,8 +72,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 62
-        with self.assertQueryCount(62):
+        # - All modules 63
+        with self.assertQueryCount(63):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache:


### PR DESCRIPTION
Due to changes in the related enterprise PR fixing timesheet Configuration menu visibility in sale_timesheet_enterprise, the number of queries has increased.

This commit increases the expected query count in test_load_menus_perf and test_load_web_menus_perf from 62 to 63.

task-5428010