### PR TITLE
[FIX] account_edi_ubl_cii: Print right message in chatter at import

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -3218,12 +3218,11 @@ class AccountEdiUBL(models.AbstractModel):
         attachments = self._import_attachments(invoice, collected_values['tree']) or self.env['ir.attachment']
 
         # Chatter.
-        body = None
+        body = Markup("<strong>%s</strong>") % _(
+            "Format used to import the invoice: %s",
+            self.env['ir.model']._get(self._name).name,
+        )
         if logs := collected_values['logs']:
-            body = Markup("<strong>%s</strong>") % _(
-                "Format used to import the invoice: %s",
-                self.env['ir.model']._get(self._name).name,
-            )
             body += Markup("<ul>%s</ul>") % Markup().join(Markup("<li>%s</li>") % l for l in logs)
         invoice.with_context(no_new_invoice=True).message_post(body=body, attachment_ids=attachments.ids)
 


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: Print right message in chatter at import

When a UBL XML invoice is imported in vendor bills and no logs are collected, a message 'None' is printed in the chatter and the message 'Format used to import the invoice: ...' is not printed This commit fixes both issues

no-task

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
