### PR TITLE
[PERF] website_sale: speedup /reorder route

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -209,18 +209,29 @@ class Cart(PaymentPortal):
         positive_added_qty_per_line = {
             line_id: qty for line_id, qty in added_qty_per_line.items() if qty > 0
         }
-
-        return {
+        # Build and return cart values.
+        cart_values = {
             'cart_quantity': order_sudo.cart_quantity,
-            'notification_info': {
-                **self._get_cart_notification_information(
-                    order_sudo, positive_added_qty_per_line
-                ),
-                'warning': warning,
-            },
-            'quantity': values.pop('quantity', 0),
-            'tracking_info': self._get_tracking_information(order_sudo, line_ids.values()),
+            'quantity': quantity,
         }
+        # When coming from /reorder route, add information to compute tracking_information later on.
+        if kwargs.get('add_reorder_info'):
+            cart_values.update({
+                'tracking_info': {
+                    'line_values': line_ids.values()
+                }
+            })
+        else:
+            cart_values.update({
+                'notification_info': {
+                    **self._get_cart_notification_information(
+                        order_sudo, positive_added_qty_per_line
+                    ),
+                    'warning': warning,
+                },
+                'tracking_info': self._get_tracking_information(order_sudo, line_ids.values()),
+            })
+        return cart_values
 
     @route(
         route='/shop/cart/quick_add', type='jsonrpc', auth='user', methods=['POST'], website=True

--- a/addons/website_sale/controllers/reorder.py
+++ b/addons/website_sale/controllers/reorder.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from itertools import chain
 
 from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.http import request, route
@@ -39,9 +40,25 @@ class CustomerPortal(sale_portal.CustomerPortal):
         Cart_controller = Cart()
         order_sudo = request.cart or request.website._create_cart()
         warnings_to_aggregate = set()
-        values = {
-            'tracking_info': [],
-        }
+        all_cart_values = []
+        product_lines = lines_to_reorder.filtered(lambda l: l.product_id.type != 'combo')
+
+        # Create new sols for product_lines in batch to speedup add_to_cart call.
+        new_cart_line_vals = []
+        for line in product_lines:
+            new_cart_line_vals.append(
+                order_sudo._prepare_order_line_values(
+                    product_id=line.product_id.id,
+                    quantity=0.0,
+                    uom_id=line.product_id.uom_id.id,
+                    product_custom_attribute_values=[{
+                        'custom_product_template_attribute_value_id': pcav.custom_product_template_attribute_value_id.id,
+                        'custom_value': pcav.custom_value,
+                    } for pcav in line.product_custom_attribute_value_ids],
+                    no_variant_attribute_value_ids=line.product_no_variant_attribute_value_ids.ids,
+                )
+            )
+        self.env['sale.order.line'].sudo().create(new_cart_line_vals)
         for line in lines_to_reorder:
 
             linked_products = []
@@ -75,15 +92,18 @@ class CustomerPortal(sale_portal.CustomerPortal):
                 } for pcav in line.product_custom_attribute_value_ids],
                 no_variant_attribute_value_ids=line.product_no_variant_attribute_value_ids.ids,
                 linked_products=linked_products,
+                add_reorder_info=True,
             )
             if not cart_values['quantity']:
                 # Only aggregate order warnings
                 warnings_to_aggregate.add(order_sudo.shop_warning)
-
-            values['tracking_info'].extend(cart_values['tracking_info'])
+            all_cart_values.append(cart_values)
 
         if warnings_to_aggregate:
             order_sudo.shop_warning = '\n'.join(warnings_to_aggregate)
-
-        values['cart_quantity'] = order_sudo.cart_quantity
+        line_ids = set(chain.from_iterable(cart_values['tracking_info']['line_values'] for cart_values in all_cart_values))
+        values = {
+            'cart_quantity': order_sudo.cart_quantity,
+            'tracking_info': self._get_tracking_information(order_sudo, line_ids),
+        }
         return values

--- a/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
+++ b/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
@@ -17,11 +17,11 @@ registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal'
         },
         {
             content: "Check that there is one out of stock product",
-            trigger: "div.alert-warning:contains('unavailable_product has not been added to your cart since it is not available.')",
+            trigger: "div.alert-warning:contains('Some products became unavailable and your cart has been updated. We're sorry for the inconvenience.')",
         },
         {
             content: "Check that there is one product that does not have enough stock",
-            trigger: "div.o_cart_product i.fa.fa-warning[title='You ask for 2 products but only 1 is available.']",
+            trigger: "div.o_cart_product i.fa.fa-warning[title='You ask for 2 partially_available_product but only 1 is available']",
         },
     ]
 });


### PR DESCRIPTION
The `/reorder route` allows users of an ecommerce to reorder the same order they made in the past. The current version of `/reorder` gets all the  sale.order.lines from the previous order and calls `Cart.add_to_cart` one line at the time. Doing that creates two bottlenecks. First, the new sale.order.lines get created one by one. This means that all the necessary computations will be carried out on a single record at a time. Second, the cart `*_information` are called and access fields on lines one by one.

This PR aims to improve this by creating non-combo lines first and then call `add_to_cart` on all the order lines. By doing this, `add_to_cart` won't create any line and will instead find an already existing line with the correct product_id to update its quantity. This batches lines creation.

Another change that was made is to build the `tracking_info` in the reorder method itself. `add_to_cart` is changing some fields on lines so they will be marked as to recompute. The methods to get notification and tracking information will then trigger lines compute methods for `price_reduce_taxinc` and `price_reduce_taxecl` on singletons. Moving `tracking_info` calls in the reorder method makes it possible to compute those fields in batch.

### speedup

In a customer database with 34K sale.order.lines, 800 products, 1000 sale.orders. No combo products in the database. Timing of reodering past orders of different sizes

|  Nbr of lines | Before PR | After PR |
|:-------------:|:---------:|:--------:|
|      25       |   1.16s   |   560ms  |
|      50       |   3.12s   |   784ms  |
|      100      |   10.76s  |   1.64s  |
|      169      |   28s     |   2.5s   |

Average speedup: 5.95

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
