### PR TITLE
[FIX] sale_project: Multi-Comp. Product creates comp-specific projects

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -138,7 +138,7 @@ class SaleOrder(models.Model):
             if len(order.project_ids) == 1:
                 project = order.project_ids[0]
                 for sol in order.order_line:
-                    if project == sol.project_id and (project_template := sol.product_template_id.project_template_id):
+                    if project == sol.project_id and (project_template := sol.product_template_id.with_company(order.company_id).project_template_id):
                         project.sudo().company_id = project_template.sudo().company_id
                         break
         return super()._action_confirm()

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import Command, SUPERUSER_ID
 from odoo.tests import Form, HttpCase, new_test_user, tagged
 from odoo.exceptions import UserError
 
@@ -937,6 +937,36 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             sale_order_action = multi_company_project.with_company(company).action_view_sos()
             self.assertEqual(sale_order_action["type"], "ir.actions.act_window")
             self.assertEqual(sale_order_action["res_model"], "sale.order")
+
+    def test_multi_company_so_creation(self):
+        # SO with project template with non-superuser company_id able creates project with proper company
+        company = self.env['res.company'].create({
+            'name': 'Multi-Company Test Company',
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+
+        company_project_template = self.env['project.project'].with_company(company).create({
+            'name': 'Multi-Company Test Company Project Template',
+            'company_id': company.id,
+        })
+
+        product_with_project_template = self.env['product.product'].with_company(company).create({
+            'name': 'product with template',
+            'list_price': 1,
+            'type': 'service',
+            'service_tracking': 'project_only',
+            'project_template_id': company_project_template.id,
+        })
+
+        # SOs with one created project
+        sale_order = self.env['sale.order'].with_company(company).create({'partner_id': self.partner.id})
+        self.env['sale.order.line'].with_company(company).create({
+            'product_id': product_with_project_template.id,
+            'order_id': sale_order.id,
+        })
+        sale_order_sudo = sale_order.with_user(SUPERUSER_ID)
+        sale_order_sudo.action_confirm()
+        self.assertEqual(company_project_template.company_id, sale_order.project_ids[0].company_id, "The created project should have the same company as the template")
 
     def test_action_view_task_stages(self):
         SaleOrder = self.env['sale.order'].with_context(tracking_disable=True)


### PR DESCRIPTION
project_template_id is a company dependent field. When creating a project, it is called without the proper company context set up. When confirming an SO through the portal, the order's env is setup without a company and `.with_user(SUPERUSER_ID)`, making future company_dependent variables use OdooBot's company.

Following examples earlier in the function, call `.with_company` while accessing project_template_id.

Steps to reproduce:
1. Install Sales and Project
2. Create second company
3. Create Customer with portal access, under created company
4. Create service product with different projects for each company
5. Create sales order with customer and service product, send to customer
6. Login as customer on portal, accept and sign SO a. Should stall, RPC Error in console

Ticket: opw-6082772

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
