### PR TITLE
[FIX] tests: Python 3.14 support for model attribute validation

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1030,6 +1030,8 @@ class TransactionCase(BaseCase):
                 *vars(model),
                 # __annotations__ pops up during testing on *some* models
                 '__annotations__',
+                '__annotate_func__',
+                '__annotations_cache__',
                 # if model is transient & transient fields are accessed
                 '_transient_max_count',
                 '_transient_max_hours',


### PR DESCRIPTION
Since Python 3.14 (PEP 649), class annotations are evaluated lazily. This introduces two new internal attributes to the class namespace:
- `__annotate_func__`: The function that computes the annotations.
- `__annotations_cache__`: The cache for the computed annotations.

This commit adds these attributes to the TransactionCase's ignored internal attributes checker.

Note: this PR is a follow-up of https://github.com/odoo/odoo/pull/247151

Reference:
- https://peps.python.org/pep-0649/
