### PR TITLE
[FIX] various: update query counters

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -31,7 +31,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=545):  # crm 545 / com 545 / ent 545
+        with self.assertQueryCount(user_sales_manager=532):
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=530):  # crm 500 / com 500 / ent 530
+        with self.assertQueryCount(user_sales_manager=516):  # crm ??
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -162,7 +162,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         user_ids = self.assign_users.ids
 
         # randomness: at least 1 query
-        with self.assertQueryCount(user_sales_manager=1760):  # crm ??
+        with self.assertQueryCount(user_sales_manager=1475):  # crm ??
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_crm_lead_duration_mixin.py
+++ b/addons/crm/tests/test_crm_lead_duration_mixin.py
@@ -13,4 +13,4 @@ class TestCrmLeadMailTrackingDuration(MailTrackingDurationMixinCase):
         self._test_record_duration_tracking()
 
     def test_crm_lead_queries_batch_mail_tracking_duration(self):
-        self._test_queries_batch_duration_tracking()
+        self._test_queries_batch_duration_tracking(query_count=1)

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -54,10 +54,10 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness: at least 1 query, +3 for demo -> 957 + 5
+        # randomness: at least 1 query, +3 for demo -> 858 + 5
         with self.with_user('user_sales_manager'):
             self.env.user._is_internal()  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=962):
+            with self.assertQueryCount(user_sales_manager=863):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads()
 
         # teams assign
@@ -100,9 +100,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness: at least 1 query, +1 for demo
+        # randomness: at least 1 query, +1 for demo: 526 + 2
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=552):
+            with self.assertQueryCount(user_sales_manager=528):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads()
 
         # teams assign
@@ -183,9 +183,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness: 5236, add 2 queries
+        # randomness: 5204, add 2 queries
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=5242):
+            with self.assertQueryCount(user_sales_manager=5206):
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads()
 
         # teams assign

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -156,7 +156,6 @@ class TestMailRenderCommon(common.MailCommon):
 
 
 @tagged('mail_render')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMailRender(TestMailRenderCommon):
 
     @users('employee')
@@ -277,7 +276,7 @@ class TestMailRender(TestMailRenderCommon):
         partner_ids = self.env['res.partner'].sudo().create([{
             'name': f'test partner {n}'
         } for n in range(20)]).ids
-        with patch('odoo.models.Model.get_base_url', new=_mock_get_base_url), self.assertQueryCount(13):
+        with patch('odoo.models.Model.get_base_url', new=_mock_get_base_url), self.assertQueryCount(12):
             # make sure name isn't already in cache
             self.env['res.partner'].browse(partner_ids).invalidate_recordset(['name', 'display_name'])
             render_results = self.env['mail.render.mixin']._render_template(

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -27,7 +27,6 @@ def _extract_values_from_document(rendered_document):
     }
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMarketingCardMail(MailCase, MarketingCardCommon):
 
     def assertSentMailCorrectCard(self, sent_mails, cards):
@@ -115,7 +114,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
         mailing.card_lang = 'fr_FR'
         self.assertFalse(mailing.card_requires_sync_count)
 
-        with self.mock_mail_gateway(), self.assertQueryCount(65):
+        with self.mock_mail_gateway(), self.assertQueryCount(42):
             mailing._action_send_mail()
 
         cards = self.env['card.card'].search([('campaign_id', '=', campaign.id)])

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -417,7 +417,7 @@ class TestAPI(ThreadRecipients):
 
         # test default computation of recipients
         self.env.invalidate_all()
-        with self.assertQueryCount(22):
+        with self.assertQueryCount(14):
             defaults_withcc = test_records.with_context()._message_get_default_recipients(with_cc=True)
             defaults_withoutcc = test_records.with_context()._message_get_default_recipients()
         for record, expected in zip(test_records, [

--- a/addons/test_mail/tests/test_mail_thread_mixins.py
+++ b/addons/test_mail/tests/test_mail_thread_mixins.py
@@ -55,7 +55,7 @@ class TestMailTrackingDurationMixin(MailTrackingDurationMixinCase):
                     })
 
     def test_queries_batch_mail_tracking_duration(self):
-        self._test_queries_batch_duration_tracking()
+        self._test_queries_batch_duration_tracking(query_count=1)
 
 
 @tagged('mail_thread', 'mail_track', 'mail_duration_mixin')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -336,7 +336,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             'default_res_model': 'mail.test.activity',
         })
 
-        with self.assertQueryCount(admin=6, employee=6):
+        with self.assertQueryCount(admin=5, employee=5):
             activity = MailActivity.create({
                 'summary': 'Test Activity',
                 'res_id': record.id,
@@ -433,7 +433,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=37, employee=37):
+        with self.assertQueryCount(admin=36, employee=36):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -454,7 +454,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(admin=40, employee=40):
+        with self.assertQueryCount(admin=38, employee=38):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -478,7 +478,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=57, employee=57):  # tm 57/57
+        with self.assertQueryCount(admin=56, employee=56):  # tm 56/56
             composer._action_send_mail()
 
         # notifications
@@ -523,7 +523,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=37, employee=37):
+        with self.assertQueryCount(admin=36, employee=36):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -541,7 +541,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=36, employee=36):
+        with self.assertQueryCount(admin=35, employee=35):
             composer._action_send_mail()
 
         # notifications
@@ -568,7 +568,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=44, employee=44):
+        with self.assertQueryCount(admin=42, employee=42):
             composer._action_send_mail()
 
         # notifications
@@ -657,7 +657,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=42, employee=41):
+        with self.assertQueryCount(admin=41, employee=40):
             record.write({
                 'user_id': self.user_emp_email.id,
             })
@@ -740,7 +740,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=31, employee=31):
+        with self.assertQueryCount(admin=30, employee=30):
             record.message_post(
                 body=Markup('<p>Test Post Performances with an email ping</p>'),
                 partner_ids=self.customer.ids,
@@ -1010,7 +1010,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=30):  # tm: 21
+        with self.assertQueryCount(employee=29):  # tm: 21
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @users('employee')
@@ -1028,7 +1028,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=55, employee=57):
+        with self.assertQueryCount(admin=54, employee=56):
             record.message_post(
                 body=Markup('<p>Test Post Performances</p>'),
                 message_type='comment',
@@ -1046,7 +1046,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=69, employee=71):
+        with self.assertQueryCount(admin=68, employee=70):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -1162,7 +1162,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
         profile = self.profile() if self.warm else nullcontext()
-        with self.assertQueryCount(admin=46, employee=46), profile:
+        with self.assertQueryCount(admin=44, employee=44), profile:
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1182,7 +1182,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(admin=95, employee=95):
+        with self.assertQueryCount(admin=93, employee=93):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -1212,7 +1212,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
 
-        with self.assertQueryCount(admin=58, employee=58):
+        with self.assertQueryCount(admin=53, employee=53):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1249,7 +1249,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=64, employee=64):
+        with self.assertQueryCount(admin=59, employee=59):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1282,7 +1282,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=34, employee=34):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,
@@ -1968,7 +1968,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=88):
+        with self.assertQueryCount(employee=80):
             ticket.message_post(
                 attachments=attachments_vals,
                 attachment_ids=attachments.ids,
@@ -2013,7 +2013,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=880):  # tm: 841
+        with self.assertQueryCount(employee=827):  # tm: ??
             for ticket, attachments in zip(tickets, attachments_all, strict=True):
                 ticket.message_post(
                     attachments=attachments_vals,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -75,7 +75,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=110):  # test_mail_full: 108
+        with self.assertQueryCount(employee=101):  # test_mail_full: ??
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/addons/test_mail_sms/tests/test_phone_format.py
+++ b/addons/test_mail_sms/tests/test_phone_format.py
@@ -1,10 +1,28 @@
-from odoo.tests import tagged
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests import tagged, users
 from odoo.tests.common import TransactionCase
 
 
-@tagged('phone_validation')
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('phone_validation', 'mail_performance')
 class TestPhoneFormat(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref('base.user_admin')
+        # standard users
+        cls.user_emp_email = mail_new_test_user(
+            cls.env,
+            company_id=cls.user_admin.company_id.id,
+            company_ids=[(4, cls.user_admin.company_id.id)],
+            email='user.emp.email@test.example.com',
+            login='user_emp_email',
+            groups='base.group_user,base.group_partner_manager',
+            name='Ernestine Email',
+            notification_type='email',
+            signature='Ernestine',
+        )
 
     def test_phone_format_country_guess(self):
         # based on partner country
@@ -46,10 +64,11 @@ class TestPhoneFormat(TransactionCase):
                         number=input_number,
                     ), expected_number)
 
+    @users('user_emp_email')
     def test_phone_format_perf(self):
         PARTNER_COUNT = 100
 
-        countries = self.env['res.country'].create([{
+        countries = self.env['res.country'].sudo().create([{
             'name': f'Test Country {n}',
             'code': str(n),
         } for n in range(20)])
@@ -74,8 +93,9 @@ class TestPhoneFormat(TransactionCase):
         test_records.invalidate_recordset()
         (country_partners + nocountry_partners).invalidate_recordset()
         countries.invalidate_recordset()
-        # 1 query per country + 4
-        with self.assertQueryCount(24):
+
+        # 1 query per country + 4 - TDE: to update since it works better than previously
+        with self.assertQueryCount(7):
             for record in test_records:
                 record._phone_format(
                     number='078 9216 4126',


### PR DESCRIPTION
Update various (main mail-related) counters according to runbot state.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
