### PR TITLE
[FIX] html_builder: prevent `cannot convert m to em` traceback

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -76,7 +76,10 @@ export class BuilderNumberInput extends Component {
         return this.convertSpaceSplitValues(rawValue, (value) => {
             const unit = this.props.unit;
             const { savedValue, savedUnit } = value.match(
-                /(?<savedValue>[\d.e+-]+)(?<savedUnit>\w*)/
+                // [+-]? - optional sign
+                // \d*\.?\d+ - number (int or decimal)
+                // (?:e[+-]?\d+)? - optional scientific notation
+                /(?<savedValue>[+-]?\d*\.?\d+(?:e[+-]?\d+)?)(?<savedUnit>\w*)/
             ).groups;
             if (savedUnit || this.props.saveUnit) {
                 // Convert value from saveUnit to unit


### PR DESCRIPTION
Steps to reproduce:
i. Create an option with "BuilderNumberInput" and set the unit to "em".
ii. Open the builder and try changing the option value.

Reason for traceback:
The regex used to separate the value and unit incorrectly allows "e" in the numeric part. As a result, a value like "12em" is parsed as "value = 12e" and "unit = m". The "e" in regex was meant to allow scientific notation (e.g. "1e3"), but it also matches the "e" in unit.

After this fix, it is ensured that the regex correctly separates the numeric value and unit, along with preserving the ability to use scientific notation.

task-6048918