### PR TITLE
[FIX] pos_self_order: only use app logo when installing kiosk app

### DIFF
--- a/addons/pos_self_order/controllers/webmanifest.py
+++ b/addons/pos_self_order/controllers/webmanifest.py
@@ -19,11 +19,7 @@ class WebManifest(webmanifest.WebManifest):
 
     def _get_scoped_app_icons(self, app_id):
         if app_id == "pos_self_order":
-            company = request.env.company
-            if company.uses_default_logo:
-                icon_src = '/point_of_sale/static/description/icon.svg'
-            else:
-                icon_src = f'/web/image?model=res.company&id={company.id}&field=logo&height=192&width=192'
+            icon_src = '/point_of_sale/static/description/icon.svg'
             return [{
                 'src': icon_src,
                 'sizes': 'any',
@@ -33,6 +29,6 @@ class WebManifest(webmanifest.WebManifest):
 
     @http.route()
     def scoped_app_icon_png(self, app_id):
-        if app_id == "pos_self_order" and request.env.company.uses_default_logo:
+        if app_id == "pos_self_order":
             return super().scoped_app_icon_png('point_of_sale')
         return super().scoped_app_icon_png(app_id)

--- a/addons/pos_self_order/tests/test_webmanifest.py
+++ b/addons/pos_self_order/tests/test_webmanifest.py
@@ -26,7 +26,6 @@ class WebManifestRoutesTest(SelfOrderCommonTest):
         response.raise_for_status()
         data = response.json()
         self.assertEqual(data['name'], self.pos_config.name)
-        icon_src = f'/web/image?model=res.company&id={self.env.company.id}&field=logo&height=192&width=192'
         self.assertCountEqual(data['icons'], [
-            {'src': icon_src, 'sizes': 'any', 'type': 'image/png'}
+            {'src': '/point_of_sale/static/description/icon.svg', 'sizes': 'any', 'type': 'image/svg+xml'}
         ])


### PR DESCRIPTION
Currently, if a company has a logo, it is very likely that the kiosk app (pwa) cannot be installed.

Steps to reproduce:
-------------------
* In the company settings, set up a company logo (screenshot size image)
* Go to point of sale app, find the kiosk
* Select "Open kiosk"
* Select "Install app"
> Observation: Instead of seeing the button to download the app you see
"You can install the app from the browser menu"

With company logo:
<img width="545" height="219" alt="image" src="https://github.com/user-attachments/assets/03053242-235a-43dd-be2d-29bcec87da1f" />

Without:
<img width="414" height="205" alt="image" src="https://github.com/user-attachments/assets/4cbd9ca7-3c91-4c04-89ab-3ef3ec7b4540" />


Why the fix:
------------
When the company has a logo, `company.uses_default_logo` is False which means we're trying to use to company logo as the app logo. When the company logo doesn't have a precise size the PWA beforeInstallPrompEvent is not triggered.

If this event is not triggered, `_handleBeforeInstallPrompt` is not called and `state.isAvailable` is not set to true.
https://github.com/odoo/odoo/blob/cdded72f0d7adfa3b3b19f6117905a273d7ef199/addons/web/static/src/core/pwa/pwa_service.js#L111 Which ultimately leads to not being able to see the button to download the app.

After discussing, there's no real need to use the company logo anyway. Instead of seeing to resize it we'll just use the app icon all the time.

opw-6111280