### PR TITLE
[FIX] account: prevent error on payment update with multiple counterpart lines

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1043,6 +1043,9 @@ class AccountPayment(models.Model):
                 continue
             liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
 
+            if len(counterpart_lines) > 1:
+                raise UserError(_("Oopsie! Multiple counterpart lines detected.\nPlease make sure that only one receivable/payable account is used on Journal Items."))
+
             if 'amount' in changed_fields and len(liquidity_lines) > 1:
                 raise UserError(_("You cannot change the amount of a payment with multiple liquidity lines."))
 

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -909,3 +909,30 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         payment.action_draft()
         with self.assertRaises(UserError):
             payment.amount = 300.0
+
+    def test_payment_with_multiple_counterpart_lines(self):
+        payment = self.env['account.payment'].create({
+            'amount': 500.0,
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'partner_id': self.partner_a.id,
+            'journal_id': self.bank_journal_1.id,
+        })
+        payment.action_post()
+        move = payment.move_id
+        move.button_draft()
+        counterpart_lines = payment._seek_for_lines()[1]
+        move.write({
+            'line_ids': [
+                Command.update(counterpart_lines.id, {'amount_currency': 400}),
+                Command.create({
+                    'account_id': counterpart_lines.account_id.id,
+                    'balance': 100.0,
+                    'currency_id': payment.currency_id.id,
+                }),
+            ],
+        })
+        move.action_post()
+        payment.action_draft()
+        with self.assertRaises(UserError):
+            payment.amount = 300.0


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `accountant` and `l10n_account_withholding_tax` modules (with demo data).
2. Create a vendor bill with "**2% WTH**" tax on the invoice line.
3. Make payment with withholding and set the withholding account as receivable.
4. Reset the payment to draft.
5. Modify the amount and save.

Video: https://drive.google.com/file/d/1Sz_5Kqs9Le89nAzZIAQoyq3bwQpMijsH/view?usp=drive_link

**Error:**
`Expected singleton: account.move.line(130, 131)`

## Cause:
During payment update, `_synchronize_to_moves` calls `_seek_for_lines()` to get the liquidity, counterpart, and write-off 
lines. - [1] Counterpart lines include accounts of type _Receivable_ or _Payable_ - [2]. 
If the withholding account is also one of these types, multiple lines are passed as counterpart lines. And this leads to a singleton error.


## Fix:
This commit raises an error, instructing the user to ensure that only one receivable/payable account is used.

[1] - https://github.com/odoo/odoo/blob/9b57d3d813c03e8d1eeab26a22dd5384106b6cd8/addons/account/models/account_payment.py#L492
[2] - https://github.com/odoo/odoo/blob/9b57d3d813c03e8d1eeab26a22dd5384106b6cd8/addons/account/models/account_payment.py#L221-L222

sentry-7377168925