### PR TITLE
[FIX] pos_sale: load archived products in sale order from pos

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -30,7 +30,7 @@ class SaleOrder(models.Model):
 
     def load_sale_order_from_pos(self, config_id):
         product_ids = self.order_line.product_id.ids
-        product_tmpls = self.env['product.template'].load_product_from_pos(
+        product_tmpls = self.env['product.template'].with_context(load_archived=True).load_product_from_pos(
             config_id,
             [('product_variant_ids.id', 'in', product_ids)]
         )


### PR DESCRIPTION
Before this commit, loading a sale order from pos would raise an error if the order contained a product that had been archived.

opw-6116760

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
