### PR TITLE
[FIX] mail: hover feedback on call layout buttons

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -42,10 +42,7 @@
 }
 
 .o-discuss-Call-layoutActions button {
-    opacity: 75%;
-    &:hover {
-        opacity: 100%;
-    }
+    --o-mail-ActionList-Button-opacity: .75;
 }
 
 .o-discuss-Call-sidebar {


### PR DESCRIPTION
Recent commit fixes an issue where items like Fullscreen in call menu had reduced opacity when this should only affect layout buttons in call view [1].

To do so it limits the opacity to the layout actions, but the style was not applied because ActionList has more CSS specificity that requires using `--o-mail-ActionList-Button-opacity` variable for the non-hover opacity value. Since this was not defined, this default to opacity 100%, thus not applying the reduced opacity when not mouse-hovering.

This commit fixes the issue with `--o-mail-ActionList-Button-opacity` of `.75`, so that opacity is slightly reduced when no mouse-hovering.

[1]: https://github.com/odoo/odoo/pull/259866

Before / After (mouse-hover on "Picture-in-Picture", see lack of visual distinction)

<img width="58" height="32" alt="Screenshot 2026-04-22 at 11 21 47" src="https://github.com/user-attachments/assets/e04b0f8c-c754-4ea4-8870-752610418587" />
<img width="57" height="28" alt="Screenshot 2026-04-22 at 11 21 25" src="https://github.com/user-attachments/assets/a5aa9987-ddaf-45f8-9e2a-260fd04dcfb9" />
