### PR TITLE
[FIX] spreadsheet_dashboard: reduce dashboard side panel spacing

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -74,12 +74,12 @@
     </t>
 
     <t t-name="spreadsheet_dashboard.DashboardAction.Expanded">
-        <div class="o_spreadsheet_dashboard_search_panel o_search_panel flex-grow-0 border-end flex-shrink-0 pe-2 pb-5 ps-4 h-100 bg-view overflow-auto position-relative pt-4 d-print-none">
+        <div class="o_spreadsheet_dashboard_search_panel o_search_panel flex-grow-0 border-end flex-shrink-0 pe-2 pb-5 ps-4 h-100 bg-view overflow-auto position-relative pt-3 d-print-none">
             <button title="Close sidebar" aria-label="Close sidebar" t-if="!this.env.isSmall and this.loader.getActiveDashboard()" class="btn btn-light btn-sm end-0 m-1 mb-2 position-absolute px-2 py-1 top-0 z-1" t-on-click="this.toggleSidebar">
                 <i class="oi oi-lg oi-panel-right fa-flip-horizontal"/>
             </button>
             <div class="mt-2"/>
-            <section t-foreach="this.getDashboardGroups()" t-as="group" t-key="group.id" class="o_search_panel_section o_search_panel_category mt-4">
+            <section t-foreach="this.getDashboardGroups()" t-as="group" t-key="group.id" class="o_search_panel_section o_search_panel_category mt-3">
                 <header class="o_search_panel_section_header pb-2 text-uppercase o_cursor_default user-select-none">
                     <b t-out="group.name"/>
                 </header>
@@ -88,7 +88,7 @@
                         t-on-click="() => this.openDashboard(dashboard.data.id)"
                         t-att-data-name="dashboard.data.name"
                         t-att-title="dashboard.data.name"
-                        class="o_search_panel_category_value list-group-item cursor-pointer border-0 d-flex justify-content-between align-items-center p-2 my-1"
+                        class="o_search_panel_category_value list-group-item cursor-pointer border-0 d-flex justify-content-between align-items-center px-2 py-1 my-1"
                         t-att-class="{'active': dashboard.data.id === this.loader.getActiveDashboard().data.id}">
                         <div class="o_dashboard_name">
                             <t t-out="dashboard.data.name" />


### PR DESCRIPTION
## Description:

The dashboard side panel had too much vertical spacing between the fold button, dashboard sections, and dashboard entries.

Reduce the top and section spacing by one Bootstrap step, and use smaller vertical padding on dashboard entries while keeping their vertical margin for readability.

Task: [6138870](https://www.odoo.com/odoo/project/2328/tasks/6138870)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
