### PR TITLE
[FIX] hr_attendance: total_overtime accessibility fix

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -47,7 +47,8 @@ class HrEmployee(models.Model):
     overtime_ids = fields.One2many(
         'hr.attendance.overtime', 'employee_id', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     total_overtime = fields.Float(
-        compute='_compute_total_overtime', compute_sudo=True)
+        compute='_compute_total_overtime', compute_sudo=True,
+        groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
- Step to reproduce: install hr_attendance, everyone can see everyone's overtimes.
- Cause: no group set for that field.
- Solution: adding group policy.

Task: 6125021
