### PR TITLE
[FIX] mrp: make test work without enterprise dependency

### DIFF
--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -478,7 +478,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
 
         mo = self.create_mo(self.mo_serial_tmpl, 1)
         mo.action_confirm()
-        mo.move_raw_line_ids.quantity = 1
+        mo.move_raw_ids.move_line_ids.quantity = 1
         mo.move_raw_ids.write({
             'move_line_ids': [
                 Command.create({


### PR DESCRIPTION
The test `test_multi_lot_component_consumption` relies on `move_raw_line_ids`, which is initialized by the `stock_barcode_mrp` module. This module is only available in enterprise, causing the test to fail in community setups.

https://github.com/odoo/odoo/blob/0ce5baf2918960591284eb494d82dfef07043af0/addons/mrp/tests/test_consume_component.py#L481

runbot-242612