### PR TITLE
[IMP] base: remove ir.mail_server max_email_size field

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -190,7 +190,6 @@ class IrMail_Server(models.Model):
     smtp_debug = fields.Boolean(string='Debugging', help="If enabled, the full output of SMTP sessions will "
                                                          "be written to the server log at DEBUG level "
                                                          "(this is very verbose and may include confidential info!)")
-    max_email_size = fields.Float(string="Max Email Size")
     sequence = fields.Integer(string='Priority', default=10, help="When no specific mail server is requested for a mail, the highest priority one "
                                                                   "is used. Default priority is 10 (smaller number = higher priority)")
     active = fields.Boolean(default=True)


### PR DESCRIPTION
In odoo/odoo#256685, we remove the use of ir.mail_server max_email_size field by making the method _get_max_email_size only rely on the ICP parameter and not any more on that field. We remove that field as it is now useless.

Task-5912830