### PR TITLE
[FIX] website: fix zoom of snippet with scoll effect in snippets dialog

### DIFF
--- a/addons/website/static/src/interactions/parallax/parallax.preview.js
+++ b/addons/website/static/src/interactions/parallax/parallax.preview.js
@@ -101,7 +101,7 @@ const ParallaxPreview = (I) =>
             let translateY = `calc(50% - ${parallaxShift}px)`;
             if (this.isZoom) {
                 const minScrollPos = -rect.height;
-                const maxScrollPos = viewportHeight;
+                const maxScrollPos = viewportHeight * 3.33;
                 const scrollRange = maxScrollPos - minScrollPos;
                 const progress = scrollRange ? clamp((rect.top - minScrollPos) / scrollRange) : 0;
                 const zoomProgress = this.isZoomIn ? Math.min(1, progress * 2.5) : progress;


### PR DESCRIPTION
Commit 468ddd4d244d0098e5c8b9726bc1c85c036a913d changed the viewport height of the iframe in the snippets preview dialog (from `333%` to `100%`). That height is used in the computation of the zoom effect of backgrounds. This computation was not adapted to the change of height, and thus the zoom was too weak.

This commit adapts the computation for the zoom to compensate the viewport height change of that previous commit.

Steps to reproduce:
- Open website builder
- Create a bunch of custom snippets (for scrolling in the dialog)
- Create a custom snippet which has a background with "Scroll Effect" set to "Zoom In" (or "Zoom Out")
- Create a bunch of custom snippets (for scrolling in the dialog)
- Open the dialog to "Insert a block", choose the "Custom" category
- Scroll
- Bug: the custom snippets with zooming

task-6088029