### PR TITLE
[FIX] html_editor: guard inline code on invalid selection

### DIFF
--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -97,6 +97,10 @@ export class InlineCodePlugin extends Plugin {
             const deepChild = (node, offset) => (node === blockEl ? node.childNodes[offset] : node);
             anchorNode = deepChild(anchorNode, anchorOffset);
             focusNode = deepChild(focusNode, focusOffset);
+            if (!anchorNode || !focusNode || !blockEl?.contains(anchorNode) || !blockEl?.contains(focusNode)) {
+                delete this.historySavePointRestore;
+                return;
+            }
             if (direction === DIRECTIONS.LEFT) {
                 // Swap anchorNode and focusNode
                 [anchorNode, anchorOffset, focusNode, focusOffset] = [


### PR DESCRIPTION
There is a risk of having an invalid selection when switching immediately after to HTML Composer in mail composer, a timing window will be generated. Inline code may get undefined endpoints when processing old selections and new DOM elements, causing deepChild and findFurthest to crash when accessing the parentNode.

This commit adds a guard to prevent processing invalid selections and avoid the possible crash when DOM elements are not found.

task-6143328




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
