### PR TITLE
[FIX] product: allow users with read access to print labels

### DIFF
--- a/addons/product/tests/test_common.py
+++ b/addons/product/tests/test_common.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import AccessError
 from odoo.tests import tagged
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -24,3 +25,30 @@ class TestProduct(ProductCommon):
             self.pricelist,
         )
         self.assertEqual(self.pricelist.currency_id.name, self.currency.name)
+
+    def test_any_user_can_print_product_labels(self):
+        base_user = self.env['res.users'].create({
+            'name': 'Base user',
+            'login': 'base_user',
+            'email': 'base.user@test.com',
+            'group_ids': self.group_user,
+        })
+        product_template_print_label_action = self.env.ref('product.action_product_template_print_labels')
+        product_template_context = {
+            'active_model': 'product.template',
+            'active_id': self.product.product_tmpl_id.id,
+        }
+        try:
+            product_template_print_label_action.with_user(base_user).with_context(product_template_context).run()
+        except AccessError:
+            self.fail("AccessError raised while printing product label with base user.")
+
+        product_product_print_label_action = self.env.ref('product.action_product_print_labels')
+        product_product_context = {
+            'active_model': 'product.product',
+            'active_id': self.product.id,
+        }
+        try:
+            product_product_print_label_action.with_user(base_user).with_context(product_product_context).run()
+        except AccessError:
+            self.fail("AccessError raised while printing product label with base user.")

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -197,6 +197,7 @@
     <record id="action_product_template_print_labels" model="ir.actions.server">
         <field name="name">Print Labels</field>
         <field name="model_id" ref="product.model_product_template"/>
+        <field name="group_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -614,6 +614,7 @@
     <record id="action_product_print_labels" model="ir.actions.server">
         <field name="name">Print Labels</field>
         <field name="model_id" ref="product.model_product_product"/>
+        <field name="group_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">


### PR DESCRIPTION
Users who do not have the "write" access on `product.template` and `product.product` cannot print product labels and product variant labels

Steps to reproduce:
1. Install Sales
2. Log in as Marc Demo
3. In Sales > Products > Products, open a product and click Print Labels from the cogwheel menu
4. An access error is raised Same issue happens for Product Variants

Issue:
https://github.com/odoo/odoo/commit/95ace0a694eaf83329b50e6b89f774f0c59fec5e removed Products-related rights from the `base.group_user`. This made a difference in terms of access rights, as the `IrActionServe.run` method checks for the "write" access by calling
`_can_execute_action_on_records`:
https://github.com/odoo/odoo/blob/d15685304f479541879fabd55ea1cae4252a2a90/odoo/addons/base/models/ir_actions.py#L1230-L1239

Solution:
Add `group_user` to the `group_ids` of the relevant actions to prevent the check on the "write" access from being performed
This is a backport of https://github.com/odoo/odoo/commit/6c2c353f30db05579f5e8b7a6752ec2d1ae365b2

opw-6111333