### PR TITLE
[WIP][IMP] l10n_ar: show better the incoterm on invoice report

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -232,11 +232,7 @@
                     <t t-if="o.invoice_incoterm_id">
                         <br/>
                         <strong>Incoterm:</strong>
-                        <p t-if="o.incoterm_location">
-                            <span t-field="o.invoice_incoterm_id.code"/> <br/>
-                            <span t-field="o.incoterm_location"/>
-                        </p>
-                        <p t-else="" t-field="o.invoice_incoterm_id.name" class="m-0"/>
+                        <span t-field="o.invoice_incoterm_id.code"/><span t-if="o.incoterm_location" t-out="' - %s' % o.incoterm_location"/>
                     </t>
 
                 </div>


### PR DESCRIPTION
**Manual FP** of https://github.com/odoo/odoo/pull/219952:

**Description of the issue/feature this PR addresses**: 
It is neccesary to show incoterm on invoice report on same line as the incoterm field.

**Steps to reproduce**:

1. Go to runbot odoo 18 enterprise instance, install l10n_ar module "Argentina - Accounting" and take position on "(AR) Responsable Inscripto" company.
2. Create a customer invoice and set incoterm and incoterm location on page "Other Info" on the invoice form view.
<img width="1202" height="793" alt="image" src="https://github.com/user-attachments/assets/749b79ca-e8a2-4c62-b6d1-d8b434a7e6eb" />
3. Print pdf without payment
<img width="1088" height="353" alt="image" src="https://github.com/user-attachments/assets/ee65af4a-3ffa-4755-abc0-2c9ab7ff01b3" />
**Current behavior before PR**:
<img width="745" height="405" alt="image" src="https://github.com/user-attachments/assets/d736ab05-e7d4-4a89-acfb-64dda08e6c1b" />
**Desired behavior after PR is merged**:
<img width="805" height="388" alt="image" src="https://github.com/user-attachments/assets/3111a081-2d56-4ec2-ab52-1f06e1b53997" />

Task Adhoc side: 52734.
Task latam side: 1354.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
