### PR TITLE
[FIX] website: only rerender dynamic snippet on breakpoint change

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -2,7 +2,7 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { rpc } from "@web/core/network/rpc";
-import { utils as uiUtils } from "@web/core/ui/ui_service";
+import { listenSizeChange, utils as uiUtils } from "@web/core/ui/ui_service";
 import { uniqueId } from "@web/core/utils/functions";
 import { renderToFragment } from "@web/core/utils/render";
 import { verifyHttpsUrl } from "@website/utils/misc";
@@ -18,7 +18,6 @@ export class DynamicSnippet extends Interaction {
         "[data-url]": {
             "t-on-click": this.callToAction,
         },
-        _window: { "t-on-resize": this.throttled(this.render) },
         _root: {
             "t-att-class": () => ({
                 // Compatibility code: A dynamic snippet may end up with one,
@@ -56,6 +55,8 @@ export class DynamicSnippet extends Interaction {
     }
 
     start() {
+        // Re-render on media breakpoint change
+        this.registerCleanup(listenSizeChange(this.render.bind(this)));
         this.render();
     }
 

--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -18,7 +18,7 @@ export class DynamicSnippet extends Interaction {
         "[data-url]": {
             "t-on-click": this.callToAction,
         },
-        _window: { "t-on-resize": this.throttled(this.render) },
+        _window: { "t-on-resize": this.throttled(this.onResize) },
         _root: {
             "t-att-class": () => ({
                 // Compatibility code: A dynamic snippet may end up with one,
@@ -44,6 +44,7 @@ export class DynamicSnippet extends Interaction {
          * @type {*|jQuery.fn.init|jQuery|HTMLElement}
          */
         this.data = [];
+        this.isDisplayedAsMobile = uiUtils.isSmall();
         this.renderedContentNode = document.createDocumentFragment();
         this.uniqueId = uniqueId("s_dynamic_snippet_");
         this.templateKey = "website.s_dynamic_snippet.grid";
@@ -202,6 +203,16 @@ export class DynamicSnippet extends Interaction {
      */
     callToAction(ev) {
         window.location = verifyHttpsUrl(ev.currentTarget.dataset.url);
+    }
+
+    /**
+     * Re-render when bootstrap size media breapoint change
+     */
+    onResize() {
+        if (this.isDisplayedAsMobile !== uiUtils.isSmall()) {
+            this.isDisplayedAsMobile = uiUtils.isSmall();
+            this.render();
+        }
     }
 }
 


### PR DESCRIPTION
Scenario:

- drop product catalog snippet and save
- go to the second page of product
- on some mobile scroll, or just change window size

Result: we are reset to the first items of the gallery.

Cause: in some mobile (eg. iOS safari) scrolling up or down make the
address bar appear, that makes the viewport size change. Since 18.4
refactor of website, we rerender dynamic widget at any size change, so
scrolling rerender the snippet.

Fix: reintroduce saas-18.2 listenSizeChange that only trigger throttled
change of media breakpoint and was removed from dynamic_snippet.js in
9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2.

opw-6137005