### PR TITLE
[FIX] core: fix manual related selection

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1369,7 +1369,8 @@ class IrModelFields(models.Model):
                 attrs['strip_style'] = field_data['strip_style']
                 attrs['strip_classes'] = field_data['strip_classes']
         elif field_data['ttype'] in ('selection', 'reference'):
-            attrs['selection'] = self.env['ir.model.fields.selection']._get_selection_data(field_data['id'])
+            if not attrs['related']:
+                attrs['selection'] = self.env['ir.model.fields.selection']._get_selection_data(field_data['id'])
             if field_data['ttype'] == 'selection':
                 attrs['group_expand'] = field_data['group_expand']
         elif field_data['ttype'] == 'many2one':


### PR DESCRIPTION
In PR https://github.com/odoo/odoo/pull/255091, the selection field has more strict validation when a field is defined with both `selection` and `related`. This commit fixes the manual related selection which uses `{'selection': '[]', 'related': 'xx.xx', ...}` to initialize the selection field object.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
