### PR TITLE
[FIX] html_builder: show round corners without border

### DIFF
--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -17,7 +17,7 @@
     </BuilderRow>
 
     <!-- TODO: handle the dependency with border_width_opt bg_color_opt-->
-    <BuilderRow t-if="props.withRoundCorner and state.hasBorder" label.translate="Round Corners">
+    <BuilderRow t-if="props.withRoundCorner" label.translate="Round Corners">
         <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('radius'), extraClass: props.withBSClass and 'rounded' }" unit="'px'" min="0" composable="true"/>
     </BuilderRow>
 </t>


### PR DESCRIPTION
Steps to reproduce:
- Open the website editor.
- Select a block with the border configurator and round corners enabled.
- Set the border width to 0 px. => The Round Corners option is hidden.

Before this commit, the change introduced by [1] hid the option when no border was set. This restriction was not needed because a block can use a border radius without a visible border.

After this commit, the option remains visible when round corners are supported, even without a border.

[1]: 97e8cc8d664e66ba62e8282a67f069805682ae41

task-6089515