### PR TITLE
[FIX] account: prevent error with multiple journals

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -185,7 +185,8 @@ class AccountBankStatement(models.Model):
     @api.depends('line_ids.journal_id')
     def _compute_journal_id(self):
         for statement in self:
-            statement.journal_id = statement.line_ids.journal_id
+            journals = statement.line_ids.mapped('journal_id')
+            statement.journal_id = journals[:1] if journals else False
 
     @api.depends('balance_end', 'balance_end_real', 'line_ids.amount', 'line_ids.state')
     def _compute_is_complete(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -895,6 +895,12 @@ class AccountMove(models.Model):
         return ['general']
 
     def _search_default_journal(self):
+        # `active_id` contains the currently active journal ID when the upload is triggered from the journal.
+        if (
+            self.env.context.get('is_statement_line')
+            and self.env.context.get('active_id')
+        ):
+            return self.env['account.journal'].browse(self.env.context['active_id'])
         if self.statement_line_ids.statement_id.journal_id:
             return self.statement_line_ids.statement_id.journal_id[:1]
 

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1472,3 +1472,17 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
 
         transaction = self.create_bank_transaction(1, '2020-01-10', journal=self.bank_journal_1)
         assert transaction.date == transaction.move_id.date == fields.Date.from_string('2020-01-10')
+
+    def test_compute_journal_id_with_multiple_line_journals(self):
+        self.statement.write({
+            'line_ids': [
+                Command.create({
+                    'date': '2019-01-02',
+                    'payment_ref': 'line_2',
+                    'partner_id': self.partner_a.id,
+                    'amount': 500.0,
+                    'journal_id': self.bank_journal_2.id,
+                }),
+            ]
+        })
+        self.assertTrue(self.statement.journal_id, "Statement should have a journal assigned")


### PR DESCRIPTION
Currently, an error occurs when processing statement 
lines with multiple journals using OCR digitization.

**Steps to reproduce:**
- Install the `accountant` module.
- Navigate to Accounting > Configuration > Journals.
- Create a new journal with `Type: Credit Card`.
- Go to Accounting > Dashboard > Credit Card (1) journal.
- Upload the PDF file mentioned in the ticket.  (Ensure **Document Digitization credit is available**)
- Wait a few seconds and refresh the page.
- Delete all generated statement lines.
- Click `Add a line` and map:
  - `Date transaction` (first )column from the PDF with `Date`.
  - `Description` (third) column with `Label`.

**Error:**
`ValueError: Wrong value for account.bank.statement.journal_id: account.journal(294, 6)`

**Root Cause:**
At [1], `_search_default_journal()` returns the first journal linked to
existing statement lines (`self.statement_line_ids.statement_id.journal_id[:1]`)
without ensuring that it matches the currently active journal. As a result,
when multiple journals are involved, newly created statement lines may be
assigned to a different journal than the one currently opened by the user,
leading to the error during OCR statement line creation.

**Fix:**
This commit prevents the error when multiple journals exist by using 
the `active_id` from the `context`, which contains the currently active 
journal ID when the upload is triggered from the journal dashboard.

[1]:
https://github.com/odoo/odoo/blob/3bb06631f0db4b78502c323b53170989138e6d49/addons/account/models/account_move.py#L897-L899

opw-6052851