### PR TITLE
[FIX] website, *: Reduce impact/resources of odoo tracker.

### DIFF
--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -48,6 +48,9 @@ def MockRequest(
             referrer=referrer or '',
             remote_addr=remote_addr,
             url_root=url_root,
+            user_agent=DotDict(
+                string='mockrequest',
+            ),
             args=[],
         ),
         type='http',

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -231,6 +231,8 @@ class Website(Home):
 
     @http.route('/website/odoo_track', type='jsonrpc', auth='public', methods=['POST'], website=True, csrf=True)
     def track(self, res_model, res_id, **kwargs):
+        if request.env['ir.http'].is_a_bot():
+            return {}
         url = request.httprequest.referrer
         extra_tracking_vals = {}
         if (

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -24,7 +24,7 @@ class IrUiView(models.Model):
     page_ids = fields.One2many('website.page', 'view_id')
     controller_page_ids = fields.One2many('website.controller.page', 'view_id')
     first_page_id = fields.Many2one('website.page', string='Website Page', help='First page linked to this view', compute='_compute_first_page_id')
-    track = fields.Boolean(string='Track', default=True, help="Allow to specify for one page of the website to be trackable or not")
+    track = fields.Boolean(string='Track', default=False, help="Allow to specify for one page of the website to be trackable or not")
     visibility = fields.Selection(
         [
             ('public', 'Public'),

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1270,6 +1270,8 @@ class Website(models.CachedModel):
         return page_temp
 
     def _is_tracking_enabled(self, main_object):
+        if self.env['ir.http'].is_a_bot():
+            return False
         if main_object._name in ['ir.ui.view', 'website.page']:
             return main_object.track
         return True

--- a/addons/website/static/src/interactions/odoo_tracker.js
+++ b/addons/website/static/src/interactions/odoo_tracker.js
@@ -11,10 +11,12 @@ export class OdooTracker extends Interaction {
         const { trackingEnabled, mainObject } = document.documentElement.dataset;
         const matches = mainObject?.match(recordRE);
         if (trackingEnabled && matches) {
-            rpc('/website/odoo_track', {
-                res_model: matches[1],
-                res_id: matches[2],
-            });
+            this.waitForTimeout(() => {
+                rpc('/website/odoo_track', {
+                    res_model: matches[1],
+                    res_id: matches[2],
+                });
+            }, 3000);
         }
     }
 }

--- a/addons/website/static/tests/tours/tracking.js
+++ b/addons/website/static/tests/tours/tracking.js
@@ -1,6 +1,30 @@
 import {
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * Patch tracker to avoid waitForTimeout.
+ */
+function patchOdooTracker() {
+    const { OdooTracker } = odoo.loader.modules.get('@website/interactions/odoo_tracker');
+    patch(OdooTracker.prototype, {
+        waitForTimeout(callback, delay) {
+            callback();
+            return {
+                clear: () => {},
+            };
+        },
+    });
+}
+
+if (odoo.loader.modules.has('@website/interactions/odoo_tracker')) {
+    patchOdooTracker();
+} else {
+    odoo.loader.bus.addEventListener('module-started', (e) => {
+        if (e.detail.moduleName === '@website/interactions/odoo_tracker') patchOdooTracker();
+    });
+}
 
 registerWebsitePreviewTour("visitor_tracking", {}, () => [
     {

--- a/addons/website_sale/static/src/interactions/recently_viewed_products.js
+++ b/addons/website_sale/static/src/interactions/recently_viewed_products.js
@@ -30,7 +30,7 @@ export class RecentlyViewedProducts extends Interaction {
             res_model: 'product.product',
             res_id: productId,
         }));
-        cookie.set(cookieName, productId, 30 * 60, 'optional');
+        cookie.set(cookieName, productId, 30 * 60);
     }
 }
 

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -10,7 +10,7 @@
         />/<span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
     </template>
 
-    <template id="website_sale.product" name="Product">
+    <template id="website_sale.product" name="Product" track="1">
         <!-- Qweb variable defining the class suffix for navbar items.
              Change accordingly to the derired visual result (eg. `primary`, `dark`...)-->
         <t t-set="navClass" t-valuef="light"/>


### PR DESCRIPTION
The odoo tracker was [recently reworked to use JS](https://github.com/odoo/odoo/pull/247438) and allow
website controllers to use readonly replicas.

In the process, we increased the number of tracked events
significantly. Since we don't intend to replace plausible/analytics - our
tracker is used primarily for functional purposes.

This PR aims to reduce calls to the tracking endpoint and
ultimately reduce the amount of data in it.

Part of
Task-4939052