### PR TITLE
[FIX] web: fix crash when cancelling drag sequence

### DIFF
--- a/addons/web/static/tests/_framework/dom_test_helpers.js
+++ b/addons/web/static/tests/_framework/dom_test_helpers.js
@@ -236,7 +236,6 @@ export function contains(target, options) {
             consumeContains();
 
             await cancelCurrentDragSequence?.();
-            cancelCurrentDragSequence = cancelWithDelay;
 
             const { cancel, drop, moveTo } = await drag(nodePromise, options);
             const helpersWithDelay = {
@@ -244,6 +243,8 @@ export function contains(target, options) {
                 drop: dropWithDelay,
                 moveTo: moveToWithDelay,
             };
+
+            cancelCurrentDragSequence = cancelWithDelay;
 
             await waitForTouchDelay(options?.pointerDownDuration);
 

--- a/addons/web/static/tests/core/utils/draggable.test.js
+++ b/addons/web/static/tests/core/utils/draggable.test.js
@@ -404,3 +404,39 @@ test("Elements are confined within their container", async () => {
 
     await drop();
 });
+
+test("Dragging cancels previous drag sequences", async () => {
+    class List extends Component {
+        static template = xml`
+                <div t-ref="root" class="root">
+                    <ul class="list">
+                        <li t-foreach="[1, 2, 3]" t-as="i" t-key="i" t-esc="i" class="item" />
+                    </ul>
+                </div>`;
+        static props = ["*"];
+
+        setup() {
+            useDraggable({
+                ref: useRef("root"),
+                elements: ".item",
+            });
+        }
+    }
+
+    await mountWithCleanup(List);
+
+    expect(".item").toHaveCount(3);
+    expect(".o_dragged").toHaveCount(0);
+
+    contains(".item").drag();
+    await Promise.resolve();
+
+    // Immediatly start new drag sequence
+    const { cancel } = await contains(".item").drag();
+
+    expect(".o_dragged").toHaveCount(1);
+
+    await cancel();
+
+    expect(".o_dragged").toHaveCount(0);
+});


### PR DESCRIPTION
### [FIX] web: fix crash when cancelling drag sequence

Before this commit: drag sequences could be aborted by new drag
sequences; the way this worked is that a new sequence would register its
"cancel" callback in a global variable, and when another sequence is
started, it calls that variable to cancel the previous one.

The issue was that the variable was assigned too early; before the
actual "cancel" callback was available.

This means that in edge cases where 2 sequences would be triggered in
less than (effectively) a resolved promise, the callback would not be
available and a crash would occur.

This commit moves the variable assignment *after* the "cancel" callback
is made available, ensuring there is no crash.

Runbot [243113](https://runbot.odoo.com/odoo/error/243113)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr