### PR TITLE
[FIX] website_sale: fix website_sale.product_tags template

### DIFF
--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -753,7 +753,7 @@
             <a
                 t-foreach="visible_tags"
                 t-as="tag"
-                t-att-href="is_view_active('website_sale.filter_products_tags') and keep(shop_path, tags=tag.id) or None"
+                t-att-href="is_view_active('website_sale.filter_products_tags') and '/shop?tags=%s' % tag.id or None"
                 class="text-decoration-none d-inline-block"
             >
                 <span t-if="tag.image"


### PR DESCRIPTION
A recent PR added a reference to `keep` in the template, however, this template is rendered in multiple places, and not all of them were adding `keep` to the rendering context, resulting in rendering errors.

Alternatively, we could have added `keep` wherever it was missing, but that wouldn't make sense in all cases. Moreover, `keep` isn't very useful anymore on the product page (one of the places where the template was called) and will be dropped soon.