### PR TITLE
[FIX] iot_drivers: use certifi CA bundle for IoT websocket TLS on Windows

### DIFF
--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -1,10 +1,12 @@
 import json
 import logging
 import platform
+import ssl
 import requests
 import time
 import urllib.parse
 import websocket
+import certifi
 
 from threading import Thread
 
@@ -191,9 +193,13 @@ class WebsocketClient(Thread):
         #
         #   This will also happen with the graceful quit as `reconnect` will trigger if the server
         #   is offline while attempting the new connection
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
         while True:
             try:
-                run_res = self.ws.run_forever(reconnect=10)
+                run_res = self.ws.run_forever(
+                    reconnect=10,
+                    sslopt={"context": ssl_context},
+                )
                 _logger.debug("websocket run_forever return with %s", run_res)
             except Exception:
                 _logger.exception("An unexpected exception happened when running the websocket")

--- a/doc/cla/corporate/corvanis.md
+++ b/doc/cla/corporate/corvanis.md
@@ -1,0 +1,16 @@
+Portugal, 2026-04-22
+
+Corvanis agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vasco Rodrigues vasco@corvanis.com https://github.com/vvro
+
+List of contributors:
+
+Vasco Rodrigues vasco@corvanis.com https://github.com/vvro
+copilot-swe-agent[bot] 198982749+Copilot@users.noreply.github.com https://github.com/Copilot

--- a/doc/cla/individual/vvro.md
+++ b/doc/cla/individual/vvro.md
@@ -1,0 +1,11 @@
+Portugal, 2026-04-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vasco Rodrigues v@vvro.net https://github.com/vvro


### PR DESCRIPTION
The websocket-client library defaults to the system's SSL context, which can be broken or outdated on Windows. This commits aligns websocket TLS verification with the `requests` library by forcing a certifi-backed CA bundle.

This improves reliability on Windows IoT environments without changing reconnect logic.

This also adds the Odoo individual CLA for vvro and the corporate CLA for Corvanis.