### PR TITLE
[FIX] base: make sequence_date a datetime

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -263,12 +263,11 @@ class IrSequence(models.Model):
         if not self.use_date_range:
             return self._next_do()
         # date mode
-        dt = sequence_date or self.env.context.get('ir_sequence_date', fields.Date.today())
+        dt = sequence_date or self.env.context.get('ir_sequence_date', fields.Datetime.now())
         seq_date = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '<=', dt), ('date_to', '>=', dt)], limit=1)
         if not seq_date:
             seq_date = self._create_date_range_seq(dt)
-        ir_sequence_date = dt.date() if isinstance(dt, datetime) else dt
-        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from, ir_sequence_date=ir_sequence_date)._next()
+        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from, ir_sequence_date=dt.replace(tzinfo=None))._next()
 
     def next_by_id(self, sequence_date=None):
         """ Draw an interpolated string using the specified sequence."""

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -263,12 +263,11 @@ class IrSequence(models.Model):
         if not self.use_date_range:
             return self._next_do()
         # date mode
-        dt = sequence_date or self.env.context.get('ir_sequence_date', fields.Date.today())
+        dt = sequence_date or self.env.context.get('ir_sequence_date', fields.Datetime.today())
         seq_date = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '<=', dt), ('date_to', '>=', dt)], limit=1)
         if not seq_date:
             seq_date = self._create_date_range_seq(dt)
-        ir_sequence_date = dt.date() if isinstance(dt, datetime) else dt
-        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from, ir_sequence_date=ir_sequence_date)._next()
+        return seq_date.with_context(ir_sequence_date_range=seq_date.date_from, ir_sequence_date=dt.replace(tzinfo=None))._next()
 
     def next_by_id(self, sequence_date=None):
         """ Draw an interpolated string using the specified sequence."""

--- a/odoo/addons/base/tests/test_ir_sequence_date_range.py
+++ b/odoo/addons/base/tests/test_ir_sequence_date_range.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date
+from datetime import date, datetime
 
 from odoo import Command
 from odoo.tests.common import SingleTransactionCase
@@ -23,7 +23,7 @@ class TestIrSequenceDateRangeStandard(SingleTransactionCase):
     def test_ir_sequence_date_range_2_change_dates(self):
         """ Draw numbers to create a first subsequence then change its date range. Then, try to draw a new number adn check a new subsequence was correctly created. """
         year = date.today().year - 1
-        january = lambda d: date(year, 1, d)
+        january = lambda d: datetime(year, 1, d)   # noqa: E731
 
         seq16 = self.env['ir.sequence'].with_context(ir_sequence_date=january(16))
         n = seq16.next_by_code('test_sequence_date_range')
@@ -41,7 +41,7 @@ class TestIrSequenceDateRangeStandard(SingleTransactionCase):
         # check the newly created sequence stops at the 17th of January
         domain = [('sequence_id.code', '=', 'test_sequence_date_range'), ('date_from', '=', january(1))]
         seq_date_range = self.env['ir.sequence.date_range'].search(domain)
-        self.assertEqual(seq_date_range.date_to, january(17))
+        self.assertEqual(seq_date_range.date_to, january(17).date())
 
     def test_ir_sequence_date_range_3_unlink(self):
         seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
@@ -64,7 +64,7 @@ class TestIrSequenceDateRangeNoGap(SingleTransactionCase):
     def test_ir_sequence_date_range_2_change_dates(self):
         """ Draw numbers to create a first subsequence then change its date range. Then, try to draw a new number adn check a new subsequence was correctly created. """
         year = date.today().year - 1
-        january = lambda d: date(year, 1, d)
+        january = lambda d: datetime(year, 1, d)   # noqa: E731
 
         seq16 = self.env['ir.sequence'].with_context({'ir_sequence_date': january(16)})
         n = seq16.next_by_code('test_sequence_date_range_2')
@@ -82,7 +82,7 @@ class TestIrSequenceDateRangeNoGap(SingleTransactionCase):
         # check the newly created sequence stops at the 17th of January
         domain = [('sequence_id.code', '=', 'test_sequence_date_range_2'), ('date_from', '=', january(1))]
         seq_date_range = self.env['ir.sequence.date_range'].search(domain)
-        self.assertEqual(seq_date_range.date_to, january(17))
+        self.assertEqual(seq_date_range.date_to, january(17).date())
 
     def test_ir_sequence_date_range_3_unlink(self):
         seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range_2')])
@@ -94,8 +94,8 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
 
     def test_ir_sequence_date_range_1_create(self):
         year = date.today().year - 1
-        january = lambda d: date(year, 1, d)   # noqa: E731
-        february = lambda d: date(year, 2, d)  # noqa: E731
+        january = lambda d: datetime(year, 1, d)   # noqa: E731
+        february = lambda d: datetime(year, 2, d)  # noqa: E731
         """ Try to create a sequence object. """
         seq = self.env['ir.sequence'].create({
             'code': 'test_sequence_date_range_3',
@@ -116,7 +116,8 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
             'code': 'test_sequence_date_range_5',
             'name': 'Test sequence',
             'use_date_range': True,
-            'prefix': '%(month)s/',
+            'prefix': '%(month)s/%(day)s/',
+            'suffix': '/%(h24)s/%(min)s/%(sec)s',
             'date_range_ids': [
                 Command.create({
                     'date_from': january(1),
@@ -135,8 +136,8 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
     def test_ir_sequence_date_range_2_use(self):
         """ Make some use of the sequences to create some subsequences """
         year = date.today().year - 1
-        january = lambda d: date(year, 1, d)
-        february = lambda d: date(year, 2, d)  # noqa: E731
+        january = lambda d, h=0, m=0, s=0: datetime(year, 1, d, h, m, s)   # noqa: E731
+        february = lambda d, h=0, m=0, s=0: datetime(year, 2, d, h, m, s)  # noqa: E731
 
         seq = self.env['ir.sequence']
         seq16 = self.env['ir.sequence'].with_context({'ir_sequence_date': january(16)})
@@ -154,11 +155,11 @@ class TestIrSequenceDateRangeChangeImplementation(SingleTransactionCase):
             n = seq16.next_by_code('test_sequence_date_range_4')
             self.assertEqual(n, str(i))
         for i in range(5):
-            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=january(16))
-            self.assertEqual(n, f'01/{i + 15}')
+            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=january(16, 1, 2, 3))   # January 16, 01:02:03
+            self.assertEqual(n, f'01/16/{i + 15}/01/02/03')
         for i in range(1, 5):
-            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=february(16))
-            self.assertEqual(n, f'02/{i}')
+            n = seq.next_by_code('test_sequence_date_range_5', sequence_date=february(16, 15, 40, 32))   # February 16, 15:40:32
+            self.assertEqual(n, f'02/16/{i}/15/40/32')
 
     def test_ir_sequence_date_range_3_write(self):
         """swap the implementation method on both"""


### PR DESCRIPTION
## Issue
When using a prefix containing a time-based placeholder (`%(h24)s`, `%(h12)s`, `%(min)s`, `%(sec)s`) with *Subsequences per date\_range*, the time information are missing and consistently set to 0 when interpolating the prefix.

## Steps to reproduce
1. Install *Sales* (`sale_management`)
2. In Settings > Technical > Sequences, update the `sale.order` sequence:
    - Prefix: `S/%(y)s/%(month)s/`
    - Suffix: `/%(h24)s/%(min)s/%(sec)s`
    - Tick the *Use subsequences per date_range* checkbox and set a range for the current month
3. Create and confirm a SO
4. **The name of the SO correctly contains the Quotation date in the prefix, but the suffix is set to /00/00/00, even though the quotation date contains time information.**

## Cause
Commit https://github.com/odoo/odoo/commit/f7c330d83cc3 sets the `ir_sequence_date` to a `datetime.date` object in `IrSequence._next`. This leads to the time information missing from the interpolation dict:

https://github.com/odoo/odoo/blob/d58f4ed332af35f6de26a93f07adf05368731e20/odoo/addons/base/models/ir_sequence.py#L211-L214

## Fix
The context key `ir_sequence_date` should be set to a `datetime.datetime` object to correctly interpolate the time information in the prefix/suffix of a sequence. To do so, the `tzinfo` needs to be drop for the date to be interpretable by the `fields.Datetime.from_string` method:

https://github.com/odoo/odoo/blob/d58f4ed332af35f6de26a93f07adf05368731e20/odoo/orm/fields_temporal.py#L239-L244

The time is not cast to a specific timezone (e.g., UTC) before dropping the tzinfo, as doing so would lead to incoherent time information from the user's perspective. For example, creating a SO at 13:00 in Brussels (UTC+2) would result in  `11` being used as the hour to interpolate the `%(h24)s` placeholder.

opw-6104485