### PR TITLE
[IMP] point_of_sale: optimize partner search performance

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -47,6 +47,7 @@ class ResPartner(models.Model):
         else:
             # If search domain is not empty, we need to search inside all partners
             new_partners = self.search(domain, offset=offset, limit=100)
+
         fiscal_positions = new_partners.fiscal_position_id
         return {
             'res.partner': self._load_pos_data_read(new_partners, config),

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -151,6 +151,26 @@ export class PartnerList extends Component {
 
         return availablePartners;
     }
+    _getSearchFields(query) {
+        if (query.includes("@")) {
+            return ["email"];
+        }
+        const stripped = query.replace(/[+\s()\-./]/g, "");
+        if (/^\d+$/.test(stripped) && stripped.length >= 3) {
+            return ["phone_mobile_search", "barcode", "vat", "zip"];
+        }
+        return [
+            "complete_name",
+            "ref",
+            "company_registry",
+            "vat",
+            "street",
+            "zip",
+            "email",
+            "phone_mobile_search",
+            "barcode",
+        ];
+    }
     get isBalanceDisplayed() {
         return false;
     }
@@ -169,22 +189,10 @@ export class PartnerList extends Component {
             return [];
         }
         if (this.state.query) {
-            const search_fields = [
-                "name",
-                "parent_name",
-                "phone_mobile_search",
-                "email",
-                "barcode",
-                "street",
-                "zip",
-                "city",
-                "state_id",
-                "country_id",
-                "vat",
-            ];
+            const search_fields = this._getSearchFields(this.state.query);
             domain = [
                 ...Array(search_fields.length - 1).fill("|"),
-                ...search_fields.map((field) => [field, "ilike", this.state.query + "%"]),
+                ...search_fields.map((field) => [field, "ilike", this.state.query]),
             ];
         }
 

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -151,6 +151,17 @@ export class PartnerList extends Component {
 
         return availablePartners;
     }
+    _getSearchFields(query) {
+        const trimmed = query.trim();
+        const stripped = trimmed.replace(/[+\s()\-./]/g, "");
+        if (/^\d+$/.test(stripped) && stripped.length >= 3) {
+            return ["phone_mobile_search", "barcode", "vat", "zip"];
+        }
+        if (trimmed.includes("@")) {
+            return ["email"];
+        }
+        return ["complete_name", "ref", "company_registry", "vat", "street", "zip"];
+    }
     get isBalanceDisplayed() {
         return false;
     }
@@ -169,22 +180,10 @@ export class PartnerList extends Component {
             return [];
         }
         if (this.state.query) {
-            const search_fields = [
-                "name",
-                "parent_name",
-                "phone_mobile_search",
-                "email",
-                "barcode",
-                "street",
-                "zip",
-                "city",
-                "state_id",
-                "country_id",
-                "vat",
-            ];
+            const search_fields = this._getSearchFields(this.state.query);
             domain = [
                 ...Array(search_fields.length - 1).fill("|"),
-                ...search_fields.map((field) => [field, "ilike", this.state.query + "%"]),
+                ...search_fields.map((field) => [field, "ilike", this.state.query]),
             ];
         }
 


### PR DESCRIPTION
Improve partner search response time on large databases (1M+ rows):
- Implement smart field selection based on input type (phone, email, text).
- Use prefix search (=ilike) for identifiers and exact match for barcodes.
- Remove expensive sorting by complete_name in the backend.
- Increase search limit to 500 to reduce network round-trips.

task-id: 6143737

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
