### PR TITLE
[FIX] account: fix email lookup when retrieving customers

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -991,7 +991,7 @@ class ResPartner(models.Model):
 
         return {
             'criteria': [{
-                'domain': [('phone', '=', email)],
+                'domain': [('email', '=', email)],
             }],
         }
 


### PR DESCRIPTION
The email-based lookup was mistakenly checking the phone field (`phone = email`)
instead of the email field. Because of this, customers could not be correctly found
using their email address.

This change fixes the domain to properly match on the email field.