### PR TITLE
[FIX] l10n_it_edi: prevent UnboundLocalError

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -117,6 +117,8 @@ class AccountMoveSend(models.AbstractModel):
                 attachment_name = move.l10n_it_edi_attachment_name
             elif attachment := move_data.get('l10n_it_edi_values'):
                 attachment_name = attachment['name']
+            else:
+                continue
             attachment_data = results.get(attachment_name, {})
             if attachment_data.get('signed') and (signed_data := attachment_data.get('signed_data')):
                 move.l10n_it_edi_attachment_file = base64.b64encode(signed_data.encode())


### PR DESCRIPTION
If a move has no l10n_it_edi_attachment_file and no l10n_it_edi_values in move_data, the variable attachment_name is never defined, causing an UnboundLocalError.

Ticket [link](https://www.odoo.com/odoo/project.task/6064501)
opw-6064501