### PR TITLE
[CLN] sale: drop hardcoded reference to documentation files

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -903,16 +903,10 @@ class ProductTemplate(models.Model):
                     <br/>
                     %s
                 </p>
-                <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/latest/_downloads/eaa2883bd361273b475c9765f64e3e0c/pdfquotebuilderexamples.zip">
-                    %s
-                    </a>
-                </p>
             """ % (
                 _("Upload files to your product"),
                 _("Use this feature to store any files you would like to share with your customers"),
                 _("(e.g: product description, ebook, legal notice, ...)."),
-                _("Download examples")
             )
         }
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1141,14 +1141,6 @@
             </h2><p>
             Boost sales with online payments or signatures, upsells, and a great customer portal.
             </p>
-            <a
-                role="button"
-                class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/latest/_downloads/4c54b867f6472b9cbcc233b4821d5c7b/sample_quotation.pdf"
-                target="_blank"
-            >
-                Check a sample. It's clean!
-            </a>
         </field>
     </record>
 
@@ -1178,14 +1170,6 @@
             </p><p>
             Boost sales with online payments or signatures, upsells, and a great customer portal.
             </p>
-            <a
-                role="button"
-                class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/latest/_downloads/4c54b867f6472b9cbcc233b4821d5c7b/sample_quotation.pdf"
-                target="_blank"
-            >
-                Check a sample. It's clean!
-            </a>
         </field>
     </record>
 


### PR DESCRIPTION
Those links were introduced to promote the quote builder & product documents features, but are too easily broken as they rely on sphinx-generated hashes.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
