### PR TITLE
[FIX] mail: correct text color on mail message focus

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -11,7 +11,7 @@ a.o-discuss-mention {
 }
 
 .o-discuss-text-body {
-    color: $o-main-text-color;
+    color: $o-main-text-color !important;
 }
 
 .o-discuss-warningBadge .i {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -97,7 +97,7 @@ $o-discuss-talkingColor: lighten($success, 10%);
 }
 
 .o-discuss-text-body {
-    color: $gray-700;
+    color: $gray-700 !important;
 }
 
 .o-discuss-badge, .o-discuss-badgeShape {


### PR DESCRIPTION
# Setup
Edit the theme of the website : in the Light & Dark section, set the first color to black. The main background color of the website should be black and the text should be in white.

# How to reproduce
- Install the Helpdesk app
- Go to Website > Help
- Submit a ticket (the ticket's information is not important)
- Click the ticket link shown when the ticket is submitted
- Start writing a message in the Communication History.

# The problem
As long as the text bubble is focused, the text is white even though the bubble is also white, making the text unreadable.

Note : the same problem is present for product reviews in the eCommerce application.

These text bubbles seems to be intended to stay white even in a dark main background color, so the text should be black : https://github.com/odoo/odoo/blob/6b21829159d3d16a0a0060e30814f9d969b44418/addons/mail/static/src/core/common/composer.scss#L103

# Cause
The textarea (text bubble) has a the `.form-control` css class coming from bootstrap that applies `color: var(--bs-body-color)` : https://github.com/odoo/odoo/blob/6b21829159d3d16a0a0060e30814f9d969b44418/addons/web/static/lib/bootstrap/dist/css/bootstrap.css#L2115-L2131

In our case, it sets `color` to #FFF  (I'm not 100% sure where this value is coming from since I did not find any instance where --bs-body-color or --body-color are ever set to that value). Anywyay, this value is overidden by `.o-discuss-text-body`: https://github.com/odoo/odoo/blob/6b21829159d3d16a0a0060e30814f9d969b44418/addons/mail/static/src/core/common/core.scss#L99-L101

But the value is overriden again when the textarea is focused by the `form-control:focus` css class that sets back the color to #FFF: https://github.com/odoo/odoo/blob/6b21829159d3d16a0a0060e30814f9d969b44418/addons/web/static/lib/bootstrap/dist/css/bootstrap.css#L2143-L2149

The issue was caused by this commit that changed the class used to define the color for the discuss messages : https://github.com/odoo/odoo/commit/3557de4232ebc307c8861379f6573d7b36cd8db6

Because `.o-discuss-text-body` is overriden by  `form-control:focus` while `.text-body` is not. This is most probably due to the order in which the stylesheets are applied.

# Proposed solution
Add `, .o-discuss-text-body:focus` to make sure the rule is also applied when the text bubble is focused

opw-6063961