### PR TITLE
[IMP] account: Improve tax lines synchronization

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3098,6 +3098,7 @@ class AccountMove(models.Model):
                 )
             ):
                 round_from_tax_lines = False
+                old_tax_lines = new_tax_lines
             else:
                 round_from_tax_lines = AccountTax._sync_tax_lines_compare_tax_lines(company, old_tax_lines, new_tax_lines)['manually_edited']
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1600,15 +1600,7 @@ class AccountMove(models.Model):
             sign=self.direction_sign,
         )
 
-    def _get_rounded_base_and_tax_lines(self, round_from_tax_lines=True):
-        """ Small helper to extract the base and tax lines for the taxes computation from the current move.
-        The move could be stored or not and could have some features generating extra journal items acting as
-        base lines for the taxes computation (e.g. epd, rounding lines).
-
-        :param round_from_tax_lines:    Indicate if the manual tax amounts of tax journal items should be kept or not.
-                                        It only works when the move is stored.
-        :return:                        A tuple <base_lines, tax_lines> for the taxes computation.
-        """
+    def _get_base_and_tax_lines(self):
         self.ensure_one()
         AccountTax = self.env['account.tax']
         is_invoice = self.is_invoice(include_receipts=True)
@@ -1628,20 +1620,33 @@ class AccountMove(models.Model):
             cash_rounding_amls = self.line_ids \
                 .filtered(lambda line: line.display_type == 'rounding' and not line.tax_repartition_line_id)
             base_lines += [self._prepare_cash_rounding_base_line_for_taxes_computation(line) for line in cash_rounding_amls]
-            AccountTax._add_tax_details_in_base_lines(base_lines, self.company_id)
             tax_amls = self.line_ids.filtered('tax_repartition_line_id')
             tax_lines = [self._prepare_tax_line_for_taxes_computation(tax_line) for tax_line in tax_amls]
-            if round_from_tax_lines == 'reapply_currency_rate':
-                for tax_line in tax_lines:
-                    rate = tax_line['record'].currency_rate
-                    if rate:
-                        tax_line['balance'] = self.company_currency_id.round(tax_line['amount_currency'] / rate)
-            AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=tax_lines if round_from_tax_lines else [])
         else:
             # The move is not stored yet so the only thing we have is the invoice lines.
             base_lines += self._prepare_epd_base_lines_for_taxes_computation_from_base_lines(base_amls)
-            AccountTax._add_tax_details_in_base_lines(base_lines, self.company_id)
-            AccountTax._round_base_lines_tax_details(base_lines, self.company_id)
+        return base_lines, tax_lines
+
+    def _get_rounded_base_and_tax_lines(self, round_from_tax_lines=True):
+        """ Small helper to extract the base and tax lines for the taxes computation from the current move.
+        The move could be stored or not and could have some features generating extra journal items acting as
+        base lines for the taxes computation (e.g. epd, rounding lines).
+
+        :param round_from_tax_lines:    Indicate if the manual tax amounts of tax journal items should be kept or not.
+                                        It only works when the move is stored.
+        :return:                        A tuple <base_lines, tax_lines> for the taxes computation.
+        """
+        self.ensure_one()
+        base_lines, tax_lines = self._get_base_and_tax_lines()
+        AccountTax = self.env['account.tax']
+        is_invoice = self.is_invoice(include_receipts=True)
+        company = self.company_id or self.env.company
+
+        AccountTax._add_tax_details_in_base_lines(base_lines, self.company_id)
+        AccountTax._round_base_lines_tax_details(
+            base_lines=base_lines,
+            company=company, tax_lines=tax_lines if round_from_tax_lines and self.id else [],
+        )
         return base_lines, tax_lines
 
     @api.depends_context('lang')
@@ -2975,6 +2980,13 @@ class AccountMove(models.Model):
                 for fname in values
             )
 
+        moves_base_lines_tax_lines_before = {}
+        for move in container['records']:
+            old_base_lines, old_tax_lines = move._get_base_and_tax_lines()
+            moves_base_lines_tax_lines_before[move] = {
+                'base_lines': old_base_lines,
+                'tax_lines': old_tax_lines,
+            }
         moves_values_before = {
             move: {
                 field: get_value(move, field)
@@ -3011,57 +3023,21 @@ class AccountMove(models.Model):
             if move.state != 'draft':
                 continue
 
-            tax_lines = get_tax_lines(move)
-            base_lines = get_base_lines(move)
-            move_tax_lines_values_before = tax_lines_values_before.get(move, {})
-            move_base_lines_values_before = base_lines_values_before.get(move, {})
-            if (
-                move.is_invoice(include_receipts=True)
-                and (
-                    field_has_changed(moves_values_before, move, 'currency_id')
-                    or field_has_changed(moves_values_before, move, 'move_type')
-                )
-            ):
-                # Changing the type of an invoice using 'switch to refund' feature or just changing the currency.
-                round_from_tax_lines = False
-            elif any(line not in base_lines for line, values in move_base_lines_values_before.items() if values['tax_ids']):
-                # Removed a base line affecting the taxes.
-                round_from_tax_lines = any_field_has_changed(move_tax_lines_values_before, tax_lines)
-            elif field_has_changed(moves_values_before, move, 'invoice_currency_rate') and not field_has_changed(moves_values_before, move, 'invoice_date'):
-                # Changing the rate should preserve the tax amounts in foreign currency but reapply the currency rate.
-                round_from_tax_lines = 'reapply_currency_rate'
-            elif changed_lines := list(get_changed_lines(move_base_lines_values_before, base_lines)):
-                # A base line has been modified.
-                round_from_tax_lines = (
-                    # The changed lines don't affect the taxes.
-                    all(
-                        not line.tax_ids and not move_base_lines_values_before.get(line, {}).get('tax_ids')
-                        for line in changed_lines
-                    )
-                    # Keep the tax lines amounts if an amount has been manually computed.
-                    or (
-                        list(move_tax_lines_values_before) != list(tax_lines)
-                        or any(
-                            self.env.is_protected(line._fields[fname], line)
-                            for line in tax_lines
-                            for fname in move_tax_lines_values_before[line]
-                        )
-                    )
-                )
-
-                # If the move has been created with all lines including the tax ones and the balance/amount_currency are provided on
-                # base lines, we don't need to recompute anything.
-                if (
-                    round_from_tax_lines
-                    and any(line[field] for line in changed_lines for field in ('amount_currency', 'balance'))
-                ):
-                    continue
-            else:
-                continue
-
-            base_lines_values, tax_lines_values = move._get_rounded_base_and_tax_lines(round_from_tax_lines=round_from_tax_lines)
-            AccountTax._add_accounting_data_in_base_lines_tax_details(base_lines_values, move.company_id, include_caba_tags=move.always_tax_exigible)
-            tax_results = AccountTax._prepare_tax_lines(base_lines_values, move.company_id, tax_lines=tax_lines_values)
+            old_base_lines = moves_base_lines_tax_lines_before.get(move, {}).get('base_lines', [])
+            old_tax_lines = moves_base_lines_tax_lines_before.get(move, {}).get('tax_lines', [])
+            new_base_lines, new_tax_lines = move._get_rounded_base_and_tax_lines(round_from_tax_lines=False)
+            AccountTax._add_accounting_data_in_base_lines_tax_details(
+                base_lines=new_base_lines,
+                company=move.company_id,
+                include_caba_tags=move.always_tax_exigible,
+            )
+            tax_results = AccountTax._sync_tax_lines(
+                company=move.company_id,
+                old_base_lines=old_base_lines,
+                old_tax_lines=old_tax_lines,
+                new_base_lines=new_base_lines,
+                new_tax_lines=new_tax_lines,
+            )
 
             for base_line, to_update in tax_results['base_lines_to_update']:
                 line = base_line['record']

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3172,6 +3172,7 @@ class AccountTax(models.Model):
                     base_line['price_unit'],
                     base_line['quantity'],
                     base_line['discount'],
+                    flat_taxes,
                 )
                 values = base_line_tracked_values[frozendict(grouping_key)]
                 values['base_lines'].append(base_line)
@@ -3337,14 +3338,14 @@ class AccountTax(models.Model):
 
         tax_lines_to_delete = []
         for tax_line in tax_results['tax_lines_to_delete']:
-            if compare_tax_lines['manually_edited'] or not base_line_tax_rep_grouping_key_mapping:
+            if compare_tax_lines['manually_edited']:
                 continue
             tax_lines_to_delete.append(tax_line)
         tax_results['tax_lines_to_delete'] = tax_lines_to_delete
 
         tax_lines_to_add = []
         for tax_line in tax_results['tax_lines_to_add']:
-            if compare_tax_lines['manually_edited'] or not base_line_tax_rep_grouping_key_mapping:
+            if compare_tax_lines['manually_edited']:
                 continue
             tax_lines_to_add.append(tax_line)
         tax_results['tax_lines_to_add'] = tax_lines_to_add

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2412,6 +2412,9 @@ class AccountTax(models.Model):
         else:
             repartition_lines_field = 'invoice_repartition_line_ids'
 
+        # Base line grouping_key.
+        base_line['grouping_key'] = base_line_grouping_key = self._prepare_base_line_grouping_key(base_line)
+
         # Tags on the base line.
         taxes_data = base_line['tax_details']['taxes_data']
         base_line['tax_tag_ids'] = self.env['account.account.tag']
@@ -2506,7 +2509,6 @@ class AccountTax(models.Model):
                             tax_rep_data['tax_tags'] |= tags
 
                 # Add the accounting grouping_key to create the tax lines.
-                base_line_grouping_key = self._prepare_base_line_grouping_key(base_line)
                 tax_rep_data['grouping_key'] = self._prepare_base_line_tax_repartition_grouping_key(
                     base_line,
                     base_line_grouping_key,
@@ -3103,12 +3105,18 @@ class AccountTax(models.Model):
         tax_lines_to_delete = []
         for tax_line in tax_lines or []:
             grouping_key = frozendict(self._prepare_tax_line_repartition_grouping_key(tax_line))
-            if grouping_key in tax_lines_mapping and grouping_key not in tax_lines_to_update:
+            if grouping_key in tax_lines_mapping:
                 amounts = tax_lines_mapping.pop(grouping_key)
                 tax_lines_to_update.append((tax_line, grouping_key, amounts))
             else:
                 tax_lines_to_delete.append(tax_line)
-        tax_lines_to_add = [{**grouping_key, **values} for grouping_key, values in tax_lines_mapping.items()]
+        tax_lines_to_add = [
+            {
+                **{k: v for k, v in grouping_key.items() if k != '__keep_zero_line'},
+                **values,
+            }
+            for grouping_key, values in tax_lines_mapping.items()
+        ]
 
         return {
             'tax_lines_to_add': tax_lines_to_add,
@@ -3116,6 +3124,119 @@ class AccountTax(models.Model):
             'tax_lines_to_update': tax_lines_to_update,
             'base_lines_to_update': base_lines_to_update,
         }
+
+    @api.model
+    def _sync_tax_lines(self, company, old_base_lines, old_tax_lines, new_base_lines, new_tax_lines):
+
+        # Track base lines values.
+
+        def track_base_lines_values(base_lines):
+            base_line_tracked_values = defaultdict(lambda: {
+                'base_lines': [],
+                'amounts': [],
+                'rates': set(),
+            })
+            for base_line in base_lines:
+                base_line_key = self._prepare_base_line_grouping_key(base_line)
+
+                # Changing the currency is handled by 'rates' because it won't necessarily
+                # change the taxes amounts.
+                base_line_key.pop('currency_id')
+
+                # Changing the analytic distribution might impact the taxes amounts or not
+                # depending if 'analytic' is ticked on the tax or if the repartition lines
+                # are 'use_in_tax_closing' or not.
+                base_line_key.pop('analytic_distribution')
+
+                # Manage formula taxes.
+                for tax in base_line['tax_ids']._flatten_taxes_and_sort_them()[0]:
+                    if tax._eval_taxes_computation_prepare_product_fields():
+                        base_line_key['product_id'] = base_line['product_id']
+                    else:
+                        base_line_key['product_id'] = None
+                    if tax._eval_taxes_computation_prepare_product_uom_fields():
+                        base_line_key['product_uom_id'] = base_line['product_uom_id']
+                    else:
+                        base_line_key['product_uom_id'] = None
+
+                amounts = (
+                    base_line['price_unit'],
+                    base_line['quantity'],
+                    base_line['discount'],
+                )
+                values = base_line_tracked_values[frozendict(base_line_key)]
+                values['base_lines'].append(base_line)
+                values['amounts'].append(amounts)
+                values['rates'].add(base_line['rate'])
+            return base_line_tracked_values
+
+        old_base_line_tracked_values = track_base_lines_values(old_base_lines)
+        new_base_line_tracked_values = track_base_lines_values(new_base_lines)
+
+        # Determine the sub groups that have to be recomputed from base lines.
+        tax_keys_recompute_amounts = set()
+        tax_keys_recompute_rates = set()
+        for key in new_base_line_tracked_values.keys() | old_base_line_tracked_values.keys():
+            new_values = new_base_line_tracked_values.get(key, {})
+            old_values = old_base_line_tracked_values.get(key, {})
+            for base_line in new_values.get('base_lines', []):
+                tax_details = base_line['tax_details']
+                for tax_data in tax_details['taxes_data']:
+                    for tax_rep_data in tax_data['tax_reps_data']:
+                        tax_rep_grouping_key = frozendict(tax_rep_data['grouping_key'])
+                        if new_values.get('amounts', []) != old_values.get('amounts', []):
+                            tax_keys_recompute_amounts.add(tax_rep_grouping_key)
+                        elif new_values.get('rates', set()).symmetric_difference(old_values.get('rates', set())):
+                            tax_keys_recompute_rates.add(tax_rep_grouping_key)
+
+        # Track tax lines values.
+
+        def track_tax_lines_values(tax_lines):
+            tax_line_tracked_values = defaultdict(list)
+            for tax_line in tax_lines:
+                tax_line_key = self._prepare_tax_line_repartition_grouping_key(tax_line)
+                tax_line_tracked_values[frozendict(tax_line_key)].append((tax_line['amount_currency'], tax_line['balance']))
+            return tax_line_tracked_values
+
+        old_tax_line_tracked_values = track_tax_lines_values(old_tax_lines)
+        new_tax_line_tracked_values = track_tax_lines_values(new_tax_lines)
+
+        tax_results = self._prepare_tax_lines(
+            base_lines=new_base_lines,
+            company=company,
+            tax_lines=new_tax_lines,
+        )
+
+        # Determine the sub groups that have to be recomputed from tax lines.
+        tax_line_protected_keys = set()
+        for key in new_tax_line_tracked_values.keys() | old_tax_line_tracked_values.keys():
+            if new_tax_line_tracked_values.get(key) and new_tax_line_tracked_values.get(key) != old_tax_line_tracked_values.get(key):
+                tax_line_protected_keys.add(key)
+
+        # Preserve the tax amounts if possible.
+        tax_lines_to_update = []
+        for tax_line_vals, grouping_key, to_update in tax_results['tax_lines_to_update']:
+            if grouping_key in tax_line_protected_keys:
+                # Preserve the tax line amounts since they have been written manually.
+                new_to_update = dict(to_update)
+                new_to_update.pop('amount_currency')
+                new_to_update.pop('balance')
+                tax_lines_to_update.append((tax_line_vals, grouping_key, new_to_update))
+            elif grouping_key in tax_keys_recompute_amounts:
+                # Recompute completely the tax line.
+                tax_lines_to_update.append((tax_line_vals, grouping_key, to_update))
+            elif grouping_key in tax_keys_recompute_rates:
+                # Recompute partially the tax line.
+                # Only adapt the new currency rate.
+                rate = to_update['amount_currency'] / to_update['balance'] if to_update['balance'] else 0.0
+                new_to_update = dict(to_update)
+                new_to_update.pop('amount_currency')
+                new_to_update['balance'] = tax_line_vals['currency_id'].round(tax_line_vals['amount_currency'] / rate if rate else 0.0)
+                tax_lines_to_update.append((tax_line_vals, grouping_key, new_to_update))
+
+        tax_results['tax_lines_to_update'] = tax_lines_to_update
+
+        return tax_results
 
     # -------------------------------------------------------------------------
     # ADVANCED LINES MANIPULATION HELPERS

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_account_move_out_refund
 from . import test_account_move_in_invoice
 from . import test_account_move_in_refund
 from . import test_account_move_entry
+from . import test_account_move_sync_tax_lines
 from . import test_account_move_date_algorithm
 from . import test_account_inalterable_hash
 from . import test_account_journal

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -393,47 +393,52 @@ class AccountTestInvoicingCommon(ProductCommon):
     # Helper: Generation of Tax / Invoice / Sale Order / etc.
     # -------------------------------------------------------------------------
 
-    def group_of_taxes(self, taxes, **kwargs):
-        self.tax_number += 1
-        return self.env['account.tax'].create({
-            'name': f"group_({self.tax_number})",
+    @classmethod
+    def group_of_taxes(cls, taxes, **kwargs):
+        cls.tax_number += 1
+        return cls.env['account.tax'].create({
+            'name': f"group_({cls.tax_number})",
             **kwargs,
             'amount_type': 'group',
             'children_tax_ids': [Command.set(taxes.ids)],
         })
 
-    def percent_tax(self, amount, **kwargs):
-        self.tax_number += 1
-        return self.env['account.tax'].create({
-            'name': f"percent_{amount}_({self.tax_number})",
+    @classmethod
+    def percent_tax(cls, amount, **kwargs):
+        cls.tax_number += 1
+        return cls.env['account.tax'].create({
+            'name': f"percent_{amount}_({cls.tax_number})",
             **kwargs,
             'amount_type': 'percent',
             'amount': amount,
         })
 
-    def division_tax(self, amount, **kwargs):
-        self.tax_number += 1
-        return self.env['account.tax'].create({
-            'name': f"division_{amount}_({self.tax_number})",
+    @classmethod
+    def division_tax(cls, amount, **kwargs):
+        cls.tax_number += 1
+        return cls.env['account.tax'].create({
+            'name': f"division_{amount}_({cls.tax_number})",
             **kwargs,
             'amount_type': 'division',
             'amount': amount,
         })
 
-    def fixed_tax(self, amount, **kwargs):
-        self.tax_number += 1
-        return self.env['account.tax'].create({
-            'name': f"fixed_{amount}_({self.tax_number})",
+    @classmethod
+    def fixed_tax(cls, amount, **kwargs):
+        cls.tax_number += 1
+        return cls.env['account.tax'].create({
+            'name': f"fixed_{amount}_({cls.tax_number})",
             **kwargs,
             'amount_type': 'fixed',
             'amount': amount,
         })
 
-    def python_tax(self, formula, **kwargs):
-        self.ensure_installed('account_tax_python')
-        self.tax_number += 1
-        return self.env['account.tax'].create({
-            'name': f"code_({self.tax_number})",
+    @classmethod
+    def python_tax(cls, formula, **kwargs):
+        cls.ensure_installed('account_tax_python')
+        cls.tax_number += 1
+        return cls.env['account.tax'].create({
+            'name': f"code_({cls.tax_number})",
             **kwargs,
             'amount_type': 'code',
             'amount': 0.0,

--- a/addons/account/tests/test_account_move_sync_tax_lines.py
+++ b/addons/account/tests/test_account_move_sync_tax_lines.py
@@ -1,0 +1,209 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import Form, tagged
+from odoo import fields, Command
+from odoo.exceptions import UserError, ValidationError
+
+from collections import defaultdict
+from unittest.mock import patch
+from datetime import timedelta
+from freezegun import freeze_time
+
+
+
+@tagged('post_install', '-at_install')
+class TestAccountMoveSyncTaxLines(AccountTestInvoicingCommon):
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.tax_21 = cls.percent_tax(21.0)
+        cls.tax_6 = cls.percent_tax(6.0)
+        cls.eur = cls.setup_other_currency('EUR', rates=[
+            ('2017-01-01', 2.0),
+            ('2018-01-01', 4.0),
+        ])
+
+    @freeze_time('2017-01-01')
+    def test_manual_tax_amount_foreign_currency_flow(self):
+        invoice = self._create_invoice_one_line(price_unit=100, tax_ids=self.tax_21)
+    
+        tax_line = invoice.line_ids.filtered('tax_line_id')
+        invoice.line_ids = [Command.update(tax_line.id, {'amount_currency': -30})]
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'amount_currency': -100},
+            {'amount_currency': -30},
+            {'amount_currency': 130},
+        ])
+
+        invoice.currency_id = self.eur
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'amount_currency': -100, 'balance': -50},
+            {'amount_currency': -30, 'balance': -15},
+            {'amount_currency': 130, 'balance': 65},
+        ])
+
+        tax_line = invoice.line_ids.filtered('tax_line_id')
+        invoice.line_ids = [Command.update(tax_line.id, {'amount_currency': -30})]
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'amount_currency': -100, 'balance': -50},
+            {'amount_currency': -30, 'balance': -15},
+            {'amount_currency': 130, 'balance': 65},
+        ])
+
+        invoice.invoice_date = '2018-01-01'
+
+        self.assertRecordValues(invoice.line_ids, [
+            {'amount_currency': -100, 'balance': -25},
+            {'amount_currency': -30, 'balance': -7.5},
+            {'amount_currency': 130, 'balance': 32.5},
+        ])
+
+    def test_manual_tax_amount_adding_removing_lines(self):
+        invoice = self._create_invoice(invoice_line_ids=[
+            self._prepare_invoice_line(price_unit=100, tax_ids=self.tax_21),
+            self._prepare_invoice_line(price_unit=100, tax_ids=self.tax_6),
+            self._prepare_invoice_line(price_unit=100),
+        ])
+    
+        tax_line_6 = invoice.line_ids.filtered(lambda line: line.tax_line_id == self.tax_6)
+        tax_line_21 = invoice.line_ids.filtered(lambda line: line.tax_line_id == self.tax_21)
+        invoice.line_ids = [
+            Command.update(tax_line_6.id, {'amount_currency': -10}),
+            Command.update(tax_line_21.id, {'amount_currency': -30}),
+        ]
+
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100},
+            {'amount_currency': -100},
+            {'amount_currency': -100},
+            {'amount_currency': -30},
+            {'amount_currency': -10},
+            {'amount_currency': 340},
+        ])
+
+        # Removing a base line not affecting the tax line should not trigger a recomputation.
+        base_line = invoice.invoice_line_ids.filtered(lambda line: not line.tax_ids)
+        invoice.line_ids = [Command.unlink(base_line.id)]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100},
+            {'amount_currency': -100},
+            {'amount_currency': -30},
+            {'amount_currency': -10},
+            {'amount_currency': 240},
+        ])
+
+        # Removing a base line affecting a specific tax line should only trigger the recomputation of that one.
+        base_line = invoice.invoice_line_ids.filtered(lambda line: line.tax_ids == self.tax_6)
+        invoice.line_ids = [Command.unlink(base_line.id)]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100},
+            {'amount_currency': -30},
+            {'amount_currency': 130},
+        ])
+
+        # Triggering the recomputation of the tax line but editing its amount at the same time should
+        # keep the user input.
+        tax_line = invoice.line_ids.filtered('tax_line_id')
+        invoice.line_ids = [
+            self._prepare_invoice_line(price_unit=100, tax_ids=self.tax_21),
+            Command.update(tax_line.id, {'amount_currency': -50}),
+        ]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100},
+            {'amount_currency': -100},
+            {'amount_currency': -50},
+            {'amount_currency': 250},
+        ])
+
+    def test_analytic_distribution_and_analytic_checkbox_on_taxes(self):
+        analytic_plan = self.env['account.analytic.plan'].create({'name': 'Default'})
+        anal_acc_a = self.env['account.analytic.account'].create({
+            'name': 'anal_acc_a',
+            'plan_id': analytic_plan.id,
+        })
+        anal_distr_a = {str(anal_acc_a.id): 100.0}
+        anal_acc_b = self.env['account.analytic.account'].create({
+            'name': 'anal_acc_b',
+            'plan_id': analytic_plan.id,
+        })
+        anal_distr_b = {str(anal_acc_b.id): 100.0}
+        anal_acc_c = self.env['account.analytic.account'].create({
+            'name': 'anal_acc_c',
+            'plan_id': analytic_plan.id,
+        })
+        anal_distr_c = {str(anal_acc_c.id): 100.0}
+
+        invoice = self._create_invoice(invoice_line_ids=[
+            self._prepare_invoice_line(price_unit=100, analytic_distribution=anal_distr_a, tax_ids=self.tax_21),
+            self._prepare_invoice_line(price_unit=100, analytic_distribution=anal_distr_b, tax_ids=self.tax_21),
+        ])
+        # There are 2 tax lines because the repartition lines are not 'use_in_tax_closing'.
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': -21, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -21, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': 242, 'analytic_distribution': None},
+        ])
+
+        # All the tax lines should now be merged into one.
+        self.tax_21.invoice_repartition_line_ids.use_in_tax_closing = True
+        invoice.invoice_line_ids = [
+            self._prepare_invoice_line(price_unit=100, analytic_distribution=anal_distr_c, tax_ids=self.tax_21),
+        ]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_c},
+            {'amount_currency': -63, 'analytic_distribution': None},
+            {'amount_currency': 363, 'analytic_distribution': None},
+        ])
+
+        # Custom tax amount.
+        tax_line = invoice.line_ids.filtered('tax_line_id')
+        invoice.line_ids = [Command.update(tax_line.id, {'amount_currency': -70})]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_c},
+            {'amount_currency': -70, 'analytic_distribution': None},
+            {'amount_currency': 370, 'analytic_distribution': None},
+        ])
+
+        # Changing the analytic accounts should not recompute the tax line.
+        base_line_b = invoice.invoice_line_ids.filtered(lambda line: line.analytic_distribution == anal_distr_b)
+        base_line_c = invoice.invoice_line_ids.filtered(lambda line: line.analytic_distribution == anal_distr_c)
+        invoice.with_context(blu=True).line_ids = [
+            Command.update(base_line_b.id, {'analytic_distribution': anal_distr_a}),
+            Command.update(base_line_c.id, {'analytic_distribution': anal_distr_a}),
+        ]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -70, 'analytic_distribution': None},
+            {'amount_currency': 370, 'analytic_distribution': None},
+        ])
+
+        # Same with the 'analytic' ticked on the tax. This time, changing the analytic distribution
+        # will impact the tax lines.
+        self.tax_21.analytic = True
+        invoice.line_ids = [
+            Command.update(invoice.invoice_line_ids[0].id, {'analytic_distribution': anal_distr_a}),
+            Command.update(invoice.invoice_line_ids[1].id, {'analytic_distribution': anal_distr_b}),
+            Command.update(invoice.invoice_line_ids[2].id, {'analytic_distribution': anal_distr_c}),
+        ]
+        self.assertRecordValues(invoice.line_ids.sorted('amount_currency'), [
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': -100, 'analytic_distribution': anal_distr_c},
+            {'amount_currency': -21, 'analytic_distribution': anal_distr_a},
+            {'amount_currency': -21, 'analytic_distribution': anal_distr_b},
+            {'amount_currency': -21, 'analytic_distribution': anal_distr_c},
+            {'amount_currency': 363, 'analytic_distribution': None},
+        ])
+


### PR DESCRIPTION
Avoid losing the custom amounts set on tax lines as much as possible. Since a recomputation might mean losing tax lines having custom amounts like "fixing" the amounts when importing an invoice, it's important to avoid a regular user to trigger a recomputation by changing an analytic distribution for example when the tax is not set as analytic.

task-id: 6030615

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
