### PR TITLE
[IMP] fleet: false hybrid

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -143,6 +143,7 @@ class FleetVehicle(models.Model):
             a full tank (for fuel-powered vehicles)")
     range_unit = fields.Selection([('km', 'km'), ('mi', 'mi')],
         compute='_compute_range_unit', store=True, readonly=False, default="km", required=True)
+    is_false_hybrid = fields.Boolean(related='model_id.is_false_hybrid')
 
     _unique_license_plate = models.Constraint(
         'UNIQUE(license_plate)',

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -74,12 +74,44 @@ class FleetVehicleModel(models.Model):
         ('rwd', 'Rear-Wheel Drive (RWD)'),
         ('4wd', 'Four-Wheel Drive (4WD)'),
     ])
+    is_false_hybrid = fields.Boolean(default=False, string="False Hybrid")
 
     @api.model
     def _search_display_name(self, operator, value):
         if operator in Domain.NEGATIVE_OPERATORS:
             return NotImplemented
         return ['|', ('name', operator, value), ('brand_id.name', operator, value)]
+
+    def _get_similar_model(self):
+        self.ensure_one()
+        searched_fuel_type = False
+        if self.default_fuel_type == 'plug_in_hybrid_diesel':
+            searched_fuel_type = 'diesel'
+        if self.default_fuel_type in ['plug_in_hybrid_gasoline', 'full_hybrid']:
+            searched_fuel_type = 'gasoline'
+        if searched_fuel_type:
+            searched_models = self.env['fleet.vehicle.model'].search([('default_fuel_type', '=', searched_fuel_type), ('name', '=', self.name), ('id', '!=', self.id)])
+            if len(searched_models):
+                return searched_models[0]
+        return None
+
+    @api.onchange('default_fuel_type')
+    def _onchange_default_fuel_type(self):
+        similar_model = self._get_similar_model()
+        if self.is_false_hybrid and similar_model:
+            self.default_co2 = similar_model.default_co2
+
+    @api.onchange('is_false_hybrid')
+    def _onchange_is_false_hybrid(self):
+        similar_model = self._get_similar_model()
+        if self.is_false_hybrid:
+            if similar_model:
+                self.default_co2 = similar_model.default_co2
+            else:
+                self.default_co2 *= 2.5
+        else:
+            if not similar_model:
+                self.default_co2 /= 2.5
 
     @api.depends('brand_id')
     def _compute_display_name(self):

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -71,6 +71,7 @@
                                         <field name="default_co2"/>
                                         <field name="co2_emission_unit"/>
                                     </div>
+                                    <field name="is_false_hybrid" invisible="default_fuel_type not in ['plug_in_hybrid_diesel', 'plug_in_hybrid_gasoline', 'full_hybrid']"/>
                                     <field name="co2_standard" placeholder="eg. WLTP, Euro 6, or EPA, ..."/>
                                     <label for="horsepower" invisible="power_unit != 'horsepower'"/>
                                     <div class="o_row" invisible="power_unit != 'horsepower'">


### PR DESCRIPTION
[IMP] fleet: false hybrid

1 - false hybrid boolean field is added to the fleet_vehicle_model
    1.1 - I added it to fleet_vehicle as a related field
    1.2 - It is displayed in fleet_vehicle_model view conditionally

2 - When Plug-in diesel is selected and false_hybrid is ticked as true
    2.1 - Look to other diesel model with same name and if there are any, take its default_co2 and use it in this model
    2.2 - If not, multiply the current default_co2 by 2.5

3 - When one of the Plug-in gasoline/full-hybrid is selected and false_hybrid is ticked as true
    3.1 - Look to other gasoline model with the same name and if there are any, take its default_co2 and use it in this model
    3.2 - If not, multiply the current default_co2 by 2.5

task - 6146410

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
