### PR TITLE
[IMP] mail: remove `msg_vals` from `_notify_get_recipients`

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -863,22 +863,16 @@ class DiscussChannel(models.Model):
     # MAILING
     # ------------------------------------------------------------
 
-    def _notify_get_recipients(self, message, msg_vals=False, **kwargs):
+    def _notify_get_recipients(self, message, **kwargs):
         # Override recipients computation as channel is not a standard
         # mail.thread document. Indeed there are no followers on a channel.
         # Instead of followers it has members that should be notified.
-        msg_vals = msg_vals or {}
-
         # notify only user input (comment, whatsapp messages or incoming / outgoing emails)
-        message_type = msg_vals['message_type'] if 'message_type' in msg_vals else message.message_type
-        if message_type not in ('comment', 'email', 'email_outgoing', 'whatsapp_message'):
+        if message.message_type not in ("comment", "email", "email_outgoing", "whatsapp_message"):
             return []
-
         recipients_data = []
-        author_id = msg_vals.get("author_id") or message.author_id.id
-        pids = msg_vals['partner_ids'] or [] if 'partner_ids' in msg_vals else message.partner_ids.ids
-        if pids:
-            email_from = tools.email_normalize(msg_vals.get('email_from') or message.email_from)
+        if message.partner_ids:
+            email_from = tools.email_normalize(message.email_from)
             self.env['res.partner'].flush_model(['active', 'email', 'partner_share'])
             self.env['res.users'].flush_model(['notification_type', 'partner_id'])
             sql_query = SQL(
@@ -897,8 +891,8 @@ class DiscussChannel(models.Model):
                        AND partner.id IN %(partner_ids)s AND partner.id != %(author_id)s
                 """,
                 email=email_from or "",
-                partner_ids=tuple(pids),
-                author_id=author_id or 0,
+                partner_ids=tuple(message.partner_ids.ids),
+                author_id=message.author_id.id or 0,
             )
             self.env.cr.execute(sql_query)
             for partner_id, email_normalized, lang, name, partner_share, uid, ushare in self.env.cr.fetchall():
@@ -917,15 +911,14 @@ class DiscussChannel(models.Model):
                     'uid': uid,
                     'ushare': ushare,
                 })
-
         domain = Domain.AND([
             [("channel_id", "=", self.id)],
-            [("partner_id", "!=", author_id)],
+            [("partner_id", "!=", message.author_id.id)],
             [("partner_id.active", "=", True)],
             [("partner_id.user_ids.manual_im_status", "!=", "busy")],
             Domain.OR([
                 [("mute_until_dt", "=", False)],
-                [("partner_id", "in", pids)],
+                [("partner_id", "in", message.partner_ids.ids)],
             ]),
             Domain.OR([
                 [("channel_id.channel_type", "!=", "channel")],
@@ -939,20 +932,19 @@ class DiscussChannel(models.Model):
                         ]),
                         Domain.AND([
                             [("custom_notifications", "=", "mentions")],
-                            [("partner_id", "in", pids)],
+                            [("partner_id", "in", message.partner_ids.ids)],
                         ]),
                         Domain.AND([
                             [("custom_notifications", "=", False)],
                             [("partner_id.user_ids.res_users_settings_ids.channel_notifications", "=", False)],
-                            [("partner_id", "in", pids)],
+                            [("partner_id", "in", message.partner_ids.ids)],
                         ]),
                     ]),
                 ]),
             ]),
         ])
         # sudo: discuss.channel.member - read to get the members of the channel and res.users.settings of the partners
-        members = self.env["discuss.channel.member"].sudo().search(domain)
-        for member in members:
+        for member in self.env["discuss.channel.member"].sudo().search(domain):
             recipients_data.append({
                 "active": True,
                 "id": member.partner_id.id,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3363,8 +3363,7 @@ class MailThread(models.AbstractModel):
         """ Main notification method. This method basically does two things
 
          * call ``_notify_get_recipients`` that computes recipients to
-           notify based on message record or message creation values if given
-           (to optimize performance if we already have data computed);
+           notify based on message record
          * performs the notification process by calling the various notification
            methods implemented;
 
@@ -3389,7 +3388,7 @@ class MailThread(models.AbstractModel):
             restricting_names=self._get_notify_valid_parameters()
         )
 
-        recipients_data = self._notify_get_recipients(message, msg_vals=msg_vals, **kwargs)
+        recipients_data = self._notify_get_recipients(message, **kwargs)
         # cache data fetched by manual query to avoid extra queries when reading user.partner_id
         uid2pid = {r['uid']: r['id'] for r in recipients_data if r['id'] and r['uid']}
         users = self.env['res.users'].browse(uid2pid)
@@ -4145,14 +4144,11 @@ class MailThread(models.AbstractModel):
             }
         }
 
-    def _notify_get_recipients(self, message, msg_vals=False, **kwargs):
+    def _notify_get_recipients(self, message, **kwargs):
         """ Compute recipients to notify based on subtype and followers. This
         method returns data structured as expected for ``_notify_recipients``.
 
-        :param record message: <mail.message> record being notified. May be
-          void as 'msg_vals' superseeds it;
-        :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries if given;
+        :param record message: <mail.message> record being notified
 
         Kwargs allow to pass various parameters that are used by sub notification
         methods. See those methods for more details about supported parameters.
@@ -4194,47 +4190,36 @@ class MailThread(models.AbstractModel):
           }, {...}]
         :rtype: list[dict]
         """
-        msg_vals = msg_vals or {}
         msg_sudo = message.sudo()
-
-        # get values from msg_vals or from message if msg_vals doen't exists
-        pids = msg_vals['partner_ids'] if 'partner_ids' in msg_vals else msg_sudo.partner_ids.ids
+        pids = msg_sudo.partner_ids.ids
         if kwargs.get('notify_skip_followers'):
             # when skipping followers, message acts like user notification, which means
             # relying on required recipients (pids) only
             message_type = 'user_notification'
         else:
-            message_type = msg_vals['message_type'] if 'message_type' in msg_vals else msg_sudo.message_type
-        subtype_id = msg_vals['subtype_id'] if 'subtype_id' in msg_vals else msg_sudo.subtype_id.id
-
+            message_type = msg_sudo.message_type
+        subtype_id = msg_sudo.subtype_id.id
         # is it possible to have record but no subtype_id ?
         recipients_data = []
         # compute partner-based recipients data: followers, mentionned partner ids
         res = self.env['mail.followers']._get_recipient_data(self, message_type, subtype_id, pids)[self.id if self else 0]
         # include optional additional emails
-        outgoing_email_to_lst = email_split_and_normalize(
-            msg_vals['outgoing_email_to'] if 'outgoing_email_to' in msg_vals else msg_sudo.outgoing_email_to
-        )
+        outgoing_email_to_lst = email_split_and_normalize(msg_sudo.outgoing_email_to)
         if not res and not outgoing_email_to_lst:
             return recipients_data
-
         # notify author of its own messages, False by default
         skip_author_id = False
         notify_author = kwargs.get('notify_author') or self.env.context.get('mail_notify_author')
         if not notify_author:
             notify_author_mention = kwargs.get('notify_author_mention') or self.env.context.get('mail_notify_author_mention')
-            author_id = msg_vals.get('author_id') or message.author_id.id
-            skip_author_id = self._message_compute_real_author(author_id).id
+            skip_author_id = self._message_compute_real_author(msg_sudo.author_id.id).id
             # allow mention of author if in direct recipients
             if notify_author_mention and skip_author_id in pids:
                 skip_author_id = False
-
         # avoid double email notification if already emailed in original email
-        emailed_normalized = [email for email in email_normalize_all(
-            f"{msg_vals.get('incoming_email_to', msg_sudo.incoming_email_to) or ''}, "
-            f"{msg_vals.get('incoming_email_cc', msg_sudo.incoming_email_cc) or ''}"
-        )]
-
+        emailed_normalized = email_normalize_all(
+            f"{msg_sudo.incoming_email_to or ''}, {msg_sudo.incoming_email_cc or ''}",
+        )
         for pid, pdata in res.items():
             if pid and pid == skip_author_id:
                 continue
@@ -4243,7 +4228,6 @@ class MailThread(models.AbstractModel):
             if pdata['email_normalized'] in emailed_normalized:
                 continue
             recipients_data.append(pdata)
-
         # include emails only
         recipients_data += [
             {
@@ -4261,7 +4245,6 @@ class MailThread(models.AbstractModel):
                 'ushare': False,
             } for name, email in outgoing_email_to_lst
         ]
-
         # avoid double notification (on demand due to additional queries)
         if kwargs.pop('skip_existing', False):
             pids = [r['id'] for r in recipients_data if r['id']]

--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -100,7 +100,7 @@ class MailTemplatePreview(models.TransientModel):
                         ActiveModel = preview.resource_ref if isinstance(preview.resource_ref, preview.pool["mail.thread"]) else preview.env["mail.thread"]
                         # Create a message without db entry for the layout.
                         message = preview.env['mail.message'].new(msg_vals)
-                        recipients_data = ActiveModel._notify_get_recipients(message, msg_vals, notify_author=True)
+                        recipients_data = ActiveModel._notify_get_recipients(message, notify_author=True)
                         if not recipients_data:
                             # Append a dummy recipient to ensure the layout is rendered
                             recipients_data.append({

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -502,7 +502,7 @@ class WebsitePublishedMixin(models.AbstractModel):
             }
 
             # Compute recipients (followers, partners, etc.)
-            recipients = target_sudo._notify_get_recipients(message_sudo, msg_vals=msg_vals)
+            recipients = target_sudo._notify_get_recipients(message_sudo)
             if recipients:
                 # Mirror the UI path so followers receive the same notifications
                 # they would if the message had been posted manually.


### PR DESCRIPTION
Using `msg_vals` is a dangerous optimization, as it ignores actual values on the record, particularly dangerous for values that are pre- or post- processed in write or message post.

On top of that it makes the code more complex.
    
The only advantage of this trick was to save queries in the past. But the message is already prefetched for other fields so it is effectively useless.
    
On top of that, nowadays the ORM now saves most fields in cache during create, and those that are not in cache must be read from the database as it means it wasn't safe to cache them from the received value in the first place.

https://github.com/odoo/enterprise/pull/114587