### PR TITLE
[FIX] website_sale: avoid category name page overflow


### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -347,14 +347,14 @@
                                     <t t-set="_classes" t-valuef="d-none me-auto d-lg-inline-block"/>
                                 </t>
 
-                                <div t-if="category" class="d-flex align-items-center d-lg-none me-auto o_not_editable">
+                                <div t-if="category" class="d-flex align-items-center d-lg-none me-auto o_not_editable overflow-hidden">
                                     <t t-if="not category.parent_id" t-set="backUrl" t-valuef="/shop"/>
                                     <t t-else="" t-set="backUrl" t-value="keep('/shop/category/' + slug(category.parent_id), category=0)"/>
 
                                     <a t-attf-class="btn btn-{{navClass}} me-2" t-att-href="category.parent_id and keep('/shop/category/' + slug(category.parent_id), category=0) or '/shop'">
                                         <i class="fa fa-angle-left"/>
                                     </a>
-                                    <h4 t-out="category.name" class="mb-0 me-auto"/>
+                                    <h4 t-out="category.name" class="mb-0 me-auto text-overflow"/>
                                 </div>
 
                                 <t t-if="is_view_active('website_sale.add_grid_or_list_option')" t-call="website_sale.add_grid_or_list_option">


### PR DESCRIPTION

Scenario:

- go to /shop
- click on long category (eg. Furnitures)
- reduce browser width (might need to use developer tools mobile size)
- horizontal scroll to the right

Result: the buttons are overflowing the page with

Cause: from 17.0 to saas-18.2 (after which the category name is removed
from the filter button line) the category name is a fixed min-size with
overflow:visible, so that and being flex-nowrap, it overflows the page
width if it doesn't fit.

Fix: truncate category name if it is too long

opw-6065145
