### PR TITLE
[FIX] {sale_purchase_,}stock: prevent cross-document deadline propagation

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -612,3 +612,47 @@ class TestSalePurchaseStockFlow(TransactionCase):
         sale_order.action_confirm()
         purchase_order = sale_order._get_purchase_orders()
         self.assertEqual(purchase_order.order_line.analytic_distribution, {str(analytic_account.id): 100})
+
+    def test_po_date_change_does_not_affect_so_delivery_after_allocation(self):
+        """ Test that a purchase order is allocated to a sales order,
+            updating the purchase order expected arrival date does not alter
+            the delivery deadline of the linked sales order picking.
+        """
+        product = self.env['product.product'].create({
+            'name': 'Test Prod Allocation',
+            'is_storable': True,
+            'seller_ids': [Command.create({
+                'partner_id': self.vendor.id,
+            })],
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 5.0,
+            })],
+        })
+        so.action_confirm()
+        so_move = so.picking_ids.move_ids
+        po = self.env['purchase.order'].create({
+            'partner_id': self.vendor.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 5.0,
+            })],
+        })
+        po.button_confirm()
+        po_move = po.picking_ids.move_ids
+        # Link via reception report allocation (action_assign)
+        self.env['report.stock.report_reception'].action_assign(
+            so_move.ids, [so_move.product_qty], po_move.ids
+        )
+        self.assertIn(so_move.id, po_move.move_dest_ids.ids, 'Moves should be linked after allocation')
+        # Change PO expected arrival and ensure SO move deadline unchanged
+        before_deadline = so.picking_ids.date_deadline
+        po.order_line.date_planned = date.today() + timedelta(days=6)
+        self.env.flush_all()
+        self.assertEqual(
+            before_deadline, so_move.date_deadline,
+            'SO delivery deadline must not change when PO expected arrival changes after allocation'
+        )

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -542,7 +542,15 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     def _get_moves_to_propagate_date_deadline(self):
         self.ensure_one()
-        return self.move_dest_ids | self.move_orig_ids
+        # Propagate to destination/origin moves, but skip those belonging to a DIFFERENT procurement group.
+        all_moves = self.move_dest_ids | self.move_orig_ids
+        return all_moves.filtered(
+            lambda m: not (
+                self.picking_id and m.picking_id and
+                self.group_id and m.group_id and
+                m.group_id != self.group_id
+            )
+        )
 
     def _set_date_deadline(self, new_deadline):
         # Handle the propagation of `date_deadline` fields (up and down stream - only update by up/downstream documents)


### PR DESCRIPTION
Version:
----------
- 18.0+

Steps to reproduce:
----------------------
1. Install `sale_management`, `purchase`, and `stock` module.
2. Go to Settings and enable Reception Report.
3. Create a storable product with tracking enabled and add
supplier information.
4. Create a Sales Order for the product with a quantity and confirm it.
5. Open the generated Delivery Order and note the deadline value.
6. Create a Purchase Order for the same product and quantity  using the vendor
set on the product and confirm it.
7. Open the generated Receipt and click on the Allocation smart button.
8. Assign the receipt to the delivery order.
9. Go back to the Purchase Order and change the Expected Arrival Date.

Issue
- Updating the Expected Arrival Date on the Purchase Order also updates
the deadline of the related Sales Order delivery.

Root cause:
------------
- Clicking Assign triggers `action_assign`, which links incoming and outgoing moves:
https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/stock/report/report_stock_reception.py#L271

- Updating the PO Expected Arrival Date triggers purchase.order.line.write(),
which calls  _update_move_date_deadline(new_date).
https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/purchase_stock/models/purchase_order_line.py#L100-L101

- Then this `_update_move_date_deadline` function updates the incoming move
`date_deadline` and this  triggers stock.move.write().
https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/purchase_stock/models/purchase_order_line.py#L165

- Inside write(), _set_date_deadline() is called.
https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/stock/models/stock_move.py#L748-L749

- Inside `_set_date_deadline()`, the method calls` _get_moves_to_propagate_date_deadline()`
to collect all related moves that should be updated.
- This method includes `move_dest_ids` in the returned moves.
Since the incoming move is manually linked to the delivery move,
the corresponding outgoing move (from the Sales Order) is part
of `move_dest_ids`, and its `date_deadline` is therefore updated as well.

https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/stock/models/stock_move.py#L553

https://github.com/odoo/odoo/blob/cfc63060926db4cec773c159b8ecf97dc0b36d1a/addons/stock/models/stock_move.py#L545

Solution:
----------
- Limit propagation to moves that share the same `group_id` or
where no formal procurement group/picking link is established.
- This prevents unintended date shifts across unrelated documents (manual links)
 while preserving correct behavior for standard MTO and Manufacturing flows.

---

opw-6085890


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
