### PR TITLE
[FIX] account, product: allow catalog access for restricted sales users

### DIFF
--- a/addons/account/controllers/catalog.py
+++ b/addons/account/controllers/catalog.py
@@ -25,7 +25,7 @@ class ProductCatalogAccountController(ProductCatalogController):
                 },
             ]
         """
-        order = request.env[res_model].browse(order_id)
+        order = request.env[res_model].browse(order_id).sudo()
         return order.with_company(order.company_id)._get_sections(child_field, **kwargs)
 
     @route('/product/catalog/create_section', auth='user', type='jsonrpc')

--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -26,7 +26,7 @@ class ProductCatalogController(Controller):
                 }
             }
         """
-        order = request.env[res_model].browse(order_id)
+        order = request.env[res_model].browse(order_id).sudo()
         return order.with_company(order.company_id)._get_product_catalog_order_line_info(
             product_ids, **kwargs,
         )


### PR DESCRIPTION
Steps to Reproduce:
- Login as a Sales user (full access): Create a task and add products (SO is created and assigned to this user)
- Switch to another user (Sales: Own Documents Only): Open the same task and click the products button.
- Observe, you will get an Access Error.

Cause:
- The product catalog controllers fetch the related Sale Order using the current user’s permissions. A user with Sales: Own Documents Only cannot read Sale Orders owned by others are causing an access error when opening the Products view.

Solution:
- Use `sudo()` when browsing the Sale Order in the catalog controllers so that the required data can be fetched regardless of ownership, preventing the access error.

task-5143815


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
