### PR TITLE
[IMP] project, hr_timesheet: restrict secret project visibility to system admins

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -78,7 +78,7 @@
             <field name="name">account.analytic.line.timesheet.manager</field>
             <field name="model_id" ref="analytic.model_account_analytic_line"/>
             <field name="domain_force">[('project_id', '!=', False)]</field>
-            <field name="groups" eval="[(4, ref('group_timesheet_manager')), (4, ref('project.group_project_manager'))]"/>
+            <field name="groups" eval="[(4, ref('group_timesheet_manager'))]"/>
         </record>
 
         <record id="project.group_project_manager" model="res.groups">
@@ -127,7 +127,7 @@
             <field name="name">Timesheets Analysis Report manager</field>
             <field name="model_id" ref="model_timesheets_analysis_report"/>
             <field name="domain_force">[(1, '=', 1)]</field>
-            <field name="groups" eval="[(4, ref('group_timesheet_manager')), (4, ref('project.group_project_manager'))]"/>
+            <field name="groups" eval="[(4, ref('group_timesheet_manager'))]"/>
         </record>
     </data>
 </odoo>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -141,7 +141,7 @@ class ProjectProject(models.Model):
              "- Edit: Same as above, with access to all tasks.\n\n"
              "Other Rules:\n"
              "- Internal users can open a task from a direct link, even without project access.\n"
-             "- Project admins have access to private projects, even if not followers.\n")
+             "- System admins have access to private projects, even if not followers.\n")
     privacy_visibility_warning = fields.Char('Privacy Visibility Warning', compute='_compute_privacy_visibility_warning', export_string_translation=False)
     access_instruction_message = fields.Char('Access Instruction Message', compute='_compute_access_instruction_message', export_string_translation=False)
     date_start = fields.Date(string='Start Date', copy=False)
@@ -1116,6 +1116,8 @@ class ProjectProject(models.Model):
         for project in self:
             if project.privacy_visibility == new_visibility:
                 continue
+            if new_visibility in ['followers', 'invited_users']:
+                project.message_subscribe(partner_ids=self.env.user.partner_id.ids)
             if new_visibility in ['invited_users', 'portal']:
                 project.message_subscribe(partner_ids=project.partner_id.ids)
                 for task in project.task_ids.filtered('partner_id'):

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -55,10 +55,21 @@
     </record>
 
     <record model="ir.rule" id="project_project_manager_rule">
-        <field name="name">Project: project manager: see all</field>
+        <field name="name">Project: Administrator: see all</field>
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+
+    <record model="ir.rule" id="project_project_manager_create_rule">
+        <field name="name">Project: project manager: create any project</field>
+        <field name="model_id" ref="model_project_project"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_project_manager'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record model="ir.rule" id="project_public_members_rule">
@@ -95,13 +106,13 @@
     </record>
 
     <record model="ir.rule" id="project_manager_all_project_tasks_rule">
-        <field name="name">Project/Task: project manager: see all tasks linked to a project or its own tasks</field>
+        <field name="name">Project/Task: Administrator: see all tasks linked to a project or its own tasks</field>
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[
             '|', ('project_id', '!=', False),
                  ('user_ids', 'in', user.id),
         ]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record model="ir.rule" id="task_type_manager_rule">
@@ -271,17 +282,17 @@
     </record>
 
     <record model="ir.rule" id="report_project_task_manager_rule">
-        <field name="name">Tasks Analysis: project visibility Manager</field>
+        <field name="name">Tasks Analysis: project visibility Administrator</field>
         <field name="model_id" ref="model_report_project_task_user"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record id="update_visibility_project_admin" model="ir.rule">
-        <field name="name">Project updates : Project user can see all project updates</field>
+        <field name="name">Project updates: Administrator can see all project updates</field>
         <field name="model_id" ref="project.model_project_update"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record model="ir.rule" id="burndown_chart_project_user_rule">
@@ -298,10 +309,10 @@
     </record>
 
     <record model="ir.rule" id="burndown_chart_project_manager_rule">
-        <field name="name">Burndown chart: project visibility User</field>
+        <field name="name">Burndown chart: project visibility Administrator</field>
         <field name="model_id" ref="model_project_task_burndown_chart_report"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record model="ir.rule" id="milestone_comp_rule">
@@ -324,10 +335,10 @@
     </record>
 
     <record id="milestone_visibility_project_admin" model="ir.rule">
-        <field name="name">Project/Milestone: Project manager can see all project milestones</field>
+        <field name="name">Project/Milestone: Administrator can see all project milestones</field>
         <field name="model_id" ref="project.model_project_milestone"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record id="project_milestone_rule_portal_project_sharing" model="ir.rule">

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -175,6 +175,7 @@ class TestProjectBase(TestProjectCommon):
     def test_search_favorite_order(self):
         """ Test the search method, ordering by favorite projects.
         """
+        self.project_goats.message_subscribe(partner_ids=self.user_projectmanager.partner_id.ids)
         self.project_goats.favorite_user_ids += self.user_projectmanager
         self.env.cr.flush()
 

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -239,6 +239,7 @@ class TestProjectFlow(TestProjectCommon, MailCase):
         self.assertEqual(task.personal_stage_id.stage_id.name, stages[0].get('name'), "tasks assigned to the current user should be in the right default stage")
 
     def test_send_rating_review(self):
+        self.project_goats.message_subscribe(partner_ids=self.user_projectmanager.partner_id.ids)
         won_stage = self.project_goats.type_ids[-1]
         won_stage.write({
             'rating_active': True,

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -454,6 +454,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
     @users('bastien')
     def test_task_notification_on_project_update(self):
         """ Test changing task's project notifies people following 'New Task' """
+        self.project_goats.message_subscribe(partner_ids=self.user_projectmanager.partner_id.ids)
         test_task = self.test_task.with_user(self.env.user)
         with self.mock_mail_gateway():
             test_task.project_id = False

--- a/addons/project/tests/test_project_tags.py
+++ b/addons/project/tests/test_project_tags.py
@@ -16,6 +16,7 @@ class TestProjectTagsSecurity(TestProjectCommon):
     @mute_logger("odoo.models.unlink")
     def setUpClass(cls):
         super().setUpClass()
+        cls.project_goats.message_subscribe(partner_ids=cls.user_projectmanager.partner_id.ids)
         cls.tag_project, cls.tag_admin = cls.env["project.tags"].create(
             [
                 {"name": "project tag", "project_ids": [cls.project_goats.id]},

--- a/addons/project/tests/test_project_task_type.py
+++ b/addons/project/tests/test_project_task_type.py
@@ -94,6 +94,7 @@ class TestProjectTaskTypeSecurity(TestProjectCommon):
     @mute_logger("odoo.models.unlink")
     def setUpClass(cls):
         super().setUpClass()
+        cls.project_goats.message_subscribe(partner_ids=cls.user_projectmanager.partner_id.ids)
         (cls.stage_project, cls.stage_manager, cls.stage_user, cls.stage_employee, cls.stage_portal) = cls.env[
             "project.task.type"
         ].create(


### PR DESCRIPTION
This commit scopes visibility rules on projects, tasks, milestones, updates, the burndown report, the task analysis report and timesheets to System Administrators instead of Project Managers.

task-5039102
