### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: strip spaces from SIRET for Peppol

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -112,7 +112,7 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
         if commercial_partner.country_code == 'FR' and commercial_partner.company_registry:
             nodes.append({
                 'cbc:ID': {
-                    '_text': commercial_partner.company_registry,
+                    '_text': commercial_partner.company_registry.replace(" ", ""),
                     'schemeID': '0009',
                 },
             })
@@ -141,7 +141,7 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             vals['party_node']['cac:PartyLegalEntity'] = [{
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
                 'cbc:CompanyID': {
-                    '_text': commercial_partner.company_registry,
+                    '_text': commercial_partner.company_registry.replace(" ", ""),
                     'schemeID': '0009',
                 },
             }]

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_ubl_export_bis3_fr.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_ubl_export_bis3_fr.py
@@ -24,6 +24,7 @@ class TestUblExportBis3FRChorusPro(TestUblBis3Common, TestUblCiiCommonChorusPro,
 
     def test_invoice_customer_party_identifiers_partner_chorus_pro(self):
         # VAT and siret set.
+        # The siret must not have spaces in the exported document
         # Supplier:
         # EndpointID is filled using the siret.
         # PartyIdentification is filled using the siret.
@@ -34,6 +35,10 @@ class TestUblExportBis3FRChorusPro(TestUblBis3Common, TestUblCiiCommonChorusPro,
         # PartyIdentification is filled using the customer siret.
         # PartyTaxScheme is filled using the VAT.
         # PartyLegalEntity is filled using the customer siret.
+        self.partner_fr_chorus_pro.commercial_partner_id.write({
+            'company_registry': '214 401 0930 0015',
+            'peppol_endpoint': '11000201100044',
+        })
         self._assert_invoice_partner_party_identifiers(
             partner=self.partner_fr_chorus_pro,
             test_file='test_invoice_customer_party_identifiers_partner_chorus_pro',


### PR DESCRIPTION
### Issue:
When sending invoices to Chorus Pro via Peppol in France, SIRET numbers may contain spaces, causing the document to be silently rejected

### Cause:
SIRET values must be exactly 14 characters long
However, spaces were not removed when generating the XML, leading to invalid values in:
`<cbc:ID schemeID="0009">` and `<cbc:CompanyID schemeID="0009">`

This issue can occur for both the company and the customer SIRET, as both rely on `company_registry`

As a result, Chorus Pro rejects the document due to invalid SIRET length

### Steps to reproduce:
- Install `l10n_fr_facturx_chorus_pro` and switch to `FR Company`
- Enable and Activate Peppol in Settings
- Go in Settings > Users & Companies > Companies and open the `FR Company`
- Add spaces in the Company ID: 968 515 7590 5808
- Create a Customer (Country: France, VAT: FR23334175221, Company ID/Siret: 123 456 7890 1234)
- In the customer's Invoicing Tab (Invoice sending: by Peppol, eInvoice format: EU Standard (Peppol Bis 3.0), France SIRET: 11000201100044)
- Create and Send an invoice via Peppol (Your Customer, any line with a tax)
- Open the XML
- Check the IDs and CompanyIDs in the document Before the fix, there is missing spaces

opw-6047840