### PR TITLE
[FIX] web: searchMenu: prevent crash from unparseable ir.filter

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -153,7 +153,14 @@
                             onSelected="() => this.onFavoriteSelected(item.id)"
         >
             <span class="d-flex p-0 align-items-center justify-content-between">
-                <span t-esc="item.description" t-att-title="item.description.length > 15 ? item.description : ''" class="text-truncate flex-grow-1"/>
+                <t t-set="invalidTooltip">Disabled due to invalid configuration</t>
+                <span
+                    t-esc="item.description"
+                    t-att-title="item.description.length > 15 ? item.description : ''"
+                    class="text-truncate flex-grow-1"
+                    t-att-class="item.isInvalid ? 'text-muted' : ''"
+                    t-att-data-tooltip="item.isInvalid and invalidTooltip"
+                />
                 <i class="ms-1 fa fa-pencil d-none"
                     title="Edit favorite"
                     t-on-click.stop="() => this.editFavorite(item.id)"

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -851,6 +851,9 @@ export class SearchModel extends EventBus {
      */
     toggleSearchItem(searchItemId) {
         const searchItem = this.searchItems[searchItemId];
+        if (searchItem.isInvalid) {
+            return;
+        }
         switch (searchItem.type) {
             case "dateFilter":
             case "dateGroupBy":
@@ -2164,7 +2167,14 @@ export class SearchModel extends EventBus {
     _irFilterToFavorite(irFilter) {
         const userIds = irFilter.user_ids;
         const groupNumber = userIds.length === 1 ? FAVORITE_PRIVATE_GROUP : FAVORITE_SHARED_GROUP;
-        const context = evaluateExpr(irFilter.context, user.context);
+        let context;
+        let isInvalid = false;
+        try {
+            context = evaluateExpr(irFilter.context, user.context);
+        } catch {
+            context = {};
+            isInvalid = true;
+        }
         let groupBys = [];
         if (context.group_by) {
             groupBys = context.group_by;
@@ -2173,12 +2183,9 @@ export class SearchModel extends EventBus {
         let sort;
         try {
             sort = JSON.parse(irFilter.sort);
-        } catch (err) {
-            if (err instanceof SyntaxError) {
-                sort = [];
-            } else {
-                throw err;
-            }
+        } catch {
+            isInvalid = true;
+            sort = [];
         }
         const orderBy = sort.map((order) => {
             let fieldName;
@@ -2209,8 +2216,9 @@ export class SearchModel extends EventBus {
             serverSideId: irFilter.id,
             type: "favorite",
             userIds,
+            isInvalid,
         };
-        if (irFilter.is_default) {
+        if (irFilter.is_default && !isInvalid) {
             favorite.isDefault = irFilter.is_default;
         }
         return favorite;

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -265,3 +265,42 @@ test("shared favorites are partially shown if there is more than 4", async () =>
     expect(".o_favorite_menu .o_expand_shared_favorites").toHaveCount(0);
     expect(".o_favorite_menu .o_favorite_item").toHaveCount(5);
 });
+
+test("display unparseable filter", async () => {
+    const irFilters = [
+        {
+            context: "{123}", // unparseable context
+            domain: "[('foo', '=', 'a')]",
+            id: 987,
+            is_default: false,
+            name: "My favorite",
+            sort: "[]",
+            user_ids: [],
+        },
+    ];
+
+    mockService("action", {
+        doAction(action) {
+            expect.step(`doAction ${action.res_model}: ${action.res_id}`);
+        },
+    });
+
+    const searchBarMenu = await mountWithSearch(SearchBarMenu, {
+        resModel: "foo",
+        searchMenuTypes: ["favorite"],
+        searchViewId: false,
+        irFilters,
+        activateFavorite: false,
+    });
+    await toggleSearchBarMenu();
+    expect(".o_favorite_menu .o_favorite_item").toHaveCount(1);
+    expect(".o_favorite_menu .o_favorite_item span[title]").toHaveAttribute(
+        "data-tooltip",
+        "Disabled due to invalid configuration"
+    );
+    expect(".o_favorite_menu .o_favorite_item span[title]").toHaveClass("text-muted");
+    await contains(".o_favorite_menu .o_favorite_item").click();
+    expect(searchBarMenu.env.searchModel.domain).toEqual([]);
+    await editFavorite("My favorite");
+    expect.verifySteps(["doAction ir.filters: 987"]);
+});

--- a/addons/web/static/tests/search/search_model.test.js
+++ b/addons/web/static/tests/search/search_model.test.js
@@ -713,6 +713,7 @@ test("process favorite filters", async () => {
             description: "Sorted filter",
             domain: "[('user_id', '=', uid)]",
             groupBys: ["foo", "bar"],
+            isInvalid: false,
             orderBy: [
                 {
                     asc: true,


### PR DESCRIPTION
On some view, create and edit a filter, but put something unparseable by JS in the `context` field eg: `{123}`.
Go back to the view.

Before this commit there was a crash, because the python parser in JS crashed.

After this commit, there is no crash, the filter is visible but not activable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
