### PR TITLE
[FIX] base: check on custom related fields more in line with the ORM

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -663,20 +663,26 @@ class IrModelFields(models.Model):
                     field_name=name,
                     related_field=self.related,
                 ))
-            model_name = field.relation
             if index < last and not field.relation:
                 raise UserError(_(
                     'Non-relational field name "%(field_name)s" in related field "%(related_field)s"',
                     field_name=name,
                     related_field=self.related,
                 ))
-            if not field.store and index < last:
+            if index < last and self.env.registry.ready and not (
+                field.store or (
+                    (model := self.env.get(model_name)) is not None
+                    and (model_field := model._fields.get(field.name))
+                    and model_field._description_searchable
+                )
+            ):
                 raise UserError(_(
-                    'Field "%(field_name)s" in related path "%(related_field)s" is not stored. '
-                    'Non-stored fields cannot be used in related fields.',
+                    'Field "%(field_name)s" in related path "%(related_field)s" is not searchable. '
+                    'Non-searchable fields cannot be used in related fields.',
                     field_name=name,
                     related_field=self.related,
                 ))
+            model_name = field.relation
         return field
 
     @api.constrains('related')

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -860,102 +860,6 @@ class TestCustomFields(TestCommonCustomFields):
         for partner in partners:
             self.assertEqual(partner.x_oh_boy, partner.country_id.code)
 
-    def test_related_field_non_stored_not_allowed(self):
-        """ Test related field behavior with stored/non-stored combinations """
-
-        model_id = self.env['ir.model']._get_id('res.partner')
-        dummy_model = self.env['ir.model'].create({
-            'name': 'Dummy Model Test',
-            'model': 'x_dummy_model_test',
-        })
-
-        # NON-STORED M2O
-        self.env['ir.model.fields'].create({
-            'model_id': model_id,
-            'name': 'x_non_stored_m2o_test',
-            'field_description': 'x_non_stored_m2o_test',
-            'ttype': 'many2one',
-            'relation': 'x_dummy_model_test',
-            'store': False,
-        })
-
-        # Stored M2O
-        self.env['ir.model.fields'].create({
-            'model_id': model_id,
-            'name': 'x_stored_m2o_test',
-            'field_description': 'x_stored_m2o_test',
-            'ttype': 'many2one',
-            'relation': 'x_dummy_model_test',
-            'store': True,
-        })
-
-        # Stored boolean
-        self.env['ir.model.fields'].create({
-            'model_id': dummy_model.id,
-            'name': 'x_bool_stored_test',
-            'field_description': 'x_bool_stored_test',
-            'ttype': 'boolean',
-            'store': True,
-        })
-
-        # Non-stored boolean
-        self.env['ir.model.fields'].create({
-            'model_id': dummy_model.id,
-            'name': 'x_bool_non_stored_test',
-            'field_description': 'x_bool_non_stored_test',
-            'ttype': 'boolean',
-            'store': False,
-        })
-
-        # 1. Intermediate non-stored → should FAIL
-        with self.assertRaises(UserError):
-            self.env.registry.clear_cache()
-            self.env['ir.model.fields'].create({
-                'model_id': model_id,
-                'name': 'x_fail_intermediate_non_stored',
-                'field_description': 'x_fail_intermediate_non_stored',
-                'ttype': 'boolean',
-                'related': 'x_non_stored_m2o_test.x_bool_stored_test',
-                'store': True,
-            })
-
-        # 2. Last non-stored → should PASS
-        self.env.registry.clear_cache()
-        field = self.env['ir.model.fields'].create({
-            'model_id': model_id,
-            'name': 'x_pass_last_non_stored',
-            'field_description': 'x_pass_last_non_stored',
-            'ttype': 'boolean',
-            'related': 'x_stored_m2o_test.x_bool_non_stored_test',
-            'store': True,
-        })
-        self.assertTrue(field)
-
-        # 3. All stored → should PASS
-        self.env.registry.clear_cache()
-        field = self.env['ir.model.fields'].create({
-            'model_id': model_id,
-            'name': 'x_pass_all_stored',
-            'field_description': 'x_pass_all_stored',
-            'ttype': 'boolean',
-            'related': 'x_stored_m2o_test.x_bool_stored_test',
-            'store': True,
-        })
-        self.assertTrue(field)
-
-        # 4. One non-stored → should PASS
-        self.env.registry.clear_cache()
-        field = self.env['ir.model.fields'].create({
-            'model_id': model_id,
-            'name': 'x_pass_single_non_stored',
-            'field_description': 'x_pass_single_non_stored',
-            'ttype': 'many2one',
-            'relation': 'x_dummy_model_test',
-            'related': 'x_non_stored_m2o_test',
-            'store': True,
-        })
-        self.assertTrue(field)
-
     def test_relation_of_a_custom_field(self):
         """ change the relation model of a custom field """
         model = self.env['ir.model'].search([('model', '=', self.MODEL)])
@@ -1029,6 +933,103 @@ class TestCustomFields(TestCommonCustomFields):
 
 @tagged('post_install', '-at_install')
 class TestCustomFieldsPostInstall(TestCommonCustomFields):
+
+    def test_related_field_non_stored_not_allowed(self):
+        """ Test related field behavior with stored/non-stored combinations """
+
+        model_id = self.env['ir.model']._get_id('res.partner')
+        dummy_model = self.env['ir.model'].create({
+            'name': 'Dummy Model Test',
+            'model': 'x_dummy_model_test',
+        })
+
+        # NON-STORED M2O
+        self.env['ir.model.fields'].create({
+            'model_id': model_id,
+            'name': 'x_non_stored_m2o_test',
+            'field_description': 'x_non_stored_m2o_test',
+            'ttype': 'many2one',
+            'relation': 'x_dummy_model_test',
+            'store': False,
+        })
+
+        # Stored M2O
+        self.env['ir.model.fields'].create({
+            'model_id': model_id,
+            'name': 'x_stored_m2o_test',
+            'field_description': 'x_stored_m2o_test',
+            'ttype': 'many2one',
+            'relation': 'x_dummy_model_test',
+            'store': True,
+        })
+
+        # Stored boolean
+        self.env['ir.model.fields'].create({
+            'model_id': dummy_model.id,
+            'name': 'x_bool_stored_test',
+            'field_description': 'x_bool_stored_test',
+            'ttype': 'boolean',
+            'store': True,
+        })
+
+        # Non-stored boolean
+        self.env['ir.model.fields'].create({
+            'model_id': dummy_model.id,
+            'name': 'x_bool_non_stored_test',
+            'field_description': 'x_bool_non_stored_test',
+            'ttype': 'boolean',
+            'store': False,
+        })
+
+        # 1. Intermediate non-stored → should FAIL
+        self.env.registry.clear_cache()
+        with self.assertRaises(UserError):
+            self.env['ir.model.fields'].create({
+                'model_id': model_id,
+                'name': 'x_fail_intermediate_non_stored',
+                'field_description': 'x_fail_intermediate_non_stored',
+                'ttype': 'boolean',
+                'related': 'x_non_stored_m2o_test.x_bool_stored_test',
+                'store': True,
+            })
+
+        # 2. Last non-stored → should PASS
+        self.env.registry.clear_cache()
+        field = self.env['ir.model.fields'].create({
+            'model_id': model_id,
+            'name': 'x_pass_last_non_stored',
+            'field_description': 'x_pass_last_non_stored',
+            'ttype': 'boolean',
+            'related': 'x_stored_m2o_test.x_bool_non_stored_test',
+            'store': True,
+        })
+        self.assertTrue(field)
+
+        # 3. All stored → should PASS
+        self.env.registry.clear_cache()
+        field = self.env['ir.model.fields'].create({
+            'model_id': model_id,
+            'name': 'x_pass_all_stored',
+            'field_description': 'x_pass_all_stored',
+            'ttype': 'boolean',
+            'related': 'x_stored_m2o_test.x_bool_stored_test',
+            'store': True,
+        })
+        self.assertTrue(field)
+
+        # 4. One non-stored → should PASS
+        self.env.registry.clear_cache()
+        field = self.env['ir.model.fields'].create({
+            'model_id': model_id,
+            'name': 'x_pass_single_non_stored',
+            'field_description': 'x_pass_single_non_stored',
+            'ttype': 'many2one',
+            'relation': 'x_dummy_model_test',
+            'related': 'x_non_stored_m2o_test',
+            'store': True,
+        })
+        self.assertTrue(field)
+
     def test_add_field_valid(self):
         """ custom field names must start with 'x_', even when bypassing the constraints
 


### PR DESCRIPTION
Following up on #259309. A field must be searchable to be used in the related path.  To know it, we must go into the instantiated field on the model to read that property, as being stored is not necessary.  This mixes two different levels of abstraction but is necessary to have more consistent behaviour and not to block valid related field going through searchable fields.

We also do this check only when the registry is ready to avoid blocking upgrades.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
