### PR TITLE
[FIX] l10n_vn_edi_viettel_stock: change field name

### DIFF
--- a/addons/l10n_vn_edi_viettel_stock/models/stock_move.py
+++ b/addons/l10n_vn_edi_viettel_stock/models/stock_move.py
@@ -7,7 +7,7 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     l10n_vn_edi_unit_price = fields.Float(
-        string='Unit Price',
+        string='Vietnam EDI Unit Price',
         compute='_compute_l10n_vn_edi_unit_price',
         store=True,
         readonly=False,

--- a/addons/l10n_vn_edi_viettel_stock/views/stock_picking_views.xml
+++ b/addons/l10n_vn_edi_viettel_stock/views/stock_picking_views.xml
@@ -15,7 +15,7 @@
                 />
             </xpath>
             <xpath expr="//page[@name='operations']//field[@name='quantity']" position="after">
-                <field name="l10n_vn_edi_unit_price" optional="show"/>
+                <field name="l10n_vn_edi_unit_price" string="Unit Price" optional="show"/>
                 <field name="l10n_vn_edi_total_price" optional="hide"/>
             </xpath>
             <xpath expr="//page[@name='extra']" position="after">


### PR DESCRIPTION
Currently, `l10n_vn_edi_unit_price` and `unit_price` have the same label, triggering a warning. This commit changes the field of `l10n_vn_edi_price_unit` to avoid the conflict.