### PR TITLE
[FIX] web: inconsistent “is set” operator for many2one in domain selector

### DIFF
--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -81,7 +81,7 @@ function introduceSetOperators(tree, options = {}) {
         }
         if (fieldType === "boolean" && c.value === true) {
             return updateCondition(c, { operator: c.operator === "=" ? "set" : "not set" });
-        } else if (!["many2one", "date", "datetime"].includes(fieldType) && c.value === false) {
+        } else if (c.value === false) {
             return updateCondition(c, { operator: c.operator === "=" ? "not set" : "set" });
         }
     }

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -81,7 +81,7 @@ function introduceSetOperators(tree, options = {}) {
         }
         if (fieldType === "boolean" && c.value === true) {
             return updateCondition(c, { operator: c.operator === "=" ? "set" : "not set" });
-        } else if (!["many2one", "date", "datetime"].includes(fieldType) && c.value === false) {
+        } else if (!["date", "datetime"].includes(fieldType) && c.value === false) {
             return updateCondition(c, { operator: c.operator === "=" ? "not set" : "set" });
         }
     }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1611,7 +1611,6 @@ test("many2one field operators (edit)", async () => {
         label("not ilike"),
         label("set"),
         label("not set"),
-        label("=", "many2one"),
     ]);
 });
 
@@ -1641,44 +1640,12 @@ test("many2one field: operator switch (edit)", async () => {
     expect.verifySteps([`[("product_id", "not ilike", "")]`]);
 });
 
-test("many2one field and operator =/!= (edit)", async () => {
-    await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
-        update(domain) {
-            expect.step(domain);
-        },
-    });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
-    expect.verifySteps([]);
-    expect(".dropdown-menu").toHaveCount(0);
-
-    await editValue("xph", { confirm: false });
-    await runAllTimers();
-    expect(".dropdown-menu").toHaveCount(1);
-    expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone"]);
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("xph");
-
-    await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("xphone");
-    expect.verifySteps([`[("product_id", "=", 37)]`]);
-    expect(".dropdown-menu").toHaveCount(0);
-
-    await editValue("", { confirm: false });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
-    await contains(".o_domain_selector").click();
-    expect.verifySteps([`[("product_id", "=", False)]`]);
-});
-
 test("many2one field on record with falsy display_name", async () => {
     Product._records[0].name = false;
     await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
+        domain: `[("product_id", "in", [])]`,
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("");
     expect(".dropdown-menu").toHaveCount(0);
 
@@ -1753,8 +1720,8 @@ test("many2many field and operator set/not set (edit)", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
     expect.verifySteps([]);
 
     await selectOperator("not set");
@@ -1776,8 +1743,8 @@ test("many2many field: clone a set/not set condition", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
     expect.verifySteps([]);
 
     await selectOperator("not set");
@@ -2313,12 +2280,12 @@ test("shorten descriptions of long lists", async () => {
 test("many2one: no domain in autocompletion", async () => {
     Partner._fields.product_id.domain = `[("display_name", "ilike", "xpa")]`;
     await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
+        domain: `[("product_id", "in", [])]`,
         update(domain) {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -2328,13 +2295,13 @@ test("many2one: no domain in autocompletion", async () => {
 
     expect(".dropdown-menu").toHaveCount(1);
     expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone", "xpad"]);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("x");
 
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("xphone");
-    expect.verifySteps([`[("product_id", "=", 37)]`]);
+    expect.verifySteps([`[("product_id", "in", [37])]`]);
     expect(".dropdown-menu").toHaveCount(0);
 });
 
@@ -2647,6 +2614,22 @@ test(`datetime: "in range" operator`, async () => {
     expect.verifySteps([`["&", ("datetime", ">=", "today"), ("datetime", "<", "today +1d")]`]);
 });
 
+test("datetime field and operator set/not set (edit)", async () => {
+    const parent = await makeDomainSelector({
+        domain: `[("datetime", "=", False)]`,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
+    expect.verifySteps([]);
+
+    await parent.set(`[("datetime", "!=", False)]`);
+    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentValue()).toBe(null);
+});
+
 test(`date: "in range" operator`, async () => {
     serverState.debug = "1";
     mockDate("2023-04-20 17:00:00", 0);
@@ -2742,6 +2725,22 @@ test(`date: default for ">"`, async () => {
     await selectOperator(">");
     expect(getCurrentValue()).toBe("03/11/2019");
     expect.verifySteps([`[("date", ">", "2019-03-11")]`]);
+});
+
+test("date field and operator set/not set (edit)", async () => {
+    const parent = await makeDomainSelector({
+        domain: `[("date", "=", False)]`,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
+    expect.verifySteps([]);
+
+    await parent.set(`[("date", "!=", False)]`);
+    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentValue()).toBe(null);
 });
 
 test(`delete single node in "|"`, async () => {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1611,7 +1611,6 @@ test("many2one field operators (edit)", async () => {
         label("not ilike"),
         label("set"),
         label("not set"),
-        label("=", "many2one"),
     ]);
 });
 
@@ -1641,44 +1640,12 @@ test("many2one field: operator switch (edit)", async () => {
     expect.verifySteps([`[("product_id", "not ilike", "")]`]);
 });
 
-test("many2one field and operator =/!= (edit)", async () => {
-    await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
-        update(domain) {
-            expect.step(domain);
-        },
-    });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
-    expect.verifySteps([]);
-    expect(".dropdown-menu").toHaveCount(0);
-
-    await editValue("xph", { confirm: false });
-    await runAllTimers();
-    expect(".dropdown-menu").toHaveCount(1);
-    expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone"]);
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("xph");
-
-    await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("xphone");
-    expect.verifySteps([`[("product_id", "=", 37)]`]);
-    expect(".dropdown-menu").toHaveCount(0);
-
-    await editValue("", { confirm: false });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
-    await contains(".o_domain_selector").click();
-    expect.verifySteps([`[("product_id", "=", False)]`]);
-});
-
 test("many2one field on record with falsy display_name", async () => {
     Product._records[0].name = false;
     await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
+        domain: `[("product_id", "in", [])]`,
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("");
     expect(".dropdown-menu").toHaveCount(0);
 
@@ -1753,8 +1720,8 @@ test("many2many field and operator set/not set (edit)", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
     expect.verifySteps([]);
 
     await selectOperator("not set");
@@ -1776,8 +1743,8 @@ test("many2many field: clone a set/not set condition", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
-    expect(getCurrentValue()).toBe("");
+    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentValue()).toBe(null);
     expect.verifySteps([]);
 
     await selectOperator("not set");
@@ -2313,12 +2280,12 @@ test("shorten descriptions of long lists", async () => {
 test("many2one: no domain in autocompletion", async () => {
     Partner._fields.product_id.domain = `[("display_name", "ilike", "xpa")]`;
     await makeDomainSelector({
-        domain: `[("product_id", "=", False)]`,
+        domain: `[("product_id", "in", [])]`,
         update(domain) {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -2328,13 +2295,13 @@ test("many2one: no domain in autocompletion", async () => {
 
     expect(".dropdown-menu").toHaveCount(1);
     expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone", "xpad"]);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("x");
 
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal to");
     expect(getCurrentValue()).toBe("xphone");
-    expect.verifySteps([`[("product_id", "=", 37)]`]);
+    expect.verifySteps([`[("product_id", "in", [37])]`]);
     expect(".dropdown-menu").toHaveCount(0);
 });
 


### PR DESCRIPTION
Previously, creating a custom filter using "is set"/
"is not set" with many2one, date or datetime fields,
applying the search, and reopening the filter converted
the operator back to =/!= ("equal to"/"not equal to")
in the frontend.

This happened because those field types were intentionally
excluded from converting back to "is set"/"is not set"
to allow editing the third component/value when reopening
the domain. However, domains stay =/!= operators and are
not converted back to set operators, leading to
inconsistent UI behavior.

After this commit, many2one, date and datetime fields are
removed from that condition so they can also be converted
back to "is set"/"is not set" when the value is false.

task-6123672
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
