### PR TITLE
[FIX] base: restore str-based HTML translation dictionary

### DIFF
--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -69,9 +69,13 @@ class BaseString(Field[str | typing.Literal[False]]):
 
     def get_trans_terms(self, value) -> list[str]:
         """ Return the sequence of terms to translate found in `value`"""
-        if not value:
+        if not isinstance(value, str):
             return []
-        return ParsedTranslation(value, self).terms
+        if not callable(self.translate):
+            # Ensure translation terms are stringified.
+            # Double quotes inside Markup are not escaped when the value is used as a polib.POEntry msgid.
+            return [str(value)]
+        return ParsedTranslation(value, self).terms if value else []
 
     def convert_to_column(self, value, record, values=None, validate=True):
         # domain condition `(name, '=', {'en_US': 'English, 'fr_FR': 'French'})` is not supported
@@ -188,9 +192,6 @@ class BaseString(Field[str | typing.Literal[False]]):
         :return: {from_lang_term: {lang: lang_term}}
         :rtype: dict
         """
-        if self.translate is True:
-            return {from_lang_value: dict(to_lang_values)} if from_lang_value else {}
-
         from_lang_terms = self.get_trans_terms(from_lang_value)
         dictionary = defaultdict(lambda: defaultdict(dict))
         if not from_lang_terms:
@@ -702,10 +703,6 @@ class Html(BaseString):
     def convert_to_record(self, value, record):
         value = super().convert_to_record(value, record)
         return False if value is False else Markup(value)
-
-    def get_trans_terms(self, value):
-        # ensure the translation terms are stringified, otherwise we can break the PO file
-        return list(map(str, super().get_trans_terms(value)))
 
     escape = staticmethod(markup_escape)
     is_empty = staticmethod(is_html_empty)


### PR DESCRIPTION
Refactor odoo/odoo#246357 made ``get_translation_dictionary`` return Markup-wrapped keys and values for `field.translate is True` HTML fields. When polib.POEntry is given Markup, double quotes in .po output are not escaped as expected, which can produce invalid PO files.

Keep ``dict[str, dict[str, str]]`` for those entries so export stays correct without special-casing each writer path.
Also revert the support for ``field.get_trans_terms()`` when ``field.translate is True``.

for solving problem
<img width="812" height="254" alt="image" src="https://github.com/user-attachments/assets/6901865a-4dd9-49a7-ba1c-f90dbb346976" />

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
