### PR TITLE
[FIX] account, *: improve po matching and grouping

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4398,7 +4398,7 @@ class AccountMove(models.Model):
 
                         if success or file_data['type'] == 'pdf' or file_data['attachment'].mimetype in ALLOWED_MIMETYPES:
                             (invoice.invoice_line_ids - existing_lines).is_imported = True
-                            if not extend_with_existing_lines:
+                            if not extend_with_existing_lines and not file_data.get('po_matching_done'):
                                 try:
                                     invoice.with_context(default_move_type=invoice.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
                                 except (UserError, ValueError):
@@ -4406,7 +4406,6 @@ class AccountMove(models.Model):
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
-                            self._post_process_link_to_purchase_order(invoice)
 
                 except RedirectWarning:
                     raise
@@ -4432,6 +4431,7 @@ class AccountMove(models.Model):
 
     @api.model
     def _post_process_link_to_purchase_order(self, invoice):
+        # DEPRECATED, will be removed in master
         # To be implemented in modules needing to process the invoice after it was linked (or not) to a PO
         pass
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4454,7 +4454,7 @@ class AccountMove(models.Model):
 
                         if success or file_data['type'] == 'pdf' or file_data['attachment'].mimetype in ALLOWED_MIMETYPES:
                             (invoice.invoice_line_ids - existing_lines).is_imported = True
-                            if not extend_with_existing_lines:
+                            if not extend_with_existing_lines and not file_data.get('po_matching_done'):
                                 try:
                                     invoice.with_context(default_move_type=invoice.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
                                 except (UserError, ValueError):
@@ -4462,7 +4462,6 @@ class AccountMove(models.Model):
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
-                            self._post_process_link_to_purchase_order(invoice)
 
                 except RedirectWarning:
                     raise
@@ -4488,6 +4487,7 @@ class AccountMove(models.Model):
 
     @api.model
     def _post_process_link_to_purchase_order(self, invoice):
+        # DEPRECATED, will be removed in master
         # To be implemented in modules needing to process the invoice after it was linked (or not) to a PO
         pass
 

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -3045,6 +3045,89 @@ class AccountEdiUBL(models.AbstractModel):
             if not base_line['currency_id'].is_zero(base_line['tax_details']['total_included_currency'])
         ]
 
+    def _import_ubl_invoice_add_purchase_order(self, collected_values):
+        """
+        This method tries to find the potential purchase orders that could match the invoice we're currently importing
+        We need to do it before writing lines on invoice so that we know if we can group lines
+        """
+        if not self.module_installed('purchase'):
+            return
+
+        invoice_origin = collected_values['to_write'].get('invoice_origin', '')
+        po_references = [ref.strip() for ref in invoice_origin.split(',') if ref.strip()] if invoice_origin else []
+
+        # Get base lines total amount
+        AccountTax = self.env['account.tax']
+        base_lines = collected_values['base_lines']
+        base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, lambda base_line, tax_data: True)
+        values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        amount_total = sum(
+            values['total_excluded_currency'] + values['tax_amount_currency']
+            for values in values_per_grouping_key.values()
+        )
+
+        # Write po matching in collected values
+        collected_values['po_matching'] = {'amount_total': amount_total}
+        collected_values['po_matching']['potential_matching'] = self.env['account.move']._find_purchase_orders(
+            po_references,
+            collected_values['company'].id,
+            collected_values['customer_values'].get('customer', self.env['res.partner']).id,
+            amount_total,
+        )
+
+    def _import_ubl_invoice_group_lines(self, collected_values):
+        """
+        This method group lines based on base lines (no invoice_line_ids are written)
+        :param invoice_lines_created: bool, invoice line are already written on invoice
+        """
+        if collected_values['invoice']._context.get('ungroup_lines'):
+            return
+
+        # Check if there's a potential matching
+        if collected_values.get('po_matching', {}).get('potential_matching'):
+            return
+
+        if not self._is_last_bill_from_vendor_grouped(collected_values):
+            return
+
+        base_lines = collected_values['base_lines']
+        AccountTax = self.env['account.tax']
+
+        def aggregate_function(target_base_line, base_line):
+            target_base_line.setdefault('_aggregated_quantity', 0.0)
+            target_base_line['_aggregated_quantity'] += base_line['quantity']
+
+        def grouping_function(base_line):
+            return {
+                '_grouping_key': frozendict(AccountTax._prepare_base_line_grouping_key(base_line)),
+            }
+
+        base_lines = AccountTax._reduce_base_lines_with_grouping_function(
+            base_lines,
+            grouping_function=grouping_function,
+            aggregate_function=aggregate_function,
+        )
+
+    def _is_last_bill_from_vendor_grouped(self, collected_values):
+        if not (customer_values := collected_values['customer_values']):
+            return False
+
+        invoice = collected_values['invoice']
+        if invoice.journal_id.type == 'sale':
+            move_types = invoice.get_sale_types(include_receipts=True)
+        else:
+            move_types = invoice.get_purchase_types(include_receipts=True)
+
+        last_bill_from_vendor = invoice.search([
+            ('move_type', 'in', move_types),
+            ('partner_id', '=', customer_values['customer'].id),
+            ('state', '=', 'posted'),
+            ('id', '!=', invoice.id),
+            *invoice._check_company_domain(collected_values['company']),
+        ], order='create_date desc', limit=1)
+
+        return last_bill_from_vendor and last_bill_from_vendor._has_lines_grouped()
+
     def _import_ubl_invoice_write_collected_values(self, collected_values):
         invoice = collected_values['invoice']
         base_lines = collected_values['base_lines']
@@ -3203,6 +3286,41 @@ class AccountEdiUBL(models.AbstractModel):
             _logger.exception("Error while generating substitute PDF attachment for invoice %s", invoice.id)
         return additional_docs
 
+    def _import_ubl_invoice_match_and_set_purchase_order(self, collected_values):
+        """
+        This method get the potential purchase orders found in _import_ubl_invoice_add_purchase_order
+        and tries to match them with the current invoice
+        """
+        if not (po_matching := collected_values.get('po_matching')):
+            return
+
+        invoice = collected_values['invoice']
+        method, matched_po_lines, matched_inv_lines = invoice._match_potential_purchase_orders(
+            po_matching['potential_matching'], po_matching['amount_total'])
+
+        # we write the values of the po matched on the invoice and we store the result (matched or not) in collected values
+        # to group lines later if no match was done
+        collected_values['po_matching']['matched'] = invoice._write_values_from_po(method, matched_po_lines, matched_inv_lines)
+
+    def _import_ubl_invoice_group_lines_after(self, collected_values):
+        """
+        This method
+        """
+        if collected_values['invoice']._context.get('ungroup_lines'):
+            return
+
+        # Group if finally we couldn't match a PO in _import_ubl_invoice_match_and_set_purchase_order
+        matching = collected_values.get('po_matching')
+        if (
+            not matching  # not potential match -> we already grouped in _import_ubl_invoice_group_lines
+            or (matching and matching['matched'])  # we matched a PO -> no grouping
+        ):
+            return
+
+        invoice = collected_values['invoice']
+        if self._is_last_bill_from_vendor_grouped(collected_values):
+            invoice._group_lines_by_tax()
+
     def _import_ubl_invoice_post_processing(self, collected_values):
         # During the import, fill 'ubl_cii_xml_file' to be retrieved later if necessary.
         invoice = collected_values['invoice']
@@ -3287,8 +3405,19 @@ class AccountEdiUBL(models.AbstractModel):
         self._import_ubl_invoice_retrieve_taxes(collected_values)
         self._import_ubl_invoice_add_base_lines(collected_values)
 
+        # Search for potential PO to match
+        self._import_ubl_invoice_add_purchase_order(collected_values)
+
+        # First lines grouping (based on base_lines)
+        self._import_ubl_invoice_group_lines(collected_values)
+
         # End the invoice.
         self._import_ubl_invoice_write_collected_values(collected_values)
         self._import_ubl_invoice_fix_taxes_amounts(collected_values)
+        # Actually match the potential PO's
+        self._import_ubl_invoice_match_and_set_purchase_order(collected_values)
+        # Second lines grouping (based on invoice_line_ids)
+        self._import_ubl_invoice_group_lines_after(collected_values)
         self._import_ubl_invoice_post_processing(collected_values)
+        file_data['po_matching_done'] = True  # We already tried to match PO so no need to try it later again
         return True

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -3614,6 +3614,94 @@ class AccountEdiUBL(models.AbstractModel):
                 continue
             collected_values['to_write'][field_name] = node_value
 
+    def _import_ubl_invoice_add_purchase_order(self, collected_values):
+        """
+        This method tries to find the potential purchase orders that could match the invoice we're currently importing
+        We need to do it before writing lines on invoice so that we know if we can group lines
+        """
+        if not self.module_installed('purchase'):
+            return
+
+        invoice_origin = collected_values['to_write'].get('invoice_origin', '')
+        po_references = [ref.strip() for ref in invoice_origin.split(',') if ref.strip()] if invoice_origin else []
+
+        # Get base lines total amount
+        AccountTax = self.env['account.tax']
+        base_lines = collected_values['base_lines']
+        base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, lambda base_line, tax_data: True)
+        values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        amount_total = sum(
+            values['total_excluded_currency'] + values['tax_amount_currency']
+            for values in values_per_grouping_key.values()
+        )
+
+        # Write po matching in collected values
+        collected_values['po_matching'] = {'amount_total': amount_total}
+        collected_values['po_matching']['potential_matching'] = self.env['account.move']._find_purchase_orders(
+            po_references,
+            collected_values['company'].id,
+            collected_values['customer_values'].get('customer', self.env['res.partner']).id,
+            amount_total,
+        )
+
+    def _import_ubl_invoice_group_lines(self, collected_values):
+        """
+        This method group lines based on base lines (no invoice_line_ids are written)
+        """
+        if collected_values['invoice']._context.get('ungroup_lines'):
+            return
+
+        # Check if there's a potential matching
+        if collected_values.get('po_matching', {}).get('potential_matching'):
+            return
+
+        if not self._is_last_bill_from_vendor_grouped(collected_values):
+            return
+
+        base_lines = collected_values['base_lines']
+        AccountTax = self.env['account.tax']
+        partner_name = collected_values.get('customer_values', {}).get('customer').name or self.env._("Unknown partner")
+
+        def aggregate_function(target_base_line, base_line):
+            target_base_line.setdefault('_aggregated_quantity', 0.0)
+            target_base_line['_aggregated_quantity'] += base_line['quantity']
+            target_base_line.setdefault('_aggregated_name', " - ".join(
+                [partner_name, base_line['account_id'].code, " / ".join(base_line.get('tax_ids', self.env['account.tax']).mapped('name')) or self.env._("Untaxed")]
+            ))
+
+        def grouping_function(base_line):
+            return {
+                '_grouping_key': frozendict(AccountTax._prepare_base_line_grouping_key(base_line)),
+            }
+
+        collected_values['base_lines'] = AccountTax._reduce_base_lines_with_grouping_function(
+            base_lines,
+            grouping_function=grouping_function,
+            aggregate_function=aggregate_function,
+        )
+        for base_line in collected_values['base_lines']:
+            base_line['_create_values']['name'] = base_line['_aggregated_name']
+
+    def _is_last_bill_from_vendor_grouped(self, collected_values):
+        if not (customer := collected_values.get('customer_values', {}).get('customer')):
+            return False
+
+        invoice = collected_values['invoice']
+        if invoice.journal_id.type == 'sale':
+            move_types = invoice.get_sale_types(include_receipts=True)
+        else:
+            move_types = invoice.get_purchase_types(include_receipts=True)
+
+        last_bill_from_vendor = invoice.search([
+            ('move_type', 'in', move_types),
+            ('partner_id', '=', customer.id),
+            ('state', '=', 'posted'),
+            ('id', '!=', invoice.id),
+            *invoice._check_company_domain(collected_values['company']),
+        ], order='create_date desc', limit=1)
+
+        return last_bill_from_vendor and last_bill_from_vendor._has_lines_grouped()
+
     def _import_ubl_invoice_write_collected_values(self, collected_values):
         invoice = collected_values['invoice']
         base_lines = collected_values['base_lines']
@@ -3816,6 +3904,41 @@ class AccountEdiUBL(models.AbstractModel):
             _logger.exception("Error while generating substitute PDF attachment for invoice %s", invoice.id)
         return additional_docs
 
+    def _import_ubl_invoice_match_and_set_purchase_order(self, collected_values):
+        """
+        This method get the potential purchase orders found in _import_ubl_invoice_add_purchase_order
+        and tries to match them with the current invoice
+        """
+        if not (po_matching := collected_values.get('po_matching')):
+            return
+
+        invoice = collected_values['invoice']
+        method, matched_po_lines, matched_inv_lines = invoice._match_potential_purchase_orders(
+            po_matching['potential_matching'], po_matching['amount_total'])
+
+        # we write the values of the po matched on the invoice and we store the result (matched or not) in collected values
+        # to group lines later if no match was done
+        collected_values['po_matching']['matched'] = invoice._write_values_from_po(method, matched_po_lines, matched_inv_lines)
+
+    def _import_ubl_invoice_group_lines_after(self, collected_values):
+        """
+        This method group lines based on records (invoice_line_ids are written)
+        """
+        if collected_values['invoice']._context.get('ungroup_lines'):
+            return
+
+        # Group if finally we couldn't match a PO in _import_ubl_invoice_match_and_set_purchase_order
+        matching = collected_values.get('po_matching')
+        if (
+            not matching  # not potential match -> we already grouped in _import_ubl_invoice_group_lines
+            or (matching and matching['matched'])  # we matched a PO -> no grouping
+        ):
+            return
+
+        invoice = collected_values['invoice']
+        if self._is_last_bill_from_vendor_grouped(collected_values):
+            invoice._group_lines_by_tax()
+
     def _import_ubl_invoice_post_processing(self, collected_values):
         # During the import, fill 'ubl_cii_xml_file' to be retrieved later if necessary.
         invoice = collected_values['invoice']
@@ -3904,9 +4027,22 @@ class AccountEdiUBL(models.AbstractModel):
         self._import_ubl_invoice_retrieve_taxes(collected_values)
         self._import_ubl_invoice_add_base_lines(collected_values)
 
+        # Search for potential PO to match
+        self._import_ubl_invoice_add_purchase_order(collected_values)
+
+        # First lines grouping (based on base_lines)
+        self._import_ubl_invoice_group_lines(collected_values)
+
         # End the invoice.
         self._import_ubl_invoice_write_collected_values(collected_values)
         self._import_ubl_invoice_fix_taxes_amounts(collected_values)
         self._import_ubl_invoice_fix_untaxed_amount(collected_values)
+
+        # Actually match the potential PO's
+        self._import_ubl_invoice_match_and_set_purchase_order(collected_values)
+        # Second lines grouping (based on invoice_line_ids)
+        self._import_ubl_invoice_group_lines_after(collected_values)
+
         self._import_ubl_invoice_post_processing(collected_values)
+        file_data['po_matching_done'] = True  # We already tried to match PO so no need to try it later again
         return True

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -96,7 +96,7 @@ class AccountMove(models.Model):
         if decoder is None:
             raise UserError(self.env._("Cannot decode origin file, try by importing it again"))
         self.invoice_line_ids = [Command.clear()]
-        if decoder(self, file_data):
+        if decoder(self.with_context({'ungroup_lines': True}), file_data):
             self._message_log(body=self.env._("Ungrouped lines from %s", file_data['attachment'].name))
         else:
             raise UserError(error_message)
@@ -213,6 +213,7 @@ class AccountMove(models.Model):
 
     @api.model
     def _post_process_link_to_purchase_order(self, invoice):
+        # DEPRECATED, will be removed in master
         # Override account.move
         try:
             invoice._check_move_for_group_ungroup_lines_by_tax()

--- a/addons/account_edi_ubl_cii/tests/__init__.py
+++ b/addons/account_edi_ubl_cii/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_ubl_import_bis3_invoice_be_auto_generate_pdf
 from . import test_ubl_import_bis3_invoice_be_cash_rounding
 from . import test_ubl_import_bis3_invoice_be_decode_invoice_line
 from . import test_ubl_import_bis3_invoice_be_group_lines_by_tax
+from . import test_ubl_import_bis3_invoice_be_purchase_matching
 from . import test_ubl_import_bis3_invoice_be_retrieve_account
 from . import test_ubl_import_bis3_invoice_be_retrieve_partner
 from . import test_ubl_import_bis3_invoice_be_retrieve_product

--- a/addons/account_edi_ubl_cii/tests/__init__.py
+++ b/addons/account_edi_ubl_cii/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_ubl_import_bis3_invoice_be_payable_rounding_amount
 from . import test_ubl_import_bis3_invoice_be_decode_invoice_line
 from . import test_ubl_import_bis3_invoice_be_group_lines_by_tax
 from . import test_ubl_import_bis3_invoice_be_optional_fields
+from . import test_ubl_import_bis3_invoice_be_purchase_matching
 from . import test_ubl_import_bis3_invoice_be_retrieve_account
 from . import test_ubl_import_bis3_invoice_be_retrieve_partner
 from . import test_ubl_import_bis3_invoice_be_retrieve_product

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_full_match.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_full_match.xml
@@ -1,0 +1,150 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2026/00004</cbc:ID>
+  <cbc:IssueDate>2026-01-01</cbc:IssueDate>
+  <cbc:DueDate>2026-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+	<cbc:ID>TEST_PURCHASE_ORDER</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0208">0202239951</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">126.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">600.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">126.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">600.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">726.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">726.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">100.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">200.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>3</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">300.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_c</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">300.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_overmatch.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_overmatch.xml
@@ -1,0 +1,168 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2026/00004</cbc:ID>
+  <cbc:IssueDate>2026-01-01</cbc:IssueDate>
+  <cbc:DueDate>2026-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+	<cbc:ID>TEST_PURCHASE_ORDER</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0208">0202239951</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1210.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">1210.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">1210.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">100.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">200.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>3</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">300.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_c</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">300.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>4</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">400.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>other product</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">400.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_submatch.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_purchase_order_submatch.xml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2026/00004</cbc:ID>
+  <cbc:IssueDate>2026-01-01</cbc:IssueDate>
+  <cbc:DueDate>2026-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+	<cbc:ID>TEST_PURCHASE_ORDER</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0208">0202239951</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">84.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">400.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">84.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">400.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">400.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">484.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">484.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">100.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>3</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.00</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">300.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>product_c</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">300.0000</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_purchase_matching.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_purchase_matching.py
@@ -1,0 +1,130 @@
+from odoo import Command
+
+from odoo.addons.account_edi_ubl_cii.tests.test_ubl_import_bis3_invoice_be import TestUblImportBis3InvoiceBE
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUblImportBis3InvoiceBEPurchaseMatching(TestUblImportBis3InvoiceBE):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ensure_installed('purchase')
+        cls.tax_21 = cls.percent_tax(cls, 21.0, type_tax_use='purchase')
+        cls.product_c = cls.env['product.product'].create({
+            'name': 'product_c',
+            'standard_price': 300.0,
+            'supplier_taxes_id': False
+        })
+        cls.po = cls.env['purchase.order'].create({  # noqa: OLS03001
+            'name': 'TEST_PURCHASE_ORDER',
+            'company_id': cls.company_data['company'].id,
+            'partner_id': cls.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': cls.product_a.id,
+                'price_unit': 100,
+                'product_qty': 1,
+                'taxes_id': cls.tax_21.ids,
+            }),
+            Command.create({
+                'product_id': cls.product_b.id,
+                'price_unit': 200,
+                'product_qty': 1,
+                'taxes_id': cls.tax_21.ids,
+            }),
+            Command.create({
+                'product_id': cls.product_c.id,
+                'price_unit': 300,
+                'product_qty': 1,
+                'taxes_id': cls.tax_21.ids,
+            })],
+        })
+        cls.po.button_confirm()
+
+    def test_import_invoice_purchase_order_full_match(self):
+        self.ensure_installed('purchase')
+        invoice = self._import_invoice_as_attachment_on(
+            test_name='test_import_invoice_purchase_order_full_match',
+            journal=self.company_data['default_journal_purchase'],
+        )
+        po_line_ids = self.po.order_line.ids
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'display_type': 'line_section',
+                'purchase_line_id': False,
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[0],
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[1],
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[2],
+            },
+        ])
+
+    def test_import_invoice_purchase_order_submatch(self):
+        self.ensure_installed('purchase')
+
+        invoice = self._import_invoice_as_attachment_on(
+            test_name='test_import_invoice_purchase_order_submatch',
+            journal=self.company_data['default_journal_purchase'],
+        )
+        po_line_ids = self.po.order_line.ids
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'display_type': 'line_section',
+                'purchase_line_id': False,
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[0],
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[2],
+            },
+        ])
+
+    def test_import_invoice_purchase_order_overmatch(self):
+        self.ensure_installed('purchase')
+
+        invoice = self._import_invoice_as_attachment_on(
+            test_name='test_import_invoice_purchase_order_overmatch',
+            journal=self.company_data['default_journal_purchase'],
+        )
+        po_line_ids = self.po.order_line.ids
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'display_type': 'product',
+                'purchase_line_id': False,
+            },
+            {
+                'display_type': 'line_section',  # FROM PO
+                'purchase_line_id': False,
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[0],
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[1],
+            },
+            {
+                'display_type': 'product',
+                'purchase_line_id': po_line_ids[2],
+            },
+            {
+                'display_type': 'line_section',  # FROM EDI but sequence = -1 so in the ui it'll be the first line
+                'purchase_line_id': False,
+            },
+        ])

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -168,11 +168,6 @@ class TestItEdiImport(TestItEdi):
                 'quantity': 5.0,
                 'price_unit': 1.0,
                 'credit': 5.0,
-            }, {
-                'display_type': 'line_section',
-                'quantity': 0.0,
-                'price_unit': 0.0,
-                'credit': 0.0,
             }],
         }])
 

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -249,11 +249,6 @@ class TestItEdiImport(TestItEdi):
                 'quantity': 5.0,
                 'price_unit': 1.0,
                 'credit': 5.0,
-            }, {
-                'display_type': 'line_section',
-                'quantity': 0.0,
-                'price_unit': 0.0,
-                'credit': 0.0,
             }],
         }])
 

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -341,6 +341,7 @@ class AccountMove(models.Model):
                     invoice._onchange_purchase_auto_complete()
 
     def _match_purchase_orders(self, po_references, partner_id, amount_total, from_ocr, timeout):
+        # /!\ DEPRECATED, please use _find_and_set_purchase_orders or methods called inside it /!\
         """Tries to match open purchase order lines with this invoice given the information we have.
 
         :param po_references: a list of potential purchase order references/names
@@ -453,15 +454,129 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
 
-        method, matched_po_lines, matched_inv_lines = self._match_purchase_orders(
-            po_references, partner_id, amount_total, from_ocr, timeout
+        purchase_order_matching = self._find_purchase_orders(
+            po_references, self.company_id.id, partner_id, amount_total
         )
 
+        method, matched_po_lines, matched_inv_lines = self._match_potential_purchase_orders(purchase_order_matching, amount_total, from_ocr, timeout)
+
+        self._write_values_from_po(method, matched_po_lines, matched_inv_lines)
+
+    @api.model
+    def _find_purchase_orders(self, po_references, company_id, partner_id, amount_total):
+        common_domain = [
+            ('company_id', '=', company_id),
+            ('state', 'in', ('purchase', 'done')),
+            ('invoice_status', 'in', ('to invoice', 'no')),
+        ]
+
+        matching_purchase_orders = self.env['purchase.order']
+
+        if po_references and amount_total:
+            matching_purchase_orders |= self.env['purchase.order'].search(
+                common_domain + [('name', 'in', po_references)])
+
+            if not matching_purchase_orders:
+                matching_purchase_orders |= self.env['purchase.order'].search(
+                    common_domain + [('partner_ref', 'in', po_references)])
+
+            if matching_purchase_orders:
+                return {
+                    'potential_purchase_orders': matching_purchase_orders,
+                    'full_match': False,
+                }
+
+        if partner_id and amount_total:
+            purchase_id_domain = common_domain + [
+                ('partner_id', 'child_of', [partner_id]),
+                ('amount_total', '>=', amount_total - TOLERANCE),
+                ('amount_total', '<=', amount_total + TOLERANCE),
+            ]
+            matching_purchase_orders = self.env['purchase.order'].search(purchase_id_domain)
+            if len(matching_purchase_orders) == 1:
+                return {
+                    'potential_purchase_orders': matching_purchase_orders,
+                    'full_match': True,
+                }
+
+        return {
+            'potential_purchase_orders': matching_purchase_orders,
+            'full_match': False,
+        }
+
+    def _match_potential_purchase_orders(self, purchase_order_matching, amount_total, from_ocr=False, timeout=10):
+        """Tries to match open purchase order lines with this invoice given the information we have.
+
+        :param purchase_order_matching: dict returned by `_find_purchase_orders`
+        :param amount_total: the total amount of the vendor bill
+        :param from_ocr: indicates whether this vendor bill was created from an OCR scan (less reliable)
+        :param timeout: the max time the line matching algorithm can take before timing out
+        :return: tuple (str, recordset, dict) containing:
+            * the match method:
+                * `total_match`: purchase order reference(s) and total amounts match perfectly
+                * `subset_total_match`: a subset of the referenced purchase orders' lines matches the total amount of
+                    this invoice (OCR only)
+                * `po_match`: only the purchase order reference matches (OCR only)
+                * `subset_match`: a subset of the referenced purchase orders' lines matches a subset of the invoice
+                    lines based on unit prices (EDI only)
+                * `no_match`: no result found
+            * recordset of `purchase.order.line` containing purchase order lines matched with an invoice line
+            * list of tuple containing every `purchase.order.line` id and its related `account.move.line`
+        """
+        potential_purchase_orders = purchase_order_matching['potential_purchase_orders']
+        if not potential_purchase_orders:
+            return ('no_match', potential_purchase_orders.order_line, None)
+
+        if purchase_order_matching['full_match']:
+            return ('total_match', potential_purchase_orders.order_line, None)
+
+        po_lines = [line for line in potential_purchase_orders.order_line if line.product_qty]
+        po_lines_with_amount = [{
+            'line': line,
+            'amount_to_invoice': (1 - line.qty_invoiced / line.product_qty) * line.price_total,
+        } for line in po_lines]
+
+        if (amount_total - TOLERANCE
+                < sum(line['amount_to_invoice'] for line in po_lines_with_amount)
+                < amount_total + TOLERANCE):
+            return ('total_match', potential_purchase_orders.order_line, None)
+
+        elif from_ocr:
+            matching_po_lines = self._find_matching_subset_po_lines(
+                po_lines_with_amount, amount_total, timeout)
+            if matching_po_lines:
+                return 'subset_total_match', self.env['purchase.order.line'].union(*matching_po_lines), None
+            else:
+                return 'po_match', potential_purchase_orders.order_line, None
+
+        else:
+            matching_po_lines, matching_inv_lines = self._find_matching_po_and_inv_lines(
+                po_lines, self.invoice_line_ids, timeout)
+
+            if matching_po_lines:
+                return ('subset_match',
+                        self.env['purchase.order.line'].union(*matching_po_lines),
+                        matching_inv_lines)
+
+        if self.partner_id and amount_total:
+            matching_purchase_orders = self.env['purchase.order'].search([
+                ('company_id', '=', self.company_id.id),
+                ('state', 'in', ('purchase', 'done')),
+                ('invoice_status', 'in', ('to invoice', 'no')),
+                ('partner_id', 'child_of', [self.partner_id.id]),
+                ('amount_total', '>=', amount_total - TOLERANCE),
+                ('amount_total', '<=', amount_total + TOLERANCE),
+            ])
+            if len(matching_purchase_orders) == 1:
+                return 'total_match', matching_purchase_orders.order_line, None
+
+        return 'no_match', matching_purchase_orders.order_line, None
+
+    def _write_values_from_po(self, method, matched_po_lines, matched_inv_lines):
         if method in ('total_match', 'po_match'):
             # The purchase order reference(s) and total amounts match perfectly or there is only one purchase order
             # reference that matches with an OCR invoice. We replace the invoice lines with the purchase order lines.
             self._set_purchase_orders(matched_po_lines.order_id, force_write=True)
-
         elif method == 'subset_total_match':
             # A subset of the referenced purchase order lines matches the total amount of this invoice.
             # We keep the invoice lines, but add all the lines from the partially matched purchase orders:
@@ -473,7 +588,6 @@ class AccountMove(models.Model):
                 unmatched_lines = invoice.invoice_line_ids.filtered(
                     lambda l: l.purchase_line_id and l.purchase_line_id not in matched_po_lines)
                 invoice.invoice_line_ids = [Command.update(line.id, {'quantity': 0}) for line in unmatched_lines]
-
         elif method == 'subset_match':
             # A subset of the referenced purchase order lines matches a subset of the invoice lines.
             # We add the purchase order lines, but adjust the quantity to the quantities in the invoice.
@@ -502,14 +616,17 @@ class AccountMove(models.Model):
                 invoice.invoice_line_ids = [Command.delete(inv_line.id) for dummy, inv_line in inv_and_po_lines]
 
                 # If there are lines left not linked to a purchase order, we add a header
-                unmatched_lines = invoice.invoice_line_ids.filtered(lambda l: not l.purchase_line_id)
+                unmatched_lines = invoice.invoice_line_ids.filtered(lambda l: not l.purchase_line_id and l.display_type == 'product')
                 if len(unmatched_lines) > 0:
                     invoice.invoice_line_ids = [Command.create({
                         'display_type': 'line_section',
                         'name': _('From Electronic Document'),
                         'sequence': -1,
                     })]
+        else:
+            return False
 
+        return True
 
 
 class AccountMoveLine(models.Model):

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -343,6 +343,7 @@ class AccountMove(models.Model):
                     invoice._onchange_purchase_auto_complete()
 
     def _match_purchase_orders(self, po_references, partner_id, amount_total, from_ocr, timeout):
+        # /!\ DEPRECATED, please use _find_and_set_purchase_orders or methods called inside it /!\
         """Tries to match open purchase order lines with this invoice given the information we have.
 
         :param po_references: a list of potential purchase order references/names
@@ -455,15 +456,129 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
 
-        method, matched_po_lines, matched_inv_lines = self._match_purchase_orders(
-            po_references, partner_id, amount_total, from_ocr, timeout
+        purchase_order_matching = self._find_purchase_orders(
+            po_references, self.company_id.id, partner_id, amount_total
         )
 
+        method, matched_po_lines, matched_inv_lines = self._match_potential_purchase_orders(purchase_order_matching, amount_total, from_ocr, timeout)
+
+        self._write_values_from_po(method, matched_po_lines, matched_inv_lines)
+
+    @api.model
+    def _find_purchase_orders(self, po_references, company_id, partner_id, amount_total):
+        common_domain = [
+            ('company_id', '=', company_id),
+            ('state', 'in', ('purchase', 'done')),
+            ('invoice_status', 'in', ('to invoice', 'no')),
+        ]
+
+        matching_purchase_orders = self.env['purchase.order']
+
+        if po_references and amount_total:
+            matching_purchase_orders |= self.env['purchase.order'].search(
+                common_domain + [('name', 'in', po_references)])
+
+            if not matching_purchase_orders:
+                matching_purchase_orders |= self.env['purchase.order'].search(
+                    common_domain + [('partner_ref', 'in', po_references)])
+
+            if matching_purchase_orders:
+                return {
+                    'potential_purchase_orders': matching_purchase_orders,
+                    'full_match': False,
+                }
+
+        if partner_id and amount_total:
+            purchase_id_domain = common_domain + [
+                ('partner_id', 'child_of', [partner_id]),
+                ('amount_total', '>=', amount_total - TOLERANCE),
+                ('amount_total', '<=', amount_total + TOLERANCE),
+            ]
+            matching_purchase_orders = self.env['purchase.order'].search(purchase_id_domain)
+            if len(matching_purchase_orders) == 1:
+                return {
+                    'potential_purchase_orders': matching_purchase_orders,
+                    'full_match': True,
+                }
+
+        return {
+            'potential_purchase_orders': matching_purchase_orders,
+            'full_match': False,
+        }
+
+    def _match_potential_purchase_orders(self, purchase_order_matching, amount_total, from_ocr=False, timeout=10):
+        """Tries to match open purchase order lines with this invoice given the information we have.
+
+        :param purchase_order_matching: dict returned by `_find_purchase_orders`
+        :param amount_total: the total amount of the vendor bill
+        :param from_ocr: indicates whether this vendor bill was created from an OCR scan (less reliable)
+        :param timeout: the max time the line matching algorithm can take before timing out
+        :return: tuple (str, recordset, dict) containing:
+            * the match method:
+                * `total_match`: purchase order reference(s) and total amounts match perfectly
+                * `subset_total_match`: a subset of the referenced purchase orders' lines matches the total amount of
+                    this invoice (OCR only)
+                * `po_match`: only the purchase order reference matches (OCR only)
+                * `subset_match`: a subset of the referenced purchase orders' lines matches a subset of the invoice
+                    lines based on unit prices (EDI only)
+                * `no_match`: no result found
+            * recordset of `purchase.order.line` containing purchase order lines matched with an invoice line
+            * list of tuple containing every `purchase.order.line` id and its related `account.move.line`
+        """
+        potential_purchase_orders = purchase_order_matching['potential_purchase_orders']
+        if not potential_purchase_orders:
+            return ('no_match', potential_purchase_orders.order_line, None)
+
+        if purchase_order_matching['full_match']:
+            return ('total_match', potential_purchase_orders.order_line, None)
+
+        po_lines = [line for line in potential_purchase_orders.order_line if line.product_qty]
+        po_lines_with_amount = [{
+            'line': line,
+            'amount_to_invoice': (1 - line.qty_invoiced / line.product_qty) * line.price_total,
+        } for line in po_lines]
+
+        if (amount_total - TOLERANCE
+                < sum(line['amount_to_invoice'] for line in po_lines_with_amount)
+                < amount_total + TOLERANCE):
+            return ('total_match', potential_purchase_orders.order_line, None)
+
+        elif from_ocr:
+            matching_po_lines = self._find_matching_subset_po_lines(
+                po_lines_with_amount, amount_total, timeout)
+            if matching_po_lines:
+                return 'subset_total_match', self.env['purchase.order.line'].union(*matching_po_lines), None
+            else:
+                return 'po_match', potential_purchase_orders.order_line, None
+
+        else:
+            matching_po_lines, matching_inv_lines = self._find_matching_po_and_inv_lines(
+                po_lines, self.invoice_line_ids, timeout)
+
+            if matching_po_lines:
+                return ('subset_match',
+                        self.env['purchase.order.line'].union(*matching_po_lines),
+                        matching_inv_lines)
+
+        if self.partner_id and amount_total:
+            matching_purchase_orders = self.env['purchase.order'].search([
+                ('company_id', '=', self.company_id.id),
+                ('state', 'in', ('purchase', 'done')),
+                ('invoice_status', 'in', ('to invoice', 'no')),
+                ('partner_id', 'child_of', [self.partner_id.id]),
+                ('amount_total', '>=', amount_total - TOLERANCE),
+                ('amount_total', '<=', amount_total + TOLERANCE),
+            ])
+            if len(matching_purchase_orders) == 1:
+                return 'total_match', matching_purchase_orders.order_line, None
+
+        return 'no_match', matching_purchase_orders.order_line, None
+
+    def _write_values_from_po(self, method, matched_po_lines, matched_inv_lines):
         if method in ('total_match', 'po_match'):
             # The purchase order reference(s) and total amounts match perfectly or there is only one purchase order
             # reference that matches with an OCR invoice. We replace the invoice lines with the purchase order lines.
             self._set_purchase_orders(matched_po_lines.order_id, force_write=True)
-
         elif method == 'subset_total_match':
             # A subset of the referenced purchase order lines matches the total amount of this invoice.
             # We keep the invoice lines, but add all the lines from the partially matched purchase orders:
@@ -475,7 +590,6 @@ class AccountMove(models.Model):
                 unmatched_lines = invoice.invoice_line_ids.filtered(
                     lambda l: l.purchase_line_id and l.purchase_line_id not in matched_po_lines)
                 invoice.invoice_line_ids = [Command.update(line.id, {'quantity': 0}) for line in unmatched_lines]
-
         elif method == 'subset_match':
             # A subset of the referenced purchase order lines matches a subset of the invoice lines.
             # We add the purchase order lines, but adjust the quantity to the quantities in the invoice.
@@ -504,14 +618,17 @@ class AccountMove(models.Model):
                 invoice.invoice_line_ids = [Command.delete(inv_line.id) for dummy, inv_line in inv_and_po_lines]
 
                 # If there are lines left not linked to a purchase order, we add a header
-                unmatched_lines = invoice.invoice_line_ids.filtered(lambda l: not l.purchase_line_id)
+                unmatched_lines = invoice.invoice_line_ids.filtered(lambda l: not l.purchase_line_id and l.display_type == 'product')
                 if len(unmatched_lines) > 0:
                     invoice.invoice_line_ids = [Command.create({
                         'display_type': 'line_section',
                         'name': _('From Electronic Document'),
                         'sequence': -1,
                     })]
+        else:
+            return False
 
+        return True
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
[FIX] account, *: improve po matching and grouping

modules: account, account_edi_ubl_cii, purchase, l10n_it_edi

With the ubl import refactor, we can now group lines at import with base lines (dict) instead of doing it after lines are created in db (account.move.line)

Also the purchase order matching main method is now split in 3 submethods. This will allow to use them separately, as the 1st one don't require move line objects but give enough data to know if there'll be a potential matching. This way, we'll be able to group lines or not before creating move lines

Last thing: corrected a bug in purchase matching when a complete match was found, a line section "From Electronic Document" was created even when all lines where written from the purchase order

task-6147801
