### PR TITLE
[IMP] html_editor, base: add trim option to HTML fields

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -29,6 +29,7 @@ import { EditorVersionPlugin } from "@html_editor/core/editor_version_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { isHtmlStringEmpty } from "@html_editor/utils/dom_info";
 
 const HTML_FIELD_METADATA_ATTRIBUTES = ["data-last-history-steps"];
 
@@ -52,6 +53,7 @@ export class HtmlField extends Component {
     static template = "html_editor.HtmlField";
     static props = {
         ...standardFieldProps,
+        trim: { type: Boolean, optional: true },
         isCollaborative: { type: Boolean, optional: true },
         collaborativeTrigger: { type: String, optional: true },
         dynamicField: { type: Boolean, optional: true },
@@ -162,6 +164,10 @@ export class HtmlField extends Component {
     }
 
     async updateValue(value, { changeId } = { changeId: this.lastChangeId }) {
+        if (this.props.trim && isHtmlStringEmpty(value)) {
+            value = false;
+        }
+
         this.lastValue = normalizeHTML(value, this.clearElementToCompare.bind(this));
         await this.props.record.update({ [this.props.name]: value }).then(
             () => {
@@ -412,6 +418,7 @@ export const htmlField = {
             sandboxedPreview: Boolean(options.sandboxedPreview),
             cssReadonlyAssetId: options.cssReadonly,
             codeview: Boolean(odoo.debug && options.codeview),
+            trim: Boolean(options.trim),
         };
 
         if (viewType === "list") {

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -1004,5 +1004,32 @@ export function isRedundantElement(node) {
     return true;
 }
 
+/**
+ * Determines whether an HTML string consists entirely of empty nodes or whitespace.
+ * * It parses the string into a temporary DOM structure and evaluates its children
+ * to ensure no visible text or structural elements (other than empty <br> or <p>) exist.
+ * * @param {string} htmlString - The raw HTML string to evaluate.
+ * @returns {boolean} True if the HTML string is structurally/visually empty, false otherwise.
+ */
+export function isHtmlStringEmpty(htmlString) {
+    if (!htmlString) {
+        return true;
+    }
+
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = htmlString;
+
+    for (const node of tempDiv.childNodes) {
+        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== "") {
+            return false;
+        }
+        if (node.nodeType === Node.ELEMENT_NODE && !isEmpty(node)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // Selector for QWeb-specific attributes
 export const PROTECTED_QWEB_SELECTOR = "[t-esc], [t-raw], [t-out], [t-field]";


### PR DESCRIPTION
Empty HTML fields are currently stored as `<p><br></p>`, which creates unwanted spacing when rendered. This commit adds a `trim` option to `HtmlField` to detect structurally empty content and store it as `false` instead.

task-4344294