### PR TITLE
[FIX] web: ensure settings load when swiping on mobile

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -2,6 +2,7 @@
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 
 import { Component, useState, useRef, useEffect } from "@odoo/owl";
+import { Deferred } from "@web/core/utils/concurrency";
 
 export class SettingsPage extends Component {
     setup() {
@@ -25,6 +26,7 @@ export class SettingsPage extends Component {
 
                 const { scrollTop } = this.scrollMap[currentTab] || 0;
                 settingsEl.scrollTop = scrollTop;
+                this.tabChangeProm?.resolve();
             },
             () => [this.settingsRef.el, this.state.selectedTab]
         );
@@ -48,14 +50,16 @@ export class SettingsPage extends Component {
             this.getCurrentIndex() !== this.props.modules.length - 1
         );
     }
-    async onRightSwipe(prom) {
+    async onRightSwipe() {
+        this.tabChangeProm = new Deferred();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() - 1].key;
-        await prom;
+        await this.tabChangeProm;
         this.scrollToSelectedTab();
     }
-    async onLeftSwipe(prom) {
+    async onLeftSwipe() {
+        this.tabChangeProm = new Deferred();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() + 1].key;
-        await prom;
+        await this.tabChangeProm;
         this.scrollToSelectedTab();
     }
 


### PR DESCRIPTION
Before this commit, swiping between settings for different apps on mobile
devices would often result in a blank page.

This occurred because the swipe method did not wait for the target page to
render completely before completing the transition. This commit ensures the
swipe action waits for the rendering process, preventing the blank state
during app navigation.